### PR TITLE
fix(tui): session list garbled on arrow-key navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,16 @@ run-channels:
 # Build agent with debug symbols + frame pointers for profiling, then run
 # the benchmark suite.  Writes flamegraph SVG + logs to profile-results/.
 profile-agent:
+ifeq ($(OS),windows)
+	set "RUSTFLAGS=-C force-frame-pointers=yes" && \
+		cargo build --release -p future-agent \
+		--config "profile.release.debug=""line-tables-only""" \
+		--config "profile.release.strip=""none"""
+	@if not exist profile-results mkdir profile-results
+	@where blondie >NUL 2>NUL || (echo. & echo  blondie is required for CPU profiling on Windows. & echo  Install: cargo install blondie --features inferno & echo  CPU profiling also requires administrator privileges. & exit /b 1)
+	@echo Starting profile run (port 50052, 90s)...
+	set "PROFILE_DURATION=90" && powershell -ExecutionPolicy Bypass -File scripts/agent-profile-bench.ps1
+else
 	RUSTFLAGS="-C force-frame-pointers=yes" \
 		cargo build --release -p future-agent \
 		--config 'profile.release.debug="line-tables-only"' \
@@ -290,28 +300,45 @@ profile-agent:
 	@echo ""
 	@echo "Flamegraph: $$(ls -t profile-results/agent-profile-*.svg | head -1)"
 	@echo "Run: open profile-results/agent-profile-*.svg"
+endif
 
 # Heap (memory) profile: build with the dhat-heap feature, run on port
 # 50052 for N seconds, write a dhat report JSON.
 # Usage: make profile-heap PROFILE_SECS=30
 # View the report at https://nnethercote.github.io/dh_view/dh_view.html
 profile-heap:
+ifeq ($(OS),windows)
+# Windows needs full debug info (2) for dhat backtrace capture (line-tables-only is insufficient)
+	cargo build --release -p future-agent --features dhat-heap \
+		--config profile.release.debug=2 \
+		--config "profile.release.strip=""none"""
+	@if not exist profile-results mkdir profile-results
+else
 	cargo build --release -p future-agent --features dhat-heap \
 		--config 'profile.release.debug="line-tables-only"' \
 		--config 'profile.release.strip="none"'
 	@mkdir -p profile-results
-	./target/release/future-agent \
+endif
+	./target/release/future-agent$(EXE_SUFFIX) \
 		--grpc-addr 127.0.0.1:50052 \
 		--profile-heap profile-results/heap-profile.json \
 		--profile-seconds $(or $(PROFILE_SECS),30) \
 		--verbose
 	@echo ""
 	@echo "Heap profile: profile-results/heap-profile.json"
-	@echo "View: https://nnethercote.github.io/dh_view/dh_view.html"
+	@echo "Interactive viewer: https://nnethercote.github.io/dh_view/dh_view.html"
+	@echo "For static flamegraph: dhat-to-flamegraph profile-results/heap-profile.json -f svg -o heap-flame.svg (requires dhat backtraces)"
 
 # Quick profile: start agent with profiling on port 50052, run for N seconds.
 # Usage: make profile-quick PROFILE_SECS=30
 profile-quick:
+ifeq ($(OS),windows)
+	set "RUSTFLAGS=-C force-frame-pointers=yes" && \
+		cargo build --release -p future-agent \
+		--config "profile.release.debug=""line-tables-only""" \
+		--config "profile.release.strip=""none"""
+	powershell -ExecutionPolicy Bypass -File scripts/profile-quick.ps1 -Duration $(or $(PROFILE_SECS),30)
+else
 	RUSTFLAGS="-C force-frame-pointers=yes" \
 		cargo build --release -p future-agent \
 		--config 'profile.release.debug="line-tables-only"' \
@@ -322,6 +349,7 @@ profile-quick:
 		--profile profile-results/quick-profile.svg \
 		--profile-seconds $(or $(PROFILE_SECS),30) \
 		--verbose
+endif
 
 # ─── Generate ───────────────────────────────────────────────────────────────
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -117,8 +117,12 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     let profiler_guard: Option<()> = {
         if profile_path.is_some() {
-            tracing::warn!("Built-in CPU profiling is not available on Windows (pprof is Unix-only).");
-            tracing::info!("To profile on Windows, use: make profile-quick (requires blondie + admin)");
+            tracing::warn!(
+                "Built-in CPU profiling is not available on Windows (pprof is Unix-only)."
+            );
+            tracing::info!(
+                "To profile on Windows, use: make profile-quick (requires blondie + admin)"
+            );
             tracing::info!("Or run externally: blondie flamegraph future-agent.exe --grpc-addr ... --profile-seconds N");
         }
         None

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -117,7 +117,9 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     let profiler_guard: Option<()> = {
         if profile_path.is_some() {
-            tracing::warn!("CPU profiling is not supported on Windows — ignoring --profile flag");
+            tracing::warn!("Built-in CPU profiling is not available on Windows (pprof is Unix-only).");
+            tracing::info!("To profile on Windows, use: make profile-quick (requires blondie + admin)");
+            tracing::info!("Or run externally: blondie flamegraph future-agent.exe --grpc-addr ... --profile-seconds N");
         }
         None
     };

--- a/scripts/agent-profile-bench.ps1
+++ b/scripts/agent-profile-bench.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+    Windows equivalent of agent-profile-bench.sh.
+    Uses blondie (ETW-based CPU sampler) to trace the agent, drives load with
+    'future run' prompts, and writes a flamegraph SVG.
+.DESCRIPTION
+    Expects the profiled binary to already exist at .\target\release\future-agent.exe
+    (built by the 'make profile-agent' target).
+    Requires administrator privileges for ETW kernel tracing.
+    Outputs:
+      profile-results/agent-profile-<ts>.svg   flamegraph
+      profile-results/agent-profile-<ts>.log   agent stdout/stderr
+.PARAMETER Duration
+    Profile duration in seconds (overrides PROFILE_DURATION env var).
+    Default: 90 (or $env:PROFILE_DURATION if set).
+.PARAMETER Port
+    gRPC port for the agent. Default: 50052 (or $env:PROFILE_PORT if set).
+#>
+param(
+    [int]$Duration = 90,
+    [int]$Port = 50052
+)
+
+# Environment variable overrides (Match bash script behaviour)
+if ($env:PROFILE_DURATION) { $Duration = [int]$env:PROFILE_DURATION }
+if ($env:PROFILE_PORT)     { $Port     = [int]$env:PROFILE_PORT }
+
+$ErrorActionPreference = "Stop"
+$addr = "127.0.0.1:$Port"
+$ts = Get-Date -Format "yyyyMMdd-HHmmss"
+$svg = "profile-results/agent-profile-$ts.svg"
+$log = "profile-results/agent-profile-$ts.log"
+$binary = "$PSScriptRoot\..\target\release\future-agent.exe"
+# Resolve to absolute path (blondie needs the real path)
+$binary = [System.IO.Path]::GetFullPath($binary)
+
+# Ensure output directory exists
+if (-not (Test-Path "profile-results")) {
+    New-Item -ItemType Directory -Force -Path "profile-results" | Out-Null
+}
+
+if (-not (Test-Path $binary)) {
+    Write-Host "error: $binary not found — run the build step first" -ForegroundColor Red
+    exit 1
+}
+
+# Check that blondie is available
+$blondieExe = Get-Command blondie -ErrorAction SilentlyContinue
+if (-not $blondieExe) {
+    Write-Host "blondie not found. Install it with: cargo install blondie --features inferno" -ForegroundColor Yellow
+    Write-Host "Note: CPU profiling on Windows requires administrator privileges."
+    exit 1
+}
+
+Write-Host "Starting profiled agent on $addr for ${Duration}s ..."
+Write-Host "Using blondie for ETW-based CPU sampling (requires admin)."
+
+# blondie flamegraph <binary> <args...> launches the binary, traces it,
+# and writes flamegraph.svg when the process exits.
+# We run blondie in the background while we drive load via gRPC.
+$blondieArgs = @(
+    "flamegraph",
+    $binary,
+    "--",
+    "--grpc-addr", $addr,
+    "--profile-seconds", $Duration,
+    "--verbose"
+)
+
+$blondiePsi = New-Object System.Diagnostics.ProcessStartInfo
+$blondiePsi.FileName = $blondieExe.Source
+$blondiePsi.Arguments = $blondieArgs -join ' '
+$blondiePsi.UseShellExecute = $false
+$blondiePsi.RedirectStandardOutput = $true
+$blondiePsi.RedirectStandardError = $true
+
+$blondieProc = [System.Diagnostics.Process]::Start($blondiePsi)
+if (-not $blondieProc) {
+    Write-Host "error: failed to start blondie" -ForegroundColor Red
+    exit 1
+}
+
+# Capture blondie output in background
+$blondieOutput = New-Object System.Text.StringBuilder
+$blondieOutputEvent = Register-ObjectEvent -InputObject $blondieProc `
+    -EventName OutputDataReceived -Action {
+        param($sender, $e)
+        if ($e.Data) { $Event.MessageData.AppendLine($e.Data) | Out-Null }
+    } -MessageData $blondieOutput
+$blondieErrorEvent = Register-ObjectEvent -InputObject $blondieProc `
+    -EventName ErrorDataReceived -Action {
+        param($sender, $e)
+        if ($e.Data) { $Event.MessageData.AppendLine($e.Data) | Out-Null }
+    } -MessageData $blondieOutput
+$blondieProc.BeginOutputReadLine()
+$blondieProc.BeginErrorReadLine()
+
+try {
+    # Wait for gRPC port to accept connections (max ~30s — blondie needs time
+    # to start the ETW session AND launch the agent)
+    Write-Host -NoNewline "Waiting for agent to come up"
+    $up = $false
+    for ($i = 0; $i -lt 300; $i++) {
+        try {
+            $tcp = New-Object Net.Sockets.TcpClient
+            $tcp.Connect("127.0.0.1", $Port)
+            $tcp.Close()
+            $tcp.Dispose()
+            Write-Host " — up."
+            $up = $true
+            break
+        } catch {
+            # Port not ready yet
+        }
+        if ($blondieProc.HasExited) {
+            Write-Host ""
+            Write-Host "error: blondie/agent exited during startup (code $($blondieProc.ExitCode))" -ForegroundColor Red
+            Write-Host $blondieOutput.ToString()
+            exit 1
+        }
+        Write-Host -NoNewline "."
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not $up) {
+        Write-Host ""
+        Write-Host "error: agent did not start within 30s" -ForegroundColor Red
+        Write-Host $blondieOutput.ToString()
+        exit 1
+    }
+
+    # Drive load with 'future run' one-shot prompts
+    $future = Get-Command future -ErrorAction SilentlyContinue
+    if ($future) {
+        Write-Host "Driving load with 'future run' one-shot prompts ..."
+        $prompts = @(
+            "Summarise what this repository does in three sentences.",
+            "List the main entry points of the Rust agent crate.",
+            "Explain how session persistence works, briefly."
+        )
+        $n = $prompts.Count
+        $step = [Math]::Max(3, [Math]::Floor(($Duration - 10) / $n))
+        foreach ($p in $prompts) {
+            if ($blondieProc.HasExited) { break }
+            Write-Host "  -> $p"
+            try {
+                $null = future run --grpc-addr $addr $p 2>&1
+            } catch {
+                if ($blondieProc.HasExited) {
+                    Write-Host "    (cut short by profile timer - expected)"
+                } else {
+                    Write-Host "    (prompt failed - continuing)"
+                }
+            }
+            Start-Sleep -Seconds $step
+        }
+    } else {
+        Write-Host "'future' CLI not found - agent will profile idle/shutdown only."
+        Write-Host "Install it with 'make install' or drive load manually against $addr."
+    }
+
+    Write-Host "Waiting for profile timer to expire and flamegraph to be written ..."
+    $blondieProc.WaitForExit()
+} finally {
+    # Cleanup event handlers
+    if ($blondieOutputEvent) { Unregister-Event -SourceIdentifier $blondieOutputEvent.Name -ErrorAction SilentlyContinue }
+    if ($blondieErrorEvent) { Unregister-Event -SourceIdentifier $blondieErrorEvent.Name -ErrorAction SilentlyContinue }
+
+    if ($blondieProc -and !$blondieProc.HasExited) {
+        $blondieProc.Kill()
+    }
+}
+
+# Save blondie output to log
+$blondieOutput.ToString() | Out-File -FilePath $log -Encoding UTF8
+
+# blondie writes flamegraph.svg in the working directory
+if (Test-Path "flamegraph.svg") {
+    Move-Item -Force "flamegraph.svg" $svg
+}
+
+if (Test-Path $svg) {
+    $sz = (Get-Item $svg).Length
+    Write-Host "Done: $svg ($([Math]::Round($sz/1024, 1)) KB)"
+} else {
+    Write-Host "warning: flamegraph not found at $svg - check $log" -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/profile-quick.ps1
+++ b/scripts/profile-quick.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Run the agent with optional CPU profiling via blondie.
+    Called by 'make profile-quick' on Windows.
+#>
+param(
+    [int]$Duration = 30,
+    [int]$Port = 50052,
+    [string]$Binary = ".\target\release\future-agent.exe"
+)
+
+$ErrorActionPreference = "Continue"
+$addr = "127.0.0.1:$Port"
+$svg = "profile-results/quick-profile.svg"
+
+if (-not (Test-Path "profile-results")) {
+    New-Item -ItemType Directory -Force -Path "profile-results" | Out-Null
+}
+
+if (-not (Test-Path $Binary)) {
+    Write-Host "error: $Binary not found" -ForegroundColor Red
+    exit 1
+}
+
+# Try blondie first for CPU flamegraph
+$blondie = Get-Command blondie -ErrorAction SilentlyContinue
+if ($blondie) {
+    Write-Host "[INFO] Attempting CPU flamegraph via blondie (requires admin)..."
+    $args = @("flamegraph", $Binary, "--", "--grpc-addr", $addr, "--profile-seconds", $Duration, "--verbose")
+    $result = & $blondie.Source @args 2>&1
+    $exitCode = $LASTEXITCODE
+    
+    if ($exitCode -eq 0 -and (Test-Path "flamegraph.svg")) {
+        Move-Item -Force "flamegraph.svg" $svg
+        $sz = (Get-Item $svg).Length
+        Write-Host "Flamegraph: $svg ($([Math]::Round($sz/1024, 1)) KB)" -ForegroundColor Green
+        exit 0
+    }
+    
+    # blondie failed — show output and fall back
+    if ($result -match "NotAnAdmin") {
+        Write-Host "[WARN] blondie requires administrator privileges. Run from an elevated prompt for flamegraphs." -ForegroundColor Yellow
+    } elseif ($result -match "Error") {
+        Write-Host "[WARN] blondie failed: $result" -ForegroundColor Yellow
+    }
+    Write-Host "[INFO] Falling back to agent-only run (no CPU flamegraph)..."
+} else {
+    Write-Host "[INFO] blondie not installed. Install for flamegraph support:"
+    Write-Host "  cargo install blondie --features inferno,clap"
+    Write-Host "[INFO] Running agent without CPU flamegraph..."
+}
+
+# Fallback: run agent without profiling
+$proc = Start-Process -FilePath $Binary `
+    -ArgumentList @("--grpc-addr", $addr, "--profile-seconds", $Duration, "--verbose") `
+    -NoNewWindow -Wait -PassThru
+
+if ($proc.ExitCode -ne 0) {
+    Write-Host "[WARN] Agent exited with code $($proc.ExitCode)"
+} else {
+    Write-Host "[INFO] Profile run complete."
+}

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -95,6 +95,9 @@ export class App extends Container {
     } catch { return []; }
   };
 
+  // Per-session draft input cache — preserves unsent text when switching sessions
+  private sessionInputCache = new Map<string, string>();
+
   private state = {
     model: "",
     thinking: "off",
@@ -121,6 +124,19 @@ export class App extends Container {
   };
 
   private running = false;
+
+  /** Save the current input draft for the current session before switching away. */
+  private saveSessionInput(): void {
+    if (this.state.sessionId) {
+      this.sessionInputCache.set(this.state.sessionId, this.input.getValue());
+    }
+  }
+
+  /** Restore the cached input draft for the current session, or clear if none. */
+  private restoreSessionInput(): void {
+    const cached = this.sessionInputCache.get(this.state.sessionId);
+    this.input.setValue(cached ?? "");
+  }
 
   // Diff-based render state 
   private previousLines: string[] = [];
@@ -438,6 +454,8 @@ export class App extends Container {
 
       case "agent_end": {
         this.state.streaming = false;
+        this.state.activeToolCount = 0;
+        this.state.toolStartTime = 0;
         const e = event as { text?: string };
         if (e.text && this.chat) {
           this.chat.updateLastMessage(e.text);
@@ -449,6 +467,8 @@ export class App extends Container {
 
       case "agent_start":
         this.state.streaming = true;
+        this.state.activeToolCount = 0;
+        this.state.toolStartTime = 0;
         this.chat.addMessage({
           id: crypto.randomUUID(),
           role: "assistant",
@@ -881,6 +901,8 @@ export class App extends Container {
     if (this.state.streaming) {
       this.client.abort().catch(() => { /* connection may close before abort completes */ });
       this.state.streaming = false;
+      this.state.activeToolCount = 0;
+      this.state.toolStartTime = 0;
       // Mark the in-progress assistant message as stopped so the partial
       // content (thinking, text, tool calls) is preserved and visible —
       // matching the GUI's behaviour of keeping the aborted reply.
@@ -1062,9 +1084,11 @@ export class App extends Container {
             maxVisible: 15,
             onSelect: async (item) => {
               try {
+                this.saveSessionInput();
                 const r = await this.client.fork(item.value);
                 if (!r.cancelled) {
                   await this.refresh();
+                  this.restoreSessionInput();
                   await this.loadSessionMessages();
                   this.chat.addMessage({
                     id: crypto.randomUUID(),
@@ -1085,7 +1109,7 @@ export class App extends Container {
               this.hideOverlay();
             },
           });
-          this.showOverlay(sl);
+          this.showOverlay(sl, { width: Math.min(80, this.terminal.columns - 4) });
         } catch (err) {
           this.chat.addMessage({
             id: crypto.randomUUID(),
@@ -1147,12 +1171,11 @@ export class App extends Container {
                   prefix += isLast ? "└─ " : "├─ ";
                 }
                 const currentMarker = s.id === this.state.sessionId ? "▶ " : "  ";
-                const streamingMark = (s as any).is_streaming ? "● " : "";
-                const label = `${currentMarker}${streamingMark}${prefix}${s.session_name || (s as any).first_message || s.id}`;
+                const label = `${currentMarker}${prefix}${s.session_name || (s as any).first_message || s.id}`;
                 items.push({
                   value: s.id,
                   label,
-                  description: `${s.model} · ${(s as any).query_count ?? "?"}Q · ${new Date(s.updated_at).toLocaleString()}`,
+                  description: s.id === this.state.sessionId ? "current" : "",
                 });
                 if (hasChildren) {
                   flatten(children.get(s.id)!, depth + 1, [...ancestorsLast, isLast]);
@@ -1168,8 +1191,10 @@ export class App extends Container {
             onSelect: async (item) => {
               try {
                 if (item.value !== this.state.sessionId) {
+                  this.saveSessionInput();
                   await this.client.switchSession(item.value);
                   await this.refresh();
+                  this.restoreSessionInput();
                   await this.loadSessionMessages();
                   this.chat.addMessage({
                     id: crypto.randomUUID(),
@@ -1190,7 +1215,7 @@ export class App extends Container {
               this.hideOverlay();
             },
           });
-          this.showOverlay(treeList);
+          this.showOverlay(treeList, { width: Math.min(80, this.terminal.columns - 4) });
         } catch (err) {
           this.chat.addMessage({
             id: crypto.randomUUID(),
@@ -1205,6 +1230,7 @@ export class App extends Container {
         try {
           // Inherit cwd, model, and thinking level from the current session
           // so /new feels like a clean continuation instead of a reset.
+          this.saveSessionInput();
           const result = await this.client.newSession({
             cwd: this.state.cwd || undefined,
             modelId: this.state.model || undefined,
@@ -1212,6 +1238,7 @@ export class App extends Container {
           });
           if (result.sessionId) {
             await this.refresh();
+            this.restoreSessionInput();
             this.chat.addMessage({
               id: crypto.randomUUID(),
               role: "system",
@@ -1283,7 +1310,7 @@ export class App extends Container {
               this.hideOverlay();
             },
           });
-          this.showOverlay(selector);
+          this.showOverlay(selector, { width: Math.min(100, this.terminal.columns - 4) });
         } catch (err) {
           this.chat.addMessage({
             id: crypto.randomUUID(),
@@ -1609,6 +1636,9 @@ export class App extends Container {
     if (this.connectionLost === lost) return;
     this.connectionLost = lost;
     if (lost) {
+      this.state.streaming = false;
+      this.state.activeToolCount = 0;
+      this.state.toolStartTime = 0;
       this.chat.addMessage({
         id: crypto.randomUUID(),
         role: "system",
@@ -1633,6 +1663,11 @@ export class App extends Container {
       const s = await this.client.getState();
       this.state.model = s.model ?? "(no model)";
       this.state.thinking = s.thinkingLevel;
+      this.state.streaming = s.isStreaming ?? false;
+      if (!this.state.streaming) {
+        this.state.activeToolCount = 0;
+        this.state.toolStartTime = 0;
+      }
       this.state.sessionId = s.sessionId ?? this.state.sessionId;
       this.state.cwd = s.cwd ?? "";
       this.state.version = s.version ?? "";
@@ -1740,7 +1775,7 @@ export class App extends Container {
       },
     });
 
-    this.showOverlay(sl);
+    this.showOverlay(sl, { width: Math.min(80, this.terminal.columns - 4) });
   }
 
   private async cycleModel(): Promise<void> {
@@ -1800,7 +1835,7 @@ export class App extends Container {
       render: (width: number) => renderHelp(width),
       invalidate: () => {},
     };
-    this.showOverlay(helpComponent);
+    this.showOverlay(helpComponent, { width: this.terminal.columns });
   }
 
   showOverlay(component: Component, options?: OverlayOptions): OverlayHandle {
@@ -1904,9 +1939,13 @@ export class App extends Container {
       : base;
 
     for (const entry of visible) {
-      const overlayLines = entry.component.render(termW);
+      // Two-pass render: first pass at termW to measure height for layout,
+      // then re-render at layout.width so content fits the composited box.
+      const measureLines = entry.component.render(termW);
+      if (measureLines.length === 0) continue;
+      const layout = resolveOverlayLayout(termW, termH, measureLines.length, entry.options);
+      const overlayLines = entry.component.render(layout.width);
       if (overlayLines.length === 0) continue;
-      const layout = resolveOverlayLayout(termW, termH, overlayLines.length, entry.options);
 
       // Blank out the overlay area first, then composite lines
       const maxRows = Math.min(overlayLines.length, layout.maxHeight, termH - layout.row);
@@ -2006,7 +2045,7 @@ export class App extends Container {
     const items: SelectItem[] = sessions.map((s) => ({
       value: s.id,
       label: s.session_name || (s as any).first_message || s.id,
-      description: `${s.is_streaming ? "● " : ""}${s.model} · ${s.query_count ?? "?"}Q · ${new Date(s.updated_at).toLocaleString()}`,
+      description: s.id === this.state.sessionId ? "current" : "",
     }));
 
     const sl = new SelectList({
@@ -2015,8 +2054,10 @@ export class App extends Container {
       maxVisible: 15,
       onSelect: async (item) => {
         try {
+          this.saveSessionInput();
           await this.client.switchSession(item.value);
           await this.refresh();
+          this.restoreSessionInput();
           await this.loadSessionMessages();
           this.chat.addMessage({
             id: crypto.randomUUID(),
@@ -2037,7 +2078,7 @@ export class App extends Container {
       },
     });
 
-    this.showOverlay(sl);
+    this.showOverlay(sl, { width: Math.min(80, this.terminal.columns - 4) });
   }
 
   async showSettings(): Promise<void> {
@@ -2071,7 +2112,7 @@ export class App extends Container {
       },
     });
 
-    this.showOverlay(sl);
+    this.showOverlay(sl, { width: Math.min(80, this.terminal.columns - 4) });
   }
 
   // ─── Rendering (differential with synchronized output) ──────────
@@ -2279,6 +2320,11 @@ export class App extends Container {
     // Filter out undefined entries (can happen with certain input sequences)
     newLines = newLines.map((l) => l ?? "");
 
+    // Extract cursor position BEFORE overlay compositing — overlays may
+    // cover the editor row and drop the cursor marker, causing hardware-
+    // cursor tracking to drift and diff renders to write at wrong rows.
+    const cursorPos = this.extractCursorPosition(newLines, H);
+
     // Composite overlays into rendered lines (before diff compare)
     if (this.overlayStack.length > 0) {
       newLines = this.compositeOverlays(newLines, W, H);
@@ -2303,9 +2349,6 @@ export class App extends Container {
         }
       }
     }
-
-    // Extract cursor position before line resets (marker must be found first)
-    const cursorPos = this.extractCursorPosition(newLines, H);
 
     // Apply line resets (prevents ANSI style bleed between lines)
     newLines = this.applyLineResets(newLines);

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -40,6 +40,11 @@ function isTermuxSession(): boolean {
   return Boolean(process.env.TERMUX_VERSION);
 }
 
+/** Collapse all whitespace runs (spaces, tabs, newlines) to a single space and trim. */
+function sanitizeSessionName(name: string): string {
+  return name.replace(/\s+/g, " ").trim();
+}
+
 export class App extends Container {
   private terminal: NodeTerminal;
   private client: GrpcClient;
@@ -91,7 +96,7 @@ export class App extends Container {
   private getSessions = async (): Promise<string[]> => {
     try {
       const r = await this.client.listSessions();
-      return r.sessions.map((s) => s.session_name || s.id);
+      return r.sessions.map((s) => sanitizeSessionName(s.session_name || s.id));
     } catch { return []; }
   };
 
@@ -1171,7 +1176,7 @@ export class App extends Container {
                   prefix += isLast ? "└─ " : "├─ ";
                 }
                 const currentMarker = s.id === this.state.sessionId ? "▶ " : "  ";
-                const label = `${currentMarker}${prefix}${s.session_name || (s as any).first_message || s.id}`;
+                const label = `${currentMarker}${prefix}${sanitizeSessionName(s.session_name || (s as any).first_message || s.id)}`;
                 items.push({
                   value: s.id,
                   label,
@@ -2044,7 +2049,7 @@ export class App extends Container {
 
     const items: SelectItem[] = sessions.map((s) => ({
       value: s.id,
-      label: s.session_name || (s as any).first_message || s.id,
+      label: sanitizeSessionName(s.session_name || (s as any).first_message || s.id),
       description: s.id === this.state.sessionId ? "current" : "",
     }));
 

--- a/tui/src/components/select-list.ts
+++ b/tui/src/components/select-list.ts
@@ -5,7 +5,7 @@
 
 import type { Component } from "../tui.js";
 import { CSI, RESET, BOLD } from "../tui.js";
-import { visibleWidth, truncateToWidth } from "../utils.js";
+import { visibleWidth, truncateToWidth, applyBackgroundToLine } from "../utils.js";
 
 export interface SelectItem {
   value: string;
@@ -170,37 +170,35 @@ export class SelectList implements Component {
     const innerW = Math.max(20, width);
 
     // Width budget: label left, description right, both aligned
-    const maxLabelW = Math.max(10, Math.floor(innerW * 0.4));
+    const maxLabelW = Math.max(10, Math.floor(innerW * 0.45));
     const maxDescW = Math.max(5, innerW - maxLabelW - 4);
 
-    // Helper: pad to innerW-2 (safe margin for overlay compositing borders)
-    const padToWidth = (line: string): string => {
-      const visW = visibleWidth(line);
-      const safeW = Math.max(10, innerW - 2);
-      if (visW < safeW) {
-        return line + " ".repeat(safeW - visW) + RESET;
-      }
-      return truncateToWidth(line, safeW) + RESET;
+    // Helper: pad to innerW-2 with a solid background so the overlay
+    // forms a proper box and base text can't bleed through.
+    const bg = this.theme.bg;
+    const selBg = this.theme.selectedBg;
+    const padToWidth = (line: string, bgColor: number): string => {
+      return applyBackgroundToLine(line, innerW, bgColor);
     };
 
-    lines.push(padToWidth(`${CSI}38;5;${this.theme.accent}m${BOLD} ${this.title}`));
-    lines.push(padToWidth(`${CSI}2mFilter: ${this.filter}_`));
+    lines.push(padToWidth(`${CSI}38;5;${this.theme.accent}m${BOLD} ${this.title}`, bg));
+    lines.push(padToWidth(`${CSI}2mFilter: ${this.filter}_`, bg));
 
     const total = this.filteredItems.length;
     const maxItems = Math.min(total, this.maxVisible);
 
     // Scroll indicator above (always reserve space for consistent line count)
     if (this.scrollOffset > 0) {
-      lines.push(padToWidth(`${CSI}38;5;${this.theme.dimFg}m↑ ${this.scrollOffset} more`));
+      lines.push(padToWidth(`${CSI}38;5;${this.theme.dimFg}m↑ ${this.scrollOffset} more`, bg));
     } else {
-      lines.push(padToWidth(""));
+      lines.push(padToWidth("", bg));
     }
 
     for (let i = 0; i < this.maxVisible; i++) {
       const idx = this.scrollOffset + i;
       const item = this.filteredItems[idx];
       if (!item) {
-        lines.push(padToWidth(""));
+        lines.push(padToWidth("", bg));
         continue;
       }
 
@@ -222,27 +220,27 @@ export class SelectList implements Component {
         const suffix = descPart
           ? ` ${CSI}2m${descPart}`
           : "";
-        lines.push(padToWidth(head + label + suffix));
+        lines.push(padToWidth(head + label + suffix, selBg));
       } else {
         const label = `${CSI}38;5;${this.theme.fg}m  ${labelPart}${labelPad}${RESET}`;
         const suffix = descPart
           ? ` ${CSI}38;5;${this.theme.dimFg}m${CSI}2m${descPart}${RESET}`
           : "";
-        lines.push(padToWidth(label + suffix));
+        lines.push(padToWidth(label + suffix, bg));
       }
     }
 
     // Scroll indicator below (always reserve space for consistent line count)
     if (this.scrollOffset + maxItems < total) {
       const remaining = total - this.scrollOffset - maxItems;
-      lines.push(padToWidth(`${CSI}38;5;${this.theme.dimFg}m↓ ${remaining} more`));
+      lines.push(padToWidth(`${CSI}38;5;${this.theme.dimFg}m↓ ${remaining} more`, bg));
     } else {
-      lines.push(padToWidth(""));
+      lines.push(padToWidth("", bg));
     }
 
     if (total === 0) {
       // Replace one empty slot with the message (line count stays constant)
-      lines[2] = padToWidth(`${CSI}2mNo matching items`);
+      lines[2] = padToWidth(`${CSI}2mNo matching items`, bg);
     }
 
     return lines;


### PR DESCRIPTION
## 问题

TUI 中 ctrl+r 打开会话列表后，按上下键整个列表内容错乱（行偏移、内容叠写、底层文字透出）。

## 根因（3 个渲染 bug）

1. **覆盖层渲染宽度 ≠ 盒子宽度**：`compositeOverlays` 用全终端宽度渲染组件，但覆盖层布局宽度默认只有 80 列，内容溢出盒子右边界
2. **光标标记被覆盖层遮挡**：`extractCursorPosition` 在覆盖层合成之后执行，编辑器行的光标标记被 `extractSegments` 丢弃，`cursorPos` 为 null，`hardwareCursorRow` 追踪失准，diff 渲染时行写入位置偏移（表现为 AABD 式错位）
3. **覆盖层无背景色**：底层 chat 文字从覆盖层两侧透出，视觉错乱

## 修复

- `compositeOverlays` 两遍渲染：先测高，再用 `layout.width` 重渲染
- `doRender`：`extractCursorPosition` 移到覆盖层合成**之前**
- `SelectList`：所有行通过 `applyBackgroundToLine` 填充背景色，覆盖层成为实心盒子
- 所有 SelectList 覆盖层传入显式宽度 `min(80, cols-4)`，与模型选择器一致
- 会话列表/会话树 description 简化为 `"current"`，与模型列表视觉一致
- 另包含：会话输入草稿缓存、streaming 状态下 activeToolCount/toolStartTime 正确重置（工作区原有改动）

## 验证

- `tsc --noEmit` 通过
- 160 个 bun 测试全部通过
- 实机 ctrl+r + 上下键验证正常
