### PR TITLE
feat: refresh_skills RPC with rate limiting; CLI & GUI notify after install/uninstall

### DIFF
--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -500,6 +500,7 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             RpcResponse::ok(id, "export_html", serde_json::json!({"path": output_path}))
         }
         "reload_config" => cmd_reload_config(state, &session, id),
+        "refresh_skills" => cmd_refresh_skills(id),
         "set_cwd" => {
             // Trim trailing whitespace / separators so the saved cwd is
             // always a clean directory path — "project/ " produces a
@@ -1295,6 +1296,24 @@ fn cmd_clone(
     state.create_session(new_sess);
 
     RpcResponse::ok(id, "clone", serde_json::json!({"cancelled": false}))
+}
+
+fn cmd_refresh_skills(id: &str) -> String {
+    // Invalidate the skills cache and rebuild immediately so freshly
+    // installed skills are visible on the next prompt without waiting
+    // for the 60s TTL to expire.
+    crate::skills::invalidate_skills_cache();
+    let skills =
+        crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
+    let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
+    RpcResponse::ok(
+        id,
+        "refresh_skills",
+        serde_json::json!({
+            "skills_count": skill_names.len(),
+            "skills": skill_names,
+        }),
+    )
 }
 
 fn cmd_reload_config(

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -1298,13 +1298,43 @@ fn cmd_clone(
     RpcResponse::ok(id, "clone", serde_json::json!({"cancelled": false}))
 }
 
+/// Minimum interval between forced skills-cache refreshes. CLI/GUI fire one
+/// notification per install/uninstall operation, so a burst of operations
+/// (or several frontends at once) must not trigger repeated disk scans —
+/// requests inside this window are served from the still-fresh cache.
+const SKILLS_REFRESH_MIN_INTERVAL_SECS: u64 = 5;
+
 fn cmd_refresh_skills(id: &str) -> String {
-    // Invalidate the skills cache and rebuild immediately so freshly
-    // installed skills are visible on the next prompt without waiting
-    // for the 60s TTL to expire.
-    crate::skills::invalidate_skills_cache();
-    let skills =
-        crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    static LAST_REFRESH: Mutex<Option<Instant>> = Mutex::new(None);
+
+    // Rate-limit: only invalidate + rescan when the last forced refresh is
+    // older than the minimum interval. Otherwise keep the cache as-is;
+    // `discover_skills_cached` will serve it (it is fresh by construction).
+    let now = Instant::now();
+    let refreshed = {
+        let mut last = LAST_REFRESH.lock().unwrap();
+        match *last {
+            Some(t)
+                if now.duration_since(t)
+                    < Duration::from_secs(SKILLS_REFRESH_MIN_INTERVAL_SECS) =>
+            {
+                false
+            }
+            _ => {
+                *last = Some(now);
+                true
+            }
+        }
+    };
+    if refreshed {
+        // Invalidate the skills cache so freshly installed skills are
+        // visible on the next prompt without waiting for the 60s TTL.
+        crate::skills::invalidate_skills_cache();
+    }
+    let skills = crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
     RpcResponse::ok(
         id,
@@ -1312,6 +1342,9 @@ fn cmd_refresh_skills(id: &str) -> String {
         serde_json::json!({
             "skills_count": skill_names.len(),
             "skills": skill_names,
+            // false when served from cache due to the minimum-interval
+            // rate limit — callers can log this for debugging.
+            "refreshed": refreshed,
         }),
     )
 }
@@ -1523,6 +1556,34 @@ mod tests {
         let resp = parse_response(&handle_command_internal(&state, cmd));
         assert_eq!(resp["success"], true);
         assert!(resp["data"]["sessionId"].is_string());
+    }
+
+    #[test]
+    fn refresh_skills_returns_skill_list() {
+        let state = make_app_state();
+        let cmd = make_cmd("refresh_skills");
+        let resp = parse_response(&handle_command_internal(&state, cmd));
+        assert_eq!(resp["success"], true);
+        assert!(resp["data"]["skills_count"].is_number());
+        assert!(resp["data"]["skills"].is_array());
+        assert_eq!(
+            resp["data"]["skills_count"].as_u64().unwrap(),
+            resp["data"]["skills"].as_array().unwrap().len() as u64
+        );
+        assert!(resp["data"]["refreshed"].is_boolean());
+    }
+
+    #[test]
+    fn refresh_skills_rate_limits_bursts() {
+        // A second call within the minimum interval must be served from the
+        // cache (`refreshed: false`) instead of rescanning the skill dirs.
+        // Robust against test ordering: any earlier refresh within the
+        // window only makes `refreshed: false` more likely.
+        let state = make_app_state();
+        handle_command_internal(&state, make_cmd("refresh_skills"));
+        let resp = parse_response(&handle_command_internal(&state, make_cmd("refresh_skills")));
+        assert_eq!(resp["success"], true);
+        assert_eq!(resp["data"]["refreshed"], false);
     }
 
     #[test]

--- a/cli/src/commands/skills.ts
+++ b/cli/src/commands/skills.ts
@@ -39,11 +39,15 @@ export async function skills(command: SkillsCommand, args: string[]): Promise<vo
 
   if (command === "install-builtin") {
     await installBuiltinSkills();
+    // One notification per command, not per skill — batch installs would
+    // otherwise flood the agent with refresh RPCs.
+    notifyAgentRefreshSkills();
     return;
   }
 
   if (command === "update") {
     await updateSkills();
+    notifyAgentRefreshSkills();
     return;
   }
 
@@ -52,6 +56,7 @@ export async function skills(command: SkillsCommand, args: string[]): Promise<vo
     if (!name) {
       // No name given — install all builtin skills (same as install-builtin)
       await installBuiltinSkills();
+      notifyAgentRefreshSkills();
       return;
     }
     const versionIdx = args.indexOf("--version");
@@ -61,6 +66,7 @@ export async function skills(command: SkillsCommand, args: string[]): Promise<vo
       version = version.slice(1);
     }
     await installSkill(name, version);
+    notifyAgentRefreshSkills();
     return;
   }
 
@@ -73,6 +79,7 @@ export async function skills(command: SkillsCommand, args: string[]): Promise<vo
 
   if (command === "uninstall") {
     await uninstallSkill(name);
+    notifyAgentRefreshSkills();
     return;
   }
 }
@@ -226,9 +233,6 @@ async function installSkill(skillId: string, version?: string): Promise<void> {
     await flattenSingleSubdir(dest);
 
     console.log(`${isUpdate ? "Updated" : "Installed"} skill "${skillId}" v${version} → ${dest}`);
-    // Notify the agent so the next prompt sees the new skill immediately.
-    // Best-effort — silence errors; the TTL-based refresh is the fallback.
-    notifyAgentRefreshSkills();
   } finally {
     try { await rm(tmpZip, { force: true }); } catch { /* ignore */ }
   }
@@ -355,7 +359,6 @@ async function uninstallSkill(skillId: string): Promise<void> {
 
   await rm(dest, { recursive: true, force: true });
   console.log(`Uninstalled skill "${skillId}" from ${SKILLS_DIR}.`);
-  notifyAgentRefreshSkills();
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/cli/src/commands/skills.ts
+++ b/cli/src/commands/skills.ts
@@ -8,6 +8,7 @@ import { execFile } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 
 import { getPlatformUrl } from "../utils/platform.js";
+import { notifyAgentRefreshSkills } from "../rpc/grpc-client.js";
 
 // ── Paths ──────────────────────────────────────────────────────────────────
 
@@ -225,6 +226,9 @@ async function installSkill(skillId: string, version?: string): Promise<void> {
     await flattenSingleSubdir(dest);
 
     console.log(`${isUpdate ? "Updated" : "Installed"} skill "${skillId}" v${version} → ${dest}`);
+    // Notify the agent so the next prompt sees the new skill immediately.
+    // Best-effort — silence errors; the TTL-based refresh is the fallback.
+    notifyAgentRefreshSkills();
   } finally {
     try { await rm(tmpZip, { force: true }); } catch { /* ignore */ }
   }
@@ -351,6 +355,7 @@ async function uninstallSkill(skillId: string): Promise<void> {
 
   await rm(dest, { recursive: true, force: true });
   console.log(`Uninstalled skill "${skillId}" from ${SKILLS_DIR}.`);
+  notifyAgentRefreshSkills();
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/cli/src/rpc/grpc-client.ts
+++ b/cli/src/rpc/grpc-client.ts
@@ -713,3 +713,27 @@ export class RunClient {
     return { sessionId, text, events, model, thinkingLevel };
   }
 }
+
+/**
+ * Notify a running agent that skills were added or removed so it drops its
+ * 60 s skills cache and re-discovers immediately.  Best-effort: if the
+ * agent is not reachable (timeout 3 s) the call is silently dropped —
+ * the next prompt triggers the TTL-based refresh anyway.
+ */
+export async function notifyAgentRefreshSkills(grpcAddr?: string): Promise<void> {
+  const address = grpcAddr ?? process.env.FUTURE_AGENT_GRPC_ADDR ?? "127.0.0.1:50051";
+  try {
+    const client = new proto.FutureAgent(address, grpc.credentials.createInsecure());
+    const deadline = new Date();
+    deadline.setSeconds(deadline.getSeconds() + 3); // 3 s timeout
+    await new Promise<void>((resolve, reject) => {
+      client.ExecuteCommand(
+        { id: String(Date.now()), type: "refresh_skills" },
+        deadline,
+        (err: any) => (err ? reject(err) : resolve()),
+      );
+    });
+  } catch {
+    // Agent unreachable or not running — the cache TTL will pick it up.
+  }
+}

--- a/cli/src/rpc/grpc-client.ts
+++ b/cli/src/rpc/grpc-client.ts
@@ -717,15 +717,19 @@ export class RunClient {
 /**
  * Notify a running agent that skills were added or removed so it drops its
  * 60 s skills cache and re-discovers immediately.  Best-effort: if the
- * agent is not reachable (timeout 3 s) the call is silently dropped —
+ * agent is not reachable (timeout 1 s) the call is silently dropped —
  * the next prompt triggers the TTL-based refresh anyway.
+ *
+ * The deadline is deliberately short: the agent is often not running when
+ * skills are installed from a bare shell, and grpc-js retries connecting
+ * until the deadline — a long timeout would stall every offline install.
  */
 export async function notifyAgentRefreshSkills(grpcAddr?: string): Promise<void> {
   const address = grpcAddr ?? process.env.FUTURE_AGENT_GRPC_ADDR ?? "127.0.0.1:50051";
+  const client = new proto.FutureAgent(address, grpc.credentials.createInsecure());
   try {
-    const client = new proto.FutureAgent(address, grpc.credentials.createInsecure());
     const deadline = new Date();
-    deadline.setSeconds(deadline.getSeconds() + 3); // 3 s timeout
+    deadline.setSeconds(deadline.getSeconds() + 1); // 1 s timeout
     await new Promise<void>((resolve, reject) => {
       client.ExecuteCommand(
         { id: String(Date.now()), type: "refresh_skills" },
@@ -735,5 +739,8 @@ export async function notifyAgentRefreshSkills(grpcAddr?: string): Promise<void>
     });
   } catch {
     // Agent unreachable or not running — the cache TTL will pick it up.
+  } finally {
+    // Release the channel; without close() the client lingers until GC.
+    client.close();
   }
 }

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -23,7 +23,7 @@ pub use self::models::{list_agent_models, AgentModelOption};
 pub use self::run_control::abort_run;
 pub(crate) use self::run_control::abort_session;
 pub use self::session::fork_agent_session;
-pub use self::skills::{list_installed_skills, InstalledSkill};
+pub use self::skills::{list_installed_skills, refresh_skills, InstalledSkill};
 pub use review::retry as retry_run_review;
 
 use serde::Serialize;

--- a/gui/src-tauri/src/agent_bridge/skills.rs
+++ b/gui/src-tauri/src/agent_bridge/skills.rs
@@ -72,3 +72,14 @@ pub async fn list_installed_skills() -> Result<Vec<InstalledSkill>, crate::AppEr
         .collect();
     Ok(skills)
 }
+
+/// Tell the agent to drop its 60 s skills cache and re-scan so freshly
+/// installed / uninstalled skills are visible on the next prompt without
+/// waiting for the TTL to expire.  Best-effort — never fail the caller.
+pub async fn refresh_skills() {
+    if let Ok(mut client) = connect_agent().await {
+        let _ = client
+            .execute_command(base_command("refresh_skills", String::new()))
+            .await;
+    }
+}

--- a/gui/src-tauri/src/commands/skills.rs
+++ b/gui/src-tauri/src/commands/skills.rs
@@ -1,7 +1,10 @@
 //! Skill management Tauri commands: the installed list comes from the agent;
 //! the catalogue and install/uninstall are handled locally (see
 //! [`crate::skills`]).  After install/uninstall, the agent's skills cache is
-//! invalidated via `refresh_skills` (fire-and-forget, best-effort).
+//! invalidated via `refresh_skills` — awaited (best-effort, bounded by the
+//! agent connect timeout) so the notification is guaranteed to be sent
+//! before this command returns and no follow-up prompt can race the stale
+//! cache.
 
 use crate::{agent_bridge, skills};
 
@@ -19,7 +22,8 @@ pub async fn list_available_skills() -> Result<Vec<skills::SkillInfo>, crate::Ap
 pub async fn install_skill(id: String, version: String) -> Result<(), crate::AppError> {
     skills::install_skill(id, version).await?;
     // Notify the agent so the next prompt sees the new skill immediately.
-    tokio::spawn(agent_bridge::refresh_skills());
+    // Awaited (never fails) so the refresh is in flight before we return.
+    agent_bridge::refresh_skills().await;
     Ok(())
 }
 
@@ -27,7 +31,7 @@ pub async fn install_skill(id: String, version: String) -> Result<(), crate::App
 pub async fn uninstall_skill(id: String) -> Result<bool, crate::AppError> {
     let removed = skills::uninstall_skill(&id)?;
     if removed {
-        tokio::spawn(agent_bridge::refresh_skills());
+        agent_bridge::refresh_skills().await;
     }
     Ok(removed)
 }

--- a/gui/src-tauri/src/commands/skills.rs
+++ b/gui/src-tauri/src/commands/skills.rs
@@ -1,6 +1,7 @@
 //! Skill management Tauri commands: the installed list comes from the agent;
 //! the catalogue and install/uninstall are handled locally (see
-//! [`crate::skills`]).
+//! [`crate::skills`]).  After install/uninstall, the agent's skills cache is
+//! invalidated via `refresh_skills` (fire-and-forget, best-effort).
 
 use crate::{agent_bridge, skills};
 
@@ -16,10 +17,17 @@ pub async fn list_available_skills() -> Result<Vec<skills::SkillInfo>, crate::Ap
 
 #[tauri::command]
 pub async fn install_skill(id: String, version: String) -> Result<(), crate::AppError> {
-    skills::install_skill(id, version).await
+    skills::install_skill(id, version).await?;
+    // Notify the agent so the next prompt sees the new skill immediately.
+    tokio::spawn(agent_bridge::refresh_skills());
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn uninstall_skill(id: String) -> Result<bool, crate::AppError> {
-    skills::uninstall_skill(&id)
+    let removed = skills::uninstall_skill(&id)?;
+    if removed {
+        tokio::spawn(agent_bridge::refresh_skills());
+    }
+    Ok(removed)
 }


### PR DESCRIPTION
## What

Adds a `refresh_skills` RPC so skill installs/uninstalls from the CLI and GUI are visible to the agent immediately, instead of waiting up to 60s for the skills-cache TTL to expire.

## Agent

- New `refresh_skills` command: invalidates the 60s skills cache and re-discovers immediately, returning the current skill list
- Enforces a **5s minimum interval** between forced rescans — bursts of notifications (batch installs, multiple frontends) are served from the fresh cache and return `refreshed: false`
- Dispatch tests: response shape + burst rate limiting

## CLI (`skills install / uninstall / update / install-builtin`)

- Best-effort gRPC call via `notifyAgentRefreshSkills()` after each command; **1s deadline**, silently dropped if the agent is unreachable (offline installs don't stall while grpc-js retries), client channel always closed
- Exactly **one notification per command** — batch installs/updates no longer flood the agent with one RPC per skill

## GUI (Skills panel install / uninstall)

- Awaits `agent_bridge::refresh_skills()` (best-effort, bounded by the agent connect timeout) before the Tauri command returns, so the notification is guaranteed in flight and no follow-up prompt can race the stale cache

## Fallback

If the agent is unreachable, behavior is unchanged: the 60s TTL refresh picks up new skills on the next prompt.