### PR TITLE
fix(agent): fail fast when compaction cannot find a valid cut point

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -61,6 +61,10 @@ pub struct Loop {
     pub cumulative_cost: Arc<parking_lot::Mutex<f64>>,
     /// Last API call's prompt_tokens (actual context size, not cumulative across turns)
     pub last_prompt_tokens: Arc<std::sync::atomic::AtomicI64>,
+    /// Set to true when auto-compaction is needed but fails to find a valid cut
+    /// point. The run loop checks this after transform_context and returns an
+    /// error instead of silently proceeding with full context.
+    pub compaction_failed: Arc<AtomicBool>,
 }
 
 impl Loop {
@@ -85,6 +89,7 @@ impl Loop {
             cumulative_cache_write_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             cumulative_cost: Arc::new(parking_lot::Mutex::new(0.0)),
             last_prompt_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+            compaction_failed: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -143,6 +143,23 @@ impl Loop {
                 messages.clone()
             };
 
+            // Auto-compaction was needed but failed — context is overflowing
+            // the model's window. Stop instead of silently proceeding.
+            if self
+                .compaction_failed
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                if let Some(ref bus) = self.event_bus {
+                    bus.emit(error_event(
+                        "Context compaction failed: unable to find a valid cut point. \
+                         The conversation is too long and cannot continue.",
+                    ));
+                }
+                return Err(anyhow!(
+                    "context compaction failed: conversation overflows model context window"
+                ));
+            }
+
             // Emit message_start
             if let Some(ref bus) = self.event_bus {
                 bus.emit(message_start("assistant"));
@@ -228,9 +245,25 @@ impl Loop {
                             messages = ConvertFromLLM(compacted);
                             if let Some(r) = compact_result {
                                 *self.last_compaction_result.lock() = Some(r);
-                            }
-                            if let Some(ref bus) = self.event_bus {
-                                bus.emit(events::compaction_end(0, "", false, "auto"));
+                                if let Some(ref bus) = self.event_bus {
+                                    bus.emit(events::compaction_end(0, "", false, "auto"));
+                                }
+                            } else {
+                                // Forced compaction (context-length error) failed to
+                                // find any valid cut point. The conversation cannot
+                                // continue safely — report the error and stop.
+                                tracing::error!(
+                                    "forced compaction after context-length error failed"
+                                );
+                                if let Some(ref bus) = self.event_bus {
+                                    bus.emit(error_event(
+                                        "Context compaction failed: unable to find a valid \
+                                         cut point. The conversation is too long and cannot continue.",
+                                    ));
+                                }
+                                return Err(anyhow!(
+                                    "context compaction failed: conversation overflows model context window"
+                                ));
                             }
                         }
                         // Don't burn a retry (and its backoff) if the user

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -641,6 +641,7 @@ impl ServerSession {
             if let Ok(mut r#loop) = self.agent_loop.try_write() {
                 let comp_tokens = self.last_prompt_tokens.clone();
                 let comp_result = r#loop.last_compaction_result.clone();
+                let comp_failed = r#loop.compaction_failed.clone();
                 // Resolve context_window once — avoid creating a new Registry
                 // on every LLM call inside the closure.
                 let context_window = crate::models::Registry::new()
@@ -664,6 +665,7 @@ impl ServerSession {
                     // substantial conversation continuity after compaction.
                     let reserve_tokens = ((context_window as f64 * 0.1) as i32).max(16384);
                     let keep_tokens = ((context_window as f64 * 0.2) as i32).max(reserve_tokens);
+                    let needs_compact = context_tokens > context_window - reserve_tokens;
                     let (compacted, result) = crate::compaction::compact(
                         msgs,
                         &crate::compaction::CompactOptions {
@@ -675,6 +677,18 @@ impl ServerSession {
                     );
                     if let Some(r) = result {
                         *comp_result.lock() = Some(r);
+                        compacted
+                    } else if needs_compact {
+                        // Compaction was needed but compact() returned no result,
+                        // meaning it found no valid cut point. Signal failure so
+                        // the run loop can report an error instead of silently
+                        // proceeding with full (overflowing) context.
+                        tracing::error!(
+                            tokens = context_tokens,
+                            window = context_window,
+                            "auto-compaction needed but failed"
+                        );
+                        comp_failed.store(true, Ordering::SeqCst);
                         compacted
                     } else {
                         compacted


### PR DESCRIPTION
压缩找不到有效切点时，不再静默溢出上下文，而是报错中断会话。

- `compaction_failed` 原子标志：`transform_context` 需要压缩但 `compact()` 返回空时置 true
- 每轮开始前检查标志，true 则报 `context compaction failed` 退出
- API 400 触发的强制压缩失败同理