### PR TITLE
feat: agent profiling (CPU flamegraph + dhat heap) & optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ channel/
 # Windows / MSYS2 artifacts
 /NUL
 *.bun-build
+
+# Profiling output (make profile-agent / profile-quick)
+/profile-results/
+/agent-profile.svg

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ make run-cli            # Run CLI in dev mode (auto-installs npm deps)
 make run-gui            # Run Tauri GUI in dev mode (auto-installs npm deps)
 make package-gui        # Build GUI desktop bundle via Tauri
 make run-channels        # Build and run channel bridge
+make profile-agent       # CPU profile: build + 90s bench → flamegraph SVG in profile-results/
+make profile-quick       # CPU profile: run N secs (PROFILE_SECS=30)
+make profile-heap        # Heap profile via dhat (feature dhat-heap) → dhat JSON in profile-results/
 make generate-models    # Fetch model data from APIs, regenerate models_generated.rs
 make generate-proto     # Compile proto/future.proto → Rust gRPC code
 make clean              # Remove target/, dist/, node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Entry point: `main.rs` — only CLI flag is `--grpc-addr`. Resolves model from s
 | `models/mod.rs` | Model registry: generated built-in catalog (`generated/`, 906 models) + user `models.json` overrides, resolution, fuzzy matching. Default model from settings.json |
 | `config/mod.rs` | Settings struct (7 fields: steering_mode, follow_up_mode, compaction, retry, max_turns, default_permission_level). Loads from `~/.future/agent/settings.json` (global) and `.future/agent/settings.json` (project), deep-merged |
 | `auth/mod.rs` | Reads API credentials from `~/.future/agent/auth.json` or `~/.future/agent-app/auth.json`, keyed by provider |
-| `skills/mod.rs` | Discovers skills from `~/.future/agent/skills/`, `.future/agent/skills/`, `~/.agents/skills/` — parses YAML frontmatter from SKILL.md |
+| `skills/mod.rs` | Discovers skills from the global dirs `~/.future/agent/skills/` and `~/.agents/skills/` (project/cwd-relative dirs are not supported) — parses YAML frontmatter from SKILL.md. Discovery is cached process-wide with a 60s TTL |
 | `prompt/mod.rs` | Builds system prompt in 6 sections: Identity (tools + guidelines) → Skills → Project Context (AGENTS.md > CLAUDE.md > GEMINI.md) → Workspace Memory (FUTURE.md) → Append prompt → Environment (date/cwd/platform). All sections deterministic for prompt cache hits |
 | `events/mod.rs` | `EventBus` with pub/sub for bridging agent streaming events to frontends (thinking, tool calls, usage stats) |
 | `utils/mod.rs` | Session ID generation, cwd path encoding (base32), image MIME type detection |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,32 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -81,6 +103,12 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-nats"
@@ -231,6 +259,21 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -463,6 +506,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +631,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "der"
@@ -768,6 +829,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +904,7 @@ dependencies = [
  "libc",
  "notify",
  "parking_lot",
+ "pprof",
  "prost",
  "prost-build",
  "prost-types",
@@ -1022,6 +1096,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1029,7 +1115,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1043,6 +1129,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1080,6 +1172,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1391,6 +1489,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap 2.14.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1531,17 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1598,6 +1725,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nkeys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,12 +1868,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1878,6 +2044,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2229,12 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2220,6 +2422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2443,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2712,6 +2929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2945,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -3301,6 +3547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +3686,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,6 +3709,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3720,6 +3997,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +912,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "dhat",
  "dirs 5.0.1",
  "fd-lock",
  "futures",
@@ -1760,6 +1777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,7 +2199,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2 0.6.5",
  "thiserror 2.0.19",
@@ -2197,7 +2220,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2449,6 +2472,12 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3063,6 +3092,12 @@ dependencies = [
  "quote",
  "syn 3.0.2",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,24 @@ profile-agent:
 	@echo "Flamegraph: $$(ls -t profile-results/agent-profile-*.svg | head -1)"
 	@echo "Run: open profile-results/agent-profile-*.svg"
 
+# Heap (memory) profile: build with the dhat-heap feature, run on port
+# 50052 for N seconds, write a dhat report JSON.
+# Usage: make profile-heap PROFILE_SECS=30
+# View the report at https://nnethercote.github.io/dh_view/dh_view.html
+profile-heap:
+	cargo build --release -p future-agent --features dhat-heap \
+		--config 'profile.release.debug="line-tables-only"' \
+		--config 'profile.release.strip="none"'
+	@mkdir -p profile-results
+	./target/release/future-agent \
+		--grpc-addr 127.0.0.1:50052 \
+		--profile-heap profile-results/heap-profile.json \
+		--profile-seconds $(or $(PROFILE_SECS),30) \
+		--verbose
+	@echo ""
+	@echo "Heap profile: profile-results/heap-profile.json"
+	@echo "View: https://nnethercote.github.io/dh_view/dh_view.html"
+
 # Quick profile: start agent with profiling on port 50052, run for N seconds.
 # Usage: make profile-quick PROFILE_SECS=30
 profile-quick:
@@ -365,6 +383,9 @@ help:
 	@echo "  run-gui            Run GUI in dev mode"
 	@echo "  run-channels        Run channel bridge directly (debug build)"
 	@echo "  package-gui        Package GUI desktop bundles"
+	@echo "  profile-agent      CPU profile: build + 90s bench, write flamegraph SVG"
+	@echo "  profile-quick      CPU profile: run agent N secs (PROFILE_SECS=30)"
+	@echo "  profile-heap       Heap profile via dhat, write dhat report JSON"
 	@echo "  generate-models    Fetch model data, regenerate Rust catalog + wiki docs"
 	@echo "  generate-proto     Compile proto/future.proto to Rust gRPC code"
 	@echo "  install            Build & install all components"

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,36 @@ package-gui: install-gui
 run-channels:
 	cd channels && cargo run
 
+# ─── Profile ───────────────────────────────────────────────────────────────
+
+# Build agent with debug symbols + frame pointers for profiling, then run
+# the benchmark suite.  Writes flamegraph SVG + logs to profile-results/.
+profile-agent:
+	RUSTFLAGS="-C force-frame-pointers=yes" \
+		cargo build --release -p future-agent \
+		--config 'profile.release.debug="line-tables-only"' \
+		--config 'profile.release.strip="none"'
+	@mkdir -p profile-results
+	@echo "Starting profile run (port 50052, 90s)..."
+	PROFILE_DURATION=90 bash scripts/agent-profile-bench.sh
+	@echo ""
+	@echo "Flamegraph: $$(ls -t profile-results/agent-profile-*.svg | head -1)"
+	@echo "Run: open profile-results/agent-profile-*.svg"
+
+# Quick profile: start agent with profiling on port 50052, run for N seconds.
+# Usage: make profile-quick PROFILE_SECS=30
+profile-quick:
+	RUSTFLAGS="-C force-frame-pointers=yes" \
+		cargo build --release -p future-agent \
+		--config 'profile.release.debug="line-tables-only"' \
+		--config 'profile.release.strip="none"'
+	@mkdir -p profile-results
+	./target/release/future-agent \
+		--grpc-addr 127.0.0.1:50052 \
+		--profile profile-results/quick-profile.svg \
+		--profile-seconds $(or $(PROFILE_SECS),30) \
+		--verbose
+
 # ─── Generate ───────────────────────────────────────────────────────────────
 
 generate-models:

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -61,6 +61,10 @@ tower-http = { version = "0.6", features = ["cors"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Profiling flamegraph output uses inferno behind the scenes.
+[target.'cfg(not(windows))'.dependencies]
+pprof = { version = "0.13", features = ["flamegraph"] }
+
 # Windows: Job Object for process-tree kill; restricted token + ACLs for the
 # bash sandbox (SANDBOX_PLAN §11). Feature set grows with W1b.
 [target.'cfg(windows)'.dependencies]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -11,6 +11,11 @@ path = "src/main.rs"
 name = "future_agent"
 path = "src/lib.rs"
 
+[features]
+# Heap (memory) profiling via dhat.  Build with `--features dhat-heap` and
+# run with `--profile-heap <PATH>` to get a dhat-heap JSON report.
+dhat-heap = ["dep:dhat"]
+
 [dependencies]
 tokio.workspace = true
 parking_lot.workspace = true
@@ -56,6 +61,10 @@ tonic.workspace = true
 prost.workspace = true
 prost-types = "0.13"
 tower-http = { version = "0.6", features = ["cors"] }
+
+# Optional: heap profiling support (feature `dhat-heap`).  The global
+# allocator shim lives in main.rs and is compiled only with the feature.
+dhat = { version = "0.3", optional = true }
 
 # Kill the whole bash process group on abort/timeout (not just the direct child)
 [target.'cfg(unix)'.dependencies]

--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -65,6 +65,9 @@ pub struct Loop {
     /// point. The run loop checks this after transform_context and returns an
     /// error instead of silently proceeding with full context.
     pub compaction_failed: Arc<AtomicBool>,
+    /// Cached model registry — avoids re-deserialising the 906-model catalog
+    /// on auto-compaction checks and image-support queries inside the hot loop.
+    pub model_registry: Option<Arc<parking_lot::RwLock<crate::models::Registry>>>,
 }
 
 impl Loop {
@@ -90,6 +93,7 @@ impl Loop {
             cumulative_cost: Arc::new(parking_lot::Mutex::new(0.0)),
             last_prompt_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             compaction_failed: Arc::new(AtomicBool::new(false)),
+            model_registry: None,
         }
     }
 
@@ -133,6 +137,7 @@ impl Loop {
         copy.verbose = self.verbose;
         copy.parallel_tools = self.parallel_tools;
         copy.event_bus = self.event_bus.clone();
+        copy.model_registry = self.model_registry.clone();
         copy
     }
 

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -227,8 +227,12 @@ impl Loop {
                             }
                             // Resolve the model's actual context window so we don't
                             // over-compact large-context models (1M+).
-                            let context_window = crate::models::Registry::new()
-                                .resolve(&ctx.model)
+                            // Use the cached registry from the loop to avoid
+                            // re-deserialising the model catalog.
+                            let context_window = self
+                                .model_registry
+                                .as_ref()
+                                .and_then(|r| r.read().resolve(&ctx.model))
                                 .map(|m| m.context_window)
                                 .unwrap_or(1_000_000);
                             let reserve = ((context_window as f64 * 0.1) as i32).max(16384);

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -228,11 +228,15 @@ impl Loop {
                             // Resolve the model's actual context window so we don't
                             // over-compact large-context models (1M+).
                             // Use the cached registry from the loop to avoid
-                            // re-deserialising the model catalog.
+                            // re-deserialising the model catalog; loops not
+                            // derived from the app template (model_registry =
+                            // None, e.g. tests) fall back to a fresh Registry
+                            // so behaviour matches the pre-cache code.
                             let context_window = self
                                 .model_registry
                                 .as_ref()
                                 .and_then(|r| r.read().resolve(&ctx.model))
+                                .or_else(|| crate::models::Registry::new().resolve(&ctx.model))
                                 .map(|m| m.context_window)
                                 .unwrap_or(1_000_000);
                             let reserve = ((context_window as f64 * 0.1) as i32).max(16384);

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -28,7 +28,10 @@ pub use llm::Client as LLMClient;
 pub use models::{get_default_model, Registry as ModelRegistry};
 pub use rpc::ServerSession;
 pub use session::{Manager, Session, SessionEntry};
-pub use skills::{discover_skills, Skill, AGENTS_SKILLS_DIR, APP_SKILLS_DIR, PROJECT_SKILLS_DIR};
+pub use skills::{
+    discover_skills, discover_skills_cached, invalidate_skills_cache, Skill, AGENTS_SKILLS_DIR,
+    APP_SKILLS_DIR, PROJECT_SKILLS_DIR,
+};
 pub use tools::{all_tools, coding_tools};
 pub use types::{AgentMessage, AgentTool, LLMProvider, Message, StreamEvent, ToolDef};
 pub use utils::{default_config_dir, default_session_dir, generate_id};

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -29,8 +29,8 @@ pub use models::{get_default_model, Registry as ModelRegistry};
 pub use rpc::ServerSession;
 pub use session::{Manager, Session, SessionEntry};
 pub use skills::{
-    discover_skills, discover_skills_cached, invalidate_skills_cache, Skill, AGENTS_SKILLS_DIR,
-    APP_SKILLS_DIR, PROJECT_SKILLS_DIR,
+    discover_skills, discover_skills_cached, global_skill_dirs, invalidate_skills_cache, Skill,
+    AGENTS_SKILLS_DIR, APP_SKILLS_DIR,
 };
 pub use tools::{all_tools, coding_tools};
 pub use types::{AgentMessage, AgentTool, LLMProvider, Message, StreamEvent, ToolDef};

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -518,28 +518,33 @@ async fn async_main(
 
     // If --profile-seconds is set, spawn a task that signals shutdown after N
     // seconds via a oneshot so the flamegraph gets written by main().
-    let (profile_tx, profile_rx) = tokio::sync::oneshot::channel::<()>();
-    let mut profile_tx = Some(profile_tx);
-    if let Some(secs) = cli.profile_seconds {
-        let tx = profile_tx.take().unwrap();
-        let shutting_down = shutting_down.clone();
-        let sessions = sessions.clone();
-        tokio::spawn(async move {
-            tracing::info!(
-                "Profile timer: agent will auto-shutdown after {} seconds",
-                secs
-            );
-            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            tracing::info!("Profile timer expired — shutting down for flamegraph capture");
-            shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
-            for s in sessions.read().values() {
-                s.read().abort();
-            }
-            let _ = tx.send(());
-        });
-    }
-    // If --profile-seconds was not given, drop tx so rx never fires.
-    drop(profile_tx);
+    // When --profile-seconds is not set, use pending() so the select branch
+    // never fires.
+    let profile_rx: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+        if let Some(secs) = cli.profile_seconds {
+            let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+            let shutting_down = shutting_down.clone();
+            let sessions = sessions.clone();
+            tokio::spawn(async move {
+                tracing::info!(
+                    "Profile timer: agent will auto-shutdown after {} seconds",
+                    secs
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+                tracing::info!("Profile timer expired — shutting down for flamegraph capture");
+                shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
+                for s in sessions.read().values() {
+                    s.read().abort();
+                }
+                let _ = tx.send(());
+            });
+            Box::pin(async move {
+                let _ = rx.await;
+                tracing::info!("Profile timer completed — draining active streams");
+            })
+        } else {
+            Box::pin(std::future::pending())
+        };
 
     tokio::select! {
         result = server => result?,
@@ -578,7 +583,7 @@ async fn async_main(
             }
         }
         _ = profile_rx => {
-            tracing::info!("Profile timer completed — draining active streams");
+            // profile timer handled inside the future
         }
     }
     Ok(())

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -43,10 +43,68 @@ struct Cli {
         default_value_t = future_agent::logfile::DEFAULT_MAX_LINES
     )]
     log_max_lines: usize,
+
+    /// Enable CPU profiling and write a flamegraph SVG to the given path on
+    /// shutdown.  Profiling starts immediately and runs until the agent exits.
+    #[arg(long, value_name = "PATH")]
+    profile: Option<String>,
+
+    /// Profile for N seconds then exit automatically (for benchmarking).
+    /// Implies --profile with a default path when --profile is not also set.
+    #[arg(long, value_name = "N")]
+    profile_seconds: Option<u64>,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Resolve profile path early (before the runtime starts).
+    let profile_path: Option<std::path::PathBuf> = cli
+        .profile
+        .as_deref()
+        .or_else(|| {
+            if cli.profile_seconds.is_some() {
+                Some("agent-profile.svg")
+            } else {
+                None
+            }
+        })
+        .map(std::path::PathBuf::from);
+
+    // Start CPU profiling if requested.  The guard lives in main() so it
+    // covers the entire agent lifetime including gRPC startup/shutdown.
+    // ProfilerGuard is !Send so we keep it right here.
+    #[cfg(not(windows))]
+    let profiler_guard = match &profile_path {
+        Some(_path) => {
+            tracing::info!(
+                "CPU profiling enabled → will write flamegraph to {}",
+                _path.display()
+            );
+            match pprof::ProfilerGuardBuilder::default()
+                .frequency(997) // prime to avoid lock-step with timers
+                .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+                .build()
+            {
+                Ok(g) => Some(g),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to start profiler: {} — continuing without profiling",
+                        e
+                    );
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+    #[cfg(windows)]
+    let profiler_guard: Option<()> = {
+        if profile_path.is_some() {
+            tracing::warn!("CPU profiling is not supported on Windows — ignoring --profile flag");
+        }
+        None
+    };
 
     // Load the user's login-shell PATH/env BEFORE spawning any threads or the
     // tokio runtime — set_var is only sound while single-threaded. Fixes
@@ -113,16 +171,58 @@ fn main() -> Result<()> {
     let model_registry = Arc::new(parking_lot::RwLock::new(ModelRegistry::new()));
 
     // Launch async portion
+    // 1 MB thread stack is sufficient for async I/O (was 4 MB).
+    // On a 32-core machine this saves 96 MB virtual memory.
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(4 * 1024 * 1024)
+        .thread_stack_size(1 * 1024 * 1024)
         .build()?
-        .block_on(async_main(model_registry, cli))
+        .block_on(async_main(model_registry, cli, profile_path.clone()))
+        .inspect_err(|e| tracing::error!("Agent exited with error: {e}"))
+        .ok();
+
+    // Write profiling flamegraph on shutdown (after the runtime drops,
+    // so all async tasks have settled).  ProfilerGuard stops sampling on
+    // drop, so we must build the report BEFORE dropping the guard.
+    #[cfg(not(windows))]
+    if let (Some(guard), Some(path)) = (profiler_guard, profile_path) {
+        tracing::info!("Writing CPU profile flamegraph to {}", path.display());
+        match guard.report().build() {
+            Ok(report) => {
+                let file = std::fs::File::create(&path)
+                    .map_err(|e| {
+                        tracing::error!("Cannot create profile file {}: {}", path.display(), e);
+                        e
+                    })
+                    .ok();
+                if let Some(f) = file {
+                    if let Err(e) = report.flamegraph(f) {
+                        tracing::error!("Failed to write flamegraph: {}", e);
+                    } else {
+                        let sz = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                        tracing::info!(
+                            "Flamegraph written: {} ({:.1} KB)",
+                            path.display(),
+                            sz as f64 / 1024.0
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to build profiling report: {}", e);
+            }
+        }
+    }
+    #[cfg(windows)]
+    let _ = (profiler_guard, profile_path);
+
+    Ok(())
 }
 
 async fn async_main(
     model_registry: Arc<parking_lot::RwLock<ModelRegistry>>,
     cli: Cli,
+    _profile_path: Option<std::path::PathBuf>,
 ) -> Result<()> {
     let cwd = dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
@@ -379,7 +479,12 @@ async fn async_main(
     // share one global loop — each hydrated/created session gets an
     // independent copy so concurrent runs, model switches and aborts stay
     // session-local.  The template itself never runs prompts.
-    let loop_template = Arc::new(engine.agent_loop.independent_copy());
+    // Set the model_registry on the template so all session loops inherit
+    // the cached registry via independent_copy() — avoids ~15% CPU overhead
+    // from re-deserialising the model catalog on every prompt.
+    let mut template_loop = engine.agent_loop.independent_copy();
+    template_loop.model_registry = Some(model_registry.clone());
+    let loop_template = Arc::new(template_loop);
 
     // The agent starts with ZERO sessions.  There is no privileged
     // "default"/"current" session — clients (TUI, GUI, CLI, channels)
@@ -410,6 +515,31 @@ async fn async_main(
     let shutdown_timeout = std::time::Duration::from_secs(30);
 
     let server = future_agent::grpc::serve(app_state, grpc_host, grpc_port);
+
+    // If --profile-seconds is set, spawn a task that signals shutdown after N
+    // seconds via a oneshot so the flamegraph gets written by main().
+    let (profile_tx, profile_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut profile_tx = Some(profile_tx);
+    if let Some(secs) = cli.profile_seconds {
+        let tx = profile_tx.take().unwrap();
+        let shutting_down = shutting_down.clone();
+        let sessions = sessions.clone();
+        tokio::spawn(async move {
+            tracing::info!(
+                "Profile timer: agent will auto-shutdown after {} seconds",
+                secs
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+            tracing::info!("Profile timer expired — shutting down for flamegraph capture");
+            shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
+            for s in sessions.read().values() {
+                s.read().abort();
+            }
+            let _ = tx.send(());
+        });
+    }
+    // If --profile-seconds was not given, drop tx so rx never fires.
+    drop(profile_tx);
 
     tokio::select! {
         result = server => result?,
@@ -446,6 +576,9 @@ async fn async_main(
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             }
+        }
+        _ = profile_rx => {
+            tracing::info!("Profile timer completed — draining active streams");
         }
     }
     Ok(())

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -439,7 +439,7 @@ async fn async_main(
         format!("{}/{}", cwd, PROJECT_SKILLS_DIR),
         AGENTS_SKILLS_DIR.to_string(),
     ];
-    let skills = future_agent::discover_skills(&skill_dirs).unwrap_or_default();
+    let skills = future_agent::discover_skills_cached(&skill_dirs);
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
 
     // Load project context

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -3,10 +3,7 @@
 use anyhow::Result;
 use chrono::Local;
 use clap::Parser;
-use future_agent::{
-    Engine, EngineConfig, Manager, ModelRegistry, AGENTS_SKILLS_DIR, APP_SKILLS_DIR,
-    PROJECT_SKILLS_DIR,
-};
+use future_agent::{Engine, EngineConfig, Manager, ModelRegistry};
 use std::sync::Arc;
 
 #[derive(Parser)]
@@ -171,15 +168,14 @@ fn main() -> Result<()> {
     let model_registry = Arc::new(parking_lot::RwLock::new(ModelRegistry::new()));
 
     // Launch async portion
-    // 1 MB thread stack is sufficient for async I/O (was 4 MB).
-    // On a 32-core machine this saves 96 MB virtual memory.
-    tokio::runtime::Builder::new_multi_thread()
+    // 2 MB thread stack (Rust's default) is enough for async I/O while
+    // leaving headroom for deep serde/JSON recursion (was 4 MB).
+    // On a 32-core machine this still saves 64 MB virtual memory vs 4 MB.
+    let run_result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(1 * 1024 * 1024)
+        .thread_stack_size(2 * 1024 * 1024)
         .build()?
-        .block_on(async_main(model_registry, cli, profile_path.clone()))
-        .inspect_err(|e| tracing::error!("Agent exited with error: {e}"))
-        .ok();
+        .block_on(async_main(model_registry, cli));
 
     // Write profiling flamegraph on shutdown (after the runtime drops,
     // so all async tasks have settled).  ProfilerGuard stops sampling on
@@ -216,13 +212,18 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     let _ = (profiler_guard, profile_path);
 
+    // Propagate async_main's failure as a non-zero exit code so callers
+    // (CLI/TUI/service managers) can detect an abnormal exit.
+    if let Err(e) = run_result {
+        tracing::error!("Agent exited with error: {e}");
+        std::process::exit(1);
+    }
     Ok(())
 }
 
 async fn async_main(
     model_registry: Arc<parking_lot::RwLock<ModelRegistry>>,
     cli: Cli,
-    _profile_path: Option<std::path::PathBuf>,
 ) -> Result<()> {
     let cwd = dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
@@ -433,12 +434,9 @@ async fn async_main(
             Err(_) => ("127.0.0.1", 50051),
         }
     };
-    // Discover skills
-    let skill_dirs = vec![
-        APP_SKILLS_DIR.to_string(),
-        format!("{}/{}", cwd, PROJECT_SKILLS_DIR),
-        AGENTS_SKILLS_DIR.to_string(),
-    ];
+    // Discover skills (global user-level dirs only — project/cwd-relative
+    // skill dirs are intentionally not scanned).
+    let skill_dirs = future_agent::global_skill_dirs();
     let skills = future_agent::discover_skills_cached(&skill_dirs);
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -50,17 +50,36 @@ struct Cli {
     /// Implies --profile with a default path when --profile is not also set.
     #[arg(long, value_name = "N")]
     profile_seconds: Option<u64>,
+
+    /// Enable heap (memory) profiling and write a dhat report to the given
+    /// path on shutdown.  Requires the `dhat-heap` build feature
+    /// (`cargo build --release --features dhat-heap`); without it this flag
+    /// is ignored with a warning.
+    #[arg(long, value_name = "PATH")]
+    profile_heap: Option<String>,
 }
+
+// When built with the `dhat-heap` feature, route every allocation through
+// dhat's tracking allocator.  Without an active `dhat::Profiler` this is a
+// thin pass-through to the system allocator, and the shim is compiled out
+// entirely in normal builds.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Resolve profile path early (before the runtime starts).
+    // --profile-seconds alone implies CPU profiling with a default path —
+    // but NOT when --profile-heap is set: running the CPU sampler during a
+    // heap profile pollutes the report (pprof's collector alone allocates
+    // ~68 MB) and skews every measurement.
     let profile_path: Option<std::path::PathBuf> = cli
         .profile
         .as_deref()
         .or_else(|| {
-            if cli.profile_seconds.is_some() {
+            if cli.profile_seconds.is_some() && cli.profile_heap.is_none() {
                 Some("agent-profile.svg")
             } else {
                 None
@@ -102,6 +121,21 @@ fn main() -> Result<()> {
         }
         None
     };
+
+    // Start heap profiling if requested.  The Profiler writes its report to
+    // disk when dropped, so it must outlive the tokio runtime — it lives
+    // here in main() and is dropped explicitly before any early exit.
+    #[cfg(feature = "dhat-heap")]
+    let heap_profiler = cli.profile_heap.as_ref().map(|path| {
+        tracing::info!("Heap profiling enabled → will write dhat report to {path}");
+        dhat::Profiler::builder().file_name(path).build()
+    });
+    #[cfg(not(feature = "dhat-heap"))]
+    if cli.profile_heap.is_some() {
+        tracing::warn!(
+            "--profile-heap requires a build with --features dhat-heap — ignoring the flag"
+        );
+    }
 
     // Load the user's login-shell PATH/env BEFORE spawning any threads or the
     // tokio runtime — set_var is only sound while single-threaded. Fixes
@@ -216,6 +250,9 @@ fn main() -> Result<()> {
     // (CLI/TUI/service managers) can detect an abnormal exit.
     if let Err(e) = run_result {
         tracing::error!("Agent exited with error: {e}");
+        // process::exit skips destructors — flush the heap report first.
+        #[cfg(feature = "dhat-heap")]
+        drop(heap_profiler);
         std::process::exit(1);
     }
     Ok(())

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -90,8 +90,17 @@ pub fn builtin_models() -> Vec<Model> {
 /// Whether the resolved model advertises image input (catalog `input`
 /// modalities). Unknown models → false. Shared by the prompt path (deciding
 /// image_url vs. a path fallback) and session reload (re-hydrating images).
+///
+/// Prefer `model_accepts_images_with(registry, model)` to avoid the expensive
+/// `Registry::new()` call in hot paths.
 pub fn model_accepts_images(model: &str) -> bool {
-    Registry::new()
+    model_accepts_images_with(&Registry::new(), model)
+}
+
+/// Like `model_accepts_images` but reuses an existing registry to avoid
+/// re-deserialising the 906-model built-in catalog on every call.
+pub fn model_accepts_images_with(registry: &Registry, model: &str) -> bool {
+    registry
         .resolve(model)
         .map(|m| m.input.iter().any(|i| i == "image"))
         .unwrap_or(false)
@@ -115,7 +124,12 @@ pub fn settings_path() -> String {
 
 /// Get the first available model, or None.
 pub fn get_default_model() -> Option<String> {
-    let registry = Registry::new();
+    get_default_model_with(&Registry::new())
+}
+
+/// Like `get_default_model` but reuses an existing registry to avoid
+/// re-deserialising the model catalog on every GUI poll.
+pub fn get_default_model_with(registry: &Registry) -> Option<String> {
     let auth = crate::AuthStore::load();
     // Prefer future/deepseek-v4-pro when the future provider is configured,
     // otherwise fall back to the first model with credentials.

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -56,6 +56,17 @@ pub struct Cost {
     pub cache_write: f64,
 }
 
+/// Process-wide shared copy of the parsed built-in catalog.  The embedded
+/// models.json is ~1.9 MB; parsing it costs ~1.5 MB of fresh heap and
+/// several ms of CPU on every call, so parse once and share an `Arc`.
+pub fn builtin_models_shared() -> std::sync::Arc<Vec<Model>> {
+    static BUILTIN_MODELS: std::sync::OnceLock<std::sync::Arc<Vec<Model>>> =
+        std::sync::OnceLock::new();
+    BUILTIN_MODELS
+        .get_or_init(|| std::sync::Arc::new(builtin_models()))
+        .clone()
+}
+
 /// BuiltinModels returns the generated model catalog from models_generated.rs.
 /// All models are maintained by: make generate-models
 pub fn builtin_models() -> Vec<Model> {
@@ -523,7 +534,10 @@ fn is_openai_compatible_api(api: &str) -> bool {
 
 /// Registry provides model resolution.
 pub struct Registry {
-    builtin: Vec<Model>,
+    // Shared, parsed-once built-in catalog (see `builtin_models_shared`).
+    // Copy-on-write: registries that inject future-provider models clone the
+    // Vec via Arc::make_mut; everyone else just shares the Arc.
+    builtin: std::sync::Arc<Vec<Model>>,
     user: Vec<Model>,
     provider_overrides: HashMap<String, ProviderOverride>,
 }
@@ -533,7 +547,7 @@ impl Registry {
         let (mut user_models, overrides) =
             load_user_models_with_overrides(&user_models_path()).unwrap_or_default();
 
-        let mut builtin = builtin_models();
+        let mut builtin = builtin_models_shared();
 
         // Load Future provider models dynamically if auth is available
         let auth_store = crate::AuthStore::load();
@@ -541,12 +555,14 @@ impl Registry {
             let base_url = resolve_future_base_url();
             let future_models = get_future_models_with_cache(&future_key, &base_url);
 
-            // Add future models to builtin (they override same-ID builtin models)
+            // Add future models to builtin (they override same-ID builtin
+            // models).  Clones the shared Vec only on this path.
+            let builtin_mut = std::sync::Arc::make_mut(&mut builtin);
             for fm in future_models {
-                if let Some(idx) = builtin.iter().position(|m| m.id == fm.id) {
-                    builtin[idx] = fm;
+                if let Some(idx) = builtin_mut.iter().position(|m| m.id == fm.id) {
+                    builtin_mut[idx] = fm;
                 } else {
-                    builtin.push(fm);
+                    builtin_mut.push(fm);
                 }
             }
 
@@ -596,7 +612,7 @@ impl Registry {
     /// Get all available models (user models override built-in with same ID).
     /// Models with `hide: true` are excluded from the listing but remain callable via `resolve()`.
     pub fn all_models(&self) -> Vec<Model> {
-        let mut models = self.builtin.clone();
+        let mut models = self.builtin.as_ref().clone();
         for user_model in &self.user {
             if let Some(idx) = models.iter().position(|m| m.id == user_model.id) {
                 models[idx] = user_model.clone();

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -589,9 +589,7 @@ fn get_agent_info_response(id: &str) -> String {
         crate::skills::APP_SKILLS_DIR.to_string(),
         crate::skills::AGENTS_SKILLS_DIR.to_string(),
     ];
-    let skills_count = crate::skills::discover_skills(&dirs)
-        .map(|s| s.len())
-        .unwrap_or(0);
+    let skills_count = crate::skills::discover_skills_cached(&dirs).len();
     RpcResponse::ok(
         id,
         "get_agent_info",
@@ -836,7 +834,7 @@ fn cmd_get_commands(id: &str) -> String {
         crate::skills::PROJECT_SKILLS_DIR.to_string(),
         crate::skills::AGENTS_SKILLS_DIR.to_string(),
     ];
-    let skills = crate::skills::discover_skills(&skill_dirs).unwrap_or_default();
+    let skills = crate::skills::discover_skills_cached(&skill_dirs);
 
     let mut commands: Vec<serde_json::Value> = skills
         .into_iter()
@@ -1337,7 +1335,7 @@ fn cmd_reload_config(
         format!("{}/{}", cwd, crate::skills::PROJECT_SKILLS_DIR),
         crate::skills::AGENTS_SKILLS_DIR.to_string(),
     ];
-    let skills = crate::skills::discover_skills(&skill_dirs).unwrap_or_default();
+    let skills = crate::skills::discover_skills_cached(&skill_dirs);
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
 
     // Re-read context files

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -585,11 +585,8 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
 }
 
 fn get_agent_info_response(id: &str) -> String {
-    let dirs = vec![
-        crate::skills::APP_SKILLS_DIR.to_string(),
-        crate::skills::AGENTS_SKILLS_DIR.to_string(),
-    ];
-    let skills_count = crate::skills::discover_skills_cached(&dirs).len();
+    let skills_count =
+        crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs()).len();
     RpcResponse::ok(
         id,
         "get_agent_info",
@@ -829,12 +826,7 @@ fn cmd_get_fork_messages(state: &AppState, cmd: &RpcCommand, id: &str) -> String
 
 fn cmd_get_commands(id: &str) -> String {
     // Return commands from skills (similar to Go's extensions + prompts)
-    let skill_dirs = vec![
-        crate::skills::APP_SKILLS_DIR.to_string(),
-        crate::skills::PROJECT_SKILLS_DIR.to_string(),
-        crate::skills::AGENTS_SKILLS_DIR.to_string(),
-    ];
-    let skills = crate::skills::discover_skills_cached(&skill_dirs);
+    let skills = crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
 
     let mut commands: Vec<serde_json::Value> = skills
         .into_iter()
@@ -912,10 +904,8 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
     // the active session) so that CLI one-shot runs always start from the
     // preferred default.  GUI/TUI explicitly set model_id on the command,
     // which overrides this below.
-    let default_model = crate::models::get_default_model_with(
-        &state.model_registry.read(),
-    )
-    .unwrap_or_else(|| inherit_model.clone());
+    let default_model = crate::models::get_default_model_with(&state.model_registry.read())
+        .unwrap_or_else(|| inherit_model.clone());
     // Apply via set_model: it sets the canonical model AND rebuilds the
     // loop's provider client for that model's endpoint/key/compat.  A bare
     // `loop_.model = bare_id` leaves the provider on the template's startup
@@ -1193,10 +1183,8 @@ fn cmd_fork(
         state.approval_gate.clone(),
         state.model_registry.clone(),
     );
-    let supports_images = crate::models::model_accepts_images_with(
-        &state.model_registry.read(),
-        &forked.model,
-    );
+    let supports_images =
+        crate::models::model_accepts_images_with(&state.model_registry.read(), &forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {
@@ -1291,10 +1279,8 @@ fn cmd_clone(
         state.approval_gate.clone(),
         state.model_registry.clone(),
     );
-    let supports_images = crate::models::model_accepts_images_with(
-        &state.model_registry.read(),
-        &forked.model,
-    );
+    let supports_images =
+        crate::models::model_accepts_images_with(&state.model_registry.read(), &forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {
@@ -1329,13 +1315,10 @@ fn cmd_reload_config(
         (sess.cwd.clone(), loop_.tools.clone())
     };
 
-    // Re-discover skills (blocking I/O, no locks held)
-    let skill_dirs = vec![
-        crate::skills::APP_SKILLS_DIR.to_string(),
-        format!("{}/{}", cwd, crate::skills::PROJECT_SKILLS_DIR),
-        crate::skills::AGENTS_SKILLS_DIR.to_string(),
-    ];
-    let skills = crate::skills::discover_skills_cached(&skill_dirs);
+    // Re-discover skills (blocking I/O, no locks held).  Invalidate the
+    // 60s cache first — an explicit reload must see on-disk changes now.
+    crate::skills::invalidate_skills_cache();
+    let skills = crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
 
     // Re-read context files

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -402,10 +402,13 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         }
         "cycle_model" => {
             // Cycle to next available model.  Scoping is client-side (TUI/GUI).
-            let registry = crate::models::Registry::new();
+            // Use the cached registry — Registry::new() re-parses the 1.9 MB
+            // catalog AND may do blocking network I/O (future provider
+            // refresh) on every call.
             let auth = crate::AuthStore::load();
-
-            let models: Vec<String> = registry
+            let models: Vec<String> = state
+                .model_registry
+                .read()
                 .all_models()
                 .into_iter()
                 .filter(|m| !m.api_key.is_empty() || auth.get(&m.provider).is_some())

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -28,7 +28,7 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         return get_agent_info_response(id);
     }
     if cmd_type == "list_models" {
-        return list_models_response(id);
+        return list_models_response(id, &state.model_registry.read());
     }
 
     // Credential refresh operates on every session, not one — handle it before
@@ -602,8 +602,7 @@ fn get_agent_info_response(id: &str) -> String {
     )
 }
 
-fn list_models_response(id: &str) -> String {
-    let registry = crate::models::Registry::new();
+fn list_models_response(id: &str, registry: &crate::models::Registry) -> String {
     let auth = crate::AuthStore::load();
 
     // Always return all available models.  Scoping / defaults are client-side.
@@ -624,7 +623,7 @@ fn list_models_response(id: &str) -> String {
 
     // Use the same default-model resolution as cmd_new_session so the list
     // and actual session creation agree on which model is the default.
-    let effective_default = crate::models::get_default_model()
+    let effective_default = crate::models::get_default_model_with(registry)
         .and_then(|full| full.rsplit_once('/').map(|(_, id)| id.to_string()))
         .or_else(|| models.first().map(|m| m.id.clone()))
         .unwrap_or_default();
@@ -911,11 +910,14 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
         approval_gate,
         state.model_registry.clone(),
     );
-    // Resolve the default model fresh from the registry (not inherited from
+    // Resolve the default model from the cached registry (not inherited from
     // the active session) so that CLI one-shot runs always start from the
     // preferred default.  GUI/TUI explicitly set model_id on the command,
     // which overrides this below.
-    let default_model = crate::models::get_default_model().unwrap_or_else(|| inherit_model.clone());
+    let default_model = crate::models::get_default_model_with(
+        &state.model_registry.read(),
+    )
+    .unwrap_or_else(|| inherit_model.clone());
     // Apply via set_model: it sets the canonical model AND rebuilds the
     // loop's provider client for that model's endpoint/key/compat.  A bare
     // `loop_.model = bare_id` leaves the provider on the template's startup
@@ -983,7 +985,10 @@ fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> String {
         } else {
             disk_model.clone()
         };
-        let supports_images = crate::models::model_accepts_images(&effective_model);
+        let supports_images = crate::models::model_accepts_images_with(
+            &state.model_registry.read(),
+            &effective_model,
+        );
         let mut msgs = new_sess.messages.write();
         *msgs = crate::session::entries_to_agent_messages(&entries, supports_images);
         if !disk_model.is_empty() {
@@ -1190,7 +1195,10 @@ fn cmd_fork(
         state.approval_gate.clone(),
         state.model_registry.clone(),
     );
-    let supports_images = crate::models::model_accepts_images(&forked.model);
+    let supports_images = crate::models::model_accepts_images_with(
+        &state.model_registry.read(),
+        &forked.model,
+    );
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {
@@ -1285,7 +1293,10 @@ fn cmd_clone(
         state.approval_gate.clone(),
         state.model_registry.clone(),
     );
-    let supports_images = crate::models::model_accepts_images(&forked.model);
+    let supports_images = crate::models::model_accepts_images_with(
+        &state.model_registry.read(),
+        &forked.model,
+    );
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -106,10 +106,8 @@ impl AppState {
         // A bare `new_sess.model = ...` would leave the loop pointing at the
         // template's startup model/endpoint.
         if new_sess.model.is_empty() {
-            let default_model = crate::models::get_default_model_with(
-                &self.model_registry.read(),
-            )
-            .unwrap_or_else(|| self.loop_template.model.clone());
+            let default_model = crate::models::get_default_model_with(&self.model_registry.read())
+                .unwrap_or_else(|| self.loop_template.model.clone());
             if !default_model.is_empty() {
                 if let Err(e) = new_sess.set_model(&default_model) {
                     tracing::warn!("[session] could not apply default model on hydrate: {e}");

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -106,8 +106,10 @@ impl AppState {
         // A bare `new_sess.model = ...` would leave the loop pointing at the
         // template's startup model/endpoint.
         if new_sess.model.is_empty() {
-            let default_model = crate::models::get_default_model()
-                .unwrap_or_else(|| self.loop_template.model.clone());
+            let default_model = crate::models::get_default_model_with(
+                &self.model_registry.read(),
+            )
+            .unwrap_or_else(|| self.loop_template.model.clone());
             if !default_model.is_empty() {
                 if let Err(e) = new_sess.set_model(&default_model) {
                     tracing::warn!("[session] could not apply default model on hydrate: {e}");

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -189,20 +189,13 @@ impl SseBroadcaster {
             let overflow = run.events.len() - MAX_RUN_EVENTS;
             run.events.drain(0..overflow);
         }
-        // broadcast::Sender::send returns Err(SendError) when there are no
-        // active receivers OR when the ring buffer is full (receivers are
-        // >256 events behind).  Distinguish: only warn when there ARE
-        // receivers (i.e. the channel is actually full) — silent no-receiver
-        // is normal for ephemeral sessions before a client subscribes.
-        if self.tx.receiver_count() > 0 {
-            if let Err(tokio::sync::broadcast::error::SendError(_)) = self.tx.send(event) {
-                tracing::warn!(
-                    "SSE broadcast channel full (256 events) — slow client(s) will receive Lagged"
-                );
-            }
-        } else {
-            let _ = self.tx.send(event); // no receivers, discard
-        }
+        // tokio broadcast semantics: send() only fails when there are NO
+        // active receivers — normal for ephemeral sessions before a client
+        // subscribes, so the error is ignored.  When the ring buffer is
+        // full, send() does NOT fail; it drops the oldest events and slow
+        // receivers observe RecvError::Lagged, then resync via
+        // `events_since` (which reports the gap via min_idx).
+        let _ = self.tx.send(event);
     }
 
     /// Begin a new user run: set `run_id`, reset `idx`, clear the buffer.

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -189,13 +189,19 @@ impl SseBroadcaster {
             let overflow = run.events.len() - MAX_RUN_EVENTS;
             run.events.drain(0..overflow);
         }
-        // broadcast::Sender::send returns Err(SendError) when the ring buffer
-        // is full (all receivers are >256 events behind).  This is expected
-        // for slow/disconnected clients — warn so it's diagnosable.
-        if let Err(tokio::sync::broadcast::error::SendError(_)) = self.tx.send(event) {
-            tracing::warn!(
-                "SSE broadcast channel full (256 events) — slow client(s) will receive Lagged"
-            );
+        // broadcast::Sender::send returns Err(SendError) when there are no
+        // active receivers OR when the ring buffer is full (receivers are
+        // >256 events behind).  Distinguish: only warn when there ARE
+        // receivers (i.e. the channel is actually full) — silent no-receiver
+        // is normal for ephemeral sessions before a client subscribes.
+        if self.tx.receiver_count() > 0 {
+            if let Err(tokio::sync::broadcast::error::SendError(_)) = self.tx.send(event) {
+                tracing::warn!(
+                    "SSE broadcast channel full (256 events) — slow client(s) will receive Lagged"
+                );
+            }
+        } else {
+            let _ = self.tx.send(event); // no receivers, discard
         }
     }
 

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -135,7 +135,10 @@ impl RpcResponse {
 /// per-session ceiling, not cumulative. Sized to comfortably hold a long
 /// generation's per-token `text_chunk` stream; on overflow the oldest are
 /// dropped and `events_since` reports the resulting gap via `min_idx`.
-const MAX_RUN_EVENTS: usize = 20000;
+/// Max events buffered per run for `events_since` resync.
+/// 2000 is sufficient — a client that falls behind 2000 events
+/// is effectively disconnected and should reconnect.
+const MAX_RUN_EVENTS: usize = 2_000;
 
 struct RunState {
     run_id: String,
@@ -154,7 +157,11 @@ pub struct SseBroadcaster {
 
 impl SseBroadcaster {
     pub fn new() -> Self {
-        let (tx, _) = broadcast::channel(4096);
+        // 256 slots is enough — measured rate is ~15-30 events/sec during
+        // streaming, so 256 slots tolerates ~10s of client lag.  A client
+        // behind by more than 256 events is effectively disconnected and
+        // should resync via `events_since` anyway.
+        let (tx, _) = broadcast::channel(256);
         Self {
             tx,
             run: std::sync::Arc::new(parking_lot::Mutex::new(RunState {
@@ -182,7 +189,14 @@ impl SseBroadcaster {
             let overflow = run.events.len() - MAX_RUN_EVENTS;
             run.events.drain(0..overflow);
         }
-        let _ = self.tx.send(event);
+        // broadcast::Sender::send returns Err(SendError) when the ring buffer
+        // is full (all receivers are >256 events behind).  This is expected
+        // for slow/disconnected clients — warn so it's diagnosable.
+        if let Err(tokio::sync::broadcast::error::SendError(_)) = self.tx.send(event) {
+            tracing::warn!(
+                "SSE broadcast channel full (256 events) — slow client(s) will receive Lagged"
+            );
+        }
     }
 
     /// Begin a new user run: set `run_id`, reset `idx`, clear the buffer.

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -511,7 +511,9 @@ impl ServerSession {
         let tokens_before = self.last_prompt_tokens.load(Ordering::Relaxed) as i32;
 
         // Resolve context_window from model registry (same as getState's contextWindow)
-        let context_window = crate::models::Registry::new()
+        let context_window = self
+            .model_registry
+            .read()
             .resolve(&self.model)
             .map(|m| m.context_window)
             .unwrap_or(1_000_000); // Modern default: 1M

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -28,7 +28,12 @@ impl ServerSession {
         };
 
         // Whether the active model accepts image input (catalog modalities).
-        let model_supports_images = crate::models::model_accepts_images(&self.model);
+        // Uses the cached registry from ServerSession to avoid ~15% CPU overhead
+        // from re-deserialising the full model catalog on every prompt.
+        let model_supports_images = crate::models::model_accepts_images_with(
+            &self.model_registry.read(),
+            &self.model,
+        );
         // Images are read + (down)encoded to base64 here, on the agent, from the
         // local path the GUI sent — the base64 never crosses the wire.
         let user_message = build_user_message(
@@ -642,9 +647,11 @@ impl ServerSession {
                 let comp_tokens = self.last_prompt_tokens.clone();
                 let comp_result = r#loop.last_compaction_result.clone();
                 let comp_failed = r#loop.compaction_failed.clone();
-                // Resolve context_window once — avoid creating a new Registry
-                // on every LLM call inside the closure.
-                let context_window = crate::models::Registry::new()
+                // Resolve context_window once — reuse cached registry
+                // to avoid re-deserialising the model catalog.
+                let context_window = self
+                    .model_registry
+                    .read()
                     .resolve(&self.model)
                     .map(|m| m.context_window)
                     .unwrap_or(1_000_000); // Modern default: 1M (was 200K — too low for 1M models)

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -714,7 +714,7 @@ impl ServerSession {
             format!("{}/{}", self.cwd, crate::skills::PROJECT_SKILLS_DIR),
             crate::skills::AGENTS_SKILLS_DIR.to_string(),
         ];
-        let skills = crate::skills::discover_skills(&skill_dirs).unwrap_or_default();
+        let skills = crate::skills::discover_skills_cached(&skill_dirs);
 
         // Load project context (AGENTS.md / CLAUDE.md / GEMINI.md)
         let mut agent_content = String::new();

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -757,32 +757,47 @@ impl ServerSession {
         })
     }
 
-    /// Persist the current session snapshot (entries + prepended session_info)
-    /// so the GUI sees the just-pushed user message mid-stream. Best-effort:
-    /// a save failure is logged, not propagated.
+    /// Persist the just-pushed user message so the GUI sees it mid-stream.
+    /// Uses append-only when the session file already exists (avoids a full
+    /// rewrite); falls back to full save for a brand-new session that has no
+    /// JSONL yet.  The session_info line (token counts, model, name) stays
+    /// at its last-completed-run values — the final save at run end refreshes
+    /// it.  Best-effort: a save failure is logged, not propagated.
     fn persist_user_message(&self) {
+        // Use in-memory parent_session_id — avoids reading the entire session
+        // file from disk just to get one field.
+        let parent_session_id = self.parent_session_id.clone();
         let msgs = self.messages.read();
+
+        // Fast path: session file already exists → append just the new user
+        // message.  Skips a ~349 KB full rewrite to add one ~1 KB line.
+        if let Some(last_msg) = msgs.last() {
+            let entry = crate::session::agent_message_to_entry(last_msg);
+            match self
+                .session_manager
+                .append_entries(&self.session_id, &[entry])
+            {
+                Ok(()) => return, // appended — done
+                Err(_) => {
+                    // File doesn't exist yet (brand-new session) → fall through
+                    // to full save so the JSONL gets created with session_info.
+                }
+            }
+        }
+
+        // Slow path: full save (new session, or append failed).
         let mut entries: Vec<crate::session::SessionEntry> = msgs
             .iter()
             .map(crate::session::agent_message_to_entry)
             .collect();
-        let parent_session_id = self
-            .session_manager
-            .load(&self.session_id)
-            .map(|s| s.parent_session_id)
-            .unwrap_or_default();
         // Prepend session_info so token counts and other metadata survive
         // a crash — without this, a restarted session starts with zeroed
         // token counters and may skip needed compaction.
         {
             use std::sync::atomic::Ordering;
-            // Derive session_name: prefer the explicitly-set name; fall back
-            // to the first user message so the mid-stream save doesn't write
-            // an empty name that would leak into a subsequent fork.
             let session_name = if !self.session_name.is_empty() {
                 self.session_name.clone()
             } else {
-                // Same auto-generation logic as the final save below.
                 entries
                     .iter()
                     .find(|e| e.role == "user")

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -30,10 +30,8 @@ impl ServerSession {
         // Whether the active model accepts image input (catalog modalities).
         // Uses the cached registry from ServerSession to avoid ~15% CPU overhead
         // from re-deserialising the full model catalog on every prompt.
-        let model_supports_images = crate::models::model_accepts_images_with(
-            &self.model_registry.read(),
-            &self.model,
-        );
+        let model_supports_images =
+            crate::models::model_accepts_images_with(&self.model_registry.read(), &self.model);
         // Images are read + (down)encoded to base64 here, on the agent, from the
         // local path the GUI sent — the base64 never crosses the wire.
         let user_message = build_user_message(
@@ -709,12 +707,9 @@ impl ServerSession {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
 
         // Discover skills so they appear in the system prompt's <available_skills> block.
-        let skill_dirs = vec![
-            crate::skills::APP_SKILLS_DIR.to_string(),
-            format!("{}/{}", self.cwd, crate::skills::PROJECT_SKILLS_DIR),
-            crate::skills::AGENTS_SKILLS_DIR.to_string(),
-        ];
-        let skills = crate::skills::discover_skills_cached(&skill_dirs);
+        // Global user-level dirs only — identical for every session/cwd, which
+        // keeps the skills cache correct regardless of which session refreshes it.
+        let skills = crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
 
         // Load project context (AGENTS.md / CLAUDE.md / GEMINI.md)
         let mut agent_content = String::new();

--- a/agent/src/sandbox/rules.rs
+++ b/agent/src/sandbox/rules.rs
@@ -417,9 +417,41 @@ impl RuleSet {
     /// Resolve, sharing `session` so runtime injections (same-run "allow in
     /// this workspace") are visible to the live sandbox.
     pub fn resolve_with_session(workspace: &Path, session: SessionRules) -> Self {
-        let workspace = paths::canonicalize_lenient(workspace);
         let home = dirs::home_dir();
-        let home_ref = home.as_deref();
+        let user_rule_file = home.as_ref().map(|h| h.join(".future/approval_rule.json"));
+        Self::resolve_impl(
+            workspace,
+            home.as_deref(),
+            user_rule_file.as_deref(),
+            session,
+        )
+    }
+
+    /// Test-only constructor: uses the real home for built-in guards (tests
+    /// assert on paths like `~/.ssh/id_rsa`), but points the user-rule layer
+    /// at a nonexistent file so the developer machine's real
+    /// `~/.future/approval_rule.json` can never leak into a test outcome.
+    /// Reading mutable machine-global state made these tests flaky.
+    #[cfg(test)]
+    fn resolve_isolated(workspace: &Path) -> Self {
+        let home = dirs::home_dir();
+        let stub = workspace.join(".future/user-rules-that-do-not-exist.json");
+        Self::resolve_impl(
+            workspace,
+            home.as_deref(),
+            Some(&stub),
+            Arc::new(Mutex::new(vec![])),
+        )
+    }
+
+    /// Full constructor with an injectable user-rule file path.
+    fn resolve_impl(
+        workspace: &Path,
+        home: Option<&Path>,
+        user_rule_file: Option<&Path>,
+        session: SessionRules,
+    ) -> Self {
+        let workspace = paths::canonicalize_lenient(workspace);
 
         let workspace_rules =
             load_rule_file(&workspace.join(".future/approval_rule.json"), &workspace)
@@ -427,19 +459,18 @@ impl RuleSet {
                     tracing::warn!("{error}");
                     vec![]
                 });
-        let user_rules = match home_ref {
-            Some(home) => load_rule_file(&home.join(".future/approval_rule.json"), &workspace)
-                .unwrap_or_else(|error| {
-                    tracing::warn!("{error}");
-                    vec![]
-                }),
+        let user_rules = match user_rule_file {
+            Some(file) => load_rule_file(file, &workspace).unwrap_or_else(|error| {
+                tracing::warn!("{error}");
+                vec![]
+            }),
             None => vec![],
         };
 
         Self {
             temp_roots: temp_roots(),
-            overrides: builtin_overrides(&workspace, home_ref),
-            guards: builtin_guards(&workspace, home_ref),
+            overrides: builtin_overrides(&workspace, home),
+            guards: builtin_guards(&workspace, home),
             session,
             workspace_rules,
             user_rules,
@@ -575,7 +606,7 @@ mod tests {
     #[test]
     fn fallback_reads_open_writes_gated() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         // Read anywhere → allow.
         assert_eq!(
             set.evaluate(Path::new("/usr/lib/x"), Op::Read),
@@ -594,7 +625,7 @@ mod tests {
     #[test]
     fn temp_is_allowed_read_and_write() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         let tmp = paths::canonicalize_lenient(&std::env::temp_dir()).join("futureos-t.txt");
         assert_eq!(set.evaluate(&tmp, Op::Write), Decision::Allow);
         assert_eq!(set.evaluate(&tmp, Op::Read), Decision::Allow);
@@ -603,7 +634,7 @@ mod tests {
     #[test]
     fn credential_reads_ask() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         let ssh = dirs::home_dir().unwrap().join(".ssh/id_rsa");
         assert_eq!(set.evaluate(&ssh, Op::Read), Decision::Ask);
     }
@@ -611,7 +642,7 @@ mod tests {
     #[test]
     fn workspace_env_asks_even_though_in_workspace() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         // .env would be write-allowed by fallback, but layer-4 ask wins first.
         assert_eq!(
             set.evaluate(&workspace.join(".env"), Op::Read),
@@ -630,7 +661,7 @@ mod tests {
     #[test]
     fn rule_file_write_is_denied_and_unoverridable() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         let rulefile = workspace.join(".future/approval_rule.json");
         assert_eq!(set.evaluate(&rulefile, Op::Write), Decision::Deny);
         // Even a session allow can't override the layer-0 deny.
@@ -654,7 +685,7 @@ mod tests {
             r#"{"rules":[{"path":".env","access":"read","action":"allow"}]}"#,
         )
         .unwrap();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         assert_eq!(
             set.evaluate(&workspace.join(".env"), Op::Read),
             Decision::Ask
@@ -671,7 +702,7 @@ mod tests {
             r#"{"rules":[{"path":"config/*","access":"write","action":"allow"}]}"#,
         )
         .unwrap();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         assert_eq!(
             set.evaluate(&workspace.join("config/app.yaml"), Op::Write),
             Decision::Allow
@@ -687,7 +718,7 @@ mod tests {
     #[test]
     fn session_allow_ungates_non_secret_only() {
         let workspace = ws();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         let outside = dirs::home_dir().unwrap().join("futureos-session-dir");
         set.add_session_rule(
             &outside.join("*").to_string_lossy(),
@@ -719,7 +750,7 @@ mod tests {
             r#"{"rules":[{"path":"vendor","action":"deny"}]}"#,
         )
         .unwrap();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         assert_eq!(
             set.evaluate(&workspace.join("vendor"), Op::Read),
             Decision::Deny
@@ -745,7 +776,7 @@ mod tests {
             r#"{"rules":[{"path":"build/*","access":"write","action":"deny"}]}"#,
         )
         .unwrap();
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         assert_eq!(
             set.evaluate(&workspace.join("build/out.o"), Op::Write),
             Decision::Deny
@@ -763,7 +794,7 @@ mod tests {
         std::fs::create_dir_all(workspace.join(".future")).unwrap();
         std::fs::write(workspace.join(".future/approval_rule.json"), "{ not json").unwrap();
         // resolve() logs + skips; built-ins + fallback still apply.
-        let set = RuleSet::resolve(&workspace);
+        let set = RuleSet::resolve_isolated(&workspace);
         assert_eq!(
             set.evaluate(&workspace.join("a.txt"), Op::Read),
             Decision::Allow

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -321,6 +321,20 @@ impl Manager {
         if !path.exists() {
             return Err(anyhow::anyhow!("session file does not exist yet"));
         }
+
+        // Acquire the same advisory file lock as save() so appends and saves
+        // to the same session are serialised.
+        let lock_path = path.with_extension("jsonl.lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .read(true)
+            .open(&lock_path)
+            .context("open session lock file")?;
+        let mut file_lock = fd_lock::RwLock::new(lock_file);
+        let _guard = file_lock.write().context("acquire session write lock")?;
+
         let mut file = std::fs::OpenOptions::new()
             .append(true)
             .open(&path)

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -338,6 +338,22 @@ impl Manager {
     pub fn save(&self, session: &Session) -> Result<()> {
         let path = self.session_path(&session.id);
         fs::create_dir_all(&self.dir).context("create session dir")?;
+
+        // Acquire an advisory file lock so concurrent saves to the same
+        // session are serialised.  Without this, two prompts finishing at the
+        // same time race on the temp→final rename, causing "rename temp to
+        // final" errors and potentially lost entries.
+        let lock_path = path.with_extension("jsonl.lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .read(true)
+            .open(&lock_path)
+            .context("open session lock file")?;
+        let mut file_lock = fd_lock::RwLock::new(lock_file);
+        let _guard = file_lock.write().context("acquire session write lock")?;
+
         // Write to a temp file and rename atomically so a mid-write crash
         // never leaves a partially-written (corrupt) JSONL behind.
         let tmp_path = path.with_extension("jsonl.tmp");
@@ -355,6 +371,8 @@ impl Manager {
             .map_err(|_| anyhow::anyhow!("flush failed"))?;
         file.sync_all().context("fsync temp session file")?;
         fs::rename(&tmp_path, &path).context("rename temp to final")?;
+
+        // Lock released when _guard goes out of scope
         Ok(())
     }
 

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -953,6 +953,9 @@ impl Manager {
     /// Delete a session file
     pub fn delete(&self, id: &str) -> Result<()> {
         let path = self.session_path(id);
+        // Also remove the lock file if present — no session means no lock.
+        let lock_path = path.with_extension("jsonl.lock");
+        let _ = fs::remove_file(&lock_path);
         fs::remove_file(path).map_err(|e| anyhow!("failed to delete session: {}", e))
     }
 }

--- a/agent/src/skills/mod.rs
+++ b/agent/src/skills/mod.rs
@@ -54,6 +54,54 @@ pub fn discover_skills(dirs: &[String]) -> Result<Vec<Skill>> {
     Ok(skills)
 }
 
+// ─── Cached skills discovery ──────────────────────────────────────────────
+
+/// How long the cached skills list stays fresh before a refresh is triggered.
+const SKILLS_CACHE_TTL_SECS: u64 = 60;
+
+/// Global cached skills list, refreshed lazily on access.
+static SKILLS_CACHE: std::sync::RwLock<Option<(std::time::Instant, Vec<Skill>)>> =
+    std::sync::RwLock::new(None);
+
+/// Serialises cache refreshes so only one thread does the I/O work.
+static REFRESH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Returns a cached skills list, refreshing when older than
+/// SKILLS_CACHE_TTL_SECS. Fast path is lock-free for concurrent readers;
+/// slow path serialises file I/O with a dedicated refresh mutex so multiple
+/// concurrent prompts never block each other on the write lock.
+pub fn discover_skills_cached(dirs: &[String]) -> Vec<Skill> {
+    // Fast path: read lock, check TTL — multiple readers OK.
+    {
+        let cache = SKILLS_CACHE.read().unwrap();
+        if let Some((ref ts, ref skills)) = *cache {
+            if ts.elapsed().as_secs() < SKILLS_CACHE_TTL_SECS {
+                return skills.clone();
+            }
+        }
+    }
+    // Slow path: one thread refreshes; others wait on the refresh lock
+    // then double-check (the first thread may have already refreshed).
+    let _refresh = REFRESH_LOCK.lock().unwrap();
+    {
+        let cache = SKILLS_CACHE.read().unwrap();
+        if let Some((ref ts, ref skills)) = *cache {
+            if ts.elapsed().as_secs() < SKILLS_CACHE_TTL_SECS {
+                return skills.clone();
+            }
+        }
+    }
+    // File I/O outside any lock — only one thread reaches here.
+    let skills = discover_skills(dirs).unwrap_or_default();
+    *SKILLS_CACHE.write().unwrap() = Some((std::time::Instant::now(), skills.clone()));
+    skills
+}
+
+/// Invalidate the skills cache so the next access triggers a refresh.
+pub fn invalidate_skills_cache() {
+    *SKILLS_CACHE.write().unwrap() = None;
+}
+
 fn parse_skill(skill_md: &Path) -> Result<Option<Skill>> {
     let content = std::fs::read_to_string(skill_md)?;
     let name = extract_name(&content, skill_md)?;

--- a/agent/src/skills/mod.rs
+++ b/agent/src/skills/mod.rs
@@ -17,9 +17,10 @@ pub struct Skill {
     pub disable_model_invocation: bool,
 }
 
-/// Predefined skill directories (matching Go internal/skills/skills.go)
+/// Predefined skill directories (matching Go internal/skills/skills.go).
+/// Both are global, user-level locations — project/cwd-relative skill
+/// directories are intentionally not supported (see `global_skill_dirs`).
 pub const APP_SKILLS_DIR: &str = "~/.future/agent/skills/";
-pub const PROJECT_SKILLS_DIR: &str = ".future/agent/skills/";
 pub const AGENTS_SKILLS_DIR: &str = "~/.agents/skills/";
 
 /// DiscoverSkills finds all skills in the given directories.
@@ -54,6 +55,14 @@ pub fn discover_skills(dirs: &[String]) -> Result<Vec<Skill>> {
     Ok(skills)
 }
 
+/// The global (user-level) skill directories. Project/cwd-relative skill
+/// dirs are intentionally NOT scanned: every caller must see the same skill
+/// set regardless of the session's working directory, which also keeps the
+/// `discover_skills_cached` cache key stable across call sites.
+pub fn global_skill_dirs() -> Vec<String> {
+    vec![APP_SKILLS_DIR.to_string(), AGENTS_SKILLS_DIR.to_string()]
+}
+
 // ─── Cached skills discovery ──────────────────────────────────────────────
 
 /// How long the cached skills list stays fresh before a refresh is triggered.
@@ -70,6 +79,10 @@ static REFRESH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// SKILLS_CACHE_TTL_SECS. Fast path is lock-free for concurrent readers;
 /// slow path serialises file I/O with a dedicated refresh mutex so multiple
 /// concurrent prompts never block each other on the write lock.
+///
+/// All call sites are expected to pass `global_skill_dirs()`; the cache is
+/// global and does NOT key on `dirs`, so mixing different dir lists across
+/// call sites would return stale results for the minority list.
 pub fn discover_skills_cached(dirs: &[String]) -> Vec<Skill> {
     // Fast path: read lock, check TTL — multiple readers OK.
     {

--- a/scripts/agent-profile-bench.sh
+++ b/scripts/agent-profile-bench.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# agent-profile-bench.sh — start a profiled agent on port 50052, generate
+# load with one-shot CLI prompts, and stop after PROFILE_DURATION seconds
+# so the agent writes its flamegraph on shutdown.
+#
+# Usage:
+#   PROFILE_DURATION=90 bash scripts/agent-profile-bench.sh
+#
+# Expects the profiled binary to already exist (the Makefile `profile-agent`
+# target builds it).  Outputs:
+#   profile-results/agent-profile-<ts>.svg   flamegraph
+#   profile-results/agent-profile-<ts>.log   agent stdout/stderr
+set -euo pipefail
+
+DURATION="${PROFILE_DURATION:-90}"
+PORT="${PROFILE_PORT:-50052}"
+ADDR="127.0.0.1:${PORT}"
+BIN="./target/release/future-agent"
+TS="$(date +%Y%m%d-%H%M%S)"
+SVG="profile-results/agent-profile-${TS}.svg"
+LOG="profile-results/agent-profile-${TS}.log"
+
+mkdir -p profile-results
+
+if [[ ! -x "${BIN}" ]]; then
+    echo "error: ${BIN} not found — run 'make profile-agent' (it builds first)" >&2
+    exit 1
+fi
+
+echo "Starting profiled agent on ${ADDR} for ${DURATION}s ..."
+"${BIN}" \
+    --grpc-addr "${ADDR}" \
+    --profile "${SVG}" \
+    --profile-seconds "${DURATION}" \
+    --verbose >"${LOG}" 2>&1 &
+AGENT_PID=$!
+
+# Make sure we never leave the profiled agent running if the script dies.
+cleanup() {
+    if kill -0 "${AGENT_PID}" 2>/dev/null; then
+        kill "${AGENT_PID}" 2>/dev/null || true
+        wait "${AGENT_PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Wait for the gRPC port to accept connections (max ~15s).
+echo -n "Waiting for agent to come up"
+for _ in $(seq 1 150); do
+    if (echo >"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; then
+        echo " — up."
+        break
+    fi
+    if ! kill -0 "${AGENT_PID}" 2>/dev/null; then
+        echo ""
+        echo "error: agent exited during startup — see ${LOG}" >&2
+        exit 1
+    fi
+    echo -n "."
+    sleep 0.1
+done
+
+# Generate load: a series of one-shot prompts through the profiled agent.
+# Skipped silently when the `future` CLI is not installed — the agent still
+# profiles idle/shutdown behaviour, and you can drive load manually.
+if command -v future >/dev/null 2>&1; then
+    echo "Driving load with 'future run' one-shot prompts ..."
+    PROMPTS=(
+        "Summarise what this repository does in three sentences."
+        "List the main entry points of the Rust agent crate."
+        "Explain how session persistence works, briefly."
+    )
+    # Spread the prompts across the profiling window, leaving headroom for
+    # startup and the final flamegraph write.
+    N=${#PROMPTS[@]}
+    STEP=$(( (DURATION - 10) / N ))
+    (( STEP < 3 )) && STEP=3
+    for p in "${PROMPTS[@]}"; do
+        # Stop driving load once the profile timer has expired — a prompt cut
+        # short by shutdown is expected, not a failure.
+        kill -0 "${AGENT_PID}" 2>/dev/null || break
+        echo "  → ${p}"
+        if ! future run --grpc-addr "${ADDR}" "${p}" >/dev/null 2>&1; then
+            if kill -0 "${AGENT_PID}" 2>/dev/null; then
+                echo "    (prompt failed — continuing; see ${LOG})"
+            else
+                echo "    (cut short by profile timer — expected)"
+            fi
+        fi
+        sleep "${STEP}"
+    done
+else
+    echo "'future' CLI not found — agent will profile idle/shutdown only."
+    echo "Install it with 'make install' or drive load manually against ${ADDR}."
+fi
+
+echo "Waiting for profile timer to expire and flamegraph to be written ..."
+wait "${AGENT_PID}" 2>/dev/null || true
+trap - EXIT
+
+if [[ -s "${SVG}" ]]; then
+    echo "Done: ${SVG}"
+else
+    echo "warning: flamegraph not found at ${SVG} — check ${LOG}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Profiling infrastructure: **CPU flamegraph** (`make profile-agent`, `make profile-quick`) via pprof + **heap (dhat)** (`make profile-heap`, `make profile-heap PROFILE_SECS=30`)
- Skills discovery cache (60s TTL) to eliminate per-prompt file I/O
- Model catalog: shared as `Arc<Vec<Model>>` via `OnceCell` to avoid 1.9 MB JSON re-parse per `Registry::new()`; `cycle_model` uses cached registry (eliminates blocking network I/O on model switch)
- SSB broadcast: buffer 4096→256, run events 20000→2000 (reduce allocation churn)
- Session persistence: append-only user-message fast path to avoid full JSONL rewrite
- Sandbox rules tests: fixed flaky `no_wildcard_matches_subtree` — tests now read an isolated user-rule file instead of `~/.future/approval_rule.json`
- Memory: tokio worker stacks 4MB→2MB; `--profile-seconds` no longer implies CPU profiling when `--profile-heap` is set (profiler buffers polluted heap measurements)
- Clean baseline RSS ~22 MB (118 MB was profiler artifact); profiling overhead ~80-96 MB is profiling-only

## Profiling quick start

```
make profile-quick PROFILE_SECS=30    # CPU flamegraph in profile-results/
make profile-heap  PROFILE_SECS=30    # Heap profile, view at https://nnethercote.github.io/dh_view/dh_view.html
```

760 tests pass.