### PR TITLE
fix(agent): handle include_reasoning in derive_thinking_compat

### DIFF
--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -347,8 +347,8 @@ fn derive_thinking_compat(
             "thinkingFormat".into(),
             serde_json::json!("reasoning-split"),
         );
-    } else if has("thinking") || has("reasoning_effort") || has("reasoning") {
-        // DeepSeek / Doubao / Kimi K2.6:
+    } else if has("thinking") || has("reasoning_effort") || has("reasoning") || has("include_reasoning") {
+        // DeepSeek / Doubao / Kimi K2.6 / Anthropic Claude:
         // thinking toggle + reasoning_effort for depth
         compat.insert("thinkingFormat".into(), serde_json::json!("deepseek"));
         tlm.insert("high".into(), serde_json::json!("high"));


### PR DESCRIPTION
## Problem
When selecting Claude Sonnet 4.6 or Opus 4.8 in the Future agent and setting thinking level to "off", the model still produces reasoning/thinking content.

## Root Cause
Claude models use `include_reasoning` as their thinking parameter in the Future API, but `derive_thinking_compat` did not match it. This left `compat_thinking_format` empty, causing `apply_thinking_params` to return early when thinking was set to "off" — no disable directive was ever sent to the API.

## Fix
Add `include_reasoning` to the deepseek-format condition in `derive_thinking_compat`. When thinking is "off", the deepseek format sends `thinking: {type: "disabled"}` to the API server.

## Companion PR
Requires https://github.com/futuregene/future-server/pull/new/fix-claude-thinking-off for the server to handle the `thinking.type="disabled"` field and translate it to Anthropic `{type: "disabled"}`.

## Testing
- `cargo check` — passes
- `cargo test --lib` — all 114 tests pass
- `cargo test helpers` — all 15 thinking params tests pass  
- `cargo test models` — all 16 model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)