### PR TITLE
Release downloads through the CDN

### DIFF
--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -236,7 +236,7 @@ jobs:
                 updater: {
                   pubkey: process.env.TAURI_UPDATER_PUBLIC_KEY,
                   endpoints: [
-                    "https://futureos.oss-cn-hangzhou.aliyuncs.com/releases/latest.json"
+                    "https://dl.future-os.cn/releases/latest.json"
                   ]
                 }
               }
@@ -555,11 +555,9 @@ jobs:
           echo "==> Uploading macOS artifacts to oss://$OSS_BUCKET/test/$version/"
           ossutil cp -r -f signed-release/ "oss://$OSS_BUCKET/test/$version/"
 
-          oss_host="$(printf '%s' "$OSS_ENDPOINT" \
-            | sed -E 's#^https?://##; s/-internal//')"
           echo "==> Download URLs:"
           find signed-release -maxdepth 1 -type f -print | while read -r output; do
-            echo "https://$OSS_BUCKET.$oss_host/test/$version/$(basename "$output")"
+            echo "https://dl.future-os.cn/test/$version/$(basename "$output")"
           done
 
       - name: Clean up signing material

--- a/.github/workflows/build-windows-signed.yml
+++ b/.github/workflows/build-windows-signed.yml
@@ -240,7 +240,7 @@ jobs:
           $config | Add-Member -NotePropertyName plugins -NotePropertyValue @{
             updater = @{
               pubkey = $env:TAURI_UPDATER_PUBLIC_KEY
-              endpoints = @("https://futureos.oss-cn-hangzhou.aliyuncs.com/releases/latest.json")
+              endpoints = @("https://dl.future-os.cn/releases/latest.json")
             }
           }
           $json = $config | ConvertTo-Json -Depth 10
@@ -351,6 +351,5 @@ jobs:
           ossutil cp -r -f "signed-release\" "oss://$env:OSS_BUCKET/test/$version/"
           if ($LASTEXITCODE -ne 0) { throw "ossutil upload failed (exit $LASTEXITCODE)" }
 
-          $ossHost = $env:OSS_ENDPOINT -replace '^https?://','' -replace '-internal',''
           Write-Host "==> Download URLs:"
-          Get-ChildItem signed-release | ForEach-Object { Write-Host "  https://$env:OSS_BUCKET.$ossHost/test/$version/$($_.Name)" }
+          Get-ChildItem signed-release | ForEach-Object { Write-Host "  https://dl.future-os.cn/test/$version/$($_.Name)" }

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -7,9 +7,9 @@ name: Publish Docs
 # Only the Chinese pages are published; the English pages under docs/wiki/en/
 # are not pushed to OSS.
 #
-# OSS publish is a full replace: `sync --delete` uploads the current zh/*.md and
-# removes any object under docs/ that no longer exists locally — so removed
-# pages don't linger.
+# OSS publish uploads and updates the current Chinese pages. It deliberately
+# does not delete objects that disappeared locally: the publishing credential
+# has no DeleteObject permission.
 
 on:
   workflow_dispatch:
@@ -41,12 +41,11 @@ jobs:
       - name: Setup ossutil
         run: bash scripts/setup-ossutil.sh
 
-      # Full replace via `sync --delete`: uploads/updates the current Chinese
-      # pages and removes any object under docs/ that no longer exists locally —
-      # in one pass, with no window where docs/ is empty.
+      # Upload/update the current Chinese pages. Old objects are retained until
+      # they are removed through a separately authorized OSS maintenance task.
       - name: Publish docs/wiki/zh to OSS
         run: |
           set -euo pipefail
-          echo "==> Syncing docs/wiki/zh/ → docs/ (with --delete)"
-          ossutil sync docs/wiki/zh/ "oss://$OSS_BUCKET/docs/" --delete -f
+          echo "==> Syncing docs/wiki/zh/ → docs/"
+          ossutil sync docs/wiki/zh/ "oss://$OSS_BUCKET/docs/" -f
           echo "==> Done."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
       OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
       VERSION: ${{ needs.version.outputs.version }}
-      RELEASE_ORIGIN: https://futureos.oss-cn-hangzhou.aliyuncs.com/releases
+      RELEASE_ORIGIN: https://dl.future-os.cn/releases
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/gui/src-tauri/src/commands/update.rs
+++ b/gui/src-tauri/src/commands/update.rs
@@ -1,6 +1,6 @@
 //! Signed in-place application updates through Tauri's updater plugin.
 //!
-//! Formal builds embed the OSS `latest.json` endpoint and the updater public
+//! Formal builds embed the CDN `latest.json` endpoint and the updater public
 //! key through a per-build Tauri config overlay. The manifest may also contain
 //! the custom top-level `assets` map used by the website; Tauri ignores those
 //! additional fields and selects only the current entry under `platforms`.

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
     "updater": {
       "pubkey": "",
       "endpoints": [
-        "https://futureos.oss-cn-hangzhou.aliyuncs.com/releases/latest.json"
+        "https://dl.future-os.cn/releases/latest.json"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- serve automatic-update manifests and packages through dl.future-os.cn
- print CDN URLs for signed test artifacts while retaining OSS upload paths
- stop deleting stale OSS documentation objects during publication

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test commands::update --lib
- workflow YAML and Tauri JSON parse
- Prettier and git diff --check