### PR TITLE
refactor(agent): per-session agent loops, SessionEntry slim-down, session fixes

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -108,6 +108,29 @@ impl Loop {
         self
     }
 
+    /// Create an independent copy of this loop: same provider, model, tools,
+    /// config, system prompt and event bus, but FRESH steering/follow-up
+    /// queues, token counters, interrupt flag and compaction state.
+    ///
+    /// Every `ServerSession` gets its own copy instead of sharing one global
+    /// loop, so a streaming run (which holds `loop.read()` for its whole
+    /// duration) never blocks another session's `set_model`/
+    /// `set_thinking_level` (`try_write`), and per-session state — interrupt
+    /// flag, steering queues, token counters, tool-execution hooks — can no
+    /// longer leak across sessions.  The provider `Arc` is cloned only as a
+    /// seed: `ServerSession::set_model` replaces it with a freshly-built
+    /// client for the session's own model before the first prompt.
+    pub fn independent_copy(&self) -> Loop {
+        let mut copy = Loop::new(self.provider.clone(), &self.model)
+            .with_tools(self.tools.clone())
+            .with_system_prompt(&self.system_prompt)
+            .with_config(self.config.clone());
+        copy.verbose = self.verbose;
+        copy.parallel_tools = self.parallel_tools;
+        copy.event_bus = self.event_bus.clone();
+        copy
+    }
+
     pub fn with_transform_context(
         mut self,
         f: Arc<dyn Fn(Vec<Message>, String) -> Vec<Message> + Send + Sync>,

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -762,6 +762,17 @@ impl Loop {
                 }
             }
 
+            // Apply the final credit_cost from this LLM call to cumulative_cost.
+            // The upstream API sends progressive credit_cost updates in each
+            // usage chunk; total_usage holds the LAST (complete) value. Adding
+            // it here — once per LLM call — avoids the N× inflation that
+            // would result from accumulating every intermediate chunk.
+            if let Some(ref u) = total_usage {
+                if let Some(cost) = u.credit_cost {
+                    *self.cumulative_cost.lock() += cost;
+                }
+            }
+
             // Stream was truncated mid-reply: the assistant text is a prefix,
             // not a finished answer. End the turn as `incomplete` (keeping the
             // partial text so it isn't lost) rather than draining the follow-up
@@ -993,9 +1004,11 @@ impl Loop {
             self.cumulative_cache_write_tokens
                 .fetch_add(cache_w, Ordering::Relaxed);
         }
-        if let Some(cost) = u.credit_cost {
-            *self.cumulative_cost.lock() += cost;
-        }
+        // NOTE: credit_cost is NOT accumulated here. The upstream API sends
+        // progressive credit_cost updates in each usage chunk (each value is
+        // the cumulative cost of the request so far). Adding every chunk
+        // inflates the total by N×. Instead, credit_cost is applied once at
+        // the end of the LLM call using the final value from total_usage.
         *total_usage = Some(u.clone());
         if let Some(ref bus) = self.event_bus {
             bus.emit(usage_event(u));

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -234,6 +234,10 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
             sess.broadcaster.subscribe()
         };
 
+        // Clone for the lag-warning closure below — `session_id` is moved
+        // into the `ping` stream and can't be borrowed across the chain.
+        let lag_session_id = session_id.clone();
+
         let ping = tokio_stream::once(Ok(proto::StreamEvent {
             r#type: "ping".to_string(),
             data: r#"{"type":"ping"}"#.to_string(),
@@ -247,19 +251,29 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                 }
                 match r {
                     Ok(event) => event_types.contains(&event.event_type),
-                    Err(_) => true, // pass through errors
+                    // Never terminate the stream on lag — the receiver can
+                    // continue after a lag, but a tonic error ends the gRPC
+                    // stream and the client must reconnect, missing every
+                    // event in between (including critical settings-change
+                    // events like model_changed).
+                    Err(_) => true,
                 }
             })
-            .map(|r| match r {
-                Ok(event) => Ok(proto::StreamEvent {
+            .filter_map(move |r| match r {
+                Ok(event) => Some(Ok(proto::StreamEvent {
                     r#type: event.event_type,
                     data: event.data,
                     run_id: event.run_id,
                     idx: event.idx,
-                }),
+                })),
+                // Log lagged messages but do NOT terminate the stream.
+                // Lag is expected under load (text_chunk bursts); the client
+                // can recover by re-reading state (get_state / get_events_since).
                 Err(e) => {
-                    tracing::warn!("SSE stream error: {}", e);
-                    Err(tonic::Status::internal(e.to_string()))
+                    tracing::warn!(
+                        "SSE stream lagged (session={lag_session_id}): {e} — skipping, stream continues"
+                    );
+                    None
                 }
             });
         let stream = ping.chain(events);

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -209,10 +209,20 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
         let event_types: std::collections::HashSet<String> = req.event_types.into_iter().collect();
         let filter_enabled = !event_types.is_empty();
 
-        let rx = if session_id.is_empty() {
-            self.state.broadcaster.subscribe()
-        } else {
-            let session = self.state.get_session(&session_id);
+        // Sessions are equal peers — every subscription must name its
+        // session.  An empty id previously subscribed to a global/default
+        // broadcaster, which could leak other sessions' events.
+        if session_id.is_empty() {
+            return Err(tonic::Status::failed_precondition(
+                "session_id is required for StreamEvents",
+            ));
+        }
+        let Some(session) = self.state.get_session(&session_id) else {
+            return Err(tonic::Status::not_found(format!(
+                "session {session_id} not found"
+            )));
+        };
+        let rx = {
             let sess = session.read();
             if self.state.verbose {
                 tracing::debug!(

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use chrono::Local;
 use clap::Parser;
 use future_agent::{
-    Engine, EngineConfig, Manager, ModelRegistry, ServerSession, AGENTS_SKILLS_DIR, APP_SKILLS_DIR,
+    Engine, EngineConfig, Manager, ModelRegistry, AGENTS_SKILLS_DIR, APP_SKILLS_DIR,
     PROJECT_SKILLS_DIR,
 };
 use std::sync::Arc;
@@ -374,47 +374,27 @@ async fn async_main(
     engine.agent_loop.config.system_prompt = system_prompt;
 
     let manager = Arc::new(Manager::default_for(&cwd));
-    let broadcaster: Arc<future_agent::rpc::SseBroadcaster> =
-        Arc::new(future_agent::rpc::SseBroadcaster::new());
     let approval_gate = future_agent::rpc::ApprovalGate::default();
     // Template for minting per-session agent loops.  Sessions no longer
     // share one global loop — each hydrated/created session gets an
     // independent copy so concurrent runs, model switches and aborts stay
     // session-local.  The template itself never runs prompts.
     let loop_template = Arc::new(engine.agent_loop.independent_copy());
-    let mut server_session = ServerSession::new(
-        future_agent::utils::generate_id(),
-        Arc::new(tokio::sync::RwLock::new(engine.agent_loop)),
-        manager,
-        &cwd,
-        event_bus.clone(),
-        broadcaster.clone(),
-        approval_gate.clone(),
-        model_registry.clone(),
-    );
-    server_session.model = resolved_model.clone();
 
-    server_session.set_steering_mode(&settings.steering_mode);
-    server_session.set_follow_up_mode(&settings.follow_up_mode);
-    if !settings.default_permission_level.is_empty() {
-        server_session.set_permission_level(&settings.default_permission_level);
-    }
-    server_session.set_auto_compaction(settings.compaction_enabled());
-    server_session.set_auto_retry(settings.retry_enabled());
-
-    let session = Arc::new(parking_lot::RwLock::new(server_session));
-
+    // The agent starts with ZERO sessions.  There is no privileged
+    // "default"/"current" session — clients (TUI, GUI, CLI, channels)
+    // create or switch to sessions explicitly, and the agent hydrates
+    // them on demand.  Settings that used to be applied to the startup
+    // default session are applied per-session in cmd_new_session.
     let app_state = future_agent::rpc::AppState {
-        session: session.clone(),
         sessions: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
-        active_session_id: Arc::new(parking_lot::RwLock::new(String::new())),
+        session_manager: manager,
         welcome_version: future_agent::utils::VERSION.to_string(),
         welcome_cwd: cwd.clone(),
         welcome_skills: Arc::new(parking_lot::RwLock::new(skill_names.clone())),
         welcome_context: Arc::new(parking_lot::RwLock::new(context_lines)),
         welcome_exts: vec![],
         explicit_session: false,
-        broadcaster: broadcaster.clone(),
         event_bus: event_bus.clone(),
         approval_gate,
         verbose: cli.verbose,
@@ -427,7 +407,6 @@ async fn async_main(
     // are rejected, then wait up to 30 s for active streams to finish.
     let shutting_down = app_state.shutting_down.clone();
     let sessions = app_state.sessions.clone();
-    let default_session = app_state.session.clone();
     let shutdown_timeout = std::time::Duration::from_secs(30);
 
     let server = future_agent::grpc::serve(app_state, grpc_host, grpc_port);
@@ -441,7 +420,6 @@ async fn async_main(
             // Actively interrupt in-flight runs. Without this, a long LLM
             // stream keeps running and the wait loop below only exits via the
             // 30 s timeout — making Ctrl-C look like a hang.
-            default_session.read().abort();
             for s in sessions.read().values() {
                 s.read().abort();
             }
@@ -449,27 +427,19 @@ async fn async_main(
             // Wait for active streams to settle
             let deadline = tokio::time::Instant::now() + shutdown_timeout;
             loop {
-                let any_streaming = {
-                    let active = default_session
-                        .read()
+                let any_streaming = sessions
+                    .read()
+                    .values()
+                    .any(|s| s.read()
                         .is_streaming
-                        .load(std::sync::atomic::Ordering::Relaxed);
-                    if active { true } else {
-                        sessions.read()
-                            .values()
-                            .any(|s| s.read()
-                                .is_streaming
-                                .load(std::sync::atomic::Ordering::Relaxed))
-                    }
-                };
+                        .load(std::sync::atomic::Ordering::Relaxed));
                 if !any_streaming {
                     tracing::info!("All streams finished — exiting");
                     break;
                 }
                 if tokio::time::Instant::now() >= deadline {
                     tracing::warn!("Shutdown timeout (30s) — forcing exit with {} active stream(s)",
-                        if default_session.read().is_streaming.load(std::sync::atomic::Ordering::Relaxed) { 1 } else { 0 }
-                        + sessions.read().values()
+                        sessions.read().values()
                             .filter(|s| s.read().is_streaming.load(std::sync::atomic::Ordering::Relaxed))
                             .count());
                     break;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -377,6 +377,11 @@ async fn async_main(
     let broadcaster: Arc<future_agent::rpc::SseBroadcaster> =
         Arc::new(future_agent::rpc::SseBroadcaster::new());
     let approval_gate = future_agent::rpc::ApprovalGate::default();
+    // Template for minting per-session agent loops.  Sessions no longer
+    // share one global loop — each hydrated/created session gets an
+    // independent copy so concurrent runs, model switches and aborts stay
+    // session-local.  The template itself never runs prompts.
+    let loop_template = Arc::new(engine.agent_loop.independent_copy());
     let mut server_session = ServerSession::new(
         future_agent::utils::generate_id(),
         Arc::new(tokio::sync::RwLock::new(engine.agent_loop)),
@@ -414,6 +419,7 @@ async fn async_main(
         verbose: cli.verbose,
         shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         model_registry: model_registry.clone(),
+        loop_template,
     };
 
     // Graceful shutdown on Ctrl+C: set the shutting_down flag so new prompts

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -390,6 +390,7 @@ async fn async_main(
         event_bus.clone(),
         broadcaster.clone(),
         approval_gate.clone(),
+        model_registry.clone(),
     );
     server_session.model = resolved_model.clone();
 

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -362,33 +362,16 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                 sess.set_session_name(&cmd.name);
                 (sess.session_manager.clone(), sess.session_id.clone())
             };
-            // Persist label entry to session JSONL so name survives restarts
+            // Update session_info so name survives restarts
             if let Ok(mut s) = session_manager.load(&session_id) {
-                s.entries.push(crate::session::SessionEntry {
-                    id: crate::utils::generate_entry_id(),
-                    parent_id: String::new(),
-                    entry_type: crate::session::ENTRY_TYPE_LABEL.to_string(),
-                    role: String::new(),
-                    content: None,
-                    tool_calls: vec![],
-                    timestamp: chrono::Local::now(),
-                    summary: String::new(),
-                    model: String::new(),
-                    label: cmd.name.clone(),
-                    thinking_level: String::new(),
-                    branch_summary: None,
-                    custom_type: String::new(),
-                    custom_data: None,
-                    display: String::new(),
-                    provider: String::new(),
-                    tool_call_id: String::new(),
-                    name: String::new(),
-                    tool_args: String::new(),
-                    thinking: String::new(),
-                    output_tokens: 0,
-                    duration_ms: 0,
-                    meta: None,
-                });
+                // Update session_info entry's session_name field
+                if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+                    if let Some(ref mut content) = info_entry.content {
+                        if let Some(obj) = content.as_object_mut() {
+                            obj.insert("session_name".to_string(), serde_json::Value::String(cmd.name.clone()));
+                        }
+                    }
+                }
                 s.name = cmd.name.clone();
                 let _ = session_manager.save(&s);
             }
@@ -1098,12 +1081,7 @@ fn cmd_get_session_entries(session: &Arc<parking_lot::RwLock<ServerSession>>, id
                     // Per-reply metadata for the GUI's message footer
                     // ("time · N tokens"); set on the final assistant
                     // entry of each run.
-                    if e.output_tokens > 0 {
-                        entry["output_tokens"] = serde_json::json!(e.output_tokens);
-                    }
-                    if e.duration_ms > 0 {
-                        entry["duration_ms"] = serde_json::json!(e.duration_ms);
-                    }
+                    // Run stats are in content JSON (run_tokens / run_duration_ms)
                     // For session_info entries, include the original content
                     // JSON (session_name, cwd, parent_session_id, …) and the
                     // model / thinking_level struct fields so callers can
@@ -1111,13 +1089,6 @@ fn cmd_get_session_entries(session: &Arc<parking_lot::RwLock<ServerSession>>, id
                     if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
                         if let Some(ref content) = e.content {
                             entry["content"] = content.clone();
-                        }
-                        if !e.model.is_empty() {
-                            entry["model"] = serde_json::Value::String(e.model.clone());
-                        }
-                        if !e.thinking_level.is_empty() {
-                            entry["thinking_level"] =
-                                serde_json::Value::String(e.thinking_level.clone());
                         }
                     }
                     entry

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -34,6 +34,11 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
     // Credential refresh operates on every session, not one — handle it before
     // resolving a target session (which would needlessly create/load one).
     if cmd_type == "reload_auth" {
+        // Rebuild the shared model registry FIRST so runtime-added/
+        // removed providers and models.json edits become visible to every
+        // session — set_model now resolves against this cache instead of
+        // constructing a fresh Registry per call.
+        *state.model_registry.write() = crate::models::Registry::new();
         state.reload_all_credentials();
         return RpcResponse::ok(id, "reload_auth", serde_json::json!({}));
     }
@@ -920,6 +925,7 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
         event_bus,
         broadcaster,
         approval_gate,
+        state.model_registry.clone(),
     );
     // Resolve the default model fresh from the registry (not inherited from
     // the active session) so that CLI one-shot runs always start from the
@@ -1197,6 +1203,7 @@ fn cmd_fork(
         event_bus,
         broadcaster,
         state.approval_gate.clone(),
+        state.model_registry.clone(),
     );
     let supports_images = crate::models::model_accepts_images(&forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
@@ -1291,6 +1298,7 @@ fn cmd_clone(
         event_bus,
         broadcaster,
         state.approval_gate.clone(),
+        state.model_registry.clone(),
     );
     let supports_images = crate::models::model_accepts_images(&forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
@@ -1436,6 +1444,7 @@ mod tests {
 
     fn make_app_state() -> AppState {
         let cwd = test_workspace();
+        let model_registry = Arc::new(parking_lot::RwLock::new(crate::models::Registry::new()));
         let session = ServerSession::new(
             "default".to_string(),
             Arc::new(tokio::sync::RwLock::new(Loop::new(
@@ -1447,6 +1456,7 @@ mod tests {
             Arc::new(crate::events::EventBus::new()),
             Arc::new(SseBroadcaster::new()),
             ApprovalGate::default(),
+            model_registry.clone(),
         );
         AppState {
             session: Arc::new(parking_lot::RwLock::new(session)),
@@ -1463,7 +1473,7 @@ mod tests {
             approval_gate: ApprovalGate::default(),
             verbose: false,
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            model_registry: Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
+            model_registry: model_registry.clone(),
             loop_template: Arc::new(Loop::new(Arc::new(EmptyProvider), "mock")),
         }
     }

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -845,13 +845,14 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     };
     let active_id = state.get_active_session_id();
     let session = state.get_session(&active_id);
-    // Snapshot everything we need from the active session up front, then
-    // drop its lock — nothing below should keep the active ServerSession
-    // borrowed while we fall back to other loops for the config template.
-    let (active_loop, inherit_model, event_bus, broadcaster, approval_gate, session_manager) = {
+    // Snapshot what we need from the active session up front, then drop its
+    // lock.  The new session's loop comes from the template (never used for
+    // runs), so creation succeeds even while every existing session is
+    // mid-stream — previously this failed with "agent is busy" whenever the
+    // shared loop was read-locked by a run.
+    let (inherit_model, event_bus, broadcaster, approval_gate, session_manager) = {
         let sess = rlock!(session, id);
         (
-            sess.agent_loop.clone(),
             sess.model.clone(),
             sess.event_bus.clone(),
             sess.broadcaster.clone(),
@@ -860,49 +861,7 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
         )
     };
 
-    // Build the fresh loop's config template from an *idle* loop. The
-    // active session's loop is held under a write lock for the whole turn
-    // while it streams, so a `try_read` on it fails mid-run — which used to
-    // make "start a second conversation while the first is running" fail
-    // outright. Fall back to the default session's loop (never used for
-    // prompts by the GUI, so effectively always idle) so concurrent
-    // sessions can be created. Clients call `set_model` on the new session
-    // right after, so this template is only a seed.
-    let snapshot = |loop_arc: &Arc<tokio::sync::RwLock<crate::agent::Loop>>| {
-        loop_arc.try_read().ok().map(|loop_guard| {
-            let config = crate::types::AgentConfig {
-                system_prompt: loop_guard.config.system_prompt.clone(),
-                max_turns: loop_guard.config.max_turns,
-                thinking_budget: loop_guard.config.thinking_budget,
-                max_retries: loop_guard.config.max_retries,
-                tools_execution_mode: loop_guard.config.tools_execution_mode.clone(),
-                ..Default::default()
-            };
-            (
-                loop_guard.provider.clone(),
-                loop_guard.model.clone(),
-                loop_guard.tools.clone(),
-                config,
-                loop_guard.verbose,
-            )
-        })
-    };
-
-    let template = snapshot(&active_loop).or_else(|| {
-        let default_loop = state.session.read().agent_loop.clone();
-        snapshot(&default_loop)
-    });
-    let Some((provider, model, tools, config, verbose)) = template else {
-        return RpcResponse::build_fail(
-            id,
-            "new_session",
-            "agent is busy; wait for the current run to finish before starting a new session",
-        );
-    };
-    let mut fresh_loop = crate::agent::Loop::new(provider, &model)
-        .with_tools(tools)
-        .with_config(config);
-    fresh_loop.verbose = verbose;
+    let fresh_loop = state.loop_template.independent_copy();
 
     let new_session_id = if cmd.session_id.is_empty() {
         crate::utils::generate_id()
@@ -918,7 +877,7 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
         .filter(|s| !s.entries.is_empty())
         .map(|s| (s.entries, s.model.clone()));
 
-    let mut new_sess = ServerSession::new_with_shared_loop(
+    let mut new_sess = ServerSession::new(
         new_session_id.clone(),
         Arc::new(tokio::sync::RwLock::new(fresh_loop)),
         Arc::new(crate::session::Manager::default_for(&session_cwd)),
@@ -1147,10 +1106,9 @@ fn cmd_fork(
     }
 
     // Extract needed data from session
-    let (agent_loop, session_manager, event_bus, broadcaster, _cwd, current_session_id) = {
+    let (session_manager, event_bus, broadcaster, _cwd, current_session_id) = {
         let sess = rlock!(session, id);
         (
-            sess.agent_loop.clone(),
             sess.session_manager.clone(),
             sess.event_bus.clone(),
             sess.broadcaster.clone(),
@@ -1158,6 +1116,11 @@ fn cmd_fork(
             sess.session_id.clone(),
         )
     };
+    // The fork gets its own agent loop — sharing the parent's loop would let
+    // a run in one session block (or be aborted by) the other.
+    let agent_loop = Arc::new(tokio::sync::RwLock::new(
+        state.loop_template.independent_copy(),
+    ));
 
     // Resolve parent session: use cmd.parent_session if provided,
     // otherwise fork from the current session.
@@ -1197,7 +1160,7 @@ fn cmd_fork(
     // the saved history on disk — session_prompt.rs saves
     // self.messages back to disk (via File::create), truncating
     // anything not held in memory.
-    let mut new_sess = ServerSession::new_with_shared_loop(
+    let mut new_sess = ServerSession::new(
         forked_id.clone(),
         agent_loop,
         session_manager,
@@ -1211,8 +1174,8 @@ fn cmd_fork(
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {
         new_sess.model = forked.model.clone();
-        // Sync the shared agent loop so the fork's first prompt uses the
-        // forked model, not whatever the previous session left behind.
+        // Sync the fork's own agent loop so the first prompt uses the
+        // forked model, not whatever the template seeded.
         if let Err(e) = new_sess.set_model(&new_sess.model.clone()) {
             tracing::warn!("[fork] could not sync agent loop model: {e}");
         }
@@ -1228,7 +1191,7 @@ fn cmd_clone(
     id: &str,
 ) -> String {
     // Extract needed data from session
-    let (agent_loop, session_manager, event_bus, broadcaster, _cwd, session_id) = {
+    let (session_manager, event_bus, broadcaster, _cwd, session_id) = {
         let sess = rlock!(session, id);
         if sess.messages.read().is_empty() {
             return RpcResponse::build_fail(
@@ -1238,7 +1201,6 @@ fn cmd_clone(
             );
         }
         (
-            sess.agent_loop.clone(),
             sess.session_manager.clone(),
             sess.event_bus.clone(),
             sess.broadcaster.clone(),
@@ -1246,6 +1208,10 @@ fn cmd_clone(
             sess.session_id.clone(),
         )
     };
+    // Own agent loop for the clone (same reasoning as fork).
+    let agent_loop = Arc::new(tokio::sync::RwLock::new(
+        state.loop_template.independent_copy(),
+    ));
 
     // Get parent session from manager
     let parent = match session_manager.load(&session_id) {
@@ -1288,7 +1254,7 @@ fn cmd_clone(
     // Add to sessions map.  Load the cloned entries into
     // in-memory messages (same reason as fork — prevents
     // the first prompt from truncating history on disk).
-    let mut new_sess = ServerSession::new_with_shared_loop(
+    let mut new_sess = ServerSession::new(
         forked_id.clone(),
         agent_loop,
         session_manager,
@@ -1469,6 +1435,7 @@ mod tests {
             verbose: false,
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             model_registry: Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
+            loop_template: Arc::new(Loop::new(Arc::new(EmptyProvider), "mock")),
         }
     }
 

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -48,14 +48,14 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
     // system (shutdown, lists), create sessions (new/switch/delete), or read
     // straight from disk (fork messages).
     match cmd_type.as_str() {
-        "shutdown" => return cmd_shutdown(state, &id),
-        "list_sessions" => return cmd_list_sessions(state, &cmd, &id),
-        "list_streaming_sessions" => return cmd_list_streaming_sessions(state, &id),
-        "new_session" => return cmd_new_session(state, &cmd, &id),
-        "switch_session" => return cmd_switch_session(state, &cmd, &id),
-        "delete_session" => return cmd_delete_session(state, &cmd, &id),
-        "get_fork_messages" => return cmd_get_fork_messages(state, &cmd, &id),
-        "get_commands" => return cmd_get_commands(&id),
+        "shutdown" => return cmd_shutdown(state, id),
+        "list_sessions" => return cmd_list_sessions(state, &cmd, id),
+        "list_streaming_sessions" => return cmd_list_streaming_sessions(state, id),
+        "new_session" => return cmd_new_session(state, &cmd, id),
+        "switch_session" => return cmd_switch_session(state, &cmd, id),
+        "delete_session" => return cmd_delete_session(state, &cmd, id),
+        "get_fork_messages" => return cmd_get_fork_messages(state, &cmd, id),
+        "get_commands" => return cmd_get_commands(id),
         "set_enabled_models" => {
             // Scoped models are managed entirely by the TUI/client; the agent
             // returns all available models. Kept as a no-op for compatibility.
@@ -69,8 +69,8 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
     // explicit error, never a silent redirect into another conversation.
     let Some(session) = state.get_session(&cmd.session_id) else {
         return RpcResponse::build_fail(
-            &id,
-            &cmd_type,
+            id,
+            cmd_type,
             "session not found — pass a valid session_id (new_session creates one)",
         );
     };

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -926,18 +926,12 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     // preferred default.  GUI/TUI explicitly set model_id on the command,
     // which overrides this below.
     let default_model = crate::models::get_default_model().unwrap_or_else(|| inherit_model.clone());
-    new_sess.model = default_model.clone();
-    // Also update the fresh loop's model so the LLM call uses the correct
-    // bare model ID (the loop takes just the ID, not provider/id).
-    // The template's model was inherited from the active session, which may
-    // have been changed by a previous --model override.
-    if let Ok(mut loop_) = new_sess.agent_loop.try_write() {
-        // Strip provider/ prefix to get the bare model ID for LLM API calls.
-        let bare_id = default_model
-            .rsplit_once('/')
-            .map(|(_, id)| id.to_string())
-            .unwrap_or_else(|| default_model.clone());
-        loop_.model = bare_id;
+    // Apply via set_model: it sets the canonical model AND rebuilds the
+    // loop's provider client for that model's endpoint/key/compat.  A bare
+    // `loop_.model = bare_id` leaves the provider on the template's startup
+    // model, which breaks whenever the current default differs.
+    if let Err(e) = new_sess.set_model(&default_model.clone()) {
+        tracing::warn!("[new_session] could not sync model to fresh loop: {e}");
     }
     // Always start new sessions at the preferred thinking level.
     new_sess.thinking_level = "xhigh".to_string();

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -43,20 +43,39 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         return RpcResponse::ok(id, "reload_auth", serde_json::json!({}));
     }
 
-    // Get the target session based on session_id, or use default
-    let session = state.get_session(&cmd.session_id);
+    // ── Sessionless commands: dispatched WITHOUT resolving a target session.
+    // Sessions are equal peers; these commands either operate on the whole
+    // system (shutdown, lists), create sessions (new/switch/delete), or read
+    // straight from disk (fork messages).
+    match cmd_type.as_str() {
+        "shutdown" => return cmd_shutdown(state, &id),
+        "list_sessions" => return cmd_list_sessions(state, &cmd, &id),
+        "list_streaming_sessions" => return cmd_list_streaming_sessions(state, &id),
+        "new_session" => return cmd_new_session(state, &cmd, &id),
+        "switch_session" => return cmd_switch_session(state, &cmd, &id),
+        "delete_session" => return cmd_delete_session(state, &cmd, &id),
+        "get_fork_messages" => return cmd_get_fork_messages(state, &cmd, &id),
+        "get_commands" => return cmd_get_commands(&id),
+        "set_enabled_models" => {
+            // Scoped models are managed entirely by the TUI/client; the agent
+            // returns all available models. Kept as a no-op for compatibility.
+            return RpcResponse::ok(id, "set_enabled_models", serde_json::json!({}));
+        }
+        _ => {}
+    }
+
+    // ── Session-scoped commands: resolve the target session or fail.
+    // No default-session fallback: an empty or unknown session_id is an
+    // explicit error, never a silent redirect into another conversation.
+    let Some(session) = state.get_session(&cmd.session_id) else {
+        return RpcResponse::build_fail(
+            &id,
+            &cmd_type,
+            "session not found — pass a valid session_id (new_session creates one)",
+        );
+    };
 
     match cmd_type.as_str() {
-        "shutdown" => {
-            state
-                .shutting_down
-                .store(true, std::sync::atomic::Ordering::SeqCst);
-            RpcResponse::ok(
-                id,
-                "shutdown",
-                serde_json::json!({"shutting_down": true, "note": "Existing runs continue; new prompts are rejected."}),
-            )
-        }
         "prompt" => {
             if state
                 .shutting_down
@@ -68,7 +87,7 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                     "agent is shutting down; no new prompts accepted",
                 );
             }
-            let Some(session) = state.find_session(&cmd.session_id) else {
+            let Some(session) = state.get_session(&cmd.session_id) else {
                 return RpcResponse::build_fail(
                     id,
                     "prompt",
@@ -156,10 +175,10 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             }
         }
         "new_session" => cmd_new_session(state, &cmd, id),
-        "get_state" => {
-            let state_val = get_state_internal(state, &cmd.session_id);
-            RpcResponse::ok(id, "get_state", state_val)
-        }
+        "get_state" => match get_state_internal(state, &cmd.session_id) {
+            Some(state_val) => RpcResponse::ok(id, "get_state", state_val),
+            None => RpcResponse::build_fail(id, "get_state", "session not found"),
+        },
         "get_messages" => {
             let msgs = rlock!(session, id).get_messages();
             RpcResponse::ok(id, "get_messages", serde_json::json!({"messages": msgs}))
@@ -313,193 +332,13 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             let stats = rlock!(session, id).get_session_stats();
             RpcResponse::ok(id, "get_session_stats", stats)
         }
-        "list_sessions" => {
-            // Clone the session manager Arc outside the lock so list_all()'s
-            // disk I/O doesn't block concurrent readers/writers.
-            let session_manager = {
-                let sess = rlock!(session, id);
-                sess.session_manager.clone()
-            };
-            let summaries = session_manager.list_all().unwrap_or_default();
-
-            // Snapshot active session streaming flags.  Collect within a
-            // single outer read guard — this is safe because we only acquire
-            // inner read locks (never writes), and ParkingLot RwLock allows
-            // concurrent reads.
-            let active_flags: std::collections::HashMap<String, bool> = {
-                let active = state.sessions.read();
-                active
-                    .iter()
-                    .map(|(sid, sess)| {
-                        let streaming = sess
-                            .read()
-                            .is_streaming
-                            .load(std::sync::atomic::Ordering::Relaxed);
-                        (sid.clone(), streaming)
-                    })
-                    .collect()
-            };
-
-            let sessions: Vec<serde_json::Value> = summaries
-                .into_iter()
-                .map(|s| {
-                    let is_streaming = active_flags.get(&s.id).copied().unwrap_or(false);
-                    serde_json::json!({
-                        "id": s.id,
-                        "session_name": s.name,
-                        "model": s.model,
-                        "cwd": s.cwd,
-                        "updated_at": s.updated_at.format("%Y-%m-%d %H:%M:%S").to_string(),
-                        "parent_session_id": s.parent_session_id,
-                        "first_message": s.first_message,
-                        "query_count": s.query_count,
-                        "is_streaming": is_streaming,
-                    })
-                })
-                .collect();
-            RpcResponse::ok(
-                id,
-                "list_sessions",
-                serde_json::json!({"sessions": sessions}),
-            )
-        }
-        // Lightweight streaming-status query: scans ONLY the in-memory
-        // session map (hydrated sessions) — never touches disk and never
-        // hydrates.  A session that isn't in the map can't be streaming
-        // (runs are always started through a hydrated ServerSession), so
-        // this is the exact set of active runs.  Lets clients (GUI thread
-        // list) poll "who is streaming" for all sessions in ONE call
-        // instead of one get_state per session (which also hydrated every
-        // polled session on the agent).
-        "list_streaming_sessions" => {
-            let mut ids: Vec<String> = vec![];
-            {
-                let default_sess = state.session.read();
-                if default_sess
-                    .is_streaming
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                {
-                    ids.push(default_sess.session_id.clone());
-                }
-            }
-            for (sid, sess) in state.sessions.read().iter() {
-                if sess
-                    .read()
-                    .is_streaming
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    && !ids.contains(sid)
-                {
-                    ids.push(sid.clone());
-                }
-            }
-            RpcResponse::ok(
-                id,
-                "list_streaming_sessions",
-                serde_json::json!({"sessionIds": ids}),
-            )
-        }
-        "switch_session" => {
-            if cmd.session_id.is_empty() {
-                return RpcResponse::build_fail(
-                    id,
-                    "switch_session",
-                    "No session selected. Choose a session from the list to switch to.",
-                );
-            }
-            let mut sess = wlock!(session, id);
-            let result = match sess.switch_session(&cmd.session_id) {
-                Ok(()) => {
-                    if let Some(mut active_id) = state.active_session_id.try_write() {
-                        *active_id = cmd.session_id.clone();
-                    }
-                    // Give this session its own private broadcaster so events
-                    // are only delivered to subscribers of this session.
-                    sess.broadcaster = Arc::new(SseBroadcaster::new());
-                    // Insert into sessions map so subsequent lookups by this
-                    // session_id succeed (avoids fallback-to-default warning).
-                    if let Some(mut sessions) = state.sessions.try_write() {
-                        sessions.insert(cmd.session_id.clone(), session.clone());
-                    }
-                    RpcResponse::ok(
-                        id,
-                        "switch_session",
-                        serde_json::json!({"cancelled": false}),
-                    )
-                }
-                Err(e) => RpcResponse::build_fail(id, "switch_session", &e.to_string()),
-            };
-            result
-        }
-        "delete_session" => {
-            if cmd.session_id.is_empty() {
-                return RpcResponse::build_fail(
-                    id,
-                    "delete_session",
-                    "No session selected to delete. Choose a session first.",
-                );
-            }
-            // Delete from disk
-            if let Err(e) = session.read().session_manager.delete(&cmd.session_id) {
-                return RpcResponse::build_fail(id, "delete_session", &e.to_string());
-            }
-            // Remove from memory if present
-            if let Some(mut sessions) = state.sessions.try_write() {
-                sessions.remove(&cmd.session_id);
-            }
-            RpcResponse::ok(id, "delete_session", serde_json::json!({"deleted": true}))
-        }
         "fork" => cmd_fork(state, &session, &cmd, id),
-        "get_fork_messages" => {
-            // Load session from disk to get entry IDs (needed for fork).
-            let (session_manager, session_id) = {
-                let sess = rlock!(session, id);
-                (sess.session_manager.clone(), sess.session_id.clone())
-            };
-            let user_entries: Vec<serde_json::Value> =
-                session_manager
-                    .load(&session_id)
-                    .map(|s| {
-                        s.entries
-                        .iter()
-                        .filter(|e| e.entry_type == crate::session::ENTRY_TYPE_USER)
-                        .map(|e| {
-                            let content_text = e.content.as_ref()
-                                .map(|c| {
-                                    if let Some(arr) = c.as_array() {
-                                        // First text block only — later text blocks are
-                                        // the agent-injected attachment-path list.
-                                        arr.iter()
-                                            .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
-                                            .next()
-                                            .unwrap_or("")
-                                            .to_string()
-                                    } else {
-                                        c.as_str().unwrap_or("").to_string()
-                                    }
-                                })
-                                .unwrap_or_default();
-                            serde_json::json!({
-                                "id": e.id,
-                                "role": e.role,
-                                "content": content_text,
-                                "timestamp": e.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
-                            })
-                        })
-                        .collect()
-                    })
-                    .unwrap_or_default();
-            RpcResponse::ok(
-                id,
-                "get_fork_messages",
-                serde_json::json!({"messages": user_entries}),
-            )
-        }
         "get_session_entries" => {
-            // Must not fall back to the default session when the requested id is
-            // unrecognised — that leaks another conversation's entries into the
-            // wrong caller (e.g. a GUI thread with no agent session yet would
-            // see whichever session happens to be the default).
-            if let Some(sess) = state.find_session(&cmd.session_id) {
+            // Must not fall back to a different session when the requested id
+            // is unrecognised — that leaks another conversation's entries
+            // into the wrong caller (e.g. a GUI thread with no agent session
+            // yet would see whichever session got resolved instead).
+            if let Some(sess) = state.get_session(&cmd.session_id) {
                 cmd_get_session_entries(&sess, id)
             } else {
                 RpcResponse::ok(
@@ -562,40 +401,6 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                 serde_json::json!({"name": cmd.name}),
             ));
             RpcResponse::ok(id, "set_session_name", serde_json::json!({}))
-        }
-        "get_commands" => {
-            // Return commands from skills (similar to Go's extensions + prompts)
-            let skill_dirs = vec![
-                crate::skills::APP_SKILLS_DIR.to_string(),
-                crate::skills::PROJECT_SKILLS_DIR.to_string(),
-                crate::skills::AGENTS_SKILLS_DIR.to_string(),
-            ];
-            let skills = crate::skills::discover_skills(&skill_dirs).unwrap_or_default();
-
-            let mut commands: Vec<serde_json::Value> = skills
-                .into_iter()
-                .map(|s| {
-                    serde_json::json!({
-                        "name": s.name,
-                        "description": s.description,
-                        "nameZh": s.name_zh,
-                        "descriptionZh": s.description_zh,
-                        "source": "skill"
-                    })
-                })
-                .collect();
-            commands.sort_by(|a, b| {
-                a["name"]
-                    .as_str()
-                    .unwrap_or("")
-                    .cmp(b["name"].as_str().unwrap_or(""))
-            });
-
-            RpcResponse::ok(
-                id,
-                "get_commands",
-                serde_json::json!({"commands": commands}),
-            )
         }
         "abort_retry" => {
             rlock!(session, id).abort();
@@ -671,12 +476,6 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                 "cycle_thinking_level",
                 serde_json::json!({"level": next_level}),
             )
-        }
-        "set_enabled_models" => {
-            // Scoped models are now managed entirely by the TUI/client.
-            // The agent no longer reads enabled_models — list_models always
-            // returns all available models.
-            RpcResponse::ok(id, "set_enabled_models", serde_json::json!({}))
         }
         "clone" => cmd_clone(state, &session, id),
         "export_html" => {
@@ -873,6 +672,209 @@ fn list_models_response(id: &str) -> String {
     )
 }
 
+fn cmd_shutdown(state: &AppState, id: &str) -> String {
+    state
+        .shutting_down
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    RpcResponse::ok(
+        id,
+        "shutdown",
+        serde_json::json!({"shutting_down": true, "note": "Existing runs continue; new prompts are rejected."}),
+    )
+}
+
+fn cmd_list_sessions(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
+    let summaries = state.session_manager.list_all().unwrap_or_default();
+    // Scope by the caller's cwd when provided (empty = all sessions).
+    let cwd_filter = cmd.cwd.trim().to_string();
+
+    // Snapshot streaming flags of live sessions.  Collect within a single
+    // outer read guard — safe because we only acquire inner read locks, and
+    // ParkingLot RwLock allows concurrent reads.
+    let active_flags: std::collections::HashMap<String, bool> = {
+        let active = state.sessions.read();
+        active
+            .iter()
+            .map(|(sid, sess)| {
+                let streaming = sess
+                    .read()
+                    .is_streaming
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                (sid.clone(), streaming)
+            })
+            .collect()
+    };
+
+    let sessions: Vec<serde_json::Value> = summaries
+        .into_iter()
+        .filter(|s| cwd_filter.is_empty() || s.cwd == cwd_filter)
+        .map(|s| {
+            let is_streaming = active_flags.get(&s.id).copied().unwrap_or(false);
+            serde_json::json!({
+                "id": s.id,
+                "session_name": s.name,
+                "model": s.model,
+                "cwd": s.cwd,
+                "updated_at": s.updated_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+                "parent_session_id": s.parent_session_id,
+                "first_message": s.first_message,
+                "query_count": s.query_count,
+                "is_streaming": is_streaming,
+            })
+        })
+        .collect();
+    RpcResponse::ok(
+        id,
+        "list_sessions",
+        serde_json::json!({"sessions": sessions}),
+    )
+}
+
+/// Lightweight streaming-status query: scans ONLY the in-memory session map
+/// (hydrated sessions) — never touches disk and never hydrates.  A session
+/// that isn't in the map can't be streaming (runs are always started through
+/// a hydrated ServerSession), so this is the exact set of active runs.
+fn cmd_list_streaming_sessions(state: &AppState, id: &str) -> String {
+    let ids: Vec<String> = state
+        .sessions
+        .read()
+        .iter()
+        .filter(|(_, sess)| {
+            sess.read()
+                .is_streaming
+                .load(std::sync::atomic::Ordering::Relaxed)
+        })
+        .map(|(sid, _)| sid.clone())
+        .collect();
+    RpcResponse::ok(
+        id,
+        "list_streaming_sessions",
+        serde_json::json!({"sessionIds": ids}),
+    )
+}
+
+/// Bind a client to an existing session.  Sessions are equal peers, so
+/// "switching" just means resolving (and hydrating) the target — the client
+/// addresses it by id from then on.
+fn cmd_switch_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
+    if cmd.session_id.is_empty() {
+        return RpcResponse::build_fail(
+            id,
+            "switch_session",
+            "No session selected. Choose a session from the list to switch to.",
+        );
+    }
+    match state.get_session(&cmd.session_id) {
+        Some(_) => RpcResponse::ok(
+            id,
+            "switch_session",
+            serde_json::json!({"cancelled": false}),
+        ),
+        None => RpcResponse::build_fail(
+            id,
+            "switch_session",
+            &format!("session `{}` not found", cmd.session_id),
+        ),
+    }
+}
+
+fn cmd_delete_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
+    if cmd.session_id.is_empty() {
+        return RpcResponse::build_fail(
+            id,
+            "delete_session",
+            "No session selected to delete. Choose a session first.",
+        );
+    }
+    if let Err(e) = state.session_manager.delete(&cmd.session_id) {
+        return RpcResponse::build_fail(id, "delete_session", &e.to_string());
+    }
+    if let Some(mut sessions) = state.sessions.try_write() {
+        sessions.remove(&cmd.session_id);
+    }
+    RpcResponse::ok(id, "delete_session", serde_json::json!({"deleted": true}))
+}
+
+/// Load user entries of a session from disk (fork-point picker).  Reads the
+/// file directly — no in-memory session required.
+fn cmd_get_fork_messages(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
+    let user_entries: Vec<serde_json::Value> = state
+        .session_manager
+        .load(&cmd.session_id)
+        .map(|s| {
+            s.entries
+                .iter()
+                .filter(|e| e.entry_type == crate::session::ENTRY_TYPE_USER)
+                .map(|e| {
+                    let content_text = e
+                        .content
+                        .as_ref()
+                        .map(|c| {
+                            if let Some(arr) = c.as_array() {
+                                // First text block only — later text blocks are
+                                // the agent-injected attachment-path list.
+                                arr.iter()
+                                    .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                                    .next()
+                                    .unwrap_or("")
+                                    .to_string()
+                            } else {
+                                c.as_str().unwrap_or("").to_string()
+                            }
+                        })
+                        .unwrap_or_default();
+                    serde_json::json!({
+                        "id": e.id,
+                        "role": e.role,
+                        "content": content_text,
+                        "timestamp": e.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    RpcResponse::ok(
+        id,
+        "get_fork_messages",
+        serde_json::json!({"messages": user_entries}),
+    )
+}
+
+fn cmd_get_commands(id: &str) -> String {
+    // Return commands from skills (similar to Go's extensions + prompts)
+    let skill_dirs = vec![
+        crate::skills::APP_SKILLS_DIR.to_string(),
+        crate::skills::PROJECT_SKILLS_DIR.to_string(),
+        crate::skills::AGENTS_SKILLS_DIR.to_string(),
+    ];
+    let skills = crate::skills::discover_skills(&skill_dirs).unwrap_or_default();
+
+    let mut commands: Vec<serde_json::Value> = skills
+        .into_iter()
+        .map(|s| {
+            serde_json::json!({
+                "name": s.name,
+                "description": s.description,
+                "nameZh": s.name_zh,
+                "descriptionZh": s.description_zh,
+                "source": "skill"
+            })
+        })
+        .collect();
+    commands.sort_by(|a, b| {
+        a["name"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["name"].as_str().unwrap_or(""))
+    });
+
+    RpcResponse::ok(
+        id,
+        "get_commands",
+        serde_json::json!({"commands": commands}),
+    )
+}
+
 fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     // Create a new session with shared agent_loop, preserving model/thinking
     // Use TUI-provided cwd if available, otherwise default workspace.
@@ -883,23 +885,15 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     } else {
         super::session::default_workspace()
     };
-    let active_id = state.get_active_session_id();
-    let session = state.get_session(&active_id);
-    // Snapshot what we need from the active session up front, then drop its
-    // lock.  The new session's loop comes from the template (never used for
-    // runs), so creation succeeds even while every existing session is
-    // mid-stream — previously this failed with "agent is busy" whenever the
-    // shared loop was read-locked by a run.
-    let (inherit_model, event_bus, broadcaster, approval_gate, session_manager) = {
-        let sess = rlock!(session, id);
-        (
-            sess.model.clone(),
-            sess.event_bus.clone(),
-            sess.broadcaster.clone(),
-            sess.approval_gate.clone(),
-            sess.session_manager.clone(),
-        )
-    };
+    // No active/default session to inherit from — everything comes from
+    // AppState-level singletons and the loop template.  The fresh loop is
+    // minted from the template (never used for runs), so creation succeeds
+    // even while every existing session is mid-stream.
+    let event_bus = state.event_bus.clone();
+    let broadcaster = Arc::new(SseBroadcaster::new());
+    let approval_gate = state.approval_gate.clone();
+    let session_manager = Arc::new(crate::session::Manager::default_for(&session_cwd));
+    let inherit_model = state.loop_template.model.clone();
 
     let fresh_loop = state.loop_template.independent_copy();
 
@@ -920,7 +914,7 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     let mut new_sess = ServerSession::new(
         new_session_id.clone(),
         Arc::new(tokio::sync::RwLock::new(fresh_loop)),
-        Arc::new(crate::session::Manager::default_for(&session_cwd)),
+        session_manager.clone(),
         &session_cwd,
         event_bus,
         broadcaster,
@@ -941,6 +935,19 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     }
     // Always start new sessions at the preferred thinking level.
     new_sess.thinking_level = "xhigh".to_string();
+
+    // Apply user settings (previously applied only to the startup "default
+    // session" — with sessions as equal peers, every new session gets them).
+    let settings_path = std::path::PathBuf::from(crate::models::settings_path());
+    if let Ok(settings) = crate::config::load_settings(&settings_path) {
+        new_sess.set_steering_mode(&settings.steering_mode);
+        new_sess.set_follow_up_mode(&settings.follow_up_mode);
+        if !settings.default_permission_level.is_empty() {
+            new_sess.set_permission_level(&settings.default_permission_level);
+        }
+        new_sess.set_auto_compaction(settings.compaction_enabled());
+        new_sess.set_auto_retry(settings.retry_enabled());
+    }
 
     // Default created_by to "tui" for sessions created without
     // explicit source info (e.g. TUI, channels). GUI passes
@@ -1445,32 +1452,41 @@ mod tests {
     fn make_app_state() -> AppState {
         let cwd = test_workspace();
         let model_registry = Arc::new(parking_lot::RwLock::new(crate::models::Registry::new()));
+        let session_manager = Arc::new(crate::session::Manager::default_for(&cwd));
+        let event_bus = Arc::new(crate::events::EventBus::new());
+        let approval_gate = ApprovalGate::default();
+        // One live session named "default" — sessions are equal peers now,
+        // so tests address it explicitly by id.
         let session = ServerSession::new(
             "default".to_string(),
             Arc::new(tokio::sync::RwLock::new(Loop::new(
                 Arc::new(EmptyProvider),
                 "mock",
             ))),
-            Arc::new(crate::session::Manager::default_for(&cwd)),
+            session_manager.clone(),
             &cwd,
-            Arc::new(crate::events::EventBus::new()),
+            event_bus.clone(),
             Arc::new(SseBroadcaster::new()),
-            ApprovalGate::default(),
+            approval_gate.clone(),
             model_registry.clone(),
         );
+        let sessions: HashMap<String, Arc<parking_lot::RwLock<ServerSession>>> = [(
+            "default".to_string(),
+            Arc::new(parking_lot::RwLock::new(session)),
+        )]
+        .into_iter()
+        .collect();
         AppState {
-            session: Arc::new(parking_lot::RwLock::new(session)),
-            sessions: Arc::new(parking_lot::RwLock::new(HashMap::new())),
-            active_session_id: Arc::new(parking_lot::RwLock::new("default".to_string())),
+            sessions: Arc::new(parking_lot::RwLock::new(sessions)),
+            session_manager,
             welcome_version: "0.0.0".to_string(),
             welcome_cwd: cwd.clone(),
             welcome_skills: Arc::new(parking_lot::RwLock::new(vec![])),
             welcome_context: Arc::new(parking_lot::RwLock::new(vec![])),
             welcome_exts: vec![],
             explicit_session: false,
-            broadcaster: Arc::new(SseBroadcaster::new()),
-            event_bus: Arc::new(crate::events::EventBus::new()),
-            approval_gate: ApprovalGate::default(),
+            event_bus,
+            approval_gate,
             verbose: false,
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             model_registry: model_registry.clone(),
@@ -1480,7 +1496,7 @@ mod tests {
 
     fn make_cmd(cmd_type: &str) -> RpcCommand {
         serde_json::from_str(&format!(
-            r#"{{"id":"test_cmd","type":"{}","sessionId":""}}"#,
+            r#"{{"id":"test_cmd","type":"{}","sessionId":"default"}}"#,
             cmd_type
         ))
         .unwrap()
@@ -1722,7 +1738,7 @@ mod tests {
     #[test]
     fn shell_echo() {
         let state = make_app_state();
-        std::fs::create_dir_all(&state.session.read().cwd).unwrap();
+        std::fs::create_dir_all(&state.welcome_cwd).unwrap();
         let mut cmd = make_cmd("shell");
         cmd.command = "echo test_output".to_string();
         let resp = parse_response(&handle_command_internal(&state, cmd));
@@ -1771,8 +1787,7 @@ mod tests {
             "nothing streams at startup"
         );
 
-        state
-            .session
+        state.sessions.read()["default"]
             .read()
             .is_streaming
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -365,10 +365,17 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             // Update session_info so name survives restarts
             if let Ok(mut s) = session_manager.load(&session_id) {
                 // Update session_info entry's session_name field
-                if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+                if let Some(info_entry) = s
+                    .entries
+                    .iter_mut()
+                    .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
+                {
                     if let Some(ref mut content) = info_entry.content {
                         if let Some(obj) = content.as_object_mut() {
-                            obj.insert("session_name".to_string(), serde_json::Value::String(cmd.name.clone()));
+                            obj.insert(
+                                "session_name".to_string(),
+                                serde_json::Value::String(cmd.name.clone()),
+                            );
                         }
                     }
                 }

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -358,6 +358,41 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                 serde_json::json!({"sessions": sessions}),
             )
         }
+        // Lightweight streaming-status query: scans ONLY the in-memory
+        // session map (hydrated sessions) — never touches disk and never
+        // hydrates.  A session that isn't in the map can't be streaming
+        // (runs are always started through a hydrated ServerSession), so
+        // this is the exact set of active runs.  Lets clients (GUI thread
+        // list) poll "who is streaming" for all sessions in ONE call
+        // instead of one get_state per session (which also hydrated every
+        // polled session on the agent).
+        "list_streaming_sessions" => {
+            let mut ids: Vec<String> = vec![];
+            {
+                let default_sess = state.session.read();
+                if default_sess
+                    .is_streaming
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    ids.push(default_sess.session_id.clone());
+                }
+            }
+            for (sid, sess) in state.sessions.read().iter() {
+                if sess
+                    .read()
+                    .is_streaming
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    && !ids.contains(sid)
+                {
+                    ids.push(sid.clone());
+                }
+            }
+            RpcResponse::ok(
+                id,
+                "list_streaming_sessions",
+                serde_json::json!({"sessionIds": ids}),
+            )
+        }
         "switch_session" => {
             if cmd.session_id.is_empty() {
                 return RpcResponse::build_fail(
@@ -1718,6 +1753,32 @@ mod tests {
         let resp = parse_response(&handle_command_internal(&state, cmd));
         assert_eq!(resp["success"], true);
         assert!(resp["data"]["sessions"].is_array());
+    }
+
+    #[test]
+    fn list_streaming_sessions_reports_only_streaming() {
+        let state = make_app_state();
+        let cmd = make_cmd("list_streaming_sessions");
+        let resp = parse_response(&handle_command_internal(&state, cmd));
+        assert_eq!(resp["success"], true);
+        assert_eq!(
+            resp["data"]["sessionIds"].as_array().unwrap().len(),
+            0,
+            "nothing streams at startup"
+        );
+
+        state
+            .session
+            .read()
+            .is_streaming
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let resp = parse_response(&handle_command_internal(
+            &state,
+            make_cmd("list_streaming_sessions"),
+        ));
+        let ids = resp["data"]["sessionIds"].as_array().unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "default");
     }
 
     #[test]

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -117,11 +117,16 @@ impl AppState {
         if new_sess.switch_session(session_id).is_err() {
             return self.session.clone();
         }
-        // If the session file had no model saved, copy from default
+        // If the session file had no model saved, fall back to the default
+        // — via set_model, which also rebuilds the loop's provider client.
+        // A bare `new_sess.model = ...` would leave the loop pointing at the
+        // template's startup model/endpoint.
         if new_sess.model.is_empty() {
             let default_model = self.session.read().model.clone();
             if !default_model.is_empty() {
-                new_sess.model = default_model.clone();
+                if let Err(e) = new_sess.set_model(&default_model) {
+                    tracing::warn!("[session] could not apply default model on hydrate: {e}");
+                }
             }
         }
 

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -113,6 +113,7 @@ impl AppState {
             event_bus,
             broadcaster,
             approval_gate,
+            self.model_registry.clone(),
         );
         if new_sess.switch_session(session_id).is_err() {
             return self.session.clone();

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -76,9 +76,7 @@ impl AppState {
                 return Some(sess.clone());
             }
         }
-        if self.session_manager.find(session_id).is_none() {
-            return None;
-        }
+        self.session_manager.find(session_id)?;
 
         // Load session from disk OUTSIDE any lock — switch_session parses
         // the JSONL file and can be slow for large histories.

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -23,19 +23,19 @@ pub use session::ServerSession;
 
 #[derive(Clone)]
 pub struct AppState {
-    /// Default session (used when no session_id specified)
-    pub session: Arc<RwLock<ServerSession>>,
-    /// Additional sessions keyed by session_id
+    /// All live sessions keyed by session_id.  Sessions are equal peers —
+    /// there is no privileged "default"/"current" session; clients address
+    /// sessions explicitly and the agent hydrates them on demand.
     pub sessions: Arc<RwLock<HashMap<String, Arc<RwLock<ServerSession>>>>>,
-    /// Active session ID (for get_state display)
-    pub active_session_id: Arc<RwLock<String>>,
+    /// On-disk session store (JSONL).  Used for hydration and sessionless
+    /// disk operations (delete, fork previews).
+    pub session_manager: Arc<crate::session::Manager>,
     pub welcome_version: String,
     pub welcome_cwd: String,
     pub welcome_skills: Arc<RwLock<Vec<String>>>,
     pub welcome_context: Arc<RwLock<Vec<String>>>,
     pub welcome_exts: Vec<String>,
     pub explicit_session: bool,
-    pub broadcaster: Arc<SseBroadcaster>,
     pub event_bus: Arc<EventBus>,
     pub approval_gate: ApprovalGate,
     pub verbose: bool,
@@ -56,74 +56,60 @@ pub struct AppState {
 }
 
 impl AppState {
-    /// Get session by ID, or return default session if id is empty/None.
+    /// Resolve a session by id: in-memory hit, else hydrate from disk.
+    /// Returns None for an empty id or an id that exists neither in memory
+    /// nor on disk — callers NEVER silently receive a different session
+    /// (the old default-session fallback leaked one conversation's state
+    /// into another's caller).
     ///
     /// Disk loading (switch_session → JSONL parse) happens **outside** the
     /// write lock.  Only the final map insertion acquires the write lock
     /// (with a double-check), so a slow session load never stalls concurrent
     /// session lookups.
-    pub fn get_session(&self, session_id: &str) -> Arc<RwLock<ServerSession>> {
+    pub fn get_session(&self, session_id: &str) -> Option<Arc<RwLock<ServerSession>>> {
         if session_id.is_empty() {
-            return self.session.clone();
+            return None;
         }
         {
             let sessions = self.sessions.read();
             if let Some(sess) = sessions.get(session_id) {
-                return sess.clone();
+                return Some(sess.clone());
             }
         }
-        // Session not found in map — if it matches the default session's own
-        // ID, return it silently.
-        let default_id = self.session.read().session_id.clone();
-        if session_id == default_id {
-            return self.session.clone();
+        if self.session_manager.find(session_id).is_none() {
+            return None;
         }
-
-        // Check whether the session exists on disk before doing expensive I/O.
-        let (session_manager, event_bus, cwd, approval_gate) = {
-            let sess = self.session.read();
-            if sess.session_manager.find(session_id).is_none() {
-                return self.session.clone(); // not on disk either
-            }
-            (
-                sess.session_manager.clone(),
-                sess.event_bus.clone(),
-                sess.cwd.clone(),
-                sess.approval_gate.clone(),
-            )
-        };
 
         // Load session from disk OUTSIDE any lock — switch_session parses
         // the JSONL file and can be slow for large histories.
         //
         // The hydrated session gets its OWN agent loop (minted from the
-        // template), not the default session's loop.  switch_session below
-        // calls set_model, which replaces the seeded provider with a fresh
-        // client for this session's model — and can no longer fail with
-        // "agent is currently streaming" just because ANOTHER session is
-        // mid-run.
+        // template), so switch_session → set_model configures only this
+        // session's provider and can never fail with "agent is currently
+        // streaming" just because ANOTHER session is mid-run.
         let broadcaster = Arc::new(SseBroadcaster::new());
         let mut new_sess = ServerSession::new(
             session_id.to_string(),
             Arc::new(tokio::sync::RwLock::new(
                 self.loop_template.independent_copy(),
             )),
-            session_manager.clone(),
-            &cwd,
-            event_bus,
+            self.session_manager.clone(),
+            &self.welcome_cwd.clone(),
+            self.event_bus.clone(),
             broadcaster,
-            approval_gate,
+            self.approval_gate.clone(),
             self.model_registry.clone(),
         );
         if new_sess.switch_session(session_id).is_err() {
-            return self.session.clone();
+            return None;
         }
         // If the session file had no model saved, fall back to the default
         // — via set_model, which also rebuilds the loop's provider client.
         // A bare `new_sess.model = ...` would leave the loop pointing at the
         // template's startup model/endpoint.
         if new_sess.model.is_empty() {
-            let default_model = self.session.read().model.clone();
+            let default_model = crate::models::get_default_model()
+                .unwrap_or_else(|| self.loop_template.model.clone());
             if !default_model.is_empty() {
                 if let Err(e) = new_sess.set_model(&default_model) {
                     tracing::warn!("[session] could not apply default model on hydrate: {e}");
@@ -136,30 +122,11 @@ impl AppState {
         {
             let mut sessions = self.sessions.write();
             if let Some(sess) = sessions.get(session_id) {
-                return sess.clone();
+                return Some(sess.clone());
             }
             let sess_arc = Arc::new(RwLock::new(new_sess));
             sessions.insert(session_id.to_string(), sess_arc.clone());
-            sess_arc
-        }
-    }
-
-    pub fn find_session(&self, session_id: &str) -> Option<Arc<RwLock<ServerSession>>> {
-        let sess = self.get_session(session_id);
-        // get_session already handles empty, map lookup, default match,
-        // and disk fallback. If it returned the default session as a
-        // fallback, check whether we actually wanted the default or if
-        // the requested session truly doesn't exist.
-        if session_id.is_empty() {
-            return Some(sess);
-        }
-        let found_id = sess.read().session_id.clone();
-        if found_id == session_id || session_id == self.session.read().session_id.clone() {
-            Some(sess)
-        } else {
-            // get_session fell back to default but the requested session
-            // doesn't match the default — session not found.
-            None
+            Some(sess_arc)
         }
     }
 
@@ -172,15 +139,7 @@ impl AppState {
         self.sessions
             .write()
             .insert(id.clone(), Arc::new(RwLock::new(session)));
-        if let Some(mut active_id) = self.active_session_id.try_write() {
-            *active_id = id.clone();
-        }
         id
-    }
-
-    /// Get active session ID
-    pub fn get_active_session_id(&self) -> String {
-        self.active_session_id.read().clone()
     }
 
     /// Refresh the in-memory API key of every live session from auth.json.
@@ -190,7 +149,6 @@ impl AppState {
     /// skipped by `reload_credentials` and pick up the new key on their next
     /// `set_model`.
     pub fn reload_all_credentials(&self) {
-        self.session.read().reload_credentials();
         let sessions = self.sessions.read();
         for sess in sessions.values() {
             sess.read().reload_credentials();
@@ -198,8 +156,8 @@ impl AppState {
     }
 }
 
-fn get_state_internal(state: &AppState, session_id: &str) -> serde_json::Value {
-    let session = state.get_session(session_id);
+fn get_state_internal(state: &AppState, session_id: &str) -> Option<serde_json::Value> {
+    let session = state.get_session(session_id)?;
     let sess = session.read();
 
     // Resolve context window: use the cached model registry from AppState.
@@ -269,7 +227,7 @@ fn get_state_internal(state: &AppState, session_id: &str) -> serde_json::Value {
         .map(|s| s.parent_session_id)
         .unwrap_or_default();
 
-    serde_json::json!({
+    Some(serde_json::json!({
         "model": sess.model,
         "imageSupport": image_support,
         "thinkingLevel": sess.thinking_level,
@@ -301,7 +259,7 @@ fn get_state_internal(state: &AppState, session_id: &str) -> serde_json::Value {
         "parentSessionId": if parent_session_id.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(parent_session_id) },
         "createdBy": sess.created_by.clone(),
         "sourceMeta": sess.source_meta.clone(),
-    })
+    }))
 }
 
 /// Generate HTML representation of a session (matches Go exportSessionToHTML)

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -46,6 +46,13 @@ pub struct AppState {
     /// Cached model registry populated once at startup.  Avoids repeated
     /// blocking network I/O on every get_state → Registry::new() call.
     pub model_registry: Arc<RwLock<ModelRegistry>>,
+    /// Template for minting per-session agent loops (`Loop::independent_copy`).
+    /// Every session gets its OWN loop — never a shared one — so a streaming
+    /// run's long-held read lock can't block another session's `set_model`
+    /// (`try_write`), and interrupt flags / steering queues / tool hooks /
+    /// token counters stay session-local.  The template itself is never used
+    /// to run prompts.
+    pub loop_template: Arc<crate::agent::Loop>,
 }
 
 impl AppState {
@@ -73,13 +80,12 @@ impl AppState {
         }
 
         // Check whether the session exists on disk before doing expensive I/O.
-        let (agent_loop, session_manager, event_bus, cwd, approval_gate) = {
+        let (session_manager, event_bus, cwd, approval_gate) = {
             let sess = self.session.read();
             if sess.session_manager.find(session_id).is_none() {
                 return self.session.clone(); // not on disk either
             }
             (
-                sess.agent_loop.clone(),
                 sess.session_manager.clone(),
                 sess.event_bus.clone(),
                 sess.cwd.clone(),
@@ -89,10 +95,19 @@ impl AppState {
 
         // Load session from disk OUTSIDE any lock — switch_session parses
         // the JSONL file and can be slow for large histories.
+        //
+        // The hydrated session gets its OWN agent loop (minted from the
+        // template), not the default session's loop.  switch_session below
+        // calls set_model, which replaces the seeded provider with a fresh
+        // client for this session's model — and can no longer fail with
+        // "agent is currently streaming" just because ANOTHER session is
+        // mid-run.
         let broadcaster = Arc::new(SseBroadcaster::new());
-        let mut new_sess = ServerSession::new_with_shared_loop(
+        let mut new_sess = ServerSession::new(
             session_id.to_string(),
-            agent_loop,
+            Arc::new(tokio::sync::RwLock::new(
+                self.loop_template.independent_copy(),
+            )),
             session_manager.clone(),
             &cwd,
             event_bus,

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -24,9 +24,11 @@ pub struct ServerSession {
     /// Stable unique session identifier (UUID v4).  Used as the JSONL filename
     /// on disk and as the key in `AppState::sessions`.
     pub session_id: String,
-    /// The agent run-loop: LLM provider + tool registry + turn counter.  Shared
-    /// across forked sessions via `new_with_shared_loop` (the loop carries its
-    /// own token counters and message queue per-session).
+    /// The agent run-loop: LLM provider + tool registry + turn counter.
+    /// Each session owns an independent loop minted from
+    /// `AppState::loop_template` (`Loop::independent_copy`) — never a shared
+    /// one — so concurrent runs, `set_model` calls and aborts stay
+    /// session-local.
     pub agent_loop: Arc<tokio::sync::RwLock<crate::agent::Loop>>,
     /// Full message history as persisted to/loaded from the session JSONL.
     pub messages: Arc<parking_lot::RwLock<Vec<crate::types::AgentMessage>>>,
@@ -190,63 +192,6 @@ impl ServerSession {
             tokens_cache_w: tcw,
             cumulative_cost: Arc::new(parking_lot::Mutex::new(0.0)),
             last_prompt_tokens: lpt,
-            steering_tx: stx,
-            follow_up_tx: ftx,
-            interrupt_tx: None,
-            interrupt_flag: None,
-            approval_gate,
-            permission_level: DEFAULT_PERMISSION_LEVEL.to_string(),
-            sandbox_policy: None,
-            session_rules: std::sync::Arc::new(parking_lot::Mutex::new(vec![])),
-        }
-    }
-
-    /// Create a new session with the same agent_loop but cleared state
-    pub fn new_with_shared_loop(
-        session_id: String,
-        agent_loop: Arc<tokio::sync::RwLock<crate::agent::Loop>>,
-        manager: Arc<Manager>,
-        cwd: &str,
-        event_bus: Arc<EventBus>,
-        broadcaster: Arc<SseBroadcaster>,
-        approval_gate: ApprovalGate,
-    ) -> Self {
-        let (stx, ftx) = if let Ok(loop_) = agent_loop.try_read() {
-            (
-                loop_.steering_queue.tx.clone(),
-                loop_.follow_up_queue.tx.clone(),
-            )
-        } else {
-            let (stx, _) = tokio::sync::mpsc::channel(64);
-            let (ftx, _) = tokio::sync::mpsc::channel(64);
-            (stx, ftx)
-        };
-        Self {
-            session_id: session_id.clone(),
-            agent_loop,
-            messages: Arc::new(parking_lot::RwLock::new(vec![])),
-            model: String::new(),
-            thinking_level: "xhigh".to_string(),
-            steering_mode: "one-at-a-time".to_string(),
-            follow_up_mode: "one-at-a-time".to_string(),
-            auto_compaction: true,
-            auto_retry: true,
-            session_manager: manager,
-            cwd: cwd.to_string(),
-            is_streaming: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            session_name: String::new(),
-            parent_session_id: String::new(),
-            created_by: String::new(),
-            source_meta: serde_json::Value::Null,
-            event_bus,
-            broadcaster,
-            ephemeral: false,
-            tokens_in: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            tokens_out: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            tokens_cache_r: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            tokens_cache_w: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            cumulative_cost: Arc::new(parking_lot::Mutex::new(0.0)),
-            last_prompt_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             steering_tx: stx,
             follow_up_tx: ftx,
             interrupt_tx: None,
@@ -645,7 +590,10 @@ impl ServerSession {
     }
 
     pub fn list_sessions(&self) -> Result<Vec<serde_json::Value>> {
-        let sessions = self.session_manager.list(&self.cwd)?;
+        // Lightweight summaries: scans each JSONL without deserializing
+        // large tool/assistant payloads, so listing stays fast even with
+        // thousands of sessions on disk.
+        let sessions = self.session_manager.list_summaries(&self.cwd)?;
         Ok(sessions
             .into_iter()
             .map(|s| {
@@ -1189,13 +1137,13 @@ mod tests {
         assert_eq!(session.thinking_level, "off");
     }
 
-    // ─── new_with_shared_loop ───────────────────────────────────────────────
+    // ─── new (per-session loop) ─────────────────────────────────────────
 
     #[test]
-    fn new_with_shared_loop_defaults() {
+    fn new_with_own_loop_defaults() {
         let cwd = test_workspace();
-        let session = ServerSession::new_with_shared_loop(
-            "shared_test".to_string(),
+        let session = ServerSession::new(
+            "own_loop_test".to_string(),
             Arc::new(tokio::sync::RwLock::new(Loop::new(
                 Arc::new(EmptyProvider),
                 "mock",
@@ -1206,10 +1154,31 @@ mod tests {
             Arc::new(SseBroadcaster::new()),
             ApprovalGate::default(),
         );
-        assert_eq!(session.session_id(), "shared_test");
+        assert_eq!(session.session_id(), "own_loop_test");
         assert_eq!(session.thinking_level, "xhigh");
         assert_eq!(session.get_permission_level(), "all");
         assert!(session.auto_compaction);
+    }
+
+    /// Sessions mint independent loops from the template: queues, counters
+    /// and interrupt flags must not be shared across sessions.
+    #[test]
+    fn independent_loop_copies_have_isolated_state() {
+        let template = Loop::new(Arc::new(EmptyProvider), "mock").with_system_prompt("tpl");
+        let a = template.independent_copy();
+        let b = template.independent_copy();
+        assert_eq!(a.system_prompt, "tpl");
+        assert_eq!(b.model, "mock");
+        // Interrupt flag: fresh Arc per copy.
+        assert!(!std::sync::Arc::ptr_eq(
+            &a.interrupt_flag,
+            &b.interrupt_flag
+        ));
+        // Token counters: fresh Arc per copy.
+        assert!(!std::sync::Arc::ptr_eq(
+            &a.cumulative_input_tokens,
+            &b.cumulative_input_tokens
+        ));
     }
 
     // ─── compact ────────────────────────────────────────────────────────────

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -329,14 +329,11 @@ impl ServerSession {
                 resolve_api_key(&auth, model, &model_config.provider, &model_config.api_key);
 
             // Build a FRESH provider (its own reqwest client) and swap it in,
-            // rather than mutating the existing provider's endpoint. Sessions
-            // are seeded from a shared provider `Arc` in `new_session`, so
-            // mutating it in place would (a) serialize concurrent sessions onto
-            // one HTTP connection and (b) let one session's endpoint change
-            // clobber another's mid-run. A per-session client makes concurrent
-            // conversations use independent connections. The GUI calls
-            // `set_model` on every session before prompting, so this is where
-            // each session gets its own client.
+            // rather than mutating the existing provider's endpoint.  Each
+            // session owns its loop (minted from AppState::loop_template), so
+            // the fresh client is this session's alone: concurrent sessions
+            // use independent connections and never clobber each other's
+            // endpoint mid-run.
             let max_tokens = if model_config.max_tokens > 0 {
                 Some(std::cmp::min(model_config.max_tokens, 32000))
             } else if model_config.reasoning {

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -380,10 +380,17 @@ impl ServerSession {
 
         // Persist model change to session JSONL so it survives restarts
         if let Ok(mut s) = self.session_manager.load(&self.session_id) {
-            if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+            if let Some(info_entry) = s
+                .entries
+                .iter_mut()
+                .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
+            {
                 if let Some(ref mut content) = info_entry.content {
                     if let Some(obj) = content.as_object_mut() {
-                        obj.insert("model".to_string(), serde_json::Value::String(self.model.clone()));
+                        obj.insert(
+                            "model".to_string(),
+                            serde_json::Value::String(self.model.clone()),
+                        );
                     }
                 }
                 let _ = self.session_manager.save(&s);
@@ -457,10 +464,17 @@ impl ServerSession {
 
         // Persist thinking level change to session JSONL so it survives restarts
         if let Ok(mut s) = self.session_manager.load(&self.session_id) {
-            if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+            if let Some(info_entry) = s
+                .entries
+                .iter_mut()
+                .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
+            {
                 if let Some(ref mut content) = info_entry.content {
                     if let Some(obj) = content.as_object_mut() {
-                        obj.insert("thinking_level".to_string(), serde_json::Value::String(self.thinking_level.clone()));
+                        obj.insert(
+                            "thinking_level".to_string(),
+                            serde_json::Value::String(self.thinking_level.clone()),
+                        );
                     }
                 }
                 let _ = self.session_manager.save(&s);

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -138,6 +138,7 @@ fn resolve_api_key(
 }
 
 impl ServerSession {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_id: String,
         agent_loop: Arc<tokio::sync::RwLock<crate::agent::Loop>>,

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -103,6 +103,11 @@ pub struct ServerSession {
     /// Runtime "allow in this workspace/chat" rules for the current run. Shared
     /// into the live sandbox at prompt start; cleared each new run.
     pub session_rules: crate::sandbox::rules::SessionRules,
+    /// Process-wide cached model registry (shared from `AppState`).  Used by
+    /// `set_model`/`reload_credentials` so hydrating N sessions costs zero
+    /// registry rebuilds; refreshed in place by the `reload_auth` command
+    /// after provider/auth changes on disk.
+    pub model_registry: Arc<parking_lot::RwLock<crate::models::Registry>>,
 }
 
 /// Default workspace directory for new sessions.
@@ -141,6 +146,7 @@ impl ServerSession {
         event_bus: Arc<EventBus>,
         broadcaster: Arc<SseBroadcaster>,
         approval_gate: ApprovalGate,
+        model_registry: Arc<parking_lot::RwLock<crate::models::Registry>>,
     ) -> Self {
         // Clone token counter Arcs and queue senders from the agent loop for lock-free access
         let (ti, to, tcr, tcw, lpt, stx, ftx) = if let Ok(loop_) = agent_loop.try_read() {
@@ -200,6 +206,7 @@ impl ServerSession {
             permission_level: DEFAULT_PERMISSION_LEVEL.to_string(),
             sandbox_policy: None,
             session_rules: std::sync::Arc::new(parking_lot::Mutex::new(vec![])),
+            model_registry,
         }
     }
 
@@ -273,9 +280,9 @@ impl ServerSession {
     }
 
     pub fn set_model(&mut self, model: &str) -> Result<()> {
-        // Resolve model config from registry to get base_url, compat settings, etc.
-        let registry = crate::models::Registry::new();
-        let resolved = registry.resolve(model);
+        // Resolve against the shared cached registry — never rebuilds it.
+        // The cache is refreshed by `reload_auth` when models.json changes.
+        let resolved = self.model_registry.read().resolve(model);
         // Store full provider/id as the canonical model identifier for display
         // and session persistence. Resolve bare ID to provider/id when possible.
         self.model = resolved
@@ -393,15 +400,14 @@ impl ServerSession {
         if self.model.is_empty() {
             return;
         }
-        let registry = crate::models::Registry::new();
-        let resolved = registry.resolve(&self.model);
-        let provider = resolved
+        let registry_resolved = self.model_registry.read().resolve(&self.model);
+        let provider = registry_resolved
             .as_ref()
             .map(|m| m.provider.clone())
             .unwrap_or_else(|| self.model.split('/').next().unwrap_or("").to_string());
 
         let auth = crate::AuthStore::load();
-        let model_key = resolved
+        let model_key = registry_resolved
             .as_ref()
             .map(|m| m.api_key.clone())
             .unwrap_or_default();
@@ -772,6 +778,7 @@ mod tests {
             Arc::new(EventBus::new()),
             Arc::new(SseBroadcaster::new()),
             ApprovalGate::default(),
+            Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
         );
 
         assert_eq!(session.get_permission_level(), "all");
@@ -792,6 +799,7 @@ mod tests {
             Arc::new(EventBus::new()),
             Arc::new(SseBroadcaster::new()),
             ApprovalGate::default(),
+            Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
         )
     }
 
@@ -1150,6 +1158,7 @@ mod tests {
             Arc::new(EventBus::new()),
             Arc::new(SseBroadcaster::new()),
             ApprovalGate::default(),
+            Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
         );
         assert_eq!(session.session_id(), "own_loop_test");
         assert_eq!(session.thinking_level, "xhigh");

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -377,6 +377,19 @@ impl ServerSession {
 
             loop_.provider = std::sync::Arc::new(client);
         }
+
+        // Persist model change to session JSONL so it survives restarts
+        if let Ok(mut s) = self.session_manager.load(&self.session_id) {
+            if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+                if let Some(ref mut content) = info_entry.content {
+                    if let Some(obj) = content.as_object_mut() {
+                        obj.insert("model".to_string(), serde_json::Value::String(self.model.clone()));
+                    }
+                }
+                let _ = self.session_manager.save(&s);
+            }
+        }
+
         Ok(())
     }
 
@@ -440,6 +453,18 @@ impl ServerSession {
         if let Ok(mut loop_) = self.agent_loop.try_write() {
             loop_.config.thinking_budget = budget;
             loop_.provider.update_thinking(level, budget);
+        }
+
+        // Persist thinking level change to session JSONL so it survives restarts
+        if let Ok(mut s) = self.session_manager.load(&self.session_id) {
+            if let Some(info_entry) = s.entries.iter_mut().find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO) {
+                if let Some(ref mut content) = info_entry.content {
+                    if let Some(obj) = content.as_object_mut() {
+                        obj.insert("thinking_level".to_string(), serde_json::Value::String(self.thinking_level.clone()));
+                    }
+                }
+                let _ = self.session_manager.save(&s);
+            }
         }
     }
 

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -400,8 +400,13 @@ impl ServerSession {
                                 entries.iter_mut().zip(old_msg_entries.iter())
                             {
                                 new_entry.timestamp = old_entry.timestamp;
-                                new_entry.output_tokens = old_entry.output_tokens;
-                                new_entry.duration_ms = old_entry.duration_ms;
+                                // Preserve run stats from old entry's content
+                                if let Some(ref old_content) = old_entry.content {
+                                    if let Some(obj) = new_entry.content.as_mut().and_then(|c| c.as_object_mut()) {
+                                        if let Some(v) = old_content.get("run_tokens") { obj.insert("run_tokens".to_string(), v.clone()); }
+                                        if let Some(v) = old_content.get("run_duration_ms") { obj.insert("run_duration_ms".to_string(), v.clone()); }
+                                    }
+                                }
                             }
 
                             // Attach this run's output tokens + wall-clock duration
@@ -417,8 +422,13 @@ impl ServerSession {
                                 .rev()
                                 .find(|e| e.entry_type == crate::session::ENTRY_TYPE_ASSISTANT)
                             {
-                                last_assistant.output_tokens = run_output_tokens;
-                                last_assistant.duration_ms = run_duration_ms;
+                                // Store run stats in the last assistant's content JSON
+                                if let Some(ref mut content) = last_assistant.content {
+                                    if let Some(obj) = content.as_object_mut() {
+                                        obj.insert("run_tokens".to_string(), serde_json::json!(run_output_tokens));
+                                        obj.insert("run_duration_ms".to_string(), serde_json::json!(run_duration_ms));
+                                    }
+                                }
                             }
                         }
 
@@ -526,7 +536,6 @@ impl ServerSession {
                                     "tokens_in": tokens_in.load(Ordering::Relaxed),
                                     "tokens_out": tokens_out.load(Ordering::Relaxed),
                                 }));
-                                comp_entry.label = "compacted".to_string();
                                 entries.insert(idx + 1, comp_entry);
                                 entries.remove(idx);
                             }

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -402,9 +402,15 @@ impl ServerSession {
                                 new_entry.timestamp = old_entry.timestamp;
                                 // Preserve run stats from old entry's content
                                 if let Some(ref old_content) = old_entry.content {
-                                    if let Some(obj) = new_entry.content.as_mut().and_then(|c| c.as_object_mut()) {
-                                        if let Some(v) = old_content.get("run_tokens") { obj.insert("run_tokens".to_string(), v.clone()); }
-                                        if let Some(v) = old_content.get("run_duration_ms") { obj.insert("run_duration_ms".to_string(), v.clone()); }
+                                    if let Some(obj) =
+                                        new_entry.content.as_mut().and_then(|c| c.as_object_mut())
+                                    {
+                                        if let Some(v) = old_content.get("run_tokens") {
+                                            obj.insert("run_tokens".to_string(), v.clone());
+                                        }
+                                        if let Some(v) = old_content.get("run_duration_ms") {
+                                            obj.insert("run_duration_ms".to_string(), v.clone());
+                                        }
                                     }
                                 }
                             }
@@ -425,8 +431,14 @@ impl ServerSession {
                                 // Store run stats in the last assistant's content JSON
                                 if let Some(ref mut content) = last_assistant.content {
                                     if let Some(obj) = content.as_object_mut() {
-                                        obj.insert("run_tokens".to_string(), serde_json::json!(run_output_tokens));
-                                        obj.insert("run_duration_ms".to_string(), serde_json::json!(run_duration_ms));
+                                        obj.insert(
+                                            "run_tokens".to_string(),
+                                            serde_json::json!(run_output_tokens),
+                                        );
+                                        obj.insert(
+                                            "run_duration_ms".to_string(),
+                                            serde_json::json!(run_duration_ms),
+                                        );
                                     }
                                 }
                             }

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -176,8 +176,8 @@ impl ServerSession {
             on_user_message: Some(user_msg_cb),
         };
 
-        // Set approval/sandbox hooks on the shared Loop config (these are not
-        // callbacks — they're tool-execution hooks on AgentConfig).
+        // Set approval/sandbox hooks on this session's Loop config (these
+        // are not callbacks — they're tool-execution hooks on AgentConfig).
         if let Ok(mut r#loop) = agent_loop.try_write() {
             let approval_gate_hook = approval_gate.clone();
             let approval_broadcaster = broadcaster.clone();
@@ -218,7 +218,7 @@ impl ServerSession {
         // for both initial prompts and follow-up turns.
 
         // Clear any stale interrupt flag left by a previous abort().
-        // Ctrl+C / abort sets interrupt_flag=true on the shared agent_loop.
+        // abort() sets interrupt_flag=true on this session's own agent_loop.
         // Without clearing it, the spawned task's first loop iteration would
         // exit immediately without calling the LLM.
         let shared_interrupt_flag = if let Ok(r#loop) = self.agent_loop.try_read() {

--- a/agent/src/rpc/session_prompt/tests.rs
+++ b/agent/src/rpc/session_prompt/tests.rs
@@ -1,4 +1,4 @@
-use super::*;
+﻿use super::*;
 use std::path::PathBuf;
 
 use crate::{
@@ -197,8 +197,6 @@ fn session_info_content_includes_required_fields() {
     let entry = SessionEntry::session_info(content.clone(), "claude".into(), "high".into());
     assert_eq!(entry.entry_type, "session_info");
     assert_eq!(entry.role, "system");
-    assert_eq!(entry.model, "claude");
-    assert_eq!(entry.thinking_level, "high");
 
     let restored = entry.content.unwrap();
     assert_eq!(

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -479,6 +479,83 @@ impl Manager {
         entries.len() != before
     }
 
+    /// Content prefix of the placeholder tool-result entries written by
+    /// `repair_dangling_tool_calls`. Used to recognise placeholders so a
+    /// later-arriving REAL tool result with the same tool_call_id can
+    /// replace them (see `dedupe_tool_entries`).
+    const TOOL_LOST_PLACEHOLDER_PREFIX: &'static str = "[Tool execution lost —";
+
+    fn entry_text_starts_with(entry: &SessionEntry, prefix: &str) -> bool {
+        match &entry.content {
+            Some(serde_json::Value::String(s)) => s.starts_with(prefix),
+            Some(serde_json::Value::Array(arr)) => arr
+                .first()
+                .and_then(|b| b.get("text"))
+                .and_then(|t| t.as_str())
+                .is_some_and(|s| s.starts_with(prefix)),
+            _ => false,
+        }
+    }
+
+    /// Remove duplicate tool-result entries that share the same tool_call_id.
+    ///
+    /// Duplicates arise when a load-time repair wrote a "tool execution lost"
+    /// placeholder for a dangling tool_call while the original agent process
+    /// was still mid-tool, and the real tool result was appended afterwards.
+    /// Two tool messages with the same tool_call_id make the LLM API reject
+    /// the request with HTTP 400 ("Messages with role 'tool' must be a
+    /// response to a preceding message with 'tool_calls'").
+    ///
+    /// When one of the duplicates is a placeholder and the other is a real
+    /// result, the placeholder is dropped; otherwise the first entry wins.
+    fn dedupe_tool_entries(entries: &mut Vec<SessionEntry>) -> bool {
+        use std::collections::{HashMap, HashSet};
+        // tool_call_id -> index of the entry currently kept for that id
+        let mut kept: HashMap<String, usize> = HashMap::new();
+        let mut drop_idx: Vec<usize> = vec![];
+        for (i, e) in entries.iter().enumerate() {
+            if e.entry_type != ENTRY_TYPE_TOOL || e.tool_call_id.is_empty() {
+                continue;
+            }
+            match kept.get(&e.tool_call_id) {
+                None => {
+                    kept.insert(e.tool_call_id.clone(), i);
+                }
+                Some(&prev) => {
+                    let prev_is_placeholder = Self::entry_text_starts_with(
+                        &entries[prev],
+                        Self::TOOL_LOST_PLACEHOLDER_PREFIX,
+                    );
+                    let cur_is_placeholder =
+                        Self::entry_text_starts_with(e, Self::TOOL_LOST_PLACEHOLDER_PREFIX);
+                    if prev_is_placeholder && !cur_is_placeholder {
+                        // The real result arrived after the placeholder was
+                        // written — drop the placeholder, keep the real one.
+                        drop_idx.push(prev);
+                        kept.insert(e.tool_call_id.clone(), i);
+                    } else {
+                        drop_idx.push(i);
+                    }
+                }
+            }
+        }
+        if drop_idx.is_empty() {
+            return false;
+        }
+        tracing::warn!(
+            "Removing {} duplicate tool-result entries from session (shared tool_call_id)",
+            drop_idx.len()
+        );
+        let drop: HashSet<usize> = drop_idx.into_iter().collect();
+        let mut i = 0;
+        entries.retain(|_| {
+            let keep = !drop.contains(&i);
+            i += 1;
+            keep
+        });
+        true
+    }
+
     /// If the last assistant entry has dangling tool_calls (no matching tool
     /// entries after it), the session was saved mid-turn — typically a crash
     /// between persisting the assistant response and executing its tools.
@@ -503,8 +580,9 @@ impl Manager {
         let now = chrono::Local::now();
         for (tc_id, tc_name) in &tool_calls {
             let placeholder = format!(
-            "[Tool execution lost — {tc_name} was not executed before the session was interrupted]",
-        );
+                "{} {tc_name} was not executed before the session was interrupted]",
+                Self::TOOL_LOST_PLACEHOLDER_PREFIX,
+            );
             entries.push(SessionEntry {
                 id: crate::utils::generate_id(),
                 parent_id: parent_id.clone(),
@@ -569,30 +647,27 @@ impl Manager {
         if entries.is_empty() {
             return Err(anyhow!("session {} has no entries", id));
         }
-        // Heal dangling tool_calls + strip empty assistants: fix up common
-        // session corruptions so the conversation remains API-valid on resume.
-        // Persist immediately so the fix doesn't re-fire on the next load.
+        // Heal common session corruptions IN MEMORY ONLY so the conversation
+        // is API-valid on resume: strip empty assistants, drop duplicate tool
+        // results, and patch dangling tool_calls with placeholders.
+        //
+        // The healed entries are deliberately NOT written back to the file
+        // here.  load_path is called from many read-only paths (session list,
+        // summaries, get_session_entries, fork/clone) that can run while the
+        // owning agent process is still mid-turn.  Persisting a placeholder
+        // for a dangling tool_call at that moment corrupts the file: when the
+        // running tool finishes, its real result is appended with the same
+        // tool_call_id, producing duplicate tool messages that the LLM API
+        // rejects with HTTP 400.  The in-memory heal is idempotent and cheap,
+        // and the owning session's next save() persists the healed state.
         let stripped = Self::strip_empty_assistants(&mut entries);
+        let deduped = Self::dedupe_tool_entries(&mut entries);
         let repaired = Self::repair_dangling_tool_calls(&mut entries);
-        if stripped || repaired {
-            // Save the repaired entries back so the next load is clean.
-            let path_owned = path.to_path_buf();
-            if let Err(e) = (|| -> Result<()> {
-                let file = File::create(&path_owned).context("create session file for repair")?;
-                let mut w = std::io::BufWriter::new(file);
-                for entry in entries.iter() {
-                    let json = serde_json::to_string(entry).context("serialize entry")?;
-                    writeln!(w, "{}", json).context("write entry")?;
-                }
-                w.flush().context("flush")?;
-                w.into_inner()
-                    .map_err(|_| anyhow::anyhow!("flush failed"))?
-                    .sync_all()
-                    .context("fsync")?;
-                Ok(())
-            })() {
-                tracing::warn!("Failed to persist repaired session: {e}");
-            }
+        if stripped || deduped || repaired {
+            tracing::info!(
+                "Healed session {id} in memory (stripped_empty={stripped}, \
+                 deduped_tools={deduped}, repaired_dangling={repaired})"
+            );
         }
         let created_at = entries[0].timestamp;
         let updated_at = entries.last().map(|e| e.timestamp).unwrap_or(created_at);
@@ -1547,6 +1622,179 @@ mod tests {
         assert_eq!(loaded.entries.len(), 2);
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression test for the HTTP 400 "Messages with role 'tool' must be a
+    /// response to a preceding message with 'tool_calls'" failure seen when
+    /// resuming a session: a load-time repair previously PERSISTED a "tool
+    /// execution lost" placeholder while the owning agent was still mid-tool;
+    /// the real tool result was appended afterwards, leaving two tool entries
+    /// with the same tool_call_id.  Load must now heal this in memory (keep
+    /// the real result, drop the placeholder) without touching the file.
+    #[test]
+    fn load_dedupes_tool_results_preferring_real_over_placeholder() {
+        let dir = std::env::temp_dir().join(format!(
+            "future_test_dedupe_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let manager = Manager::new(dir.clone());
+        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        session
+            .entries
+            .push(SessionEntry::new_user("user", serde_json::json!("hello")));
+        session.entries.push(SessionEntry::new_assistant(
+            serde_json::json!("running tool"),
+            vec![crate::types::ToolCall {
+                id: "tc1".to_string(),
+                call_type: "function".to_string(),
+                function: crate::types::ToolCallFn {
+                    name: "shell".to_string(),
+                    arguments: serde_json::json!({"cmd": "ls"}),
+                },
+            }],
+        ));
+        // Placeholder written by a stale repair, then the real result.
+        session.entries.push(SessionEntry::new_tool(
+            "tc1",
+            "[Tool execution lost — shell was not executed before the session was interrupted]",
+        ));
+        session
+            .entries
+            .push(SessionEntry::new_tool("tc1", "real output"));
+        manager.save(&session).unwrap();
+
+        let loaded = manager.load(&session.id).unwrap();
+        let tool_entries: Vec<_> = loaded
+            .entries
+            .iter()
+            .filter(|e| e.entry_type == ENTRY_TYPE_TOOL)
+            .collect();
+        assert_eq!(
+            tool_entries.len(),
+            1,
+            "duplicate tool entries must be deduped"
+        );
+        assert_eq!(
+            tool_entries[0].content.as_ref().unwrap(),
+            &serde_json::json!("real output"),
+            "the real result must win over the placeholder"
+        );
+
+        // The file on disk must NOT be rewritten by load: read-only callers
+        // (session list, get_session_entries) can run while the owning agent
+        // is mid-turn, and persisting repairs is what created the duplicates.
+        let on_disk = std::fs::read_to_string(manager.session_path(&session.id)).unwrap();
+        assert_eq!(
+            on_disk.lines().count(),
+            4,
+            "load must not persist healed entries back to the session file"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Two REAL tool results with the same tool_call_id: keep the first.
+    #[test]
+    fn load_dedupes_tool_results_keeping_first_real() {
+        let dir = std::env::temp_dir().join(format!(
+            "future_test_dedupe2_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let manager = Manager::new(dir.clone());
+        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        session
+            .entries
+            .push(SessionEntry::new_user("user", serde_json::json!("hello")));
+        session.entries.push(SessionEntry::new_assistant(
+            serde_json::json!("running tool"),
+            vec![crate::types::ToolCall {
+                id: "tc1".to_string(),
+                call_type: "function".to_string(),
+                function: crate::types::ToolCallFn {
+                    name: "shell".to_string(),
+                    arguments: serde_json::json!({"cmd": "ls"}),
+                },
+            }],
+        ));
+        session
+            .entries
+            .push(SessionEntry::new_tool("tc1", "first result"));
+        session
+            .entries
+            .push(SessionEntry::new_tool("tc1", "second result"));
+        manager.save(&session).unwrap();
+
+        let loaded = manager.load(&session.id).unwrap();
+        let tool_entries: Vec<_> = loaded
+            .entries
+            .iter()
+            .filter(|e| e.entry_type == ENTRY_TYPE_TOOL)
+            .collect();
+        assert_eq!(tool_entries.len(), 1);
+        assert_eq!(
+            tool_entries[0].content.as_ref().unwrap(),
+            &serde_json::json!("first result")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A dangling tool_call (assistant saved, tool never executed) is still
+    /// patched with a placeholder in memory — but the file stays untouched.
+    #[test]
+    fn load_repairs_dangling_tool_calls_in_memory_only() {
+        let dir = std::env::temp_dir().join(format!(
+            "future_test_dangling_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let manager = Manager::new(dir.clone());
+        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        session
+            .entries
+            .push(SessionEntry::new_user("user", serde_json::json!("hello")));
+        session.entries.push(SessionEntry::new_assistant(
+            serde_json::json!("running tool"),
+            vec![crate::types::ToolCall {
+                id: "tc1".to_string(),
+                call_type: "function".to_string(),
+                function: crate::types::ToolCallFn {
+                    name: "shell".to_string(),
+                    arguments: serde_json::json!({"cmd": "ls"}),
+                },
+            }],
+        ));
+        manager.save(&session).unwrap();
+
+        let loaded = manager.load(&session.id).unwrap();
+        let tool_entries: Vec<_> = loaded
+            .entries
+            .iter()
+            .filter(|e| e.entry_type == ENTRY_TYPE_TOOL)
+            .collect();
+        assert_eq!(
+            tool_entries.len(),
+            1,
+            "dangling tool_call must get a placeholder"
+        );
+        assert_eq!(tool_entries[0].tool_call_id, "tc1");
+
+        let on_disk = std::fs::read_to_string(manager.session_path(&session.id)).unwrap();
+        assert_eq!(
+            on_disk.lines().count(),
+            2,
+            "dangling repair must not be persisted to the session file"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -954,17 +954,62 @@ impl Manager {
         Ok(summaries)
     }
 
-    /// List all sessions in the flat sessions directory
+    /// List all sessions in the flat sessions directory.
+    ///
+    /// Files are scanned in parallel (each JSONL is an independent cheap
+    /// line-scan via `read_summary`); with thousands of sessions on disk a
+    /// sequential scan is the dominant startup cost for the GUI/TUI list.
     pub fn list_all(&self) -> Result<Vec<SessionSummary>> {
         if !self.dir.exists() {
             return Ok(vec![]);
         }
-        let mut summaries = vec![];
+        let mut paths = vec![];
         for entry in fs::read_dir(&self.dir)? {
             let entry = entry?;
             let path = entry.path();
-            self.try_push_summary(&path, &mut summaries);
+            if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
+                paths.push(path);
+            }
         }
+        let mut summaries = if paths.len() <= 8 {
+            // Few files: thread-spawn overhead outweighs the scan time.
+            let mut summaries = vec![];
+            for path in &paths {
+                self.try_push_summary(path, &mut summaries);
+            }
+            summaries
+        } else {
+            // Work-stealing over a shared index; capped worker count to
+            // avoid I/O thrash on spinning disks.
+            let workers = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4)
+                .min(8)
+                .min(paths.len());
+            let next = std::sync::atomic::AtomicUsize::new(0);
+            let per_worker: Vec<Vec<SessionSummary>> = std::thread::scope(|s| {
+                let handles: Vec<_> = (0..workers)
+                    .map(|_| {
+                        s.spawn(|| {
+                            let mut local = vec![];
+                            loop {
+                                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if i >= paths.len() {
+                                    break;
+                                }
+                                self.try_push_summary(&paths[i], &mut local);
+                            }
+                            local
+                        })
+                    })
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|h| h.join().unwrap_or_default())
+                    .collect()
+            });
+            per_worker.into_iter().flatten().collect()
+        };
         summaries.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         Ok(summaries)
     }

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -1,4 +1,4 @@
-﻿//! Session management — 1:1 compatible with Go internal/session/
+//! Session management — 1:1 compatible with Go internal/session/
 
 use crate::types::{Message, ToolCall};
 use crate::utils::{default_session_dir, generate_entry_id, generate_id};
@@ -155,7 +155,11 @@ impl SessionEntry {
     /// Build the `session_info` metadata entry prepended to every saved session.
     /// `content` holds the token/cost/name JSON snapshot; `model`/`thinking_level`
     /// pin the session's active settings. All other fields take entry defaults.
-    pub fn session_info(content: serde_json::Value, _model: String, _thinking_level: String) -> Self {
+    pub fn session_info(
+        content: serde_json::Value,
+        _model: String,
+        _thinking_level: String,
+    ) -> Self {
         Self {
             id: generate_entry_id(),
             entry_type: ENTRY_TYPE_SESSION_INFO.to_string(),
@@ -568,7 +572,8 @@ impl Manager {
             .rev()
             .find_map(|e| {
                 if e.entry_type == ENTRY_TYPE_MODEL_CHANGE {
-                    e.content.as_ref()
+                    e.content
+                        .as_ref()
                         .and_then(|c| c.get("model"))
                         .and_then(|v| v.as_str())
                         .filter(|s| !s.is_empty())
@@ -764,7 +769,11 @@ impl Manager {
                     }
                     if model.is_empty() {
                         if let Some(ref content) = e.content {
-                            if let Some(m) = content.get("model").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
+                            if let Some(m) = content
+                                .get("model")
+                                .and_then(|v| v.as_str())
+                                .filter(|s| !s.is_empty())
+                            {
                                 model = m.to_string();
                             }
                         }

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -1,4 +1,4 @@
-//! Session management — 1:1 compatible with Go internal/session/
+﻿//! Session management — 1:1 compatible with Go internal/session/
 
 use crate::types::{Message, ToolCall};
 use crate::utils::{default_session_dir, generate_entry_id, generate_id};
@@ -21,27 +21,12 @@ pub const ENTRY_TYPE_MODEL_CHANGE: &str = "model_change";
 pub const ENTRY_TYPE_LABEL: &str = "label";
 pub const ENTRY_TYPE_SESSION_INFO: &str = "session_info";
 pub const ENTRY_TYPE_THINKING_LEVEL_CHANGE: &str = "thinking_level_change";
-pub const ENTRY_TYPE_BRANCH_SUMMARY: &str = "branch_summary";
 pub const ENTRY_TYPE_CUSTOM: &str = "custom";
 pub const ENTRY_TYPE_CUSTOM_MESSAGE: &str = "custom_message";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BranchSummaryMeta {
-    #[serde(rename = "from_id", skip_serializing_if = "Option::is_none")]
-    pub from_id: Option<String>,
-    #[serde(rename = "from_hook", skip_serializing_if = "Option::is_none")]
-    pub from_hook: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionEntry {
     pub id: String,
-    #[serde(
-        rename = "parent_id",
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
-    pub parent_id: String,
     #[serde(rename = "type")]
     pub entry_type: String,
     #[serde(rename = "role", default, skip_serializing_if = "String::is_empty")]
@@ -55,40 +40,6 @@ pub struct SessionEntry {
         default = "default_timestamp"
     )]
     pub timestamp: DateTime<Local>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub summary: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub model: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub label: String,
-    #[serde(
-        rename = "thinking_level",
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
-    pub thinking_level: String,
-    #[serde(
-        rename = "branch_summary",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub branch_summary: Option<BranchSummaryMeta>,
-    #[serde(
-        rename = "custom_type",
-        default,
-        skip_serializing_if = "String::is_empty"
-    )]
-    pub custom_type: String,
-    #[serde(
-        rename = "custom_data",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub custom_data: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub display: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub provider: String,
     #[serde(
         rename = "tool_call_id",
         default,
@@ -101,15 +52,6 @@ pub struct SessionEntry {
     pub tool_args: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub thinking: String,
-    /// Output (completion) tokens for the reply this entry belongs to. Only the
-    /// final assistant entry of a run carries a non-zero value; used by the GUI
-    /// to show per-reply token counts when reloading history from JSONL.
-    #[serde(rename = "output_tokens", default, skip_serializing_if = "is_zero_i64")]
-    pub output_tokens: i64,
-    /// Wall-clock duration of the run this entry belongs to, in milliseconds.
-    /// Set alongside `output_tokens` on the final assistant entry of a run.
-    #[serde(rename = "duration_ms", default, skip_serializing_if = "is_zero_i64")]
-    pub duration_ms: i64,
     /// Structured per-entry metadata (not model-visible). For user entries this
     /// carries `{ "attachments": [{ path, kind, name }] }` — the files the user
     /// attached, referenced by original absolute path (never copied). Populated
@@ -161,35 +103,19 @@ fn default_timestamp() -> DateTime<Local> {
     chrono::Local::now()
 }
 
-fn is_zero_i64(v: &i64) -> bool {
-    *v == 0
-}
-
 impl SessionEntry {
     pub fn new_user(role: &str, content: serde_json::Value) -> Self {
         Self {
             id: generate_entry_id(),
-            parent_id: String::new(),
             entry_type: ENTRY_TYPE_USER.to_string(),
             role: role.to_string(),
             content: Some(content),
             tool_calls: vec![],
             timestamp: Local::now(),
-            summary: String::new(),
-            model: String::new(),
-            label: String::new(),
-            thinking_level: String::new(),
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: String::new(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         }
     }
@@ -197,27 +123,15 @@ impl SessionEntry {
     pub fn new_assistant(content: serde_json::Value, tool_calls: Vec<ToolCall>) -> Self {
         Self {
             id: generate_entry_id(),
-            parent_id: String::new(),
             entry_type: ENTRY_TYPE_ASSISTANT.to_string(),
             role: "assistant".to_string(),
             content: Some(content),
             tool_calls,
             timestamp: Local::now(),
-            summary: String::new(),
-            model: String::new(),
-            label: String::new(),
-            thinking_level: String::new(),
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: String::new(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         }
     }
@@ -225,27 +139,15 @@ impl SessionEntry {
     pub fn new_tool(call_id: &str, content: &str) -> Self {
         Self {
             id: generate_entry_id(),
-            parent_id: String::new(),
             entry_type: ENTRY_TYPE_TOOL.to_string(),
             role: "tool".to_string(),
             content: Some(serde_json::json!(content)),
             tool_calls: vec![],
             timestamp: Local::now(),
-            summary: String::new(),
-            model: String::new(),
-            label: String::new(),
-            thinking_level: String::new(),
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: call_id.to_string(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         }
     }
@@ -253,30 +155,18 @@ impl SessionEntry {
     /// Build the `session_info` metadata entry prepended to every saved session.
     /// `content` holds the token/cost/name JSON snapshot; `model`/`thinking_level`
     /// pin the session's active settings. All other fields take entry defaults.
-    pub fn session_info(content: serde_json::Value, model: String, thinking_level: String) -> Self {
+    pub fn session_info(content: serde_json::Value, _model: String, _thinking_level: String) -> Self {
         Self {
             id: generate_entry_id(),
-            parent_id: String::new(),
             entry_type: ENTRY_TYPE_SESSION_INFO.to_string(),
             role: ENTRY_TYPE_SYSTEM.to_string(),
             content: Some(content),
             tool_calls: vec![],
             timestamp: Local::now(),
-            summary: String::new(),
-            model,
-            label: String::new(),
-            thinking_level,
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: String::new(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         }
     }
@@ -576,7 +466,7 @@ impl Manager {
             .iter()
             .map(|tc| (tc.id.clone(), tc.function.name.clone()))
             .collect();
-        let parent_id = entries[last_idx].id.clone();
+        let _parent_id = entries[last_idx].id.clone();
         let now = chrono::Local::now();
         for (tc_id, tc_name) in &tool_calls {
             let placeholder = format!(
@@ -585,27 +475,15 @@ impl Manager {
             );
             entries.push(SessionEntry {
                 id: crate::utils::generate_id(),
-                parent_id: parent_id.clone(),
                 entry_type: ENTRY_TYPE_TOOL.to_string(),
                 role: "tool".to_string(),
                 content: Some(serde_json::Value::String(placeholder)),
                 tool_calls: vec![],
                 timestamp: now,
-                summary: String::new(),
-                model: String::new(),
-                label: String::new(),
-                thinking_level: String::new(),
-                branch_summary: None,
-                custom_type: String::new(),
-                custom_data: None,
-                display: String::new(),
-                provider: String::new(),
                 tool_call_id: tc_id.clone(),
                 name: tc_name.clone(),
                 tool_args: String::new(),
                 thinking: String::new(),
-                output_tokens: 0,
-                duration_ms: 0,
                 meta: None,
             });
         }
@@ -689,8 +567,12 @@ impl Manager {
             .iter()
             .rev()
             .find_map(|e| {
-                if e.entry_type == ENTRY_TYPE_MODEL_CHANGE && !e.model.is_empty() {
-                    Some(e.model.clone())
+                if e.entry_type == ENTRY_TYPE_MODEL_CHANGE {
+                    e.content.as_ref()
+                        .and_then(|c| c.get("model"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
                 } else {
                     None
                 }
@@ -701,33 +583,21 @@ impl Manager {
                 entries
                     .iter()
                     .find(|e| e.entry_type == ENTRY_TYPE_SESSION_INFO)
-                    .and_then(|e| {
-                        if !e.model.is_empty() {
-                            Some(e.model.clone())
-                        } else {
-                            None
-                        }
-                    })
-            })
-            .unwrap_or_default();
-        let name = entries
-            .iter()
-            .rev()
-            .find(|e| e.entry_type == ENTRY_TYPE_LABEL && !e.label.is_empty())
-            .map(|e| e.label.clone())
-            .or_else(|| {
-                // Fall back to session_info.session_name when no LABEL entry
-                // exists (e.g. sessions that were auto-named but never
-                // explicitly renamed).
-                entries
-                    .iter()
-                    .find(|e| e.entry_type == ENTRY_TYPE_SESSION_INFO)
                     .and_then(|e| e.content.as_ref())
-                    .and_then(|c| c.get("session_name"))
+                    .and_then(|c| c.get("model"))
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string())
             })
+            .unwrap_or_default();
+        let name = entries
+            .iter()
+            .find(|e| e.entry_type == ENTRY_TYPE_SESSION_INFO)
+            .and_then(|e| e.content.as_ref())
+            .and_then(|c| c.get("session_name"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
             .unwrap_or_default();
         let parent_session_id = entries
             .iter()
@@ -892,20 +762,20 @@ impl Manager {
                             parent_session_id = p.to_string();
                         }
                     }
-                    if model.is_empty() && !e.model.is_empty() {
-                        model = e.model.clone();
+                    if model.is_empty() {
+                        if let Some(ref content) = e.content {
+                            if let Some(m) = content.get("model").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
+                                model = m.to_string();
+                            }
+                        }
                     }
                 }
                 Some(ENTRY_TYPE_MODEL_CHANGE) => {
                     let e: SessionEntry = serde_json::from_str(&last_line).ok()?;
-                    if !e.model.is_empty() {
-                        model = e.model.clone(); // last one wins
-                    }
-                }
-                Some(ENTRY_TYPE_LABEL) => {
-                    let e: SessionEntry = serde_json::from_str(&last_line).ok()?;
-                    if !e.label.is_empty() {
-                        name = e.label.clone(); // last one wins
+                    if let Some(ref content) = e.content {
+                        if let Some(m) = content.get("model").and_then(|v| v.as_str()) {
+                            model = m.to_string(); // last one wins
+                        }
                     }
                 }
                 Some(ENTRY_TYPE_USER) => {
@@ -1062,9 +932,6 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
     let mut entries: Vec<SessionEntry> = chain.into_iter().cloned().collect();
     for e in &mut entries {
         e.id = generate_entry_id();
-        // Reset parent_id too — the old references point into the
-        // parent session and are meaningless (orphaned) in the fork.
-        e.parent_id.clear();
     }
     // Read parent metadata from the session_info entry.  The values live on
     // the SessionEntry struct fields (model, thinking_level) and also inside
@@ -1079,25 +946,17 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
     // when neither is set, so a `low`/`medium` parent doesn't silently fork to
     // `high`.
     let parent_thinking_level = parent_info
-        .map(|e| e.thinking_level.as_str())
+        .and_then(|e| e.content.as_ref())
+        .and_then(|c| c.get("thinking_level"))
+        .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-        .or_else(|| {
-            parent_info
-                .and_then(|e| e.content.as_ref())
-                .and_then(|c| c.get("thinking_level"))
-                .and_then(|v| v.as_str())
-                .filter(|s| !s.is_empty())
-        })
         .unwrap_or("high");
 
     let parent_model = parent_info
-        .and_then(|e| {
-            if !e.model.is_empty() {
-                Some(e.model.as_str())
-            } else {
-                None
-            }
-        })
+        .and_then(|e| e.content.as_ref())
+        .and_then(|c| c.get("model"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
         .unwrap_or(&parent.model)
         .to_string();
 
@@ -1107,7 +966,7 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
         .and_then(|v| v.as_str())
         .unwrap_or("tui");
 
-    // Derive fork name: read from session_info content first, then LABEL.
+    // Derive fork name: read from session_info content.
     let parent_name = parent_info
         .and_then(|e| e.content.as_ref())
         .and_then(|c| c.get("session_name"))
@@ -1134,27 +993,15 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
         0,
         SessionEntry {
             id: generate_entry_id(),
-            parent_id: String::new(),
             entry_type: ENTRY_TYPE_SESSION_INFO.to_string(),
             role: "system".to_string(),
             content: Some(info),
             tool_calls: vec![],
             timestamp: Local::now(),
-            summary: String::new(),
-            model: parent_model.clone(),
-            label: String::new(),
-            thinking_level: parent_thinking_level.to_string(),
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: String::new(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         },
     );
@@ -1364,21 +1211,11 @@ pub fn agent_message_to_entry(msg: &crate::types::AgentMessage) -> SessionEntry 
 
     SessionEntry {
         id: generate_entry_id(),
-        parent_id: String::new(),
         entry_type: entry_type.to_string(),
         role: msg.role.clone(),
         content,
         tool_calls,
         timestamp: Local::now(),
-        summary: String::new(),
-        model: String::new(),
-        label: String::new(),
-        thinking_level: String::new(),
-        branch_summary: None,
-        custom_type: String::new(),
-        custom_data: None,
-        display: String::new(),
-        provider: String::new(),
         tool_call_id: msg.tool_call_id.clone(),
         name: msg.name.clone(),
         tool_args: msg.tool_args.clone(),
@@ -1386,8 +1223,6 @@ pub fn agent_message_to_entry(msg: &crate::types::AgentMessage) -> SessionEntry 
         // Populated at the save site (session_prompt.rs): only the final
         // assistant entry of a run gets a non-zero value, and prior entries'
         // values are preserved from the previously-saved session.
-        output_tokens: 0,
-        duration_ms: 0,
         // Carry structured metadata (e.g. user attachments) into the JSONL so it
         // survives reload; the reverse mapping restores it in
         // entries_to_agent_messages.
@@ -1481,10 +1316,7 @@ mod tests {
         let e = SessionEntry::new_user("user", serde_json::json!("hello"));
         assert_eq!(e.entry_type, ENTRY_TYPE_USER);
         assert_eq!(e.role, "user");
-        assert!(e.parent_id.is_empty());
         assert!(!e.id.is_empty());
-        assert_eq!(e.output_tokens, 0);
-        assert_eq!(e.duration_ms, 0);
     }
 
     #[test]
@@ -1514,12 +1346,13 @@ mod tests {
 
     #[test]
     fn session_info_entry() {
-        let content = serde_json::json!({"session_name": "test", "model": "gpt-4o"});
+        let content = serde_json::json!({"session_name": "test", "model": "gpt-4o", "thinking_level": "high"});
         let e = SessionEntry::session_info(content, "gpt-4o".to_string(), "high".to_string());
         assert_eq!(e.entry_type, ENTRY_TYPE_SESSION_INFO);
         assert_eq!(e.role, ENTRY_TYPE_SYSTEM);
-        assert_eq!(e.model, "gpt-4o");
-        assert_eq!(e.thinking_level, "high");
+        let c = e.content.as_ref().unwrap();
+        assert_eq!(c["model"], "gpt-4o");
+        assert_eq!(c["thinking_level"], "high");
     }
 
     #[test]
@@ -1774,7 +1607,7 @@ mod tests {
         let manager = Manager::new(dir.clone());
         let mut session = Session::new("/tmp/test", "gpt-4o", "");
         session.entries.push(SessionEntry::session_info(
-            serde_json::json!({"session_name": "named-session", "cwd": "/tmp/test"}),
+            serde_json::json!({"session_name": "named-session", "cwd": "/tmp/test", "model": "gpt-4o", "thinking_level": "high"}),
             "gpt-4o".to_string(),
             "high".to_string(),
         ));
@@ -1865,9 +1698,9 @@ mod tests {
         ));
         let manager = Manager::new(dir.clone());
         let mut session = Session::new("/tmp/test", "gpt-4o", "");
-        // Add session_info entry (model is persisted here, not at session level)
+        // Add session_info entry (model/thinking_level are in content JSON)
         session.entries.push(SessionEntry::session_info(
-            serde_json::json!({"session_name": "test", "cwd": "/tmp/test"}),
+            serde_json::json!({"session_name": "test", "cwd": "/tmp/test", "model": "gpt-4o", "thinking_level": "high"}),
             "gpt-4o".to_string(),
             "high".to_string(),
         ));
@@ -2251,27 +2084,15 @@ mod fork_tests {
     fn make_entry(id: &str, entry_type: &str, role: &str, content: &str) -> SessionEntry {
         SessionEntry {
             id: id.to_string(),
-            parent_id: String::new(),
             entry_type: entry_type.to_string(),
             role: role.to_string(),
             content: Some(serde_json::json!(content)),
             tool_calls: vec![],
             timestamp: chrono::Local::now(),
-            summary: String::new(),
-            model: String::new(),
-            label: String::new(),
-            thinking_level: String::new(),
-            branch_summary: None,
-            custom_type: String::new(),
-            custom_data: None,
-            display: String::new(),
-            provider: String::new(),
             tool_call_id: String::new(),
             name: String::new(),
             tool_args: String::new(),
             thinking: String::new(),
-            output_tokens: 0,
-            duration_ms: 0,
             meta: None,
         }
     }

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -759,26 +759,199 @@ impl Manager {
         Ok(session)
     }
 
-    pub fn list(&self, cwd: &str) -> Result<Vec<Session>> {
-        fs::create_dir_all(&self.dir).ok();
-        let mut sessions = vec![];
-        if self.dir.exists() {
-            for entry in fs::read_dir(&self.dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-                    continue;
+    /// Extract the `"type":"..."` value from a serialized entry line without
+    /// parsing the whole JSON.  `SessionEntry` serializes `id` first and
+    /// `type` second (struct field order is deterministic), so the marker
+    /// always appears within the first ~80 bytes regardless of how large the
+    /// `content` payload is.
+    fn cheap_entry_type(line: &str) -> Option<&str> {
+        // Boundary-safe head slice: a multi-byte char may straddle byte 96.
+        let head = line.get(..96).unwrap_or(line);
+        let start = head.find("\"type\":\"")? + 8;
+        let end = head[start..].find('"')? + start;
+        Some(&head[start..end])
+    }
+
+    /// Extract the last `"timestamp":"..."` occurrence from a line without
+    /// parsing the whole JSON.  Used for `updated_at` from the final entry,
+    /// which may itself be a huge tool-result line.
+    fn cheap_timestamp(line: &str) -> Option<DateTime<Local>> {
+        let start = line.rfind("\"timestamp\":\"")? + 13;
+        let end = line[start..].find('"')? + start;
+        let ts = chrono::DateTime::parse_from_rfc3339(&line[start..end]).ok()?;
+        Some(ts.with_timezone(&Local))
+    }
+
+    /// Extract the display text of a user entry's content (first text block),
+    /// trimmed and truncated to ~40 visible columns for the session list.
+    fn summary_first_message(entry: &SessionEntry) -> Option<String> {
+        let content_val = entry.content.as_ref()?;
+        let text: String = if let Some(arr) = content_val.as_array() {
+            // First text block only — a later one is the agent-injected
+            // attachment-path list, not the user's message.
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .next()
+                .unwrap_or("")
+                .to_string()
+        } else if let Some(s) = content_val.as_str() {
+            s.to_string()
+        } else {
+            String::new()
+        };
+        let truncated: String = truncate_visible(text.trim(), 40);
+        if truncated.is_empty() {
+            None
+        } else {
+            Some(truncated)
+        }
+    }
+
+    /// Build a summary from a fully-loaded session (fallback path for files
+    /// whose structure the cheap scanner doesn't recognise).
+    fn summary_from_session(sess: &Session) -> SessionSummary {
+        let mut first_message: Option<String> = None;
+        let mut query_count: usize = 0;
+        let mut session_info_name: Option<String> = None;
+        for entry in &sess.entries {
+            if entry.role == "user" {
+                query_count += 1;
+                if first_message.is_none() {
+                    first_message = Self::summary_first_message(entry);
                 }
-                let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                if let Ok(sess) = self.load_path(&path, id) {
-                    if sess.cwd == cwd || cwd.is_empty() {
-                        sessions.push(sess);
+            } else if entry.entry_type == ENTRY_TYPE_SESSION_INFO && session_info_name.is_none() {
+                if let Some(ref content_val) = entry.content {
+                    if let Some(n) = content_val.get("session_name").and_then(|v| v.as_str()) {
+                        let trimmed = n.trim();
+                        if !trimmed.is_empty() {
+                            session_info_name = Some(trimmed.to_string());
+                        }
                     }
                 }
             }
         }
-        sessions.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
-        Ok(sessions)
+        SessionSummary {
+            id: sess.id.clone(),
+            cwd: sess.cwd.clone(),
+            updated_at: sess.updated_at,
+            model: sess.model.clone(),
+            name: if !sess.name.is_empty() {
+                Some(sess.name.clone())
+            } else {
+                session_info_name
+            },
+            parent_session_id: sess.parent_session_id.clone(),
+            first_message,
+            query_count,
+        }
+    }
+
+    /// Build a SessionSummary by scanning the JSONL cheaply: fully parse only
+    /// the small metadata lines (session_info / model_change / label) and the
+    /// first user entry; every other line is inspected via a `"type"` prefix
+    /// scan, so multi-hundred-KB tool/assistant lines are never deserialized.
+    /// Returns None when the file has no usable session_info or a metadata
+    /// line fails to parse — callers should fall back to a full `load_path`.
+    fn read_summary(&self, path: &Path, id: &str) -> Option<SessionSummary> {
+        let file = File::open(path).ok()?;
+        let reader = BufReader::new(file);
+        let mut cwd = String::new();
+        let mut model = String::new();
+        let mut name = String::new();
+        let mut parent_session_id = String::new();
+        let mut first_message: Option<String> = None;
+        let mut query_count: usize = 0;
+        let mut saw_session_info = false;
+        let mut last_line = String::new();
+
+        for line in reader.lines() {
+            let line = line.ok()?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            last_line = line;
+            match Self::cheap_entry_type(&last_line) {
+                Some(ENTRY_TYPE_SESSION_INFO) => {
+                    let e: SessionEntry = serde_json::from_str(&last_line).ok()?;
+                    saw_session_info = true;
+                    if let Some(ref content) = e.content {
+                        if let Some(c) = content.get("cwd").and_then(|v| v.as_str()) {
+                            cwd = c.to_string();
+                        }
+                        if name.is_empty() {
+                            if let Some(n) = content
+                                .get("session_name")
+                                .and_then(|v| v.as_str())
+                                .map(str::trim)
+                                .filter(|s| !s.is_empty())
+                            {
+                                name = n.to_string();
+                            }
+                        }
+                        if let Some(p) = content.get("parent_session_id").and_then(|v| v.as_str()) {
+                            parent_session_id = p.to_string();
+                        }
+                    }
+                    if model.is_empty() && !e.model.is_empty() {
+                        model = e.model.clone();
+                    }
+                }
+                Some(ENTRY_TYPE_MODEL_CHANGE) => {
+                    let e: SessionEntry = serde_json::from_str(&last_line).ok()?;
+                    if !e.model.is_empty() {
+                        model = e.model.clone(); // last one wins
+                    }
+                }
+                Some(ENTRY_TYPE_LABEL) => {
+                    let e: SessionEntry = serde_json::from_str(&last_line).ok()?;
+                    if !e.label.is_empty() {
+                        name = e.label.clone(); // last one wins
+                    }
+                }
+                Some(ENTRY_TYPE_USER) => {
+                    query_count += 1;
+                    if first_message.is_none() {
+                        if let Ok(e) = serde_json::from_str::<SessionEntry>(&last_line) {
+                            first_message = Self::summary_first_message(&e);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !saw_session_info || last_line.is_empty() {
+            return None;
+        }
+        // updated_at: timestamp of the final entry (cheap extraction — the
+        // last line may be a huge tool result), falling back to file mtime.
+        let updated_at = Self::cheap_timestamp(&last_line).or_else(|| {
+            std::fs::metadata(path)
+                .and_then(|m| m.modified())
+                .ok()
+                .map(DateTime::<Local>::from)
+        })?;
+
+        Some(SessionSummary {
+            id: id.to_string(),
+            cwd,
+            updated_at,
+            model,
+            name: if name.is_empty() { None } else { Some(name) },
+            parent_session_id,
+            first_message,
+            query_count,
+        })
+    }
+
+    /// List sessions for a cwd as lightweight summaries (no full JSONL
+    /// parse per file — see `read_summary`).
+    pub fn list_summaries(&self, cwd: &str) -> Result<Vec<SessionSummary>> {
+        let mut summaries = self.list_all()?;
+        if !cwd.is_empty() {
+            summaries.retain(|s| s.cwd == cwd);
+        }
+        Ok(summaries)
     }
 
     /// List all sessions in the flat sessions directory
@@ -801,66 +974,13 @@ impl Manager {
             return;
         }
         let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-        if let Ok(sess) = self.load_path(path, id) {
-            // Scan entries for user messages: first user message and total count.
-            // Also read session_name from the session_info entry as a fallback
-            // for the name when the Session-level name field is empty (older
-            // sessions saved before the name was plumbed through).
-            let mut first_message: Option<String> = None;
-            let mut query_count: usize = 0;
-            let mut session_info_name: Option<String> = None;
-            for entry in &sess.entries {
-                if entry.role == "user" {
-                    query_count += 1;
-                    if first_message.is_none() {
-                        if let Some(ref content_val) = entry.content {
-                            let text: String = if let Some(arr) = content_val.as_array() {
-                                // First text block only — a later one is the agent-
-                                // injected attachment-path list, not the user's message.
-                                arr.iter()
-                                    .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
-                                    .next()
-                                    .unwrap_or("")
-                                    .to_string()
-                            } else if let Some(s) = content_val.as_str() {
-                                s.to_string()
-                            } else {
-                                String::new()
-                            };
-                            // Trim, then truncate to ~40 visible-width (≈20 CJK chars)
-                            let trimmed = text.trim();
-                            let truncated: String = truncate_visible(trimmed, 40);
-                            if !truncated.is_empty() {
-                                first_message = Some(truncated);
-                            }
-                        }
-                    }
-                } else if entry.entry_type == ENTRY_TYPE_SESSION_INFO && session_info_name.is_none()
-                {
-                    if let Some(ref content_val) = entry.content {
-                        if let Some(n) = content_val.get("session_name").and_then(|v| v.as_str()) {
-                            let trimmed = n.trim();
-                            if !trimmed.is_empty() {
-                                session_info_name = Some(trimmed.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-            summaries.push(SessionSummary {
-                id: sess.id,
-                cwd: sess.cwd,
-                updated_at: sess.updated_at,
-                model: sess.model,
-                name: if !sess.name.is_empty() {
-                    Some(sess.name)
-                } else {
-                    session_info_name.clone()
-                },
-                parent_session_id: sess.parent_session_id.clone(),
-                first_message,
-                query_count,
-            });
+        // Fast path: cheap line scan that never deserializes large
+        // tool/assistant payloads.  Falls back to a full load for files the
+        // scanner can't handle (legacy layouts, missing session_info).
+        if let Some(summary) = self.read_summary(path, id) {
+            summaries.push(summary);
+        } else if let Ok(sess) = self.load_path(path, id) {
+            summaries.push(Self::summary_from_session(&sess));
         }
     }
 
@@ -1593,6 +1713,101 @@ mod tests {
     }
 
     // ─── Manager save/load/delete ───────────────────────────────────────────
+
+    /// The lightweight summary scanner must produce the same SessionSummary
+    /// as the full load_path-based fallback — including on files with huge
+    /// tool payloads, model changes and labels.
+    #[test]
+    fn list_summaries_matches_full_load() {
+        let dir = std::env::temp_dir().join(format!(
+            "future_test_summary_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let manager = Manager::new(dir.clone());
+        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        session.entries.push(SessionEntry::session_info(
+            serde_json::json!({"session_name": "named-session", "cwd": "/tmp/test"}),
+            "gpt-4o".to_string(),
+            "high".to_string(),
+        ));
+        session.entries.push(SessionEntry::new_user(
+            "user",
+            serde_json::json!("first question"),
+        ));
+        // A huge tool payload — the cheap scanner must skip it.
+        session.entries.push(SessionEntry::new_assistant(
+            serde_json::json!("calling tool"),
+            vec![crate::types::ToolCall {
+                id: "tc1".to_string(),
+                call_type: "function".to_string(),
+                function: crate::types::ToolCallFn {
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"path": "/big"}),
+                },
+            }],
+        ));
+        session
+            .entries
+            .push(SessionEntry::new_tool("tc1", &"x".repeat(500_000)));
+        session.entries.push(SessionEntry::new_user(
+            "user",
+            serde_json::json!("second question"),
+        ));
+        manager.save(&session).unwrap();
+
+        let summaries = manager.list_all().unwrap();
+        assert_eq!(summaries.len(), 1);
+        let fast = &summaries[0];
+
+        let full = Manager::summary_from_session(&manager.load(&session.id).unwrap());
+        assert_eq!(fast.id, full.id);
+        assert_eq!(fast.cwd, full.cwd);
+        assert_eq!(fast.model, full.model);
+        assert_eq!(fast.name, full.name);
+        assert_eq!(fast.first_message, full.first_message);
+        assert_eq!(fast.query_count, full.query_count);
+        assert_eq!(fast.updated_at, full.updated_at);
+        // Sanity: the expected values themselves.
+        assert_eq!(fast.query_count, 2);
+        assert_eq!(fast.first_message.as_deref(), Some("first question"));
+        assert_eq!(fast.name.as_deref(), Some("named-session"));
+        assert_eq!(fast.model, "gpt-4o");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A file without session_info falls back to the full-load summary path
+    /// instead of being dropped from the list.
+    #[test]
+    fn list_summaries_falls_back_without_session_info() {
+        let dir = std::env::temp_dir().join(format!(
+            "future_test_summary_fb_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let manager = Manager::new(dir.clone());
+        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        // No session_info entry — legacy/corrupt layout.
+        session
+            .entries
+            .push(SessionEntry::new_user("user", serde_json::json!("hello")));
+        manager.save(&session).unwrap();
+
+        let summaries = manager.list_all().unwrap();
+        assert_eq!(
+            summaries.len(),
+            1,
+            "session must still be listed via fallback"
+        );
+        assert_eq!(summaries[0].first_message.as_deref(), Some("hello"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn manager_save_and_load() {

--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -828,7 +828,7 @@ async fn spawn_shell(
         // signal, or it would recreate the same hang.
         drop(stderr_task);
 
-        return match result {
+        match result {
             Ok(Ok(())) => {
                 let combined = String::from_utf8_lossy(&output_buf);
                 Ok(format_shell_output(&combined, combined.len(), 0))
@@ -847,7 +847,7 @@ async fn spawn_shell(
                     Ok(format_shell_output(&combined, total, 0))
                 }
             }
-        };
+        }
     }
 
     #[cfg(not(windows))]

--- a/cli/src/rpc/grpc-client.ts
+++ b/cli/src/rpc/grpc-client.ts
@@ -428,8 +428,8 @@ export class RunClient {
     return this.executeCommand("get_state", {}, sessionId, 5) as Promise<RpcSessionState>;
   }
 
-  async fork(entryId: string): Promise<{ cancelled: boolean; sessionId?: string }> {
-    return this.executeCommand("fork", { entryId }, undefined, 5) as Promise<{
+  async fork(entryId: string, sessionId?: string): Promise<{ cancelled: boolean; sessionId?: string }> {
+    return this.executeCommand("fork", { entryId }, sessionId, 5) as Promise<{
       cancelled: boolean;
       sessionId?: string;
     }>;
@@ -563,12 +563,27 @@ export class RunClient {
     // other config changes are isolated to this run and never pollute the
     // default session.
     if (config.fork) {
-      const state = await this.getState();
-      sessionId = state.sessionId;
+      // Fork needs an explicit parent session — the agent no longer has a
+      // default session to fall back to.  Without --session, fork from the
+      // most recently updated session.
+      let parentId = config.session;
+      if (!parentId) {
+        const { sessions } = await this.listSessions();
+        if (sessions.length === 0) {
+          throw new Error("No previous session to fork from.");
+        }
+        sessions.sort(
+          (a, b) =>
+            new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        );
+        parentId = sessions[0].id;
+      }
+      await this.switchSession(parentId);
+      sessionId = parentId;
       if (verbose) {
         process.stderr.write(`Forking from entry ${config.fork}...\n`);
       }
-      const result = await this.fork(config.fork);
+      const result = await this.fork(config.fork, sessionId);
       if (result.cancelled) {
         throw new Error("Fork was cancelled");
       }

--- a/gui/src-tauri/src/agent_bridge/client.rs
+++ b/gui/src-tauri/src/agent_bridge/client.rs
@@ -102,6 +102,13 @@ pub fn list_sessions_command() -> RpcCommand {
     base_command("list_sessions", String::new())
 }
 
+/// Bulk "who is streaming" query: one RPC returns every streaming session
+/// id, so the thread list doesn't fan out one get_state per thread (which
+/// also hydrated each polled session on the agent).
+pub fn list_streaming_sessions_command() -> RpcCommand {
+    base_command("list_streaming_sessions", String::new())
+}
+
 pub fn get_session_entries_command(session_id: String) -> RpcCommand {
     base_command("get_session_entries", session_id)
 }

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -14,8 +14,8 @@ pub use self::approval::{decide_approval, inject_session_rule};
 pub(crate) use self::client::raw_agent_addr;
 pub use self::client::{
     connect_agent, delete_session_command, get_session_entries_command, get_state_command,
-    set_cwd_command, set_model_command, set_session_name_command, set_thinking_level_command,
-    RpcResponseExt,
+    list_streaming_sessions_command, set_cwd_command, set_model_command,
+    set_session_name_command, set_thinking_level_command, RpcResponseExt,
 };
 pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, PreparedPrompt};
 pub(crate) use self::import::import_missing_sessions;

--- a/gui/src-tauri/src/commands/threads.rs
+++ b/gui/src-tauri/src/commands/threads.rs
@@ -143,6 +143,54 @@ pub async fn delete_thread(thread_id: String) -> Result<store::ThreadRecord, cra
     Ok(thread)
 }
 
+/// Bulk streaming-status query: ONE agent RPC (`list_streaming_sessions`,
+/// which only scans the agent's in-memory session map — no hydration, no
+/// disk I/O) mapped back to GUI thread ids via the stored agent_session_id.
+/// Replaces the old per-thread get_state fan-out, which hydrated every
+/// polled session on the agent at startup.
+///
+/// Agent unreachable → empty list (nothing shows as streaming); callers
+/// self-heal on the next poll tick.
+#[tauri::command]
+pub async fn list_streaming_thread_ids() -> Result<Vec<String>, crate::AppError> {
+    let mut client = match crate::agent_bridge::connect_agent().await {
+        Ok(client) => client,
+        Err(_) => return Ok(vec![]),
+    };
+    let resp = client
+        .execute_command(crate::agent_bridge::list_streaming_sessions_command())
+        .await;
+    let streaming_session_ids: std::collections::HashSet<String> = match resp {
+        Ok(resp) => {
+            let inner = resp.into_inner();
+            if !inner.success {
+                return Ok(vec![]);
+            }
+            serde_json::from_str::<serde_json::Value>(&inner.data)
+                .ok()
+                .and_then(|v| v.get("sessionIds")?.as_array().cloned())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        }
+        Err(_) => return Ok(vec![]),
+    };
+    if streaming_session_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let threads = store::list_threads()?;
+    Ok(threads
+        .into_iter()
+        .filter(|t| {
+            t.agent_session_id
+                .as_deref()
+                .is_some_and(|sid| streaming_session_ids.contains(sid))
+        })
+        .map(|t| t.id)
+        .collect())
+}
+
 /// Fetch a thread's session state from the agent (model, thinking, name, cwd).
 /// Falls back to the stored DB values when the agent is unreachable.
 ///

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -259,6 +259,7 @@ pub fn run() {
             fork_thread,
             get_session_entries,
             get_thread_agent_state,
+            list_streaming_thread_ids,
             get_thread_cleanup_summary,
             attach_remote_stream,
             observe_session,

--- a/gui/src/components/layout/hooks/useThreadStore.ts
+++ b/gui/src/components/layout/hooks/useThreadStore.ts
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type { StoredRun, StoredThread, StoredWorkspace } from "../../../integrations/storage/threadStore";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import i18n from "../../../i18n";
-import { pollStreamingStatuses, prefetchAgentState } from "../../../integrations/agent/agentStateCache";
+import { pollStreamingThreadIds, prefetchAgentState } from "../../../integrations/agent/agentStateCache";
 import {
   getRecentOrCreateDefaultThread,
   initializeAppStore,
@@ -191,12 +191,17 @@ export function useThreadStore(): ThreadStore {
   });
   // Poll agent streaming status so threads that are being prompted by other
   // clients (TUI, CLI) show a running indicator without waiting for a local
-  // StoredRun entry.
+  // StoredRun entry. ONE bulk call for all threads — the agent only scans
+  // its in-memory map, so this never hydrates sessions at startup.
   usePolling(async () => {
     if (activeThreads.length === 0)
       return;
-    const streaming = await pollStreamingStatuses(activeThreads.map(t => t.id));
-    setThreadStreamingStatuses(streaming);
+    const streamingIds = new Set(await pollStreamingThreadIds());
+    const next: ThreadStreamingStatuses = {};
+    for (const thread of activeThreads) {
+      next[thread.id] = streamingIds.has(thread.id);
+    }
+    setThreadStreamingStatuses(next);
   }, 1000, {
     enabled: activeThreads.length > 0,
     deps: [activeThreads],

--- a/gui/src/features/agent/useThreadMessages.ts
+++ b/gui/src/features/agent/useThreadMessages.ts
@@ -2,7 +2,6 @@ import type { StoredRun } from "../../integrations/storage/threadStore";
 import type { AgentMessage } from "./agentThreadTypes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import i18n from "../../i18n";
-import { fetchSessionStreaming } from "../../integrations/agent/agentStateCache";
 import { getSessionEntries, listRuns } from "../../integrations/storage/threadStore";
 import { invokeCommand } from "../../integrations/tauri/invoke";
 import { errorMessage } from "../../lib/errors";
@@ -273,7 +272,17 @@ export function useThreadMessages({ threadId, workspaceId, agentSessionId }: Use
     async () => {
       if (!threadId || isRunActive)
         return;
-      const streaming = await fetchSessionStreaming(threadId);
+      // Per-thread streaming check for the OPEN thread only (reattach).
+      // Deliberately uncached: attach decisions need fresh truth, unlike
+      // the thread-list indicator which uses the bulk poll.
+      let streaming = false;
+      try {
+        const raw = await invokeCommand<Record<string, unknown>>("get_thread_agent_state", { threadId });
+        streaming = raw.isStreaming === true;
+      }
+      catch {
+        // Agent unreachable — treat as not streaming; retry next tick.
+      }
       if (streaming && !attachedRef.current) {
         try {
           const result = await invokeCommand<{ runId?: string }>("attach_remote_stream", { threadId });

--- a/gui/src/integrations/agent/agentStateCache.ts
+++ b/gui/src/integrations/agent/agentStateCache.ts
@@ -281,68 +281,22 @@ function applySettingsEvent(
   notify();
 }
 
-// ── Streaming-status cache (short TTL, separate from full agent state) ────
-
-const STREAMING_TTL_MS = 1_000;
-const streamingCache = new Map<string, { streaming: boolean; fetchedAt: number }>();
+// ── Bulk streaming-status poll (no per-thread get_state fan-out) ────────
 
 /**
- * Lightweight check: is this session currently streaming?
- * Uses a short-lived cache (1s) so the thread list picks up TUI-initiated
- * streaming quickly without hammering the agent with get_state RPCs.
+ * Bulk streaming-status poll: ONE Tauri command returns every streaming
+ * thread id. The agent only scans its in-memory session map (no hydration,
+ * no disk I/O), so polling never creates agent sessions/loops for threads
+ * the user hasn't opened — unlike the old per-thread get_state fan-out,
+ * which hydrated every polled session at startup.
  */
-export async function fetchSessionStreaming(threadId: string): Promise<boolean> {
-  const cached = streamingCache.get(threadId);
-  if (cached && Date.now() - cached.fetchedAt < STREAMING_TTL_MS) {
-    return cached.streaming;
-  }
+export async function pollStreamingThreadIds(): Promise<string[]> {
   try {
-    const raw = await invokeCommand<Record<string, unknown>>("get_thread_agent_state", { threadId });
-    const streaming = raw.isStreaming === true;
-    streamingCache.set(threadId, { streaming, fetchedAt: Date.now() });
-    // Always update the full agent-state cache so settings changes
-    // (model, thinking, name, cwd) are reflected in near real-time,
-    // not just when streaming starts.
-    const state: AgentSessionState = {
-      model: typeof raw.model === "string" ? raw.model : null,
-      thinkingLevel: typeof raw.thinkingLevel === "string" ? raw.thinkingLevel : null,
-      sessionName: typeof raw.session_name === "string" ? raw.session_name : null,
-      sessionId: typeof raw.sessionId === "string" ? raw.sessionId : null,
-      cwd: typeof raw.cwd === "string" ? raw.cwd : null,
-      parentSessionId: typeof raw.parentSessionId === "string" ? raw.parentSessionId : null,
-      isStreaming: streaming,
-    };
-    cache.set(threadId, { state, fetchedAt: Date.now() });
-    pruneCache();
-    notify();
-    return streaming;
+    const raw = await invokeCommand<string[]>("list_streaming_thread_ids");
+    return Array.isArray(raw) ? raw : [];
   }
   catch {
-    return cached?.streaming ?? false;
+    // Agent unreachable: report "nothing streaming" — the next tick retries.
+    return [];
   }
-}
-
-/**
- * Poll streaming status for a batch of threads and return a map of
- * threadId → isStreaming. Fires all requests in parallel.
- */
-export async function pollStreamingStatuses(
-  threadIds: string[],
-): Promise<Record<string, boolean>> {
-  const entries = await Promise.all(
-    threadIds.map(async (id) => {
-      try {
-        const streaming = await fetchSessionStreaming(id);
-        return { id, streaming };
-      }
-      catch {
-        return { id, streaming: false };
-      }
-    }),
-  );
-  const result: Record<string, boolean> = {};
-  for (const entry of entries) {
-    result[entry.id] = entry.streaming;
-  }
-  return result;
 }

--- a/gui/src/integrations/agent/agentStateCache.ts
+++ b/gui/src/integrations/agent/agentStateCache.ts
@@ -228,6 +228,19 @@ function applySettingsEvent(
   eventType: string,
   p: Record<string, unknown>,
 ) {
+  // cwd_changed must reconcile workspace even when the session isn't yet
+  // in the agent-state cache (e.g. TUI /cwd on a just-imported session
+  // whose state hasn't been fetched). Fire it unconditionally — once per
+  // event, regardless of how many cached threads share the session.
+  if (eventType === "cwd_changed" && typeof p.cwd === "string") {
+    invokeCommand("reconcile_thread_workspace", {
+      sessionId,
+      cwd: p.cwd,
+    }).then(() => {
+      window.dispatchEvent(new CustomEvent("future:cwd-changed"));
+    }).catch(() => {});
+  }
+
   for (const [threadId, entry] of cache) {
     if (entry.state.sessionId !== sessionId)
       continue;
@@ -258,12 +271,7 @@ function applySettingsEvent(
         if (typeof p.cwd === "string") {
           next.cwd = p.cwd;
           changed = true;
-          invokeCommand("reconcile_thread_workspace", {
-            sessionId,
-            cwd: p.cwd,
-          }).then(() => {
-            window.dispatchEvent(new CustomEvent("future:cwd-changed"));
-          }).catch(() => {});
+          // reconcile_thread_workspace already called above
         }
         break;
       case "config_reloaded":

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -5,7 +5,7 @@
 
 import { GrpcClient } from "./rpc/index.js";
 import { VERSION } from "./version.generated.js";
-import type { SessionSummary } from "./rpc/types.js";
+import type { SessionSummary, ThinkingLevel } from "./rpc/types.js";
 import { ChatArea, type ChatMessage } from "./components/chat-area.js";
 import { Footer, type FooterData } from "./components/footer.js";
 import { SelectList, type SelectItem } from "./components/select-list.js";
@@ -1152,7 +1152,13 @@ export class App extends Container {
 
       if (cmd === "new") {
         try {
-          const result = await this.client.newSession();
+          // Inherit cwd, model, and thinking level from the current session
+          // so /new feels like a clean continuation instead of a reset.
+          const result = await this.client.newSession({
+            cwd: this.state.cwd || undefined,
+            modelId: this.state.model || undefined,
+            level: (this.state.thinking || undefined) as ThinkingLevel | undefined,
+          });
           if (result.sessionId) {
             await this.refresh();
             this.chat.addMessage({

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -451,6 +451,10 @@ export class App extends Container {
         this.chat.finishTool(e.tool_id ?? "", e.text);
         this.state.activeToolCount = Math.max(0, this.state.activeToolCount - 1);
         if (this.state.activeToolCount === 0) this.state.toolStartTime = 0;
+        // Each LLM turn may have its own cost (which was finalised before
+        // tools executed).  Pull the latest cumulative cost/token totals so
+        // the footer updates after every tool call, not just at agent_end.
+        this.refresh().then(() => this.requestRender());
         break;
       }
 

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -837,7 +837,7 @@ export class App extends Container {
 
   private handleInterrupt(): void {
     if (this.state.streaming) {
-      this.client.abort();
+      this.client.abort().catch(() => { /* connection may close before abort completes */ });
       this.state.streaming = false;
       // Mark the in-progress assistant message as stopped so the partial
       // content (thinking, text, tool calls) is preserved and visible —

--- a/tui/src/rpc/grpc-client.ts
+++ b/tui/src/rpc/grpc-client.ts
@@ -19,6 +19,7 @@ import type {
   RpcSessionState,
   SessionSummary,
   AgentEvent,
+  ThinkingLevel,
 } from "./types.js";
 
 export type EventListener = (event: AgentEvent) => void;
@@ -645,9 +646,14 @@ export class GrpcClient {
 
   // ─── Session Management RPC Methods ──────────────────────────────────
 
-  async newSession(): Promise<{ sessionId?: string; cancelled: boolean }> {
+  async newSession(opts?: { cwd?: string; modelId?: string; level?: ThinkingLevel }): Promise<{ sessionId?: string; cancelled: boolean }> {
     const result = await this.call("new_session", {
-      cwd: process.cwd(),
+      // Clear sessionId so the agent generates a fresh ID instead of
+      // reusing the current session's ID (which would load old entries).
+      sessionId: undefined as any,
+      cwd: opts?.cwd || process.cwd(),
+      modelId: opts?.modelId,
+      level: opts?.level,
       customInstructions: JSON.stringify({ createdBy: "tui" }),
     }) as any;
     if (result?.sessionId) {


### PR DESCRIPTION
### 1. 会话架构重构（4 commits）
- feat: per-session agent loops + lightweight session summaries
- perf: share one cached model registry across sessions
- refactor: remove privileged default session, all sessions are equal peers
- fix: rebuild provider via set_model on hydration fallback and new_session

### 2. 会话持久化修复（2 commits）
- fix: prevent load_path from polluting session files with duplicate tool entries
- feat: parallel session summaries + bulk streaming-status poll

### 3. 修复 & UI（4 commits）
- fix: cumulative cost double-counting and delayed TUI footer update
- fix: gRPC stream lag tolerance and GUI cwd reconciliation
- fix(tui): catch unhandled rejection on fire-and-forget abort
- feat(tui): /new inherits current session cwd, model, and thinking level

### 4. SessionEntry 精简（1 commit）
- refactor: slim SessionEntry from 23 to 11 fields（删除 12 个死/冗余字段，net -270 行）