### PR TITLE
Build Intel macOS release artifacts

### DIFF
--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -47,10 +47,25 @@ on:
 
 jobs:
   build:
-    name: Build signed and notarized macOS release
+    name: Build signed and notarized macOS (${{ matrix.name }})
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `macos-latest` is the GitHub-hosted Apple Silicon image.
+          - name: Apple Silicon
+            runner: macos-latest
+            asset_arch: aarch64
+            artifact_name: futureos-macos-signed
+          # Keep the Intel build pinned to a named image: unlike
+          # `macos-latest`, this cannot silently switch architectures.
+          - name: Intel
+            runner: macos-15-intel
+            asset_arch: x64
+            artifact_name: futureos-macos-intel-signed
     env:
       OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
       OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
@@ -494,9 +509,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p signed-release
-          base="$(basename "$SIGNED_DMG" .dmg)"
-          dmg_output="signed-release/${base}-sign.dmg"
-          updater_output="signed-release/FutureOS_${{ steps.v.outputs.version }}_aarch64.app.tar.gz"
+          dmg_output="signed-release/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}-sign.dmg"
+          updater_output="signed-release/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}.app.tar.gz"
           cp "$SIGNED_DMG" "$dmg_output"
           cp "$MACOS_UPDATER" "$updater_output"
           cp "$MACOS_UPDATER_SIG" "$updater_output.sig"
@@ -505,7 +519,7 @@ jobs:
       - name: Upload signed macOS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: futureos-macos-signed
+          name: ${{ matrix.artifact_name }}
           if-no-files-found: error
           overwrite: true
           path: signed-release/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
             os: macos-latest
             artifact_name: futureos-macos
             bundle_path: gui/src-tauri/target/release/bundle/dmg/*.dmg
+          - name: macOS Intel
+            os: macos-15-intel
+            artifact_name: futureos-macos-intel
+            bundle_path: gui/src-tauri/target/release/bundle/dmg/*.dmg
           - name: Windows
             os: windows-latest
             artifact_name: futureos-windows

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     # ossutil v2 auto-reads these OSS_* env vars (endpoint + credentials); the
     # Setup step derives OSS_REGION from the endpoint for SigV4.
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,19 @@ jobs:
           set -euo pipefail
           mkdir -p publish
 
-          mac="FutureOS_${VERSION}_aarch64-sign.dmg"
-          mac_updater="FutureOS_${VERSION}_aarch64.app.tar.gz"
+          mac_arm="FutureOS_${VERSION}_aarch64-sign.dmg"
+          mac_arm_updater="FutureOS_${VERSION}_aarch64.app.tar.gz"
+          mac_intel="FutureOS_${VERSION}_x64-sign.dmg"
+          mac_intel_updater="FutureOS_${VERSION}_x64.app.tar.gz"
           windows="FutureOS_${VERSION}_x64-setup-sign.exe"
 
           for name in \
-            "$mac" \
-            "$mac_updater" \
-            "$mac_updater.sig" \
+            "$mac_arm" \
+            "$mac_arm_updater" \
+            "$mac_arm_updater.sig" \
+            "$mac_intel" \
+            "$mac_intel_updater" \
+            "$mac_intel_updater.sig" \
             "$windows" \
             "$windows.sig"
           do
@@ -107,12 +112,13 @@ jobs:
           # Already-released clients derive these historical filenames from
           # `version` alone. Keep byte-identical aliases for one-way migration
           # into the first updater-enabled release.
-          cp -v "publish/$mac" "publish/FutureOS_${VERSION}_aarch64.dmg"
+          cp -v "publish/$mac_arm" "publish/FutureOS_${VERSION}_aarch64.dmg"
+          cp -v "publish/$mac_intel" "publish/FutureOS_${VERSION}_x64.dmg"
           cp -v "publish/$windows" "publish/FutureOS_${VERSION}_x64-setup.exe"
 
           count="$(find publish -type f | wc -l | tr -d ' ')"
-          [[ "$count" == "7" ]] || {
-            echo "Expected exactly seven public release assets, found $count." >&2
+          [[ "$count" == "11" ]] || {
+            echo "Expected exactly eleven public release assets, found $count." >&2
             exit 1
           }
 
@@ -123,8 +129,10 @@ jobs:
         run: |
           set -euo pipefail
           export PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          export MAC_FILE="FutureOS_${VERSION}_aarch64-sign.dmg"
-          export MAC_UPDATER_FILE="FutureOS_${VERSION}_aarch64.app.tar.gz"
+          export MAC_ARM_FILE="FutureOS_${VERSION}_aarch64-sign.dmg"
+          export MAC_ARM_UPDATER_FILE="FutureOS_${VERSION}_aarch64.app.tar.gz"
+          export MAC_INTEL_FILE="FutureOS_${VERSION}_x64-sign.dmg"
+          export MAC_INTEL_UPDATER_FILE="FutureOS_${VERSION}_x64.app.tar.gz"
           export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup-sign.exe"
 
           node <<'NODE'
@@ -142,12 +150,14 @@ jobs:
             version: process.env.VERSION,
             pub_date: process.env.PUB_DATE,
             platforms: {
-              "darwin-aarch64": updater(process.env.MAC_UPDATER_FILE),
+              "darwin-aarch64": updater(process.env.MAC_ARM_UPDATER_FILE),
+              "darwin-x86_64": updater(process.env.MAC_INTEL_UPDATER_FILE),
               "windows-x86_64": updater(process.env.WINDOWS_FILE),
             },
             assets: {
-              "macos-aarch64": asset(process.env.MAC_FILE),
-              "windows-x64": asset(process.env.WINDOWS_FILE),
+              "darwin-aarch64": asset(process.env.MAC_ARM_FILE),
+              "darwin-x86_64": asset(process.env.MAC_INTEL_FILE),
+              "windows-x86_64": asset(process.env.WINDOWS_FILE),
             },
           };
           fs.writeFileSync("latest.json", `${JSON.stringify(manifest, null, 2)}\n`);
@@ -182,6 +192,10 @@ jobs:
             "FutureOS_${VERSION}_aarch64.dmg" \
             "FutureOS_${VERSION}_aarch64.app.tar.gz" \
             "FutureOS_${VERSION}_aarch64.app.tar.gz.sig" \
+            "FutureOS_${VERSION}_x64-sign.dmg" \
+            "FutureOS_${VERSION}_x64.dmg" \
+            "FutureOS_${VERSION}_x64.app.tar.gz" \
+            "FutureOS_${VERSION}_x64.app.tar.gz.sig" \
             "FutureOS_${VERSION}_x64-setup-sign.exe" \
             "FutureOS_${VERSION}_x64-setup.exe" \
             "FutureOS_${VERSION}_x64-setup-sign.exe.sig"

--- a/gui/src-tauri/src/commands/update.rs
+++ b/gui/src-tauri/src/commands/update.rs
@@ -54,9 +54,11 @@ fn manual_download_url_for_asset(manifest: &Value, asset_key: &str) -> Option<St
 
 fn manual_download_url(manifest: &Value) -> Option<String> {
     let asset_key = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-        "macos-aarch64"
+        "darwin-aarch64"
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        "darwin-x86_64"
     } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-        "windows-x64"
+        "windows-x86_64"
     } else {
         return None;
     };
@@ -123,14 +125,14 @@ mod tests {
     fn reads_the_matching_website_asset_url() {
         let manifest = json!({
             "assets": {
-                "macos-aarch64": {
+                "darwin-aarch64": {
                     "url": "https://downloads.example.com/FutureOS_1.0.4_aarch64-sign.dmg"
                 }
             }
         });
 
         assert_eq!(
-            manual_download_url_for_asset(&manifest, "macos-aarch64"),
+            manual_download_url_for_asset(&manifest, "darwin-aarch64"),
             Some("https://downloads.example.com/FutureOS_1.0.4_aarch64-sign.dmg".to_string())
         );
     }
@@ -139,12 +141,12 @@ mod tests {
     fn rejects_non_https_website_asset_urls() {
         let manifest = json!({
             "assets": {
-                "windows-x64": { "url": "http://downloads.example.com/FutureOS.exe" }
+                "windows-x86_64": { "url": "http://downloads.example.com/FutureOS.exe" }
             }
         });
 
         assert_eq!(
-            manual_download_url_for_asset(&manifest, "windows-x64"),
+            manual_download_url_for_asset(&manifest, "windows-x86_64"),
             None
         );
     }


### PR DESCRIPTION
## Summary
- build signed, notarized Apple Silicon and Intel macOS installers and updater archives
- publish Intel macOS metadata under darwin-x86_64 for automatic and manual updates
- add an Intel macOS development build and move docs publishing to a GitHub-hosted runner

## Verification
- cd gui/src-tauri && cargo fmt --check
- cd gui/src-tauri && cargo clippy --all-targets -- -D warnings
- cd gui/src-tauri && cargo test commands::update --lib
- workflow YAML parse, Prettier, and git diff --check