### PR TITLE
fix: TUI agent reconnect + streaming guards

### DIFF
--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -485,12 +485,18 @@ impl ServerSession {
 
     pub fn set_steering_mode(&mut self, mode: &str) {
         self.steering_mode = mode.to_string();
-        self.agent_loop.try_write().unwrap().steering_queue.mode = mode.to_string();
+        if let Ok(mut loop_) = self.agent_loop.try_write() {
+            loop_.steering_queue.mode = mode.to_string();
+        }
+        // If the loop is busy (streaming), the mode takes effect next prompt.
     }
 
     pub fn set_follow_up_mode(&mut self, mode: &str) {
         self.follow_up_mode = mode.to_string();
-        self.agent_loop.try_write().unwrap().follow_up_queue.mode = mode.to_string();
+        if let Ok(mut loop_) = self.agent_loop.try_write() {
+            loop_.follow_up_queue.mode = mode.to_string();
+        }
+        // If the loop is busy (streaming), the mode takes effect next prompt.
     }
 
     pub fn compact(&self, _instructions: &str) -> Result<serde_json::Value> {

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -911,6 +911,15 @@ export class App extends Container {
       const arg = parts.slice(1).join(" ");
 
       if (cmd === "model") {
+        if (this.state.streaming) {
+          this.chat.addMessage({
+            id: crypto.randomUUID(),
+            role: "system",
+            content: "Cannot change model while agent is streaming. Wait for the current run to finish.",
+          });
+          this.requestRender();
+          return;
+        }
         if (arg) {
           // Set model directly — agent resolves and stores provider/id
           try {
@@ -1286,6 +1295,15 @@ export class App extends Container {
       }
 
       if (cmd === "cwd" && arg) {
+        if (this.state.streaming) {
+          this.chat.addMessage({
+            id: crypto.randomUUID(),
+            role: "system",
+            content: "Cannot change working directory while agent is streaming.",
+          });
+          this.requestRender();
+          return;
+        }
         try {
           let resolved = arg;
           if (resolved === "~") {
@@ -1661,6 +1679,15 @@ export class App extends Container {
   }
 
   async showModelSelector(): Promise<void> {
+    if (this.state.streaming) {
+      this.chat.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: "Cannot change model while agent is streaming.",
+      });
+      this.requestRender();
+      return;
+    }
     let models: string[] = [];
     try {
       const allModels = await this.client.listModels();
@@ -1717,6 +1744,15 @@ export class App extends Container {
   }
 
   private async cycleModel(): Promise<void> {
+    if (this.state.streaming) {
+      this.chat.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: "Cannot change model while agent is streaming.",
+      });
+      this.requestRender();
+      return;
+    }
     try {
       // If scoped models are set, cycle within them locally.
       if (this.enabledModelIds && this.enabledModelIds.length > 0) {
@@ -1737,6 +1773,15 @@ export class App extends Container {
   }
 
   private async cycleThinking(): Promise<void> {
+    if (this.state.streaming) {
+      this.chat.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: "Cannot change thinking level while agent is streaming.",
+      });
+      this.requestRender();
+      return;
+    }
     try {
       const r = await this.client.cycleThinkingLevel();
       if (r) {

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -1602,8 +1602,10 @@ export class App extends Container {
         role: "system",
         content: "✅  Reconnected to agent",
       });
-      // Refresh state after reconnect so footer shows correct model/tokens
-      this.refresh().catch(() => {});
+      // Delay refresh — after stream reconnect the gRPC channel may need
+      // a moment to become ready for unary RPCs (the stream delivers data
+      // before the channel finishes its HTTP/2 handshake).
+      setTimeout(() => this.refresh().catch(() => {}), 500);
     }
     this.requestRender();
   }

--- a/tui/src/rpc/grpc-client.ts
+++ b/tui/src/rpc/grpc-client.ts
@@ -437,6 +437,7 @@ export type ConnectionChangeListener = (connected: boolean) => void;
 
 export class GrpcClient {
   private client: any;
+  private readonly address: string;
   private eventListeners: EventListener[] = [];
   private streamCall: any = null;
   private connected = false;
@@ -448,9 +449,25 @@ export class GrpcClient {
   private connectResolve: ((value: boolean) => void) | null = null;
   private connectionChangeListeners: ConnectionChangeListener[] = [];
 
+  // ─── Reconnect bookkeeping ───────────────────────────────────────────
+
+  /// Counts consecutive tryConnect() failures during reconnect polling.
+  /// After 3 failures the gRPC channel is likely stuck in TRANSIENT_FAILURE
+  /// and we recreate the client to force a fresh channel.
+  private reconnectFailures = 0;
+  /// Periodic health-check that calls tryConnect() to detect silent
+  /// disconnections (agent process killed without the stream emitting
+  /// an error/end event).
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
   constructor(address = "localhost:50051") {
+    this.address = address;
+    this.client = this.createClient();
+  }
+
+  private createClient(): any {
     const credentials = grpc.credentials.createInsecure();
-    this.client = new proto.FutureAgent(address, credentials);
+    return new proto.FutureAgent(this.address, credentials);
   }
 
   // ─── Connection state callbacks ──────────────────────────────────────
@@ -532,13 +549,32 @@ export class GrpcClient {
       if (!this.reconnectTimer) {
         const wasConnected = this.connected;
         this.connected = false;
+        this.stopHeartbeat(); // stop health-checks while disconnected
         this.connectResolve?.(false); // let call() proceed with timeout
         if (wasConnected) {
           this.notifyConnectionChange(false);
         }
-        this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = setTimeout(async () => {
           this.reconnectTimer = null;
-          this.connectEvents();
+          // Poll via unary RPC (3 s deadline) instead of blindly calling
+          // StreamEvents.  When the agent is down the gRPC channel may
+          // return a stream object that never emits data/error/end — the
+          // reconnect loop would stall forever.  tryConnect() fails fast
+          // when the server is unreachable, so we only attempt the
+          // streaming handshake when the agent is confirmed alive.
+          if (await this.tryConnect()) {
+            this.reconnectFailures = 0;
+            this.connectEvents();
+          } else {
+            this.reconnectFailures++;
+            // After 3 consecutive failures the gRPC channel is likely stuck
+            // in TRANSIENT_FAILURE — recreate the client for a fresh channel.
+            if (this.reconnectFailures >= 3) {
+              this.reconnectFailures = 0;
+              this.client = this.createClient();
+            }
+            scheduleReconnect();
+          }
         }, 1000);
       }
     };
@@ -555,12 +591,26 @@ export class GrpcClient {
     }
     this.streamCall = call;
 
+    // Watchdog: if StreamEvents created a stream but no data arrives
+    // within 5 s the underlying channel is likely stuck.  Cancel the
+    // stream so the reconnect loop can try again from scratch.
+    let connectWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      connectWatchdog = null;
+      if (this.streamCall === call) {
+        this.streamCall = null;
+        call.cancel();
+        scheduleReconnect();
+      }
+    }, 5000);
+
     call.on("data", (response: any) => {
+      if (connectWatchdog) { clearTimeout(connectWatchdog); connectWatchdog = null; }
       if (!this.connected) {
         this.connected = true;
         this.connectResolve?.(true);
         this.connectResolve = null;
         this.notifyConnectionChange(true);
+        this.startHeartbeat();
       }
       try {
         const rawData = typeof response.data === "string" ? JSON.parse(response.data) : response.data;
@@ -583,6 +633,7 @@ export class GrpcClient {
     });
 
     call.on("end", () => {
+      if (connectWatchdog) { clearTimeout(connectWatchdog); connectWatchdog = null; }
       if (this.streamCall === call) {
         this.streamCall = null;
         scheduleReconnect();
@@ -590,6 +641,7 @@ export class GrpcClient {
     });
 
     call.on("error", (_err: Error) => {
+      if (connectWatchdog) { clearTimeout(connectWatchdog); connectWatchdog = null; }
       if (this.streamCall === call) {
         this.streamCall = null;
         scheduleReconnect();
@@ -614,6 +666,7 @@ export class GrpcClient {
   }
 
   disconnect(): void {
+    this.stopHeartbeat();
     this.streamCall?.cancel();
     this.streamCall = null;
     if (this.reconnectTimer) {
@@ -621,6 +674,43 @@ export class GrpcClient {
       this.reconnectTimer = null;
     }
     this.connected = false;
+  }
+
+  // ─── Heartbeat ──────────────────────────────────────────────────────
+
+  /// Start a periodic health-check that calls tryConnect() every 10 s.
+  /// If the agent is unreachable but the stream didn't emit error/end
+  /// (e.g. the process was SIGKILL'd), the heartbeat detects the silent
+  /// disconnection and triggers the reconnect loop.
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(async () => {
+      if (!this.connected) return;
+      try {
+        const alive = await this.tryConnect();
+        if (!alive && this.connected) {
+          // Agent is down — cancel the stale stream and kick off reconnect.
+          this.streamCall?.cancel();
+          this.streamCall = null;
+          const wasConnected = this.connected;
+          this.connected = false;
+          this.connectResolve?.(false);
+          if (wasConnected) {
+            this.notifyConnectionChange(false);
+          }
+          this.connectEvents();
+        }
+      } catch {
+        // tryConnect threw — treat as unreachable.
+      }
+    }, 10_000);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
   }
 
   // ─── RPC Call Helper ─────────────────────────────────────────────────
@@ -676,16 +766,22 @@ export class GrpcClient {
       // Don't retry the call itself — for non-idempotent commands like
       // 'prompt', the request may have already reached the agent and
       // we'd create a duplicate. The stream will deliver events either way.
+      //
+      // IMPORTANT: when the stream already reports we're connected (data
+      // arrived via StreamEvents), a transient unary RPC failure must NOT
+      // override `connected` and tear down the working stream.  The stream
+      // may be alive while the unary channel is still warming up after a
+      // reconnect.  Let the heartbeat or stream error/end handlers detect
+      // a real disconnection instead.
       const msg = err?.message || String(err);
       const isTransport = msg.includes("transport") || msg.includes("14 UNAVAILABLE")
         || msg.includes("Connect Failed") || msg.includes("ECONNREFUSED");
       if (isTransport) {
-        const wasConnected = this.connected;
-        this.connected = false;
-        this.connectEvents();
-        if (wasConnected) {
-          this.notifyConnectionChange(false);
+        if (!this.connected) {
+          // Stream also reports disconnected — full reconnect needed.
+          this.connectEvents();
         }
+        // else: stream is alive, transient unary failure — don't tear it down.
       }
       throw err;
     }


### PR DESCRIPTION
## Changes

### fix(tui): reliable agent reconnect with proper UI feedback
- 修复 TUI 在 agent 重启后无法自动重连的问题
- 根因：stream 重连成功后 `refresh()` 调 unary RPC 时 channel 还没 warm up，`call()` 的 transport error 又把正常工作的 stream cancel 了
- 修复：`call()` 中当 stream 已报活时不覆盖 `connected`；`setConnectionLost` 中延迟 500ms 刷状态；加心跳检测和 channel 重建

### tui: reject model/thinking/cwd changes while agent is streaming
- streaming 期间禁止修改模型、思考等级、工作目录
- 覆盖入口：/model、/cwd、ctrl+p、ctrl+t、model selector overlay

### fix(agent): remove unwrap() panics in set_steering_mode / set_follow_up_mode
- `try_write().unwrap()` 在 streaming 中会 panic，改为 `if let Ok`