### PR TITLE
feat(gui): startup update check, single-instance, UI polish

### DIFF
--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -57,6 +57,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +160,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +227,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -294,6 +414,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -533,6 +666,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1031,6 +1173,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1224,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1208,6 +1398,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "thiserror 2.0.19",
  "tokio",
@@ -1264,6 +1455,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1696,6 +1900,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2780,6 +2990,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,6 +3047,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2956,6 +3182,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,6 +3245,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4498,6 +4749,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,6 +5420,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6120,6 +6398,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,4 +6601,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["time"] }
 async-nats = "0.49"
 futures = "0.3"
 tauri-plugin-dialog = "2"
+tauri-plugin-single-instance = "2"
 # System opener for paths/URLs (ShellExecuteW on Windows — never `cmd /C start`,
 # whose re-parsing of `&`/`^`/`%VAR%` in arguments is an injection vector).
 open = "5"

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -229,6 +229,15 @@ pub(crate) fn emit_remote_activity(thread_id: &str) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // A second instance was launched — activate the existing window.
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.unminimize();
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -242,9 +251,9 @@ pub fn run() {
                         let _ = app.emit("open-settings", ());
                     }
                     menu::MENU_RESTART_WEBVIEW => {
-                        // Debug escape hatch: reload a hung/crashed webview in
-                        // place (native reload, so it recovers even when the JS
-                        // context is dead) instead of relaunching the app.
+                        // Reload a hung/crashed webview in place (native reload,
+                        // so it recovers even when the JS context is dead)
+                        // instead of relaunching the app.
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.reload();
                         }

--- a/gui/src-tauri/src/menu.rs
+++ b/gui/src-tauri/src/menu.rs
@@ -4,8 +4,8 @@
 //! take the app name from the bundle — or, in dev and unbundled runs, from the
 //! lowercase executable name (`futureos`). We build the menu explicitly so the
 //! brand name always reads "FutureOS", and so we can add two macOS-only items:
-//! "About FutureOS" (opens the in-app About page) and "Restart Webview" (a
-//! debug escape hatch to reload a hung/crashed webview without relaunching).
+//! "About FutureOS" (opens the in-app About page) and "Restart Webview"
+//! (reloads a hung/crashed webview in place without relaunching the app).
 //!
 //! Windows/Linux keep Tauri's default behaviour (no window menu, no About), so
 //! there is nothing to build for them.
@@ -17,7 +17,7 @@ use tauri::{
 
 /// Menu item id for "About FutureOS" → opens Settings.
 pub const MENU_ABOUT: &str = "about";
-/// Menu item id for the "Restart Webview" debug action.
+/// Menu item id for the "Restart Webview" recovery action.
 pub const MENU_RESTART_WEBVIEW: &str = "restart-webview";
 
 const APP_NAME: &str = "FutureOS";

--- a/gui/src/components/layout/ActivityRail.tsx
+++ b/gui/src/components/layout/ActivityRail.tsx
@@ -34,6 +34,7 @@ interface ActivityRailProps {
   expanded: boolean;
   floating?: boolean;
   activeThreadId: string | null;
+  hasUpdate?: boolean;
   threads: StoredThread[];
   threadRunStatuses: Record<string, ThreadRunInfo | undefined>;
   threadStreamingStatuses: Record<string, boolean>;
@@ -71,6 +72,7 @@ export function ActivityRail({
   activeThreadId,
   expanded,
   floating,
+  hasUpdate,
   threads,
   threadRunStatuses,
   threadStreamingStatuses,
@@ -451,13 +453,21 @@ export function ActivityRail({
                 onClick={() => onChange(settingsItem.id)}
                 type="button"
               >
-                <Settings className="size-4 shrink-0" />
+                <span className="relative inline-flex shrink-0">
+                  <Settings className="size-4" />
+                  {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                </span>
                 <span className="truncate">{t("activityRail.settings")}</span>
               </button>
             )
           : (
               <IconButton
-                icon={<Settings className="size-4" />}
+                icon={(
+                  <span className="relative inline-flex">
+                    <Settings className="size-4" />
+                    {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                  </span>
+                )}
                 label={t("activityRail.settings")}
                 active={active === settingsItem.id}
                 onClick={() => onChange(settingsItem.id)}

--- a/gui/src/components/layout/AppShell.tsx
+++ b/gui/src/components/layout/AppShell.tsx
@@ -32,6 +32,7 @@ import { useRightPanelWidth } from "./hooks/useRightPanelWidth";
 import { useThreadDialogs } from "./hooks/useThreadDialogs";
 import { useThreadStore } from "./hooks/useThreadStore";
 import { useUnreadThreads } from "./hooks/useUnreadThreads";
+import { useUpdateChecker } from "./hooks/useUpdateChecker";
 import { useWorkspaceDialogs } from "./hooks/useWorkspaceDialogs";
 import { WorkspaceDialogs } from "./WorkspaceDialogs";
 
@@ -66,6 +67,7 @@ export function AppShell() {
 
   const { appSettings, changeSettings } = useAppSettings();
   useAutoUpgradeSkills(appSettings.autoUpgradeSkills);
+  const { hasUpdate, cachedStatus, markSeen: markUpdateSeen } = useUpdateChecker();
 
   const centerRef = useRef<HTMLElement>(null);
   const {
@@ -319,6 +321,7 @@ export function AppShell() {
   const activityRailProps = {
     active: section,
     activeThreadId,
+    hasUpdate,
     threads,
     threadRunStatuses,
     threadStreamingStatuses,
@@ -387,11 +390,11 @@ export function AppShell() {
             )
           : section === "skill"
             ? (
-                <SkillsView />
+                <SkillsView leftPanelExpanded={leftExpanded} onToggleLeftPanel={handleToggleLeftPanel} />
               )
             : section === "remote"
               ? (
-                  <RemoteView appSettings={appSettings} onChangeSettings={patch => void changeSettings(patch)} />
+                  <RemoteView appSettings={appSettings} leftPanelExpanded={leftExpanded} onChangeSettings={patch => void changeSettings(patch)} onToggleLeftPanel={handleToggleLeftPanel} />
                 )
               : storeError
                 ? (
@@ -473,11 +476,14 @@ export function AppShell() {
       />
       <SettingsDialog
         appSettings={appSettings}
+        cachedUpdateStatus={cachedStatus}
+        hasUpdate={hasUpdate}
         initialTab={settingsTab}
         modelOptions={modelOptions}
         onChangeSettings={patch => void changeSettings(patch)}
         onClose={() => setSettingsOpen(false)}
         onProvidersChanged={() => void refreshAgentModels()}
+        onUpdateSeen={markUpdateSeen}
         open={settingsOpen}
       />
       <ToastHost />

--- a/gui/src/components/layout/hooks/useUpdateChecker.ts
+++ b/gui/src/components/layout/hooks/useUpdateChecker.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invokeCommand } from "../../../integrations/tauri/invoke";
+
+/** Mirrors the backend `UpdateStatus` (serde camelCase). */
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string;
+  hasUpdate: boolean;
+  platformSupported: boolean;
+  downloadUrl: string | null;
+}
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Silently checks for app updates on mount and every 24 hours thereafter.
+ * The last successful check result is cached for the app's lifetime so the
+ * UpdatePage can display it immediately without a redundant round-trip.
+ *
+ * - `hasUpdate` — true when a new version exists and the user hasn't visited
+ *   the update tab yet (drives the red-dot indicators).
+ * - `cachedStatus` — the full result from the most recent successful check.
+ * - `markSeen` — clears the red-dot flag (user acknowledged the update).
+ */
+export function useUpdateChecker(): {
+  hasUpdate: boolean;
+  cachedStatus: UpdateStatus | null;
+  markSeen: () => void;
+} {
+  const [hasUpdate, setHasUpdate] = useState(false);
+  const [cachedStatus, setCachedStatus] = useState<UpdateStatus | null>(null);
+  const seenRef = useRef(false);
+
+  const check = useCallback(async () => {
+    try {
+      const status = await invokeCommand<UpdateStatus>("check_app_update");
+      setCachedStatus(status);
+      if (status.hasUpdate && !seenRef.current) {
+        setHasUpdate(true);
+      }
+    }
+    catch {
+      // Silent — network errors or non-release builds shouldn't surface UI noise.
+    }
+  }, []);
+
+  useEffect(() => {
+    void check();
+    const timer = setInterval(() => void check(), CHECK_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [check]);
+
+  const markSeen = useCallback(() => {
+    seenRef.current = true;
+    setHasUpdate(false);
+  }, []);
+
+  return { hasUpdate, cachedStatus, markSeen };
+}

--- a/gui/src/features/remote/RemoteView.tsx
+++ b/gui/src/features/remote/RemoteView.tsx
@@ -2,20 +2,24 @@ import type { AppSettings } from "../../integrations/storage/appSettings";
 import type { RemoteStatus } from "./remoteClient";
 import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { LeftPanelTitlebarToggle } from "../../components/layout/LeftPanelTitlebarToggle";
 import { Button } from "../../components/ui/Button";
 import { TextInput } from "../../components/ui/TextInput";
 import { cn } from "../../lib/cn";
 import { errorMessage } from "../../lib/errors";
 import { useAsyncResource } from "../../lib/useAsyncResource";
 import { usePolling } from "../../lib/usePolling";
+import { startWindowDrag } from "../../lib/windowDrag";
 import { getRemoteStatus, startRemote, stopRemote } from "./remoteClient";
 
 interface RemoteViewProps {
   appSettings: AppSettings;
+  leftPanelExpanded: boolean;
   onChangeSettings: (patch: Partial<AppSettings>) => void;
+  onToggleLeftPanel: () => void;
 }
 
-export function RemoteView({ appSettings, onChangeSettings }: RemoteViewProps) {
+export function RemoteView({ appSettings, leftPanelExpanded, onChangeSettings, onToggleLeftPanel }: RemoteViewProps) {
   const { t } = useTranslation("remote");
   const [natsUrl, setNatsUrl] = useState(appSettings.remoteNatsUrl);
   const [pairId, setPairId] = useState(appSettings.remotePairId);
@@ -88,87 +92,94 @@ export function RemoteView({ appSettings, onChangeSettings }: RemoteViewProps) {
   }
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-y-auto bg-surface p-8">
-      <div className="mx-auto w-full max-w-xl space-y-6">
-        <header>
-          <h1 className="text-lg font-semibold text-ink">{t("title")}</h1>
-          <p className="mt-1 text-sm text-ink-muted">
-            {t("description")}
-          </p>
-        </header>
+    <section className="flex h-full min-h-0 flex-col bg-surface">
+      <header
+        className="flex h-12 shrink-0 select-none items-center justify-between border-b border-line-soft/40 px-4"
+        onMouseDown={startWindowDrag}
+      >
+        <div className="flex min-w-0 flex-1 items-center" data-tauri-drag-region>
+          <LeftPanelTitlebarToggle expanded={leftPanelExpanded} onToggle={onToggleLeftPanel} />
+          <span className="truncate text-sm font-semibold text-ink">{t("title")}</span>
+        </div>
+      </header>
 
-        <div className="rounded-lg border border-line-soft bg-surface-subtle p-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className={cn("inline-block size-2 rounded-full", running ? "bg-accent" : "bg-ink-muted/60")} />
-            <span className="text-sm font-medium text-ink">{running ? t("running") : t("notRunning")}</span>
+      <div className="min-h-0 flex-1 overflow-y-auto p-8">
+        <div className="mx-auto w-full max-w-xl space-y-6">
+          <p className="text-sm text-ink-muted">{t("description")}</p>
+
+          <div className="rounded-lg border border-line-soft bg-surface-subtle p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={cn("inline-block size-2 rounded-full", running ? "bg-accent" : "bg-ink-muted/60")} />
+              <span className="text-sm font-medium text-ink">{running ? t("running") : t("notRunning")}</span>
+              {running
+                ? (
+                    <span className="text-xs text-ink-muted">
+                      ·
+                      {" "}
+                      {status?.natsUrl}
+                      {" "}
+                      · pair
+                      {" "}
+                      {status?.pairId}
+                    </span>
+                  )
+                : null}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <label className="block space-y-1">
+              <span className="text-sm font-medium text-ink-soft">{t("natsUrlLabel")}</span>
+              <TextInput
+                disabled={running || busy}
+                onChange={event => setNatsUrl(event.target.value)}
+                placeholder="nats://localhost:4222"
+                value={natsUrl}
+              />
+              <span className="block text-xs text-ink-muted">
+                <Trans i18nKey="natsUrlHint" ns="remote" components={[<code key="url" />]} />
+              </span>
+            </label>
+
+            <label className="block space-y-1">
+              <span className="text-sm font-medium text-ink-soft">{t("pairIdLabel")}</span>
+              <TextInput
+                disabled={running || busy}
+                onChange={event => setPairId(event.target.value)}
+                placeholder="DEVPAIR"
+                value={pairId}
+              />
+            </label>
+          </div>
+
+          {error
+            ? (
+                <div className="rounded-md border border-danger-line bg-danger-soft px-3 py-2 text-sm text-danger">{error}</div>
+              )
+            : null}
+
+          <div className="flex gap-2">
             {running
               ? (
-                  <span className="text-xs text-ink-muted">
-                    ·
-                    {" "}
-                    {status?.natsUrl}
-                    {" "}
-                    · pair
-                    {" "}
-                    {status?.pairId}
-                  </span>
+                  <Button disabled={busy} onClick={() => void handleStop()} variant="secondary">
+                    {t("stop")}
+                  </Button>
                 )
-              : null}
+              : (
+                  <Button
+                    disabled={busy || !natsUrl.trim() || !pairId.trim()}
+                    onClick={() => void handleStart()}
+                    variant="primary"
+                  >
+                    {t("start")}
+                  </Button>
+                )}
           </div>
+
+          <p className="text-xs text-ink-muted">
+            {t("note")}
+          </p>
         </div>
-
-        <div className="space-y-4">
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-ink-soft">{t("natsUrlLabel")}</span>
-            <TextInput
-              disabled={running || busy}
-              onChange={event => setNatsUrl(event.target.value)}
-              placeholder="nats://localhost:4222"
-              value={natsUrl}
-            />
-            <span className="block text-xs text-ink-muted">
-              <Trans i18nKey="natsUrlHint" ns="remote" components={[<code key="url" />]} />
-            </span>
-          </label>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-ink-soft">{t("pairIdLabel")}</span>
-            <TextInput
-              disabled={running || busy}
-              onChange={event => setPairId(event.target.value)}
-              placeholder="DEVPAIR"
-              value={pairId}
-            />
-          </label>
-        </div>
-
-        {error
-          ? (
-              <div className="rounded-md border border-danger-line bg-danger-soft px-3 py-2 text-sm text-danger">{error}</div>
-            )
-          : null}
-
-        <div className="flex gap-2">
-          {running
-            ? (
-                <Button disabled={busy} onClick={() => void handleStop()} variant="secondary">
-                  {t("stop")}
-                </Button>
-              )
-            : (
-                <Button
-                  disabled={busy || !natsUrl.trim() || !pairId.trim()}
-                  onClick={() => void handleStart()}
-                  variant="primary"
-                >
-                  {t("start")}
-                </Button>
-              )}
-        </div>
-
-        <p className="text-xs text-ink-muted">
-          {t("note")}
-        </p>
       </div>
     </section>
   );

--- a/gui/src/features/settings/ModelsPage.tsx
+++ b/gui/src/features/settings/ModelsPage.tsx
@@ -62,8 +62,20 @@ export function ModelsPage({
     }
   }
 
+  function setProviderVisibility(models: AgentModelOption[], visible: boolean) {
+    const keys = new Set(models.map(modelKey));
+    if (visible) {
+      onChangeHidden(hiddenModels.filter(item => !keys.has(item)));
+    }
+    else {
+      const toAdd = models.map(modelKey).filter(key => !hidden.has(key));
+      if (toAdd.length > 0)
+        onChangeHidden([...hiddenModels, ...toAdd]);
+    }
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <TextInput
         onChange={event => setQuery(event.target.value)}
         placeholder={t("models.searchPlaceholder")}
@@ -74,28 +86,43 @@ export function ModelsPage({
         ? <p className="text-sm text-ink-muted">{t("models.noModels")}</p>
         : null}
 
-      {groups.map(([provider, models]) => (
-        <SettingsSection key={provider} title={providerLabel(provider)}>
-          <SettingsList>
-            {models.map(model => (
-              <SettingsRow
-                key={modelKey(model)}
-                title={model.label}
-                // Subtitle: raw model id (dropped when it equals the label so it
-                // isn't shown twice) followed by the input modality, e.g.
-                // "Text" or "Text Image".
-                description={modelSubtitle(model)}
-              >
+      {groups.map(([provider, models]) => {
+        const allVisible = models.every(model => !hidden.has(modelKey(model)));
+        return (
+          <SettingsSection
+            key={provider}
+            title={providerLabel(provider)}
+            action={(
+              <div className="pr-4">
                 <Switch
-                  checked={!hidden.has(modelKey(model))}
-                  label={model.label}
-                  onChange={visible => setVisibility(model, visible)}
+                  checked={allVisible}
+                  label={providerLabel(provider)}
+                  onChange={visible => setProviderVisibility(models, visible)}
                 />
-              </SettingsRow>
-            ))}
-          </SettingsList>
-        </SettingsSection>
-      ))}
+              </div>
+            )}
+          >
+            <SettingsList>
+              {models.map(model => (
+                <SettingsRow
+                  key={modelKey(model)}
+                  title={model.label}
+                  // Subtitle: raw model id (dropped when it equals the label so it
+                  // isn't shown twice) followed by the input modality, e.g.
+                  // "Text" or "Text Image".
+                  description={modelSubtitle(model)}
+                >
+                  <Switch
+                    checked={!hidden.has(modelKey(model))}
+                    label={model.label}
+                    onChange={visible => setVisibility(model, visible)}
+                  />
+                </SettingsRow>
+              ))}
+            </SettingsList>
+          </SettingsSection>
+        );
+      })}
 
       {modelOptions.length > 0 && groups.length === 0
         ? <p className="text-sm text-ink-muted">{t("models.noMatch")}</p>

--- a/gui/src/features/settings/SettingsDialog.tsx
+++ b/gui/src/features/settings/SettingsDialog.tsx
@@ -1,3 +1,4 @@
+import type { UpdateStatus } from "../../components/layout/hooks/useUpdateChecker";
 import type { AgentModelOption } from "../../integrations/agent/agentClient";
 import type { AppSettings } from "../../integrations/storage/appSettings";
 import { Boxes, FlaskConical, Info, RefreshCw, RotateCcw, Settings2, Sparkles, UserRound } from "lucide-react";
@@ -58,14 +59,21 @@ const TAB_TITLE_KEYS: Record<SettingsTab, string> = {
 
 export function SettingsDialog({
   appSettings,
+  cachedUpdateStatus,
+  hasUpdate,
   initialTab = "general",
   modelOptions,
   onChangeSettings,
   onClose,
   onProvidersChanged,
+  onUpdateSeen,
   open,
 }: {
   appSettings: AppSettings;
+  /** Cached update-check result from the background checker. */
+  cachedUpdateStatus?: UpdateStatus | null;
+  /** Whether a new app version is available (shows a dot on the update nav item). */
+  hasUpdate?: boolean;
   /** Tab to show when the dialog opens (e.g. a "Models" quick entry). */
   initialTab?: SettingsTab;
   modelOptions: AgentModelOption[];
@@ -73,6 +81,8 @@ export function SettingsDialog({
   onClose: () => void;
   /** Refresh the available model list after a provider mutation. */
   onProvidersChanged?: () => void;
+  /** Called when the user navigates to the "Check for updates" tab. */
+  onUpdateSeen?: () => void;
   open: boolean;
 }) {
   const { t } = useTranslation("settings");
@@ -112,6 +122,7 @@ export function SettingsDialog({
                   .filter(item => showEnvironment || !("devOnly" in item && item.devOnly))
                   .map((item) => {
                     const Icon = item.icon;
+                    const showDot = item.value === "update" && hasUpdate;
                     return (
                       <button
                         key={item.value}
@@ -119,10 +130,17 @@ export function SettingsDialog({
                           "flex h-8 w-full items-center gap-2 rounded-md border border-transparent px-2 text-sm font-medium text-ink-soft transition-colors hover:bg-surface hover:text-ink",
                           tab === item.value && "border-line-soft bg-surface text-ink shadow-xs",
                         )}
-                        onClick={() => setTab(item.value)}
+                        onClick={() => {
+                          setTab(item.value);
+                          if (item.value === "update")
+                            onUpdateSeen?.();
+                        }}
                         type="button"
                       >
-                        <Icon className="size-4 shrink-0" />
+                        <span className="relative inline-flex shrink-0">
+                          <Icon className="size-4" />
+                          {showDot ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                        </span>
                         <span className="truncate">{t(item.labelKey)}</span>
                       </button>
                     );
@@ -157,7 +175,7 @@ export function SettingsDialog({
                 )
               : null}
             {tab === "account" ? <AccountPage /> : null}
-            {tab === "update" ? <UpdatePage /> : null}
+            {tab === "update" ? <UpdatePage cachedStatus={cachedUpdateStatus} /> : null}
             {tab === "about" ? <AboutPage /> : null}
             {tab === "providers" ? <ProvidersPage onProvidersChanged={onProvidersChanged} /> : null}
             {tab === "models"

--- a/gui/src/features/settings/UpdatePage.tsx
+++ b/gui/src/features/settings/UpdatePage.tsx
@@ -1,3 +1,4 @@
+import type { UpdateStatus } from "../../components/layout/hooks/useUpdateChecker";
 import { listen } from "@tauri-apps/api/event";
 import { Download, RefreshCw, RotateCcw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -9,15 +10,6 @@ import { useBuildInfo } from "../../integrations/tauri/useBuildInfo";
 import { errorMessage } from "../../lib/errors";
 import { SettingsSection } from "./SettingsPrimitives";
 
-/** Mirrors the backend `UpdateStatus` (serde camelCase). */
-interface UpdateStatus {
-  currentVersion: string;
-  latestVersion: string;
-  hasUpdate: boolean;
-  platformSupported: boolean;
-  downloadUrl: string | null;
-}
-
 interface DownloadProgress {
   downloaded: number;
   total: number;
@@ -25,11 +17,13 @@ interface DownloadProgress {
 
 /**
  * Software update page backed by Tauri's signed in-place updater.
+ * Accepts an optional `cachedStatus` from the background update checker so
+ * the result is displayed immediately without a redundant network round-trip.
  */
-export function UpdatePage() {
+export function UpdatePage({ cachedStatus }: { cachedStatus?: UpdateStatus | null }) {
   const { t } = useTranslation("settings");
   const build = useBuildInfo();
-  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [status, setStatus] = useState<UpdateStatus | null>(cachedStatus ?? null);
   const [checking, setChecking] = useState(false);
   const [checkError, setCheckError] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);

--- a/gui/src/features/skills/SkillsView.tsx
+++ b/gui/src/features/skills/SkillsView.tsx
@@ -3,6 +3,7 @@ import type { SkillFilters } from "./skillsFilter";
 import { ArrowUpCircle, Blocks, Download, RotateCcw, Search, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { LeftPanelTitlebarToggle } from "../../components/layout/LeftPanelTitlebarToggle";
 import { Badge } from "../../components/ui/Badge";
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
@@ -17,6 +18,7 @@ import {
 import { cn } from "../../lib/cn";
 import { errorMessage } from "../../lib/errors";
 import { emitFutureEvent, onFutureEvent } from "../../lib/futureEvents";
+import { startWindowDrag } from "../../lib/windowDrag";
 import { computeSkillUpgrades } from "./autoUpgrade";
 import {
   allCategoriesValue,
@@ -30,7 +32,7 @@ type SkillsTab = "installed" | "all";
 
 const emptyFilters: SkillFilters = { category: allCategoriesValue, query: "" };
 
-export function SkillsView() {
+export function SkillsView({ leftPanelExpanded, onToggleLeftPanel }: { leftPanelExpanded: boolean; onToggleLeftPanel: () => void }) {
   const { t } = useTranslation("skills");
   const [tab, setTab] = useState<SkillsTab>("installed");
   const [installed, setInstalled] = useState<InstalledSkill[]>([]);
@@ -184,10 +186,19 @@ export function SkillsView() {
 
   return (
     <section className="flex h-full min-h-0 flex-col bg-surface">
-      <header className="border-b border-line-soft px-8 pb-3 pt-6">
-        <h1 className="text-base font-semibold text-ink">{t("title")}</h1>
-        <p className="mt-1 text-sm text-ink-muted">{t("subtitle")}</p>
-        <div className="mt-4 grid w-64 grid-cols-2 gap-1 rounded-md bg-surface-subtle p-1">
+      <header
+        className="flex h-12 shrink-0 select-none items-center justify-between border-b border-line-soft/40 px-4"
+        onMouseDown={startWindowDrag}
+      >
+        <div className="flex min-w-0 flex-1 items-center" data-tauri-drag-region>
+          <LeftPanelTitlebarToggle expanded={leftPanelExpanded} onToggle={onToggleLeftPanel} />
+          <span className="truncate text-sm font-semibold text-ink">{t("title")}</span>
+        </div>
+      </header>
+
+      <header className="border-b border-line-soft px-8 pb-3 pt-4">
+        <p className="text-sm text-ink-muted">{t("subtitle")}</p>
+        <div className="mt-3 grid w-64 grid-cols-2 gap-1 rounded-md bg-surface-subtle p-1">
           <TabButton active={tab === "installed"} label={t("tab.installed")} onClick={() => setTab("installed")} />
           <TabButton active={tab === "all"} label={t("tab.all")} onClick={() => setTab("all")} />
         </div>


### PR DESCRIPTION
## Changes

- **Auto-check updates on startup**: Background update check on app launch + every 24h. Red dot on settings button and 'Check for updates' nav item when a new version is available. Dots clear once user visits the update tab.
- **UpdatePage shows cached result**: Background check result is passed to UpdatePage so it displays immediately without requiring a manual 'Check' click.
- **Single-instance enforcement**: `tauri-plugin-single-instance` ensures only one app instance runs. Second launch activates existing window (cross-platform).
- **Skills/Remote titlebar headers**: Both views now have a proper titlebar with window drag support and left-panel toggle, matching the chat view style.
- **Models page batch toggle**: Each provider group header has a switch to enable/disable all models at once. Partial state shows as off.
- **Restart Webview**: Promoted from debug-only to production feature (macOS menu).

## Verification

- `npx tsc --noEmit` ✅
- `npx eslint` ✅
- `npx vitest run` (193 tests) ✅
- `cargo fmt --check && cargo clippy` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)