### PR TITLE
fix(gui): stop duplicate assistant output when switching to a streaming thread

### DIFF
--- a/gui/src/features/agent/threadRunProjection.test.ts
+++ b/gui/src/features/agent/threadRunProjection.test.ts
@@ -188,6 +188,43 @@ describe("applyRunMetadata", () => {
     expect(applyRunMetadata(messages, [])).toBe(messages);
   });
 
+  it("leaves the in-flight turn unstamped when its mid-run partial entry is persisted", () => {
+    // The agent's save_callback persists each completed LLM call mid-run, so a
+    // reload during streaming surfaces a partial assistant entry for the
+    // ACTIVE run's turn. Turns then outnumber settled runs — stamping the
+    // newest settled run onto the partial entry misaligns every pairing and
+    // defeats streamingBubbleBase's dedup (the frozen partial renders next to
+    // the growing live bubble).
+    const result = applyRunMetadata([
+      user("u1"),
+      assistant("a1", { content: "first answer" }),
+      user("u2"),
+      assistant("a2-partial", { content: "ABC" }),
+    ], [
+      run("r2", { status: "running", createdAt: 2 }),
+      run("r1", { status: "completed", createdAt: 1, modelId: "m-1" }),
+    ]);
+    // The in-flight turn keeps no runId — the streaming bubble owns it.
+    expect(result[3]?.runId).toBeUndefined();
+    // The settled run pairs with its real owner.
+    expect(result[1]).toMatchObject({ id: "a1", runId: "r1", modelId: "m-1" });
+  });
+
+  it("still stamps the newest turn when the active run has no persisted entry yet", () => {
+    // Turns == settled runs here: the active run's first LLM call hasn't
+    // completed, so its turn has no entry on disk and the newest assistant
+    // turn belongs to the last settled run.
+    const result = applyRunMetadata([
+      user("u1"),
+      assistant("a1", { content: "answer" }),
+      user("u2"),
+    ], [
+      run("r2", { status: "running", createdAt: 2 }),
+      run("r1", { status: "completed", createdAt: 1 }),
+    ]);
+    expect(result[1]).toMatchObject({ id: "a1", runId: "r1" });
+  });
+
   it("keeps an existing agent-recorded durationMs over the run's wall-clock", () => {
     const result = applyRunMetadata(
       [user("u1"), assistant("a1", { durationMs: 1234 })],
@@ -328,5 +365,42 @@ describe("streamingBubbleBase", () => {
     // as events arrive.
     const base = streamingBubbleBase(current, RUN, BUBBLE, "");
     expect(base?.some(m => m.id === "a-partial")).toBe(false);
+  });
+
+  it("drops the same-turn persisted entry even when it carries another run's id", () => {
+    // Defense in depth: a runId that is NOT the active run's (e.g. a stale
+    // misaligned stamp) must not shield the in-flight turn's mid-run snapshot
+    // from the dedup — the bubble replaces it either way.
+    const persisted = assistant("a-partial", { content: "ABC", runId: "r-old-settled" });
+    const current = [user("u1"), assistant("a1", { content: "earlier reply" }), user("u2"), persisted];
+    const base = streamingBubbleBase(current, RUN, BUBBLE, "ABC");
+    expect(base?.some(m => m.id === "a-partial")).toBe(false);
+    expect(base?.some(m => m.id === "a1")).toBe(true);
+  });
+
+  it("drops the same-turn snapshot that has no text yet (thinking/tools-only)", () => {
+    // Mid-run the turn may have produced only thinking + tool calls: the
+    // persisted entry's `content` is empty but its segments still render, so
+    // leaving it in place duplicates the live bubble's thinking/activity.
+    const persisted = assistant("a-partial", {
+      content: "",
+      segments: [
+        { id: "s1", kind: "thinking", text: "Let me think…" },
+        { id: "s2", kind: "activity", item: { id: "t1", kind: "read", status: "completed", target: "/a.ts" } },
+      ],
+    });
+    const current = [user("u1"), assistant("a1", { content: "earlier reply" }), user("u2"), persisted];
+    const base = streamingBubbleBase(current, RUN, BUBBLE, "");
+    expect(base?.some(m => m.id === "a-partial")).toBe(false);
+    expect(base?.some(m => m.id === "a1")).toBe(true);
+  });
+
+  it("keeps a compaction divider sitting at the head of the in-flight turn", () => {
+    // A divider is a marker, not a reply snapshot — the bubble must be
+    // appended AFTER it, never replace it.
+    const divider = assistant("div", { content: "", segments: [{ id: "s", kind: "compaction" }] });
+    const current = [user("u1"), divider];
+    const base = streamingBubbleBase(current, RUN, BUBBLE, "live text");
+    expect(base?.some(m => m.id === "div")).toBe(true);
   });
 });

--- a/gui/src/features/agent/threadRunProjection.ts
+++ b/gui/src/features/agent/threadRunProjection.ts
@@ -46,10 +46,10 @@ async function projectRunForLivePreview(
  *
  * The agent's save_callback persists each completed LLM call mid-run, so a
  * reload during streaming surfaces a persisted assistant entry for THIS
- * in-flight turn (no runId — applyRunMetadata only stamps settled runs). Left
- * in place, it renders alongside the live bubble as a duplicate of the same
- * reply. Detect it — the entry sits after the last user message and its text
- * overlaps the live projection — and drop it, so the turn renders once.
+ * in-flight turn (no runId of its own — applyRunMetadata leaves in-flight
+ * turns unstamped). Left in place, it renders alongside the live bubble as a
+ * duplicate of the same reply. Detect it — the entry sits after the last user
+ * message — and drop it, so the turn renders once.
  */
 export function streamingBubbleBase(
   current: AgentMessage[],
@@ -64,8 +64,13 @@ export function streamingBubbleBase(
 
   const lastAssistantIdx = current.map(message => message.role).lastIndexOf("assistant");
   const lastAssistant = lastAssistantIdx >= 0 ? current[lastAssistantIdx] : undefined;
-  if (lastAssistant && !lastAssistant.runId) {
-    const persisted = lastAssistant.content.trim();
+  // Reaching here, no message carries `runId` (checked above) — so a runId on
+  // the last assistant always belongs to ANOTHER run. If that assistant sits
+  // in the in-flight turn (after the last user message), its stamp can only be
+  // a misaligned leftover (e.g. persisted by an older build) and the entry is
+  // this turn's mid-run snapshot regardless — don't let a stray runId shield
+  // it from the dedup.
+  if (lastAssistant && lastAssistant.runId !== runId) {
     // The mid-run persisted entry belongs to the in-flight turn only when the
     // last user message precedes it; an assistant that appears before the last
     // user is an earlier completed turn.
@@ -73,14 +78,18 @@ export function streamingBubbleBase(
     const sameTurn = lastUserIdx >= 0 && lastUserIdx < lastAssistantIdx;
 
     // A mid-run snapshot for THIS in-flight turn — the streaming bubble is
-    // authoritative, even if no text has landed in the event log yet (the
-    // very first reattach tick may fire before the collector has persisted
-    // the first text chunks). Drop the persisted snapshot so the turn
-    // renders once and keeps updating instead of duplicating.
-    if (sameTurn && persisted) {
+    // authoritative: it re-projects the turn's thinking, tool activity AND
+    // text from the run's event log, so dropping the snapshot loses nothing,
+    // even when the snapshot carries no text yet (thinking/tools-only — its
+    // `content` is empty but its segments render) or when no event has landed
+    // in the log at all (the very first reattach tick may fire before the
+    // collector persists the first chunks). The one thing that is NOT a reply
+    // snapshot is a compaction divider — keep it in place.
+    if (sameTurn && !isCompactionDivider(lastAssistant)) {
       return current.filter(message => message.id !== lastAssistant.id);
     }
 
+    const persisted = lastAssistant.content.trim();
     // Another turn's persisted reply already covers the head of the live
     // text (a settled-run reload raced this poll tick) — keep the persisted
     // message and suppress the bubble.
@@ -285,15 +294,28 @@ export function applyRunMetadata(messages: AgentMessage[], runs: StoredRun[]): A
     .filter(index => index >= 0)
     .reverse();
 
-  // Only assign settled runs to persistent assistant messages.  An active
-  // (still-streaming) run has no assistant entry on disk yet; its live
-  // preview is inserted by upsertStreamingPreview.  Matching an active run
-  // to an old assistant turn (positional misalignment after an abort) would
-  // steal the runId and block the streaming bubble from ever appearing.
+  // Only assign settled runs to persistent assistant messages.  Matching an
+  // active run to an old assistant turn (positional misalignment after an
+  // abort) would steal the runId and block the streaming bubble from ever
+  // appearing.
   const settled = runs.filter(run => matchesSettledRun(run.status));
+
+  // The agent's save_callback persists each completed LLM call MID-RUN, so an
+  // active (still-streaming) run can already have a partial assistant entry on
+  // disk — it projects as the newest turn. When turns outnumber settled runs,
+  // the excess newest turns belong to the in-flight runs: leave them
+  // unstamped. Stamping the newest settled run onto such a turn instead
+  // misaligns every older pairing (the real owner loses its runId/model badge)
+  // and — worse — defeats streamingBubbleBase's duplicate detection, so the
+  // frozen partial renders next to the growing live bubble (the "ABC, ABC →
+  // ABC, ABCDE" duplicate).
+  const inFlight = runs.length - settled.length;
+  const skipNewest = Math.min(Math.max(turnIndices.length - settled.length, 0), inFlight);
+  const assignable = turnIndices.slice(skipNewest);
+
   const patched = [...messages];
-  for (let i = 0; i < turnIndices.length && i < settled.length; i++) {
-    const index = turnIndices[i]!;
+  for (let i = 0; i < assignable.length && i < settled.length; i++) {
+    const index = assignable[i]!;
     const run = settled[i]!;
     const message = patched[index]!;
     // An aborted turn projects with no content and no reply time (the agent


### PR DESCRIPTION
## 问题

流式输出期间切到该会话，同一段 AI 回复显示两遍：前面一段静止的快照（ABC），后面一段不断增长的直播气泡（ABC → ABCDE），其中 A/B/C/D/E 是 thinking、正文、工具调用等 block。

## 根因

agent 的 `save_callback` 在每次 LLM 调用完成后就把 assistant 条目持久化到会话 JSONL，所以流式中途切会话时，重新加载会投影出一条在飞轮次的「快照」消息。重连去重（`streamingBubbleBase`）本应丢掉它，但有两个漏洞：

1. **`applyRunMetadata` 错位盖章**：按「最新对最新」把 settled runs 贴到 assistant 轮次上，假设进行中的 run 在磁盘上还没有 assistant 条目。中途快照打破了这个假设（轮次数 = settled run 数 + 1），于是上一轮的 runId 被错贴到在飞轮次的快照上 —— 去重逻辑要求快照「无 runId」，直接被绕过。
2. **去重只在快照有文本时生效**：只有 thinking/工具调用、还没写出正文的快照 `content` 为空（内容在 segments 里），`persisted` 非空的前置条件把它漏过去了。

## 修复

- `applyRunMetadata`：轮次数多于 settled run 数且存在进行中 run 时，多出来的最新轮次不贴 runId，保持配对不错位。
- `streamingBubbleBase`：同轮次快照（在最后一个 user 消息之后）**无条件丢弃** —— 直播气泡会从运行事件日志完整重放 thinking、工具调用和正文，快照没有任何不可替代的内容；唯一例外是 compaction 分隔条（是标记，不是回复快照），予以保留。快照携带其他 run 的陈旧 runId 也不再能屏蔽去重。

## 测试

新增 5 个回归测试（错位盖章、正常对齐不误伤、陈旧 runId、thinking/tools-only 空文本快照、compaction 分隔条保留）。GUI 全部 20 个测试文件 192 个测试通过，`tsc --noEmit` 与 ESLint 干净。