### PR TITLE
refactor(ci): split Rust lint and test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ─── Rust quality gate (Linux): fmt + clippy + tests ─────────────────────
-  # Lint and test ALL Rust crates in one hard gate: the workspace members
-  # (agent / channels / remote) plus the GUI Tauri backend. Platform-agnostic,
-  # so one OS suffices; Windows/macOS *compilation* is the rust-build job's
-  # job. clippy implicitly compiles, so this also covers Linux compilation of
-  # every crate (the rust-build Linux leg re-checks them — a deliberate,
-  # cached, incremental overlap kept so that matrix stays symmetric).
+  # ─── Rust lint gate (Linux): fmt + clippy ─────────────────────────────────
+  # Lint all workspace crates plus the GUI Tauri backend. Tests run in the
+  # independent `rust-tests` job below so both gates can execute in parallel.
   rust-quality:
-    name: Rust fmt + clippy + tests (Linux)
+    name: Rust fmt + clippy (Linux)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,7 +47,7 @@ jobs:
           cache-all-crates: true
 
       # protoc for the workspace build.rs proto codegen. mold + binutils
-      # because .cargo/config.toml pins -fuse-ld=mold and clippy/test still
+      # because .cargo/config.toml pins -fuse-ld=mold and clippy still
       # link build scripts, proc-macros and test binaries. WebKit/GTK for the
       # Tauri -sys build scripts (GUI backend is part of this gate now).
       - name: Install Linux deps
@@ -70,8 +66,8 @@ jobs:
             protobuf-compiler
 
       # tauri-build's build script aborts with `resource path ... doesn't exist`
-      # unless every `bundle.externalBin` sidecar is present. For lint/test
-      # empty placeholders suffice.
+      # unless every `bundle.externalBin` sidecar is present. For lint empty
+      # placeholders suffice.
       - name: Create placeholder sidecars
         run: |
           triple=$(rustc -Vv | sed -n 's/^host: //p')
@@ -88,15 +84,60 @@ jobs:
       - name: clippy (workspace)
         run: cargo clippy --workspace --all-targets --manifest-path Cargo.toml -- -D warnings
 
-      - name: cargo test (workspace)
-        run: cargo test --workspace --manifest-path Cargo.toml
-
       # ── GUI Tauri backend ──
       - name: rustfmt (GUI backend)
         run: cargo fmt --check --manifest-path gui/src-tauri/Cargo.toml
 
       - name: clippy (GUI backend)
         run: cargo clippy --all-targets --manifest-path gui/src-tauri/Cargo.toml -- -D warnings
+
+  # ─── Rust test gate (Linux) ───────────────────────────────────────────────
+  # This deliberately duplicates setup from `rust-quality`: separate jobs do
+  # not share a live target directory, but running lint and tests in parallel
+  # reduces PR wall-clock time.
+  rust-tests:
+    name: Rust tests (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            gui/src-tauri
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            binutils \
+            mold \
+            pkg-config \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            protobuf-compiler
+
+      - name: Create placeholder sidecars
+        run: |
+          triple=$(rustc -Vv | sed -n 's/^host: //p')
+          mkdir -p gui/src-tauri/binaries
+          : > "gui/src-tauri/binaries/future-agent-$triple"
+          : > "gui/src-tauri/binaries/future-$triple"
+
+      - name: cargo test (workspace)
+        run: cargo test --workspace --manifest-path Cargo.toml
 
       - name: cargo test (GUI backend)
         run: cargo test --manifest-path gui/src-tauri/Cargo.toml
@@ -198,115 +239,6 @@ jobs:
 
       - name: cargo check (workspace)
         run: cargo check --workspace --manifest-path Cargo.toml
-
-      - name: cargo check (GUI Tauri backend)
-        run: cargo check --manifest-path gui/src-tauri/Cargo.toml
-
-  # ─── Rust cross-platform compile check ───────────────────────────────────
-  # The `rust` job above only ever compiles on Linux, so platform-conditional
-  # code is never type-checked on Windows/macOS in CI. That is exactly how the
-  # GUI Tauri backend regressed twice (a macOS-only fix dropped the `windows`
-  # crate unconditionally, breaking Windows). This matrix runs `cargo check` on
-  # all three release targets so a missing `cfg`/crate surfaces on the PR.
-  #
-  # Scope: the root workspace (agent + channels) and the GUI Tauri backend.
-  # `remote/` is a standalone crate outside the workspace and is already
-  # compiled by the Linux `rust` job; it is platform-agnostic and left out here
-  # to keep this matrix focused. The GUI backend's proto is checked into
-  # src/generated/ (build.rs only regenerates under REGENERATE_PROTO), so it
-  # needs no protoc — but agent/channels regenerate proto on every build, so
-  # protoc is installed on every runner. System-dep install is copied verbatim
-  # from build.yml so this check runs in an environment proven to build.
-  # `cargo check` type-checks without linking, so this is far cheaper than the
-  # packaging jobs and needs no Node/npm (tauri-build reads config files only).
-  rust-cross:
-    name: Rust cross-check (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux
-            os: ubuntu-22.04
-          - name: Windows
-            os: windows-latest
-          - name: macOS
-            os: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            gui/src-tauri
-          cache-on-failure: true
-          cache-all-crates: true
-
-      # Tauri on Linux needs the WebKit/GTK system libraries even for `check`,
-      # because the -sys crates' build scripts run pkg-config. `cargo check`
-      # does not link the final crate, but it DOES link build scripts and
-      # proc-macros (they are executables / .so that get run / loaded), and
-      # `.cargo/config.toml` pins `-fuse-ld=mold` for this target — so mold must
-      # be installed or those link steps fail with `collect2: cannot find 'ld'`.
-      # binutils provides the traditional ld/collect2 toolchain.
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            binutils \
-            mold \
-            pkg-config \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            protobuf-compiler
-
-      - name: Install macOS protoc
-        if: runner.os == 'macOS'
-        run: brew install protobuf
-
-      # protoc for the agent/channels build.rs proto codegen (gui's proto is
-      # checked in and needs none). taiki-e/install-action is a composite action
-      # (no Node runtime / deprecation warning); choco was unreliable here.
-      - name: Install Windows protoc
-        if: runner.os == 'Windows'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: protoc
-
-      # lib + bin only (no `--all-targets`): this matrix guards platform
-      # conditional *compilation* (the E0433 class of regression), which shows
-      # up in the default targets. The GUI backend's Rust tests have never been
-      # compiled in CI, so pulling them in here would risk unrelated red on a
-      # platform nobody has type-checked them on; agent/channels tests are
-      # already compiled+run on Linux by the `rust` job.
-      - name: cargo check (agent + channels)
-        run: cargo check --workspace --manifest-path Cargo.toml
-
-      # tauri-build's build script verifies every `bundle.externalBin` sidecar
-      # exists (it appends the host triple, and `.exe` on Windows) and aborts
-      # with `resource path ... doesn't exist` otherwise. The real sidecars are
-      # produced by the packaging jobs; for a type-check the paths just need to
-      # exist, so drop empty placeholders. CI-only — `binaries/` is gitignored.
-      - name: Create placeholder sidecar binaries
-        shell: bash
-        run: |
-          triple=$(rustc -Vv | sed -n 's/^host: //p')
-          suf=""
-          case "$triple" in *windows*) suf=".exe" ;; esac
-          mkdir -p gui/src-tauri/binaries
-          : > "gui/src-tauri/binaries/future-agent-$triple$suf"
-          : > "gui/src-tauri/binaries/future-$triple$suf"
 
       - name: cargo check (GUI Tauri backend)
         run: cargo check --manifest-path gui/src-tauri/Cargo.toml


### PR DESCRIPTION
## Summary
- run Rust formatting and Clippy checks independently from Rust tests on Linux
- remove the redundant Rust cross-check matrix while retaining the three-platform Rust build matrix

## Validation
- GitHub Actions YAML syntax check passed
- git diff --check passed