### PR TITLE
tui: startup retry + runtime disconnect handling for agent connection

### DIFF
--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -55,6 +55,7 @@ export class App extends Container {
   private acManager = new AutocompleteManager();
   private keybindings = new KeybindingManager();
   private enabledModelIds: string[] | null = null;  // client-side scoped models
+  private connectionLost = false;  // true when agent RPC stream is down
 
   // ── TUI-local settings (persisted to disk, not on agent) ──────────────
   private tuiSettings: { defaultModel?: string; defaultThinkingLevel?: string; defaultPermissionLevel?: string; enabledModelIds?: string[] } = {};
@@ -228,6 +229,38 @@ export class App extends Container {
 
   // ─── Lifecycle ────────────────────────────────────────────────────────────
 
+  /// Poll the agent every 1 s until it responds (or the TUI is stopped).
+  /// Shows a single "Connecting…" message on first failure; clears it on success.
+  private async waitForAgent(): Promise<void> {
+    let firstAttempt = true;
+    while (this.running) {
+      if (await this.client.tryConnect()) {
+        if (!firstAttempt) {
+          // Remove the "Connecting..." placeholder if we added one earlier
+          this.chat.addMessage({
+            id: crypto.randomUUID(),
+            role: "system",
+            content: "✅  Connected to agent",
+          });
+          this.requestRender();
+        }
+        return;
+      }
+      if (firstAttempt) {
+        this.chat.addMessage({
+          id: crypto.randomUUID(),
+          role: "system",
+          content: "Connecting to agent… (retrying every 1s)",
+        });
+        this.requestRender();
+        // Yield to the event loop so the "Connecting…" message renders
+        await new Promise((r) => setTimeout(r, 50));
+        firstAttempt = false;
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+
   async start(): Promise<void> {
     this.loadTuiSettings();
     this.terminal.hideCursor();
@@ -239,6 +272,10 @@ export class App extends Container {
       (data: string) => this.handleInput(data),
       () => this.requestResizeRender(),
     );
+
+    // Wait for agent to be reachable (retries every 1 s).
+    await this.waitForAgent();
+    if (!this.running) return;
 
     // Handle CLI session options
     if (this.cliOptions.session) {
@@ -316,6 +353,11 @@ export class App extends Container {
         this.client.prompt(this.cliOptions.initialPrompt!);
       }, 100);
     }
+
+    // Listen for connection state changes (runtime disconnects / reconnects).
+    this.client.onConnectionChange((connected) => {
+      this.setConnectionLost(!connected);
+    });
 
     // Subscribe to events only after session is established — prevents
     // cross-session event leakage (e.g. GUI streaming bleeding into TUI).
@@ -1545,6 +1587,27 @@ export class App extends Container {
     } catch { /* ok if agent doesn't support a command yet */ }
   }
 
+  private setConnectionLost(lost: boolean): void {
+    if (this.connectionLost === lost) return;
+    this.connectionLost = lost;
+    if (lost) {
+      this.chat.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: "⚠️  Connection to agent lost — retrying every 1s...",
+      });
+    } else {
+      this.chat.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: "✅  Reconnected to agent",
+      });
+      // Refresh state after reconnect so footer shows correct model/tokens
+      this.refresh().catch(() => {});
+    }
+    this.requestRender();
+  }
+
   private async refresh(): Promise<void> {
     try {
       const s = await this.client.getState();
@@ -1574,6 +1637,17 @@ export class App extends Container {
       if (s.sessionId && s.sessionId !== this.client.getCurrentSessionId()) {
         this.client.setCurrentSessionId(s.sessionId);
         this.client.connectEvents();
+      }
+
+      // Clear connection-lost flag if we successfully reached the agent.
+      if (this.connectionLost) {
+        this.connectionLost = false;
+        this.chat.addMessage({
+          id: crypto.randomUUID(),
+          role: "system",
+          content: "✅  Reconnected to agent",
+        });
+        this.requestRender();
       }
     } catch {
       // Keep last known model; footer briefly showing "(not connected)" is

--- a/tui/src/components/chat-area.ts
+++ b/tui/src/components/chat-area.ts
@@ -147,6 +147,14 @@ export class ChatArea implements Component {
   }
 
   appendToLastMessage(delta: string): void {
+    // When the last message is a tool result from a previous turn,
+    // a new assistant response is starting — push a fresh message.
+    // (startThinking has the same guard; without thinking events we
+    //  would otherwise append across turn boundaries into one block.)
+    const lastMsg = this.messages[this.messages.length - 1];
+    if (lastMsg?.role === "tool") {
+      this.addMessage({ id: this.newId(), role: "assistant", content: "" });
+    }
     const idx = this.findAssistantIndex();
     if (idx >= 0) {
       this.messages[idx].content += delta;

--- a/tui/src/rpc/grpc-client.ts
+++ b/tui/src/rpc/grpc-client.ts
@@ -433,6 +433,8 @@ const proto = protoDescriptor.proto as any;
 
 // ─── RPC Client ─────────────────────────────────────────────────────────
 
+export type ConnectionChangeListener = (connected: boolean) => void;
+
 export class GrpcClient {
   private client: any;
   private eventListeners: EventListener[] = [];
@@ -444,10 +446,26 @@ export class GrpcClient {
   /// this instead of spinning every 100ms.
   private connectPromise: Promise<boolean> | null = null;
   private connectResolve: ((value: boolean) => void) | null = null;
+  private connectionChangeListeners: ConnectionChangeListener[] = [];
 
   constructor(address = "localhost:50051") {
     const credentials = grpc.credentials.createInsecure();
     this.client = new proto.FutureAgent(address, credentials);
+  }
+
+  // ─── Connection state callbacks ──────────────────────────────────────
+
+  onConnectionChange(listener: ConnectionChangeListener): () => void {
+    this.connectionChangeListeners.push(listener);
+    return () => {
+      this.connectionChangeListeners = this.connectionChangeListeners.filter((l) => l !== listener);
+    };
+  }
+
+  private notifyConnectionChange(connected: boolean): void {
+    for (const listener of this.connectionChangeListeners) {
+      try { listener(connected); } catch { /* ignore */ }
+    }
   }
 
   // ─── Session Management ───────────────────────────────────────────────
@@ -461,6 +479,26 @@ export class GrpcClient {
   }
 
   // ─── Event Streaming ─────────────────────────────────────────────────
+
+  /// Lightweight connectivity check — sends a simple RPC (list_models) without
+  /// requiring a session or event-stream handshake.  Returns true if the agent
+  /// is reachable, false otherwise.  Times out after 3 s.
+  async tryConnect(): Promise<boolean> {
+    try {
+      const request = { id: String(Date.now()), type: "list_models" };
+      const deadline = new Date();
+      deadline.setSeconds(deadline.getSeconds() + 3);
+      await new Promise<void>((resolve, reject) => {
+        this.client.ExecuteCommand(request, { deadline }, (err: Error | null, _response: any) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -492,12 +530,16 @@ export class GrpcClient {
 
     const scheduleReconnect = () => {
       if (!this.reconnectTimer) {
+        const wasConnected = this.connected;
         this.connected = false;
         this.connectResolve?.(false); // let call() proceed with timeout
+        if (wasConnected) {
+          this.notifyConnectionChange(false);
+        }
         this.reconnectTimer = setTimeout(() => {
           this.reconnectTimer = null;
           this.connectEvents();
-        }, 2000);
+        }, 1000);
       }
     };
 
@@ -518,6 +560,7 @@ export class GrpcClient {
         this.connected = true;
         this.connectResolve?.(true);
         this.connectResolve = null;
+        this.notifyConnectionChange(true);
       }
       try {
         const rawData = typeof response.data === "string" ? JSON.parse(response.data) : response.data;
@@ -637,8 +680,12 @@ export class GrpcClient {
       const isTransport = msg.includes("transport") || msg.includes("14 UNAVAILABLE")
         || msg.includes("Connect Failed") || msg.includes("ECONNREFUSED");
       if (isTransport) {
+        const wasConnected = this.connected;
         this.connected = false;
         this.connectEvents();
+        if (wasConnected) {
+          this.notifyConnectionChange(false);
+        }
       }
       throw err;
     }


### PR DESCRIPTION
## Summary

- **Startup**: TUI retries agent connection every 1s until reachable (shows Connecting... message)
- **Runtime**: When agent RPC drops, shows connection lost in chat and retries every 1s; shows Reconnected on recovery

### Changes

**grpc-client.ts**
- Add tryConnect() lightweight connectivity check (list_models RPC, 3s timeout)
- Add onConnectionChange() callback for connection state notifications
- Reduce reconnect timer from 2s to 1s
- Notify listeners on connection state transitions

**app.ts**
- Add waitForAgent() startup loop calling tryConnect() every 1s
- Add setConnectionLost() shows system messages on disconnect/reconnect
- Subscribe to onConnectionChange for runtime disconnect detection

**chat-area.ts**
- Fix appendToLastMessage starting a new assistant message when last message is a tool result (cross-turn boundary)