### PR TITLE
fix(deps): bump fast-uri to 3.1.4 in gui

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -4764,9 +4764,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bump `fast-uri` from 3.1.3 → 3.1.4 in `gui/package-lock.json` (transitive dev dependency: `table` → `ajv` `^3.0.1` → `fast-uri`).
- Fixes Dependabot alert #10 (high): host confusion via literal backslash authority delimiter.
- Lockfile-only; `^3.0.1` range already allows 3.1.4 (the patched 3.x release, dist-tag `three`).

## Diff
`gui/package-lock.json`: version `3.1.3` → `3.1.4`, resolved URL + integrity updated (host normalized to registry.npmjs.org). No other changes.

## Test plan
- [ ] GUI CI job (lint + tests) passes
- [ ] `cd gui && npm install --package-lock-only` resolves fast-uri@3.1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)