### PR TITLE
chore: remove push-to-main CI trigger; bump pprof 0.13→0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,16 @@ name: CI
 
 permissions: read-all
 
-# Fast feedback on every push to main, every PR, and on manual dispatch:
+# Fast feedback on every PR and on manual dispatch:
 # lint + typecheck + tests + a 3-platform Rust compile check. Full
 # cross-platform *packaging* stays in build.yml (tags / dispatch) — this
 # workflow exists so breakage (especially platform-conditional Rust that only
 # shows up on Windows/macOS) is caught BEFORE a release build is cut.
+#
+# Push-to-main trigger is intentionally absent: "Require branches to be up
+# to date before merging" on branch protection already forces the PR check
+# to re-run on the merged result, so a post-merge run would be redundant.
 on:
-  push:
-    branches: [main]
   pull_request:
   # Lets you run the whole PR-check suite manually from the Actions tab
   # (e.g. to verify a cross-platform fix on a feature branch without a PR).
@@ -22,10 +24,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # On PRs, run only the suites affected by the changed paths. Pushes to main
-  # and manual dispatches are deliberately full runs: the former validates the
-  # merge result, and the latter is the escape hatch for dependency/runner
-  # changes that do not show up in a source diff.
+  # On PRs, run only the suites affected by the changed paths. Manual
+  # dispatches are deliberately full runs: the escape hatch for dependency/
+  # runner changes that do not show up in a source diff.
   changes:
     name: Detect affected checks
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +788,26 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "equivalent"
@@ -2068,10 +2097,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
+ "aligned-vec",
  "backtrace",
  "cfg-if",
  "findshlibs",
@@ -2080,11 +2110,11 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
- "parking_lot",
  "smallvec",
+ "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2939,6 +2969,15 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -72,7 +72,7 @@ libc = "0.2"
 
 # Profiling flamegraph output uses inferno behind the scenes.
 [target.'cfg(not(windows))'.dependencies]
-pprof = { version = "0.13", features = ["flamegraph"] }
+pprof = { version = "0.15", features = ["flamegraph"] }
 
 # Windows: Job Object for process-tree kill; restricted token + ACLs for the
 # bash sandbox (SANDBOX_PLAN §11). Feature set grows with W1b.


### PR DESCRIPTION
## Changes

### CI workflow
- Remove `push: branches: [main]` trigger from `ci.yml`
- Branch protection's "Require branches to be up to date before merging" already forces the PR check to re-run on the merged result, making post-merge runs redundant

### Dependabot fixes
- Bump `pprof` 0.13 → 0.15 to fix two code-scanning alerts (#12, #13) about unsound `std::slice::from_raw_parts` usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)