### PR TITLE
fix(gui): restore Windows build; add 3-platform Rust CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,14 +117,20 @@ jobs:
           cache-all-crates: true
 
       # Tauri on Linux needs the WebKit/GTK system libraries even for `check`,
-      # because the -sys crates' build scripts run pkg-config. Copied from
-      # build.yml (a proven-good set); mold/binutils are link-only and omitted.
+      # because the -sys crates' build scripts run pkg-config. `cargo check`
+      # does not link the final crate, but it DOES link build scripts and
+      # proc-macros (they are executables / .so that get run / loaded), and
+      # `.cargo/config.toml` pins `-fuse-ld=mold` for this target — so mold must
+      # be installed or those link steps fail with `collect2: cannot find 'ld'`.
+      # binutils provides the traditional ld/collect2 toolchain.
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            binutils \
+            mold \
             pkg-config \
             libayatana-appindicator3-dev \
             libgtk-3-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,21 @@ jobs:
       - name: cargo check (agent + channels)
         run: cargo check --workspace --manifest-path Cargo.toml
 
+      # tauri-build's build script verifies every `bundle.externalBin` sidecar
+      # exists (it appends the host triple, and `.exe` on Windows) and aborts
+      # with `resource path ... doesn't exist` otherwise. The real sidecars are
+      # produced by the packaging jobs; for a type-check the paths just need to
+      # exist, so drop empty placeholders. CI-only — `binaries/` is gitignored.
+      - name: Create placeholder sidecar binaries
+        shell: bash
+        run: |
+          triple=$(rustc -Vv | sed -n 's/^host: //p')
+          suf=""
+          case "$triple" in *windows*) suf=".exe" ;; esac
+          mkdir -p gui/src-tauri/binaries
+          : > "gui/src-tauri/binaries/future-agent-$triple$suf"
+          : > "gui/src-tauri/binaries/future-$triple$suf"
+
       - name: cargo check (GUI Tauri backend)
         run: cargo check --manifest-path gui/src-tauri/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Lets you run the whole PR-check suite manually from the Actions tab
+  # (e.g. to verify a cross-platform fix on a feature branch without a PR).
+  workflow_dispatch:
 
 # Re-pushing a branch cancels its stale run; release tags are unaffected
 # (this workflow never triggers on tags anyway).
@@ -66,6 +69,94 @@ jobs:
           cargo test --manifest-path agent/Cargo.toml
           cargo test --manifest-path channels/Cargo.toml
           cargo test --manifest-path remote/Cargo.toml
+
+  # ─── Rust cross-platform compile check ───────────────────────────────────
+  # The `rust` job above only ever compiles on Linux, so platform-conditional
+  # code is never type-checked on Windows/macOS in CI. That is exactly how the
+  # GUI Tauri backend regressed twice (a macOS-only fix dropped the `windows`
+  # crate unconditionally, breaking Windows). This matrix runs `cargo check` on
+  # all three release targets so a missing `cfg`/crate surfaces on the PR.
+  #
+  # Scope: the root workspace (agent + channels) and the GUI Tauri backend.
+  # `remote/` is a standalone crate outside the workspace and is already
+  # compiled by the Linux `rust` job; it is platform-agnostic and left out here
+  # to keep this matrix focused. The GUI backend's proto is checked into
+  # src/generated/ (build.rs only regenerates under REGENERATE_PROTO), so it
+  # needs no protoc — but agent/channels regenerate proto on every build, so
+  # protoc is installed on every runner. System-dep install is copied verbatim
+  # from build.yml so this check runs in an environment proven to build.
+  # `cargo check` type-checks without linking, so this is far cheaper than the
+  # packaging jobs and needs no Node/npm (tauri-build reads config files only).
+  rust-cross:
+    name: Rust cross-check (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-22.04
+          - name: Windows
+            os: windows-latest
+          - name: macOS
+            os: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            gui/src-tauri
+          cache-on-failure: true
+          cache-all-crates: true
+
+      # Tauri on Linux needs the WebKit/GTK system libraries even for `check`,
+      # because the -sys crates' build scripts run pkg-config. Copied from
+      # build.yml (a proven-good set); mold/binutils are link-only and omitted.
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            protobuf-compiler
+
+      - name: Install macOS protoc
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      # protoc for the agent/channels build.rs proto codegen (gui's proto is
+      # checked in and needs none). taiki-e/install-action is a composite action
+      # (no Node runtime / deprecation warning); choco was unreliable here.
+      - name: Install Windows protoc
+        if: runner.os == 'Windows'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
+
+      # lib + bin only (no `--all-targets`): this matrix guards platform
+      # conditional *compilation* (the E0433 class of regression), which shows
+      # up in the default targets. The GUI backend's Rust tests have never been
+      # compiled in CI, so pulling them in here would risk unrelated red on a
+      # platform nobody has type-checked them on; agent/channels tests are
+      # already compiled+run on Linux by the `rust` job.
+      - name: cargo check (agent + channels)
+        run: cargo check --workspace --manifest-path Cargo.toml
+
+      - name: cargo check (GUI Tauri backend)
+        run: cargo check --manifest-path gui/src-tauri/Cargo.toml
 
   # ─── CLI: typecheck + bun test ───────────────────────────────────────────
   # `bun run test` runs the unit set only (src/commands + browser unit tests);

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "windows",
  "zip",
 ]
 

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -45,6 +45,19 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 ignore = "0.4"
 fuzzy-matcher = "0.3"
 
+# Win32 API for high-quality window icon (taskbar clarity). Loads the ICO file
+# with proper multi-size support instead of Tauri's single-size GDI HICON.
+# Target-specific on purpose: an unconditional dep pulls the `windows` crate
+# into every platform's dependency graph, and windows v0.61's transitive
+# windows-future conflicts with windows-core on macOS, breaking that build.
+# Gating it on cfg(target_os = "windows") keeps it out of non-Windows graphs
+# entirely while still satisfying the `use windows::...` in lib.rs on Windows.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Gdi",
+] }
 
 # Stripped symbols + no debug info: smaller desktop binary and less link/scan
 # I/O, negligible runtime cost for a Tauri shell. See ../../.cargo/config.toml.


### PR DESCRIPTION
## What

Two changes:

1. **Fix the Windows GUI build.** The macOS fix in `42b1cae9` deleted the `windows`
   crate from `gui/src-tauri/Cargo.toml` outright instead of scoping it to Windows.
   macOS kept building (the Win32 taskbar-icon code is behind
   `#[cfg(target_os = "windows")]`), but on Windows every `use windows::...` in
   `src/lib.rs` failed with `E0433: cannot find module or crate 'windows'`. The dep
   is now declared under `[target.'cfg(target_os = "windows")'.dependencies]`, so it
   enters the graph only on Windows — and on macOS/Linux the cfg is false, so cargo
   never pulls it in (which also avoids the `windows-future` / `windows-core` conflict
   that prompted the original removal). `Cargo.lock` gains the matching entry.

2. **Add a 3-platform Rust compile check.** The existing CI `rust` job only compiles on
   Linux, so platform-conditional code was never type-checked on Windows/macOS — exactly
   how this backend regressed twice without the PR check noticing (the breakage only
   showed up at packaging time, and `build.yml` runs on tags / manual dispatch, not PRs).
   A new `rust-cross` matrix job (`ubuntu-22.04` / `windows-latest` / `macos-latest`) runs
   `cargo check` on the root workspace (agent + channels) and the GUI Tauri backend on
   every PR. System-dep install is copied verbatim from `build.yml` (a proven-good set);
   `cargo check` type-checks without linking, so it is much cheaper than packaging and
   needs no Node/npm. Also added `workflow_dispatch` so the suite can be triggered by
   hand from the Actions tab on a feature branch.

## Why

The Windows build was red, and there was no PR-time signal for this class of
platform-conditional regression. This restores the build and closes the CI gap.

## Reviewer notes

- **Node/TS is intentionally not in the matrix.** `tsc` / eslint / vitest / vite are
  platform-agnostic (already covered by the `cli` / `tui` / `gui` jobs on a single OS);
  the only platform-specific GUI code lives in the Tauri Rust backend, which `rust-cross`
  now covers on all three targets.
- **`rust-cross` deliberately omits `--all-targets`.** This class of regression shows up in
  the default lib/bin targets. The GUI backend's Rust tests have never been compiled in CI,
  so pulling them in would risk unrelated red on a platform nobody has type-checked them on;
  `agent`/`channels` lib+bin are already proven to build on all three targets by `build.yml`.
- **I could not run the full Windows compile locally.** This git worktree is nested inside the
  main repo dir, which trips cargo's workspace discovery, and cross-compiling to MSVC from
  macOS dies in `ring`'s C build (no Windows C sysroot) — unrelated to this fix. Correctness
  rests on: macOS/Linux by construction (a target-specific dep with a false cfg adds nothing
  to those graphs, so they equal the pre-existing buildable state), and Windows via a minimal
  crate that compiled `windows 0.61` on the MSVC target and type-checked the replicated Win32
  calls. The new CI job is the authoritative 3-platform confirmation.
- Out of scope (left as-is): root `Cargo.toml`'s comment claims `remote/` is gone but the
  crate still exists and the `rust` job still builds it; the GUI Rust backend still has no
  `cargo clippy`/`cargo test` in CI (only frontend vitest). Both are worth follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
