### PR TITLE
Fix manual download link for unsupported updates

### DIFF
--- a/gui/src-tauri/src/commands/update.rs
+++ b/gui/src-tauri/src/commands/update.rs
@@ -6,6 +6,7 @@
 //! additional fields and selects only the current entry under `platforms`.
 
 use serde::Serialize;
+use serde_json::Value;
 use tauri::Emitter;
 use tauri_plugin_updater::UpdaterExt;
 
@@ -20,6 +21,8 @@ pub struct UpdateStatus {
     pub latest_version: String,
     pub has_update: bool,
     pub platform_supported: bool,
+    /// Website installer URL for builds that cannot use the in-place updater.
+    pub download_url: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -32,6 +35,33 @@ struct DownloadProgress {
 
 fn updater_error(context: &str, error: impl std::fmt::Display) -> AppError {
     AppError::Message(format!("{context}: {error}"))
+}
+
+/// Return the website installer URL from the custom `assets` manifest field.
+///
+/// Tauri consumes `platforms` for its updater archive, while `assets` points
+/// to the normal DMG/EXE users should download when automatic installation is
+/// unavailable (for example from a local build).
+fn manual_download_url_for_asset(manifest: &Value, asset_key: &str) -> Option<String> {
+    let url = manifest
+        .get("assets")?
+        .get(asset_key)?
+        .get("url")?
+        .as_str()?;
+
+    url.starts_with("https://").then(|| url.to_owned())
+}
+
+fn manual_download_url(manifest: &Value) -> Option<String> {
+    let asset_key = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "macos-aarch64"
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "windows-x64"
+    } else {
+        return None;
+    };
+
+    manual_download_url_for_asset(manifest, asset_key)
 }
 
 /// Check the signed static manifest configured in `tauri.conf.json`.
@@ -47,6 +77,7 @@ pub async fn check_app_update(app: tauri::AppHandle) -> Result<UpdateStatus, App
             current_version,
             has_update: false,
             platform_supported: false,
+            download_url: None,
         });
     }
 
@@ -59,22 +90,64 @@ pub async fn check_app_update(app: tauri::AppHandle) -> Result<UpdateStatus, App
         .map_err(|error| updater_error("Failed to check for updates", error))?;
 
     Ok(match update {
-        Some(update) => UpdateStatus {
-            current_version,
-            latest_version: update.version,
-            has_update: true,
-            // Only formal signed builds embed the updater public key. Local and
-            // daily builds may inspect the public manifest, but must not offer
-            // installation without signature verification.
-            platform_supported: build_info::is_release(),
-        },
+        Some(update) => {
+            let download_url = manual_download_url(&update.raw_json);
+            UpdateStatus {
+                current_version,
+                latest_version: update.version,
+                has_update: true,
+                // Only formal signed builds embed the updater public key. Local and
+                // daily builds may inspect the public manifest, but must not offer
+                // installation without signature verification.
+                platform_supported: build_info::is_release(),
+                download_url,
+            }
+        }
         None => UpdateStatus {
             latest_version: current_version.clone(),
             current_version,
             has_update: false,
             platform_supported: true,
+            download_url: None,
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::manual_download_url_for_asset;
+
+    #[test]
+    fn reads_the_matching_website_asset_url() {
+        let manifest = json!({
+            "assets": {
+                "macos-aarch64": {
+                    "url": "https://downloads.example.com/FutureOS_1.0.4_aarch64-sign.dmg"
+                }
+            }
+        });
+
+        assert_eq!(
+            manual_download_url_for_asset(&manifest, "macos-aarch64"),
+            Some("https://downloads.example.com/FutureOS_1.0.4_aarch64-sign.dmg".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_https_website_asset_urls() {
+        let manifest = json!({
+            "assets": {
+                "windows-x64": { "url": "http://downloads.example.com/FutureOS.exe" }
+            }
+        });
+
+        assert_eq!(
+            manual_download_url_for_asset(&manifest, "windows-x64"),
+            None
+        );
+    }
 }
 
 /// Download, verify and install the platform updater package.

--- a/gui/src/features/settings/UpdatePage.tsx
+++ b/gui/src/features/settings/UpdatePage.tsx
@@ -3,6 +3,7 @@ import { Download, RefreshCw, RotateCcw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/ui/Button";
+import { openExternalUrl } from "../../integrations/storage/files";
 import { invokeCommand } from "../../integrations/tauri/invoke";
 import { useBuildInfo } from "../../integrations/tauri/useBuildInfo";
 import { errorMessage } from "../../lib/errors";
@@ -14,6 +15,7 @@ interface UpdateStatus {
   latestVersion: string;
   hasUpdate: boolean;
   platformSupported: boolean;
+  downloadUrl: string | null;
 }
 
 interface DownloadProgress {
@@ -34,6 +36,7 @@ export function UpdatePage() {
   const [progress, setProgress] = useState(0);
   const [installed, setInstalled] = useState(false);
   const [installError, setInstallError] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   // Tear down the streamed-progress listener if the page unmounts mid-download
   // (the download command itself still settles in the background).
@@ -50,6 +53,7 @@ export function UpdatePage() {
     setCheckError(null);
     setInstalled(false);
     setInstallError(null);
+    setDownloadError(null);
     try {
       setStatus(await invokeCommand<UpdateStatus>("check_app_update"));
     }
@@ -102,6 +106,18 @@ export function UpdatePage() {
     }
     catch (error) {
       setInstallError(errorMessage(error));
+    }
+  }
+
+  async function handleManualDownload() {
+    if (!status?.downloadUrl)
+      return;
+    setDownloadError(null);
+    try {
+      await openExternalUrl(status.downloadUrl);
+    }
+    catch (error) {
+      setDownloadError(errorMessage(error));
     }
   }
 
@@ -182,7 +198,28 @@ export function UpdatePage() {
                                   {installError ? <p className="text-xs text-danger">{`${t("update.installFailed")}: ${installError}`}</p> : null}
                                 </div>
                               )
-                            : <p className="text-xs text-ink-muted">{t("update.noAsset")}</p>}
+                            : (
+                                <div className="space-y-1">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <span className="text-xs text-ink-muted">{t("update.noAsset")}</span>
+                                    {status.downloadUrl
+                                      ? (
+                                          <a
+                                            className="text-xs font-medium text-accent underline underline-offset-2"
+                                            href={status.downloadUrl}
+                                            onClick={(event) => {
+                                              event.preventDefault();
+                                              void handleManualDownload();
+                                            }}
+                                          >
+                                            {t("update.download")}
+                                          </a>
+                                        )
+                                      : null}
+                                  </div>
+                                  {downloadError ? <p className="text-xs text-danger">{`${t("update.downloadFailed")}: ${downloadError}`}</p> : null}
+                                </div>
+                              )}
                         </>
                       )
                     : <p className="text-sm text-ink-soft">{t("update.upToDate")}</p>}

--- a/gui/src/i18n/locales/en/settings.json
+++ b/gui/src/i18n/locales/en/settings.json
@@ -36,6 +36,8 @@
     "installed": "Update installed. Restart to finish.",
     "restart": "Restart FutureOS",
     "noAsset": "Automatic updates are not available for this platform",
+    "download": "Download latest version",
+    "downloadFailed": "Could not open download link",
     "checkFailed": "Update check failed",
     "installFailed": "Update failed"
   },

--- a/gui/src/i18n/locales/zh/settings.json
+++ b/gui/src/i18n/locales/zh/settings.json
@@ -36,6 +36,8 @@
     "installed": "更新已安装，重启后生效",
     "restart": "重启 FutureOS",
     "noAsset": "当前平台暂不支持自动更新",
+    "download": "前往下载",
+    "downloadFailed": "无法打开下载链接",
     "checkFailed": "检查更新失败",
     "installFailed": "更新失败"
   },


### PR DESCRIPTION
## Summary
- expose the platform-specific website installer URL from the update manifest
- show a manual download link when signed in-place updates are unavailable
- add coverage for manifest asset URL selection

## Verification
- cd gui && npx tsc --noEmit
- cd gui && npx eslint "src/**/*.{ts,tsx}"
- cd gui && npx vitest run
- cd gui/src-tauri && cargo fmt --check
- cd gui/src-tauri && cargo clippy --all-targets -- -D warnings
- cd gui/src-tauri && cargo test commands::update --lib