### PR TITLE
fix(deps): bump protobufjs to 7.6.5 in tui and cli

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/tui/package-lock.json
+++ b/tui/package-lock.json
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bump `protobufjs` from 7.6.4 → 7.6.5 in both `tui/` and `cli/` lockfiles (transitive via `@grpc/proto-loader@0.8.1`).
- Fixes Dependabot alerts #8 (cli) and #9 (tui): moderate DoS via infinite loop in .proto option parsing (GHSA-hf8c-rj6w-qx6w / CVE-2026-8964).
- Lockfile-only; `^7.5.5` range already allows 7.6.5.

## Diff
Each `package-lock.json`: version `7.6.4` → `7.6.5`, resolved URL version bump, integrity updated. No other changes.

## Test plan
- [ ] `npm install --package-lock-only` in both `tui/` and `cli/` resolves protobufjs@^7.6.5
- [ ] `make lint-tui` and `make lint-cli` pass (transitive patch, no TS impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)