### PR TITLE
fix(gui): crisp taskbar icon + no flash; build: keep .exe suffix on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,33 +41,33 @@ install-nogui: install-agent install-tui install-cli install-channels install-sk
 
 uninstall:
 ifeq ($(OS),windows)
-	cmd /c del /q "$(PREFIX)\future-agent" 2>NUL
-	cmd /c del /q "$(PREFIX)\future" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-tui" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-gui" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-channel" 2>NUL
+	cmd /c del /q "$(PREFIX)\future-agent$(EXE_SUFFIX)" 2>NUL
+	cmd /c del /q "$(PREFIX)\future$(EXE_SUFFIX)" 2>NUL
+	cmd /c del /q "$(PREFIX)\future-tui$(EXE_SUFFIX)" 2>NUL
+	cmd /c del /q "$(PREFIX)\future-gui$(EXE_SUFFIX)" 2>NUL
+	cmd /c del /q "$(PREFIX)\future-channel$(EXE_SUFFIX)" 2>NUL
 else
-	$(SUDO) rm -f $(PREFIX)/future-agent $(PREFIX)/future $(PREFIX)/future-tui $(PREFIX)/future-gui $(PREFIX)/future-channel
+	$(SUDO) rm -f $(PREFIX)/future-agent$(EXE_SUFFIX) $(PREFIX)/future$(EXE_SUFFIX) $(PREFIX)/future-tui$(EXE_SUFFIX) $(PREFIX)/future-gui$(EXE_SUFFIX) $(PREFIX)/future-channel$(EXE_SUFFIX)
 endif
 	@echo "Removed: future-agent, future, future-tui, future-gui, future-channel"
 
 install-agent: build-agent
 ifeq ($(OS),windows)
-	$(SUDO) $(COPY_CMD) target\release\future-agent$(EXE_SUFFIX) "$(PREFIX)\future-agent"
+	$(SUDO) $(COPY_CMD) target\release\future-agent$(EXE_SUFFIX) "$(PREFIX)\future-agent$(EXE_SUFFIX)"
 else
 	$(SUDO) cp target/release/future-agent "$(PREFIX)/future-agent"
 endif
 
 install-tui: build-tui
 ifeq ($(OS),windows)
-	$(SUDO) $(COPY_CMD) tui\dist\future-tui$(EXE_SUFFIX) "$(PREFIX)\future-tui"
+	$(SUDO) $(COPY_CMD) tui\dist\future-tui$(EXE_SUFFIX) "$(PREFIX)\future-tui$(EXE_SUFFIX)"
 else
 	$(SUDO) cp tui/dist/future-tui "$(PREFIX)/future-tui"
 endif
 
 install-cli: build-cli
 ifeq ($(OS),windows)
-	$(SUDO) $(COPY_CMD) cli\dist\future$(EXE_SUFFIX) "$(PREFIX)\future"
+	$(SUDO) $(COPY_CMD) cli\dist\future$(EXE_SUFFIX) "$(PREFIX)\future$(EXE_SUFFIX)"
 else
 	$(SUDO) cp cli/dist/future "$(PREFIX)/future"
 endif
@@ -85,7 +85,7 @@ endif
 	$(call npm-install-if-needed,gui)
 	cd gui && npx tauri build --no-bundle
 ifeq ($(OS),windows)
-	$(SUDO) $(COPY_CMD) gui\src-tauri\target\release\futureos$(EXE_SUFFIX) "$(PREFIX)\future-gui"
+	$(SUDO) $(COPY_CMD) gui\src-tauri\target\release\futureos$(EXE_SUFFIX) "$(PREFIX)\future-gui$(EXE_SUFFIX)"
 else
 	$(SUDO) cp gui/src-tauri/target/release/futureos "$(PREFIX)/future-gui"
 endif
@@ -302,11 +302,11 @@ ifeq ($(OS),windows)
 	@if exist gui\node_modules rmdir /s /q gui\node_modules
 	@if exist gui\src-tauri\target rmdir /s /q gui\src-tauri\target
 	@if exist gui\src-tauri\binaries rmdir /s /q gui\src-tauri\binaries
-	@if exist "$(PREFIX)\future-agent" del /q "$(PREFIX)\future-agent"
-	@if exist "$(PREFIX)\future" del /q "$(PREFIX)\future"
-	@if exist "$(PREFIX)\future-tui" del /q "$(PREFIX)\future-tui"
-	@if exist "$(PREFIX)\future-gui" del /q "$(PREFIX)\future-gui"
-	@if exist "$(PREFIX)\future-channel" del /q "$(PREFIX)\future-channel"
+	@if exist "$(PREFIX)\future-agent$(EXE_SUFFIX)" del /q "$(PREFIX)\future-agent$(EXE_SUFFIX)"
+	@if exist "$(PREFIX)\future$(EXE_SUFFIX)" del /q "$(PREFIX)\future$(EXE_SUFFIX)"
+	@if exist "$(PREFIX)\future-tui$(EXE_SUFFIX)" del /q "$(PREFIX)\future-tui$(EXE_SUFFIX)"
+	@if exist "$(PREFIX)\future-gui$(EXE_SUFFIX)" del /q "$(PREFIX)\future-gui$(EXE_SUFFIX)"
+	@if exist "$(PREFIX)\future-channel$(EXE_SUFFIX)" del /q "$(PREFIX)\future-channel$(EXE_SUFFIX)"
 else
 	rm -rf target
 	rm -rf tui/dist tui/node_modules
@@ -314,7 +314,7 @@ else
 	rm -rf cli/dist cli/node_modules
 	rm -f cli/src/version.generated.ts
 	rm -rf gui/dist gui/node_modules gui/src-tauri/target gui/src-tauri/binaries
-	$(SUDO) rm -f $(PREFIX)/future-agent $(PREFIX)/future $(PREFIX)/future-tui $(PREFIX)/future-gui $(PREFIX)/future-channel
+	$(SUDO) rm -f $(PREFIX)/future-agent$(EXE_SUFFIX) $(PREFIX)/future$(EXE_SUFFIX) $(PREFIX)/future-tui$(EXE_SUFFIX) $(PREFIX)/future-gui$(EXE_SUFFIX) $(PREFIX)/future-channel$(EXE_SUFFIX)
 endif
 
 # ─── Help ───────────────────────────────────────────────────────────────────

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -90,9 +90,6 @@ fn set_windows_taskbar_icon(app: &tauri::App) {
         CreateIconFromResourceEx, SendMessageW, ICON_BIG, ICON_SMALL, WM_SETICON,
     };
 
-    // The ICO is bundled next to the exe at dev time (src-tauri/icons/icon.ico).
-    // At release time it is embedded in the exe resources, but Tauri already
-    // handles that path — this function is primarily for dev-mode clarity.
     let Some(window) = app.get_webview_window("main") else {
         return;
     };
@@ -101,12 +98,7 @@ fn set_windows_taskbar_icon(app: &tauri::App) {
     };
     let hwnd = HWND(hwnd.0 as _);
 
-    // Read the ICO file — try a few candidate paths (dev mode).
-    let ico_data = find_icon_ico_bytes();
-    let Some(ico_data) = ico_data else {
-        eprintln!("set_windows_taskbar_icon: icon.ico not found");
-        return;
-    };
+    let ico_data = icon_ico_bytes();
 
     // Parse the ICO directory and pick the best entry for a given target size.
     fn find_best_entry(data: &[u8], target: u32) -> Option<(u32, u32)> {
@@ -191,24 +183,15 @@ fn set_windows_taskbar_icon(app: &tauri::App) {
     }
 }
 
-/// Locate `icon.ico` on disk (dev mode). Tries candidate paths relative to
-/// the current working directory and the executable.
+/// The multi-size ICO, embedded into the binary at compile time.
+///
+/// Reading it from disk at runtime would depend on the process working
+/// directory, which is unreliable for installed release builds (e.g. launched
+/// from the Start menu). Embedding costs ~230KB in the exe but makes the icon
+/// setup behave identically in dev, release, and packaged installs.
 #[cfg(target_os = "windows")]
-fn find_icon_ico_bytes() -> Option<Vec<u8>> {
-    let candidates = [
-        // Dev: working directory is gui/ or gui/src-tauri/
-        std::path::Path::new("src-tauri/icons/icon.ico"),
-        std::path::Path::new("icons/icon.ico"),
-        // Relative to exe: gui/src-tauri/target/{debug,release}/futureos.exe
-        std::path::Path::new("../../icons/icon.ico"),
-        std::path::Path::new("../../../icons/icon.ico"),
-    ];
-    for path in &candidates {
-        if let Ok(data) = std::fs::read(path) {
-            return Some(data);
-        }
-    }
-    None
+fn icon_ico_bytes() -> &'static [u8] {
+    include_bytes!("../icons/icon.ico")
 }
 
 /// Notify the frontend that a Thread's "previous turn changes" changeset has updated. The
@@ -293,6 +276,15 @@ pub fn run() {
             // size — the ICO contains 16,20,24,30,32,36,40,48,64,72,96,128,256.
             #[cfg(target_os = "windows")]
             set_windows_taskbar_icon(app);
+            // The window is created hidden (`"visible": false` in tauri.conf.json)
+            // so the taskbar never flashes Tauri's default (blurry, upscaled) icon
+            // before the crisp one above is in place. Reveal it now.
+            {
+                use tauri::Manager;
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                }
+            }
             if let Err(error) = store::initialize_app_store() {
                 eprintln!("FutureOS store initialization failed: {error}");
             }

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -15,6 +15,7 @@
         "title": "FutureOS",
         "width": 1440,
         "height": 960,
+        "visible": false,
         "minWidth": 1024,
         "minHeight": 720,
         "decorations": true,


### PR DESCRIPTION
Two fixes:

1. **GUI taskbar icon** (follow-up to #20):
   - Embed icon.ico with include_bytes! instead of disk reads — previously the CWD-relative paths failed in installed release builds, silently falling back to Tauri blurry default icon.
   - Create window hidden ("visible": false) and show only after WM_SETICON sets the crisp HICONs, eliminating the startup flash of the blurry upscaled icon.

2. **Makefile**: install-agent/-tui/-cli/-gui on Windows copied binaries to destinations without .exe suffix. cmd copy preserves the literal destination name, so installed binaries were extensionless and could not be executed. Added EXE_SUFFIX to copy destinations and uninstall/clean delete lists.
