### PR TITLE
shell 执行加固:PS flags + 跨平台 prompt 借鉴 + Unix 登录 shell env

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -33,6 +33,12 @@ fn main() -> Result<()> {
         )
         .init();
 
+    // Load the user's login-shell PATH/env BEFORE spawning any threads or the
+    // tokio runtime — set_var is only sound while single-threaded. Fixes
+    // "command not found" for user-installed tools (nvm/Homebrew/npm-global)
+    // when the agent is launched from a GUI with a minimal inherited PATH.
+    future_agent::sandbox::hydrate_from_login_shell();
+
     // Build model registry BEFORE tokio runtime starts.
     // Registry::new() uses reqwest::blocking::Client internally,
     // which creates a nested runtime that cannot be dropped in async context.

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -177,12 +177,12 @@ fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
         // PowerShell 5.1 on Windows (see sandbox::shell_invocation).
         #[cfg(not(target_os = "windows"))]
         guidelines.push(
-            "Use the shell tool for command-line exploration such as ls, rg, and find; prefer write/edit tools for ordinary file writes."
+            "Use the shell tool for command-line exploration such as ls, rg, and find; but to read a known file's contents use the read tool, not cat. Prefer write/edit tools for ordinary file writes."
                 .to_string(),
         );
         #[cfg(target_os = "windows")]
         guidelines.push(
-            "Use the shell tool (PowerShell) for command-line exploration such as Get-ChildItem and Select-String; prefer write/edit tools for ordinary file writes."
+            "Use the shell tool (PowerShell) for command-line exploration such as Get-ChildItem and Select-String; but to read a known file's contents use the read tool, not Get-Content. Prefer write/edit tools for ordinary file writes."
                 .to_string(),
         );
     }

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -264,9 +264,13 @@ fn os_hint() -> String {
 
     match std::env::consts::OS {
         "macos" => {
+            // Name the shell actually resolved at runtime ($SHELL — often zsh on
+            // macOS). bash and zsh share command-line syntax, so no separate
+            // syntax rules are needed — only the accurate name.
+            let shell = crate::sandbox::shell_display_name();
             format!(
-                "Host platform: macOS. Shell commands are interpreted by bash; \
-                 macOS command-line tools (BSD variants) apply. \
+                "Host platform: macOS. Shell commands are interpreted by {shell} \
+                 (POSIX shell syntax); macOS command-line tools (BSD variants) apply. \
                  {skills_hint} (Example: ~/.agents/skills/my-skill/SKILL.md)"
             )
         }
@@ -294,8 +298,10 @@ fn os_hint() -> String {
             )
         }
         "linux" => {
+            let shell = crate::sandbox::shell_display_name();
             format!(
-                "Host platform: Linux. \
+                "Host platform: Linux. Shell commands are interpreted by {shell} \
+                 (POSIX shell syntax). \
                  {skills_hint} (Example: ~/.agents/skills/my-skill/SKILL.md)"
             )
         }

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -278,8 +278,12 @@ fn os_hint() -> String {
             let chaining = if crate::sandbox::shell_supports_chain_operators() {
                 "chain commands with `;`, `&&`, or `||`"
             } else {
-                "chain commands with `;` (never `&&` or `||` — this PowerShell \
-                 version does not support them)"
+                // PowerShell 5.1 rejects `&&`/`||` at parse time. `;` runs the
+                // next command unconditionally; to run one ONLY if the previous
+                // succeeded, use `cmd1; if ($?) { cmd2 }`.
+                "chain commands with `;` (run-if-previous-succeeded is \
+                 `cmd1; if ($?) { cmd2 }`); never use `&&` or `||` — this \
+                 PowerShell version rejects them at parse time"
             };
             format!(
                 "Host platform: Windows. Shell commands are interpreted by \

--- a/agent/src/sandbox/mod.rs
+++ b/agent/src/sandbox/mod.rs
@@ -312,7 +312,7 @@ impl Default for ResolvedSandbox {
 pub fn shell_invocation(command: &str) -> (&'static str, Vec<String>) {
     #[cfg(not(target_os = "windows"))]
     {
-        ("bash", vec!["-c".to_string(), command.to_string()])
+        (unix_shell(), vec!["-c".to_string(), command.to_string()])
     }
     #[cfg(target_os = "windows")]
     {
@@ -428,6 +428,148 @@ fn pwsh_on_path() -> bool {
     std::env::split_paths(&path).any(|dir| dir.join("pwsh.exe").is_file())
 }
 
+/// The shell used to execute commands on Unix, resolved once. Honors the
+/// user's `$SHELL` when it is bash or zsh (both POSIX-compatible with the
+/// `( … ) 2>&1` wrapper the caller applies); otherwise probes for bash then
+/// zsh on PATH, falling back to `sh`. Never fish/nu — their syntax would break
+/// the wrapper. Returns a program name or absolute path for `Command::new`.
+#[cfg(not(target_os = "windows"))]
+pub fn unix_shell() -> &'static str {
+    use std::sync::OnceLock;
+    static SHELL: OnceLock<String> = OnceLock::new();
+    SHELL.get_or_init(|| {
+        // $SHELL, but only if it is a bash/zsh we can actually run.
+        if let Some(raw) = std::env::var_os("SHELL") {
+            let path = PathBuf::from(&raw);
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if (name == "bash" || name == "zsh") && path.is_file() {
+                return raw.to_string_lossy().into_owned();
+            }
+        }
+        for cand in ["bash", "zsh"] {
+            if on_path(cand) {
+                return cand.to_string();
+            }
+        }
+        // Last resort: POSIX sh is guaranteed present, and our wrapper is
+        // POSIX-safe.
+        "sh".to_string()
+    })
+}
+
+/// Basename of the resolved Unix shell for prompt text ("bash" / "zsh" / "sh").
+#[cfg(not(target_os = "windows"))]
+fn unix_shell_display_name() -> &'static str {
+    let shell = unix_shell();
+    shell.rsplit('/').next().unwrap_or(shell)
+}
+
+/// Whether an executable named `name` resolves on PATH. Pure env scan.
+#[cfg(not(target_os = "windows"))]
+fn on_path(name: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(name).is_file())
+}
+
+/// Load the user's login-shell environment into this process at startup, so
+/// commands find tools the user installed via their shell rc (nvm/pyenv/conda,
+/// Homebrew, npm-global) — not just the minimal PATH a GUI launched from the
+/// Finder/dock inherits. Mirrors what VS Code and similar tools do.
+///
+/// Runs `$SHELL -l -i -c` once to dump `env` between markers (rc noise on
+/// stderr is discarded; a 5s timeout guards against a hanging rc). PATH is
+/// always taken from the login shell; other vars are merged only when absent,
+/// so intentional launcher overrides are never clobbered. No-op on Windows,
+/// where GUI processes already inherit the full registry PATH.
+#[cfg(not(target_os = "windows"))]
+pub fn hydrate_from_login_shell() {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    // The shell whose rc files define the user's real env — their actual login
+    // shell ($SHELL), even if it is fish/nu (we only harvest the resulting env,
+    // we don't run shell-specific syntax beyond printf + the env binary).
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| unix_shell().to_string());
+    let marker = "__future_env_boundary_9c4f__";
+    let script = format!("printf '%s' '{marker}'; /usr/bin/env; printf '%s' '{marker}'");
+
+    let mut child = match Command::new(&shell)
+        .args(["-l", "-i", "-c", &script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!("login-shell env hydration skipped: spawn {shell} failed: {e}");
+            return;
+        }
+    };
+
+    let Some(mut stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        return;
+    };
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let dump = match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(buf) => {
+            let _ = child.wait();
+            buf
+        }
+        Err(_) => {
+            tracing::debug!("login-shell env hydration timed out; using inherited env");
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+    };
+
+    // Content strictly between the two markers is the env dump (rc scripts may
+    // print before the first marker; we ignore that).
+    let Some(start) = dump.find(marker) else {
+        return;
+    };
+    let after = &dump[start + marker.len()..];
+    let body = after.split(marker).next().unwrap_or("");
+
+    let mut applied_path = false;
+    let mut merged = 0usize;
+    for line in body.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.is_empty() {
+            continue;
+        }
+        if key == "PATH" {
+            std::env::set_var("PATH", value);
+            applied_path = true;
+        } else if std::env::var_os(key).is_none() {
+            // Additive only: never overwrite a var the launcher set on purpose.
+            std::env::set_var(key, value);
+            merged += 1;
+        }
+    }
+    if applied_path {
+        tracing::info!("hydrated PATH from login shell ({shell}); merged {merged} env vars");
+    }
+}
+
+/// No-op on Windows — GUI processes already inherit the full registry PATH.
+#[cfg(target_os = "windows")]
+pub fn hydrate_from_login_shell() {}
+
 /// Runtime hint for prompt text: does the host's shell support `&&`/`||`
 /// chaining? True for any POSIX shell and for pwsh 7 on Windows; false for
 /// Windows PowerShell 5.1. Callable on every target so prompt code that runs
@@ -456,7 +598,7 @@ pub fn shell_display_name() -> &'static str {
     }
     #[cfg(not(target_os = "windows"))]
     {
-        "bash"
+        unix_shell_display_name()
     }
 }
 
@@ -565,10 +707,16 @@ mod tests {
 
     #[test]
     #[cfg(not(target_os = "windows"))]
-    fn shell_invocation_unix_is_bash_c_passthrough() {
+    fn shell_invocation_unix_passes_command_through_to_the_resolved_shell() {
         let (program, args) = shell_invocation("echo hi; false");
-        assert_eq!(program, "bash");
+        // The command is passed verbatim to `-c`; the program is the resolved
+        // shell (bash/zsh/sh or an absolute $SHELL path), never fish/nu.
         assert_eq!(args, vec!["-c".to_string(), "echo hi; false".to_string()]);
+        let name = program.rsplit('/').next().unwrap_or(program);
+        assert!(
+            matches!(name, "bash" | "zsh" | "sh"),
+            "unexpected shell: {program}"
+        );
     }
 
     #[test]

--- a/agent/src/sandbox/mod.rs
+++ b/agent/src/sandbox/mod.rs
@@ -320,7 +320,13 @@ pub fn shell_invocation(command: &str) -> (&'static str, Vec<String>) {
         (
             windows_shell().program,
             vec![
+                // -NoProfile: skip profile scripts (speed + no stray output).
+                // -NonInteractive: fail fast instead of hanging on a prompt —
+                //   there is no console for the agent to answer one.
+                // -NoLogo: suppress the startup banner on 5.1.
                 "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-NoLogo".to_string(),
                 "-EncodedCommand".to_string(),
                 encode_powershell_command(&script),
             ],
@@ -590,13 +596,20 @@ mod tests {
         let (program, args) = shell_invocation("Get-ChildItem");
         // pwsh when present, else Windows PowerShell 5.1 — both accept these args.
         assert!(program == "pwsh" || program == "powershell");
-        assert_eq!(args[0], "-NoProfile");
-        assert_eq!(args[1], "-EncodedCommand");
+        // Non-interactive so a prompt can't hang the agent; profile/logo off.
+        assert!(args.contains(&"-NoProfile".to_string()));
+        assert!(args.contains(&"-NonInteractive".to_string()));
+        // The command is the base64 payload right after -EncodedCommand.
+        let enc = args
+            .iter()
+            .position(|a| a == "-EncodedCommand")
+            .expect("has -EncodedCommand");
+        let payload = &args[enc + 1];
         // The payload is base64 of the UTF-16LE wrapper script; decode and
         // confirm it round-trips to the readable wrapper.
         use base64::Engine;
         let raw = base64::engine::general_purpose::STANDARD
-            .decode(&args[2])
+            .decode(payload)
             .expect("valid base64");
         let utf16: Vec<u16> = raw
             .chunks_exact(2)

--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -205,7 +205,7 @@ pub fn shell_tool() -> AgentTool {
     // PowerShell 5.1) and its chaining rules live in the host-platform section
     // of the system prompt (prompt::os_hint), resolved at runtime.
     #[cfg(target_os = "windows")]
-    let description = "Execute a shell command in the current working directory. Commands are interpreted by PowerShell — use PowerShell syntax: environment variables as $env:VAR (never %VAR%), single quotes for literal strings, and see the host-platform note for command chaining. Use this for exploration and command-line programs. For ordinary file creation or edits, prefer write/edit tools. Returns stdout and stderr merged. Output is truncated to last 500000 bytes.";
+    let description = "Execute a shell command in the current working directory. Commands are interpreted by PowerShell — use PowerShell syntax: environment variables as $env:VAR (never %VAR%), single quotes for literal strings, and see the host-platform note for command chaining. To run an executable whose path contains spaces, use the call operator: & \"C:\\Program Files\\app\\tool.exe\" args. Use this for exploration and command-line programs. For ordinary file creation or edits, prefer write/edit tools. Returns stdout and stderr merged. Output is truncated to last 500000 bytes.";
 
     #[cfg(not(target_os = "windows"))]
     let guidelines = vec![
@@ -215,7 +215,7 @@ pub fn shell_tool() -> AgentTool {
     #[cfg(target_os = "windows")]
     let guidelines = vec![
         "Prefer one shell command per turn",
-        "Prefer write/edit for ordinary file writes; use PowerShell redirection (> or Out-File) only when it is more appropriate for the task.",
+        "Prefer write/edit for ordinary file writes; use PowerShell redirection (> or Out-File) only when it is more appropriate for the task. Note: on Windows PowerShell 5.1 these default to UTF-16 with a BOM — pass -Encoding utf8 if another tool must read the file.",
     ];
 
     make_tool(


### PR DESCRIPTION
承接 PR #4,借鉴 opencode / Claude Code 的 shell 层做的一组加固。

## 改动
- **PowerShell 调用**:加 `-NonInteractive -NoLogo`(防交互提示卡死、去 5.1 横幅);os_hint 教 5.1 短路写法 `cmd1; if ($?) { cmd2 }`。
- **prompt 借鉴**:读已知文件用 read 工具(不用 `cat`/`Get-Content`);Windows 带空格路径用调用运算符 `& "..."`;PS 5.1 `>`/`Out-File` 默认 UTF-16+BOM 提示。
- **Unix 登录 shell env 注入(修 `command not found`)**:启动时(tokio 前)跑 `$SHELL -l -i -c` 抓 env,取 PATH + 增量合并;修 GUI 从访达启动只有极简 PATH、找不到用户装的工具(nvm/Homebrew/npm-global)的问题。5s 超时兜底,Windows no-op。实机验证:极简 PATH 启动 → `hydrated PATH from login shell (/bin/zsh)`。
- **Unix shell 探测**:不再硬编码 bash——优先 `$SHELL`(bash/zsh)→ 探测 → 兜底 sh,拒绝 fish/nu;os_hint 如实报出探测到的 shell。

## 验证
- agent:118 测试通过,x86_64-pc-windows-msvc 交叉检查干净,fmt/clippy 干净。
- 登录 shell env 注入实机跑通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)