### PR TITLE
perf(gui): share gRPC channel, batch polls, sync names, fix Win tests & build-gui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: version build build-agent build-tui build-cli build-gui build-channels test lint lint-agent lint-channels lint-tui lint-cli lint-gui stylelint-gui check-gui clean run run-agent run-tui run-cli run-gui run-channels package-gui install install-nogui uninstall install-agent install-tui install-cli install-gui install-channels install-skills fmt generate-models generate-proto help test-gui-rust
+.PHONY: version build build-agent build-tui build-cli build-gui build-gui-dist build-channels test lint lint-agent lint-channels lint-tui lint-cli lint-gui stylelint-gui check-gui clean run run-agent run-tui run-cli run-gui run-channels package-gui install install-nogui uninstall install-agent install-tui install-cli install-gui install-channels install-skills fmt generate-models generate-proto help test-gui-rust gui-sidecars
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 # Single source of truth for the build version (see scripts/version.mjs).
@@ -72,16 +72,7 @@ else
 	$(SUDO) cp cli/dist/future "$(PREFIX)/future"
 endif
 
-install-gui: install-cli install-agent
-ifeq ($(OS),windows)
-	cmd /c "if not exist gui\src-tauri\binaries mkdir gui\src-tauri\binaries"
-	$(COPY_CMD) target\release\future-agent$(EXE_SUFFIX) "gui\src-tauri\binaries\future-agent-$(TARGET)$(EXE_SUFFIX)"
-	$(COPY_CMD) cli\dist\future$(EXE_SUFFIX) "gui\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)"
-else
-	@mkdir -p gui/src-tauri/binaries
-	cp target/release/future-agent gui/src-tauri/binaries/future-agent-$(TARGET)
-	cp cli/dist/future gui/src-tauri/binaries/future-$(TARGET)
-endif
+install-gui: install-cli install-agent gui-sidecars
 	$(call npm-install-if-needed,gui)
 	cd gui && npx tauri build --no-bundle
 ifeq ($(OS),windows)
@@ -164,9 +155,30 @@ build-cli:
 	$(call npm-install-if-needed,cli)
 	cd cli && npm run gen-version && npm run build && bun build --compile dist/index.js --outfile dist/future
 
-build-gui:
+# Internal: copy sidecar binaries (agent + CLI) into the Tauri resource dir.
+# Tauri's externalBin references these at build time; they are embedded next
+# to the GUI binary and extracted on first launch so the GUI can auto-start
+# the agent, run CLI commands (skill bootstrap), etc.
+gui-sidecars: build-agent build-cli
+ifeq ($(OS),windows)
+	cmd /c "if not exist gui\src-tauri\binaries mkdir gui\src-tauri\binaries"
+	$(COPY_CMD) target\release\future-agent$(EXE_SUFFIX) "gui\src-tauri\binaries\future-agent-$(TARGET)$(EXE_SUFFIX)"
+	$(COPY_CMD) cli\dist\future$(EXE_SUFFIX) "gui\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)"
+else
+	@mkdir -p gui/src-tauri/binaries
+	cp target/release/future-agent gui/src-tauri/binaries/future-agent-$(TARGET)
+	cp cli/dist/future gui/src-tauri/binaries/future-$(TARGET)
+endif
+
+# Compile the React frontend only — needed by check-gui and as a dep of build-gui.
+build-gui-dist:
 	$(call npm-install-if-needed,gui)
 	cd gui && npm run build
+
+# Self-contained standalone binary (no installer).  Produces
+#   gui/src-tauri/target/release/futureos$(EXE_SUFFIX)
+build-gui: build-gui-dist gui-sidecars
+	cd gui && npx tauri build --no-bundle
 
 build-channels:
 	cd channels && cargo build --release
@@ -224,7 +236,7 @@ lint-gui:
 stylelint-gui:
 	cd gui && npm run stylelint
 
-check-gui: lint-gui stylelint-gui build-gui
+check-gui: lint-gui stylelint-gui build-gui-dist
 	cd gui/src-tauri && cargo check
 
 fmt:

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 thiserror = "2"
 tonic = "0.12"
 prost = "0.13"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "sync"] }
 async-nats = "0.49"
 futures = "0.3"
 tauri-plugin-dialog = "2"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 thiserror = "2"
 tonic = "0.12"
 prost = "0.13"
-tokio = { version = "1", features = ["time", "sync"] }
+tokio = { version = "1", features = ["time", "sync", "rt-multi-thread"] }
 async-nats = "0.49"
 futures = "0.3"
 tauri-plugin-dialog = "2"

--- a/gui/src-tauri/src/agent_bridge/client.rs
+++ b/gui/src-tauri/src/agent_bridge/client.rs
@@ -36,25 +36,91 @@ fn agent_endpoint() -> String {
     }
 }
 
+/// Process-lifetime runtime that owns the shared agent channel. tonic spawns
+/// the h2 connection's driver task on whatever runtime first touches the
+/// channel, and several startup callers (session import, run reanimation)
+/// `block_on` a throwaway per-thread `Runtime` that is dropped as soon as the
+/// thread returns — which used to kill the driver and poison the cached
+/// channel for the rest of the process (every later call failed with
+/// `Service was not ready: transport error`). Pinning channel creation to a
+/// runtime that never shuts down keeps the connection alive regardless of
+/// which runtime any caller runs on.
+fn agent_channel_runtime() -> tokio::runtime::Handle {
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+    RUNTIME
+        .get_or_init(|| {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .thread_name("agent-channel")
+                .build()
+                .expect("build agent channel runtime");
+            let handle = runtime.handle().clone();
+            std::thread::Builder::new()
+                .name("agent-channel-runtime".to_string())
+                .spawn(move || {
+                    // Park forever: dropping the runtime would kill the shared
+                    // connection's driver task.
+                    runtime.block_on(std::future::pending::<()>());
+                })
+                .expect("spawn agent channel runtime thread");
+            handle
+        })
+        .clone()
+}
+
 /// Resolve the agent endpoint and open a gRPC client. A connection failure maps
 /// to `AppError::AgentUnavailable` so callers can tolerate a down agent (e.g.
 /// `abort_run` still cancels the run locally).
 pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppError> {
-    let endpoint = agent_endpoint();
+    static AGENT_CHANNEL: tokio::sync::OnceCell<Channel> = tokio::sync::OnceCell::const_new();
+    let endpoint_str = agent_endpoint();
     let unavailable = |error: tonic::transport::Error| {
         crate::AppError::AgentUnavailable(format!(
-            "Unable to connect to Future Agent at {endpoint}: {error}"
+            "Unable to connect to Future Agent at {endpoint_str}: {error}"
         ))
     };
-    let channel = Endpoint::from_shared(endpoint.clone())
+    let endpoint = Endpoint::from_shared(endpoint_str.clone())
         .map_err(unavailable)?
-        .connect_timeout(CONNECT_TIMEOUT)
-        .connect()
+        .connect_timeout(CONNECT_TIMEOUT);
+    // Shared, lazily-established HTTP/2 channel. Previously every command
+    // opened a fresh TCP connection (incl. the per-second status polls), so a
+    // fully idle GUI burnt ~0.25 core in backend just on connect/teardown.
+    // Cloning a Channel is cheap — every clone shares one underlying h2
+    // connection. The channel is created and first used on the pinned
+    // process-lifetime runtime (see agent_channel_runtime) so its connection
+    // driver outlives any caller's runtime. A one-shot health check validates
+    // reachability on first init so callers see a friendly error.
+    let channel = agent_channel_runtime()
+        .spawn(async move {
+            AGENT_CHANNEL
+                .get_or_try_init(|| async {
+                    let ch = endpoint.connect_lazy();
+                    // Validate the lazy channel with a cheap, no-side-effect RPC
+                    // so a down agent surfaces the familiar AgentUnavailable
+                    // message rather than a raw tonic transport error on the
+                    // next real command.
+                    let mut client = FutureAgentClient::new(ch.clone())
+                        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+                        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE);
+                    client
+                        .execute_command(list_streaming_sessions_command())
+                        .await
+                        .map_err(|status| {
+                            crate::AppError::AgentUnavailable(format!(
+                                "Unable to connect to Future Agent at {endpoint_str}: {}",
+                                status.message()
+                            ))
+                        })?;
+                    Ok::<Channel, crate::AppError>(ch)
+                })
+                .await
+                .map(|ch| ch.clone())
+        })
         .await
-        .map_err(unavailable)?;
-    // Match the agent server's raised limits: a prompt can carry several
-    // base64-encoded images (two ~3MB images ≈ 7MB), which blows past tonic's
-    // 4MB default and would otherwise fail the send before the run starts.
+        .map_err(|join_error| {
+            crate::AppError::AgentUnavailable(format!("Agent channel task failed: {join_error}"))
+        })??;
     Ok(FutureAgentClient::new(channel)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE))
@@ -284,4 +350,51 @@ fn command_id() -> String {
         .unwrap_or_default();
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     format!("gui_{millis}_{seq}")
+}
+
+#[cfg(test)]
+mod tests {
+    /// Regression test for the startup channel-poisoning bug: the first
+    /// `connect_agent` caller of the process runs on a throwaway per-thread
+    /// runtime (mirrors lib.rs's session-import startup thread), which is
+    /// dropped as soon as the thread returns. The shared channel must stay
+    /// usable afterwards — before the fix, every later call failed with
+    /// `Service was not ready: transport error` (surfaced as the run
+    /// reanimation failure at startup).
+    ///
+    /// Requires a live agent on 127.0.0.1:50051: `cargo test -- --ignored`.
+    #[test]
+    #[ignore = "requires a running future-agent on 127.0.0.1:50051"]
+    fn shared_channel_survives_caller_runtime_drop() {
+        // First caller on a throwaway runtime, dropped on thread exit.
+        std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().expect("runtime 1");
+            rt.block_on(async {
+                let mut client = super::connect_agent()
+                    .await
+                    .expect("connect on throwaway runtime");
+                client
+                    .execute_command(super::list_streaming_sessions_command())
+                    .await
+                    .expect("first RPC");
+            });
+        })
+        .join()
+        .expect("first caller thread");
+
+        // Second caller on a fresh runtime (mirrors the run-reanimation
+        // startup thread): with the bug this failed with a transport error.
+        let rt = tokio::runtime::Runtime::new().expect("runtime 2");
+        rt.block_on(async {
+            let mut client = super::connect_agent()
+                .await
+                .expect("connect after caller runtime drop");
+            // Transport-level success is what matters here — an app-level
+            // error (unknown session) still proves the connection works.
+            client
+                .execute_command(super::get_state_command(String::new()))
+                .await
+                .expect("RPC after caller runtime drop");
+        });
+    }
 }

--- a/gui/src-tauri/src/agent_bridge/client.rs
+++ b/gui/src-tauri/src/agent_bridge/client.rs
@@ -132,7 +132,7 @@ pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppErr
                     Ok::<Channel, crate::AppError>(ch)
                 })
                 .await
-                .map(|ch| ch.clone())
+                .cloned()
         })
         .await
         .map_err(|join_error| {

--- a/gui/src-tauri/src/agent_bridge/client.rs
+++ b/gui/src-tauri/src/agent_bridge/client.rs
@@ -69,6 +69,23 @@ fn agent_channel_runtime() -> tokio::runtime::Handle {
         .clone()
 }
 
+/// Classify an RPC failure from a shared-channel call. With the cached lazy
+/// channel, `connect_agent` succeeds even when the agent dies *after* the
+/// channel was established — a down agent then surfaces here as a tonic
+/// `Unavailable` transport status. Map that to `AppError::AgentUnavailable`
+/// so the tolerance sites (`abort_run`'s local cancel, credential reload's
+/// "down agent is success") keep working; anything else is an app-level
+/// failure and keeps the generic message variant. The agent reports
+/// command-level failures inside an OK `RpcResponse` (`success = false`),
+/// never as gRPC statuses, so a status error is always transport-level.
+pub fn map_rpc_error(context: &str, status: tonic::Status) -> crate::AppError {
+    if status.code() == tonic::Code::Unavailable {
+        crate::AppError::AgentUnavailable(format!("{context}: {}", status.message()))
+    } else {
+        crate::AppError::Message(format!("{context}: {status}"))
+    }
+}
+
 /// Resolve the agent endpoint and open a gRPC client. A connection failure maps
 /// to `AppError::AgentUnavailable` so callers can tolerate a down agent (e.g.
 /// `abort_run` still cancels the run locally).

--- a/gui/src-tauri/src/agent_bridge/import.rs
+++ b/gui/src-tauri/src/agent_bridge/import.rs
@@ -310,13 +310,30 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
     // workspace directory name. Re-sync when the stored title is clearly
     // stale and a better one is available.
     if let Some(existing) = store::find_thread_by_agent_session(&summary.id)? {
-        let is_default = existing.title.is_empty()
-            || existing.title == cwd_basename
-            || existing.title == "New Chat"
-            || existing.title == "新对话";
+        // Converge the DB title to the agent's session_name — the name shared
+        // with every client (TUI `/name`, CLI, channels). Renames made outside
+        // the GUI never reach the GUI DB, and the sidebar falls back to that
+        // stale DB title whenever agent state is unavailable.
+        let mut current_title = existing.title.clone();
+        if let Some(name) = summary
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+        {
+            if name != current_title
+                && crate::store::sync_thread_title(&existing.id, name).unwrap_or(false)
+            {
+                current_title = name.to_string();
+            }
+        }
+        let is_default = current_title.is_empty()
+            || current_title == cwd_basename
+            || current_title == "New Chat"
+            || current_title == "新对话";
         if is_default
             && !best_title.is_empty()
-            && best_title != existing.title
+            && best_title != current_title
             && best_title != cwd_basename
         {
             let input = crate::store::RenameThreadInput {

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -14,8 +14,8 @@ pub use self::approval::{decide_approval, inject_session_rule};
 pub(crate) use self::client::raw_agent_addr;
 pub use self::client::{
     connect_agent, delete_session_command, get_session_entries_command, get_state_command,
-    list_streaming_sessions_command, set_cwd_command, set_model_command, set_session_name_command,
-    set_thinking_level_command, RpcResponseExt,
+    list_streaming_sessions_command, map_rpc_error, set_cwd_command, set_model_command,
+    set_session_name_command, set_thinking_level_command, RpcResponseExt,
 };
 pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, PreparedPrompt};
 pub(crate) use self::import::import_missing_sessions;
@@ -110,7 +110,9 @@ pub async fn reload_agent_credentials() -> Result<(), crate::AppError> {
     client
         .execute_command(base_command("reload_auth", String::new()))
         .await
-        .map_err(|error| format!("Unable to refresh Future Agent credentials: {error}"))?
+        // Transport-level Unavailable → AgentUnavailable → treated as success
+        // above ("no in-memory state to refresh on a down agent").
+        .map_err(|status| map_rpc_error("Unable to refresh Future Agent credentials", status))?
         .into_inner()
         .ok_or_rpc_error("Future Agent rejected the credential refresh.")?;
     Ok(())

--- a/gui/src-tauri/src/agent_bridge/run_control.rs
+++ b/gui/src-tauri/src/agent_bridge/run_control.rs
@@ -2,7 +2,7 @@
 //! the agent to confirm idle before snapshotting. These back the abort command
 //! and the parent module's prompt finalization.
 
-use super::client::{base_command, connect_agent, get_state_command, RpcResponseExt};
+use super::client::{base_command, connect_agent, get_state_command, map_rpc_error, RpcResponseExt};
 use crate::store;
 
 pub(super) async fn abort_agent_thread(thread_id: &str) -> Result<(), crate::AppError> {
@@ -15,7 +15,10 @@ pub(super) async fn abort_agent_thread(thread_id: &str) -> Result<(), crate::App
             thread.agent_session_id.unwrap_or(thread.id),
         ))
         .await
-        .map_err(|error| format!("Unable to abort Future Agent run: {error}"))?
+        // Transport-level Unavailable → AgentUnavailable, so `abort_run`
+        // still cancels the run locally when the agent died after the shared
+        // channel was established.
+        .map_err(|status| map_rpc_error("Unable to abort Future Agent run", status))?
         .into_inner()
         .ok_or_rpc_error("Future Agent rejected the abort request.")?;
     Ok(())

--- a/gui/src-tauri/src/agent_bridge/run_control.rs
+++ b/gui/src-tauri/src/agent_bridge/run_control.rs
@@ -2,7 +2,9 @@
 //! the agent to confirm idle before snapshotting. These back the abort command
 //! and the parent module's prompt finalization.
 
-use super::client::{base_command, connect_agent, get_state_command, map_rpc_error, RpcResponseExt};
+use super::client::{
+    base_command, connect_agent, get_state_command, map_rpc_error, RpcResponseExt,
+};
 use crate::store;
 
 pub(super) async fn abort_agent_thread(thread_id: &str) -> Result<(), crate::AppError> {

--- a/gui/src-tauri/src/commands/files.rs
+++ b/gui/src-tauri/src/commands/files.rs
@@ -679,7 +679,10 @@ mod tests {
         let resolved =
             resolve_preview_link_path("/docs/guide/index.md".into(), "../assets/logo.png".into())
                 .unwrap();
-        assert_eq!(resolved.path, "/docs/guide/../assets/logo.png");
+        // Joined with the platform separator (e.g. `guide\../assets` on
+        // Windows) — still a valid, equivalent path for the local OS.
+        let expected = Path::new("/docs/guide").join("../assets/logo.png");
+        assert_eq!(resolved.path, expected.to_string_lossy().into_owned());
         assert_eq!(resolved.name, "logo.png");
     }
 

--- a/gui/src-tauri/src/commands/runs.rs
+++ b/gui/src-tauri/src/commands/runs.rs
@@ -13,6 +13,16 @@ pub fn list_runs(thread_id: String) -> Result<Vec<store::RunRecord>, crate::AppE
     store::list_runs(&thread_id)
 }
 
+/// Batch query: the latest run's (status, ended_at) for each thread in one IPC.
+/// Replaces the per-thread [`list_runs`] fan-out that powered the thread-list
+/// run-indicator poll (N connections, N full row-sets 6+ times per second).
+#[tauri::command]
+pub fn list_latest_run_infos(
+    thread_ids: Vec<String>,
+) -> Result<Vec<store::LatestRunInfo>, crate::AppError> {
+    store::latest_run_infos(&thread_ids)
+}
+
 /// Update a run's status from the frontend's completion/failure paths. Guarded:
 /// a run that is already terminal (e.g. a concurrent `abort_run` set `cancelled`)
 /// is not clobbered. Returns the run's real current state so the caller

--- a/gui/src-tauri/src/commands/threads.rs
+++ b/gui/src-tauri/src/commands/threads.rs
@@ -39,10 +39,20 @@ pub fn create_thread(
 pub async fn rename_thread(
     input: store::RenameThreadInput,
 ) -> Result<store::ThreadRecord, crate::AppError> {
-    let title = input.title.clone();
-    let thread = store::rename_thread(input)?;
-    // Propagate to the agent immediately so the session name stays in sync
-    // (best-effort — a failure here must not fail the local rename).
+    // Propagate to the agent FIRST and only rename the DB row on success. The
+    // agent's session_name is the authoritative name shared with every client
+    // (TUI /name, CLI, channels), and get_thread_agent_state / startup import
+    // converge the DB title toward it — so a local-only rename whose
+    // propagation failed would be silently synced back (reverted) on the next
+    // poll. Renaming is therefore all-or-nothing: if the agent call fails,
+    // the rename fails and the user sees the error in the dialog.
+    // Validate up front (store::rename_thread re-checks) so an invalid title
+    // never reaches the agent.
+    if input.title.trim().is_empty() {
+        return Err("title cannot be empty.".to_string().into());
+    }
+    let thread = store::get_thread(&input.thread_id)?
+        .ok_or_else(|| "Thread could not be loaded.".to_string())?;
     let session_id = thread
         .agent_session_id
         .as_deref()
@@ -50,28 +60,22 @@ pub async fn rename_thread(
         .filter(|id| !id.is_empty())
         .unwrap_or(&thread.id)
         .to_string();
-    if let Ok(mut client) = crate::agent_bridge::connect_agent().await {
-        let cmd = crate::agent_bridge::set_session_name_command(title, session_id.clone());
-        // Without propagation the agent keeps the old name and — being the
-        // authoritative source — later syncs it back over this DB rename.
-        match client.execute_command(cmd).await {
-            Ok(resp) => {
-                let resp = resp.into_inner();
-                if !resp.success {
-                    eprintln!(
-                        "FutureOS rename propagation rejected for {session_id}: {}",
-                        resp.error
-                    );
-                }
-            }
-            Err(error) => {
-                eprintln!("FutureOS rename propagation failed for {session_id}: {error}")
-            }
-        }
-    } else {
-        eprintln!("FutureOS rename propagation skipped for {session_id}: agent unreachable");
+    let mut client = crate::agent_bridge::connect_agent().await?;
+    let cmd = crate::agent_bridge::set_session_name_command(input.title.clone(), session_id);
+    let resp = client
+        .execute_command(cmd)
+        .await
+        .map_err(|status| {
+            crate::agent_bridge::map_rpc_error("FutureOS rename propagation failed", status)
+        })?
+        .into_inner();
+    if !resp.success && !resp.error.contains("session not found") {
+        return Err(format!("Future Agent rejected the rename: {}", resp.error).into());
     }
-    Ok(thread)
+    // "session not found" is the one benign rejection: the thread has no
+    // agent session (never prompted, or deleted), so nothing can ever sync a
+    // stale name back over this rename.
+    store::rename_thread(input)
 }
 
 #[tauri::command]

--- a/gui/src-tauri/src/commands/threads.rs
+++ b/gui/src-tauri/src/commands/threads.rs
@@ -51,8 +51,25 @@ pub async fn rename_thread(
         .unwrap_or(&thread.id)
         .to_string();
     if let Ok(mut client) = crate::agent_bridge::connect_agent().await {
-        let cmd = crate::agent_bridge::set_session_name_command(title, session_id);
-        let _ = client.execute_command(cmd).await;
+        let cmd = crate::agent_bridge::set_session_name_command(title, session_id.clone());
+        // Without propagation the agent keeps the old name and — being the
+        // authoritative source — later syncs it back over this DB rename.
+        match client.execute_command(cmd).await {
+            Ok(resp) => {
+                let resp = resp.into_inner();
+                if !resp.success {
+                    eprintln!(
+                        "FutureOS rename propagation rejected for {session_id}: {}",
+                        resp.error
+                    );
+                }
+            }
+            Err(error) => {
+                eprintln!("FutureOS rename propagation failed for {session_id}: {error}")
+            }
+        }
+    } else {
+        eprintln!("FutureOS rename propagation skipped for {session_id}: agent unreachable");
     }
     Ok(thread)
 }
@@ -237,8 +254,27 @@ pub async fn get_thread_agent_state(
     if !resp.success {
         return Err(format!("get_state rejected: {}", resp.error).into());
     }
-    serde_json::from_str::<serde_json::Value>(&resp.data)
-        .map_err(|e| format!("get_state parse error: {e}").into())
+    let value = serde_json::from_str::<serde_json::Value>(&resp.data)
+        .map_err(|e| format!("get_state parse error: {e}"))?;
+    // Converge the DB title toward the agent's session_name — the name shared
+    // with every client (TUI `/name`, CLI, channels), whose renames never
+    // reach the GUI DB. The sidebar treats the agent name as authoritative
+    // and falls back to the DB title whenever agent state is unavailable, so
+    // a stale DB title surfaces as "the rename didn't survive a restart".
+    // Best-effort; sync_thread_title never bumps updated_at (sidebar order).
+    if let Some(name) = value
+        .get("session_name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|n| !n.is_empty())
+    {
+        if name != thread.title {
+            if let Err(error) = store::sync_thread_title(&thread_id, name) {
+                eprintln!("FutureOS thread title sync failed for {thread_id}: {error}");
+            }
+        }
+    }
+    Ok(value)
 }
 
 /// Fetch session entries from the agent (user, assistant, tool messages).

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -430,6 +430,7 @@ pub fn run() {
             append_message,
             create_run,
             list_runs,
+            list_latest_run_infos,
             update_run_status,
             abort_run,
             list_run_events,

--- a/gui/src-tauri/src/shadow_review/repository.rs
+++ b/gui/src-tauri/src/shadow_review/repository.rs
@@ -9,16 +9,6 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use crate::AppError;
 
-/// Null device for `core.excludesFile`, so the shadow repo never inherits the
-/// user's global git excludes (§5.5).
-pub fn null_device_path() -> &'static str {
-    if cfg!(windows) {
-        "NUL"
-    } else {
-        "/dev/null"
-    }
-}
-
 fn review_root() -> Result<PathBuf, AppError> {
     let app_dir = crate::store::app_data_path()?.app_dir;
     Ok(PathBuf::from(app_dir).join("review"))
@@ -299,14 +289,35 @@ impl ShadowRepo {
         check_status(&["init"], &output)
     }
 
+    /// Real empty file for `core.excludesFile`, so the shadow repo never
+    /// inherits the user's global git excludes (§5.5). A file rather than the
+    /// null device: git-for-Windows rejects `NUL` outright ("fatal: cannot use
+    /// NUL as an exclude file"), while an empty file behaves the same
+    /// everywhere. Lives inside the shadow git dir, which `ensure_initialized`
+    /// creates before this runs.
+    fn ensure_empty_excludes_file(&self) -> Result<PathBuf, AppError> {
+        let path = self.git_dir.join("empty-excludes");
+        if !path.exists() {
+            fs::write(&path, b"")?;
+        }
+        Ok(path)
+    }
+
     fn configure(&self) -> Result<(), AppError> {
         // §5.2: autocrlf/symlinks are correctness; the rest are large-repo perf.
+        // Forward slashes in the excludes path: unquoted backslashes are
+        // escape characters in git config syntax, and git accepts `/` paths
+        // on every platform (incl. git-for-Windows).
+        let excludes_file = self
+            .ensure_empty_excludes_file()?
+            .to_string_lossy()
+            .replace('\\', "/");
         let pairs: [(&str, &str); 8] = [
             ("core.autocrlf", "false"),
             ("core.symlinks", "true"),
             ("core.fsmonitor", "false"),
             ("core.untrackedCache", "true"),
-            ("core.excludesFile", null_device_path()),
+            ("core.excludesFile", excludes_file.as_str()),
             ("feature.manyFiles", "true"),
             ("index.version", "4"),
             ("index.threads", "true"),

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -52,10 +52,10 @@ pub use review_snapshots::{
 };
 pub use runs::{
     active_run_sessions, append_run_event, clear_all_run_events_files, clear_run_event_buffer,
-    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input,
-    latest_run_infos, list_run_events, list_run_events_bulk, list_runs, list_tool_calls,
-    list_tool_outputs, update_run_status_if_active, LatestRunInfo, RunEventRecord, RunRecord,
-    ToolCallRecord, ToolOutputRecord,
+    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input, latest_run_infos,
+    list_run_events, list_run_events_bulk, list_runs, list_tool_calls, list_tool_outputs,
+    update_run_status_if_active, LatestRunInfo, RunEventRecord, RunRecord, ToolCallRecord,
+    ToolOutputRecord,
 };
 pub use threads::{
     archive_thread, create_thread, delete_thread, find_thread_by_agent_session, get_recent_thread,

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -52,15 +52,16 @@ pub use review_snapshots::{
 };
 pub use runs::{
     active_run_sessions, append_run_event, clear_all_run_events_files, clear_run_event_buffer,
-    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input, list_run_events,
-    list_run_events_bulk, list_runs, list_tool_calls, list_tool_outputs,
-    update_run_status_if_active, RunEventRecord, RunRecord, ToolCallRecord, ToolOutputRecord,
+    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input,
+    latest_run_infos, list_run_events, list_run_events_bulk, list_runs, list_tool_calls,
+    list_tool_outputs, update_run_status_if_active, LatestRunInfo, RunEventRecord, RunRecord,
+    ToolCallRecord, ToolOutputRecord,
 };
 pub use threads::{
     archive_thread, create_thread, delete_thread, find_thread_by_agent_session, get_recent_thread,
     get_thread, list_threads, move_thread_to_workspace, pin_thread, purge_soft_deleted_threads,
-    rename_thread, restore_thread, update_thread_model, update_thread_session_id,
-    update_thread_thinking_level, ThreadRecord,
+    rename_thread, restore_thread, sync_thread_title, update_thread_model,
+    update_thread_session_id, update_thread_thinking_level, ThreadRecord,
 };
 pub use workspace_files::{search_workspace_files, WorkspaceFileResult, WorkspaceFileSearchInput};
 pub use workspaces::{

--- a/gui/src-tauri/src/store/markdown_refs/mod.rs
+++ b/gui/src-tauri/src/store/markdown_refs/mod.rs
@@ -160,11 +160,14 @@ mod tests {
             )
         };
 
-        // Workspace-relative path → inside, shown relative.
+        // Workspace-relative path → inside, shown relative. The absolute path
+        // is joined with the platform separator (`space\sub` on Windows) —
+        // equivalent for the local open/copy actions it feeds.
         let relative = resolve("sub/note.md");
         assert_eq!(relative.status, "resolved");
         let relative = relative.data.expect("data");
-        assert_eq!(relative["path"], "/work/space/sub/note.md");
+        let expected_path = std::path::Path::new("/work/space").join("sub/note.md");
+        assert_eq!(relative["path"], expected_path.to_string_lossy().into_owned());
         assert_eq!(relative["relativePath"], "sub/note.md");
         assert_eq!(relative["insideWorkspace"], true);
         assert_eq!(relative["name"], "note.md");

--- a/gui/src-tauri/src/store/markdown_refs/mod.rs
+++ b/gui/src-tauri/src/store/markdown_refs/mod.rs
@@ -167,7 +167,10 @@ mod tests {
         assert_eq!(relative.status, "resolved");
         let relative = relative.data.expect("data");
         let expected_path = std::path::Path::new("/work/space").join("sub/note.md");
-        assert_eq!(relative["path"], expected_path.to_string_lossy().into_owned());
+        assert_eq!(
+            relative["path"],
+            expected_path.to_string_lossy().into_owned()
+        );
         assert_eq!(relative["relativePath"], "sub/note.md");
         assert_eq!(relative["insideWorkspace"], true);
         assert_eq!(relative["name"], "note.md");

--- a/gui/src-tauri/src/store/runs.rs
+++ b/gui/src-tauri/src/store/runs.rs
@@ -134,6 +134,47 @@ pub fn list_runs(thread_id: &str) -> Result<Vec<RunRecord>, crate::AppError> {
         .map_err(crate::AppError::from)
 }
 
+/// The single latest run's basic info for each of `thread_ids`. Powers the
+/// thread-list run-indicator poll: one connection, one query replaces N ×
+/// [`list_runs`] fan-out, which opened N connections and decoded full row sets
+/// 6–12 times per second at idle. Threads with no runs are omitted from the
+/// result — callers treat missing as "no run yet".
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LatestRunInfo {
+    pub thread_id: String,
+    pub status: String,
+    pub ended_at: Option<i64>,
+}
+
+pub fn latest_run_infos(thread_ids: &[String]) -> Result<Vec<LatestRunInfo>, crate::AppError> {
+    if thread_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let conn = connect()?;
+    let placeholders: Vec<String> = (0..thread_ids.len()).map(|i| format!("?{}", i + 1)).collect();
+    let sql = format!(
+        "SELECT thread_id, status, ended_at FROM (
+             SELECT thread_id, status, ended_at,
+                    ROW_NUMBER() OVER (PARTITION BY thread_id ORDER BY created_at DESC, id DESC) AS rn
+             FROM runs
+             WHERE thread_id IN ({})
+         ) WHERE rn = 1",
+        placeholders.join(",")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> = thread_ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        Ok(LatestRunInfo {
+            thread_id: row.get(0)?,
+            status: row.get(1)?,
+            ended_at: row.get(2)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(crate::AppError::from)
+}
+
 /// Which runs' still-open children (pending approvals, running tool calls) a
 /// cancel-cascade settles. The two scopes differ only in how a child's owning
 /// run is matched — everything else about the cascade is identical, which is why

--- a/gui/src-tauri/src/store/runs.rs
+++ b/gui/src-tauri/src/store/runs.rs
@@ -152,7 +152,9 @@ pub fn latest_run_infos(thread_ids: &[String]) -> Result<Vec<LatestRunInfo>, cra
         return Ok(vec![]);
     }
     let conn = connect()?;
-    let placeholders: Vec<String> = (0..thread_ids.len()).map(|i| format!("?{}", i + 1)).collect();
+    let placeholders: Vec<String> = (0..thread_ids.len())
+        .map(|i| format!("?{}", i + 1))
+        .collect();
     let sql = format!(
         "SELECT thread_id, status, ended_at FROM (
              SELECT thread_id, status, ended_at,
@@ -163,7 +165,10 @@ pub fn latest_run_infos(thread_ids: &[String]) -> Result<Vec<LatestRunInfo>, cra
         placeholders.join(",")
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = thread_ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+    let params: Vec<&dyn rusqlite::types::ToSql> = thread_ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::types::ToSql)
+        .collect();
     let rows = stmt.query_map(params.as_slice(), |row| {
         Ok(LatestRunInfo {
             thread_id: row.get(0)?,

--- a/gui/src-tauri/src/store/threads.rs
+++ b/gui/src-tauri/src/store/threads.rs
@@ -179,6 +179,34 @@ pub fn rename_thread(input: RenameThreadInput) -> Result<ThreadRecord, crate::Ap
     loaded(get_thread(&input.thread_id)?, "Thread")
 }
 
+pub(super) fn sync_thread_title_in(
+    conn: &Connection,
+    thread_id: &str,
+    title: &str,
+) -> Result<bool, crate::AppError> {
+    let title = title.trim();
+    if title.is_empty() {
+        return Ok(false);
+    }
+    let changed = conn.execute(
+        "UPDATE threads
+         SET title = ?1
+         WHERE id = ?2 AND status != 'deleted' AND title != ?1",
+        params![title, thread_id],
+    )?;
+    Ok(changed > 0)
+}
+
+/// Background convergence of the title toward the agent's `session_name` —
+/// the name shared with every client (TUI `/name`, CLI, channels), whose
+/// renames never reach the GUI DB. Unlike `rename_thread` this is not a user
+/// edit: `updated_at` is untouched so the sidebar order is undisturbed, and
+/// matching titles are a no-op. Returns whether the title changed.
+pub fn sync_thread_title(thread_id: &str, title: &str) -> Result<bool, crate::AppError> {
+    let conn = connect()?;
+    sync_thread_title_in(&conn, thread_id, title)
+}
+
 pub fn update_thread_model(input: UpdateThreadModelInput) -> Result<ThreadRecord, crate::AppError> {
     // Model is now managed by the agent (set_model RPC). The GUI cache
     // (agentStateCache) handles reads; DB write is a no-op.
@@ -519,5 +547,43 @@ mod tests {
             // tx dropped here without commit -> rollback.
         }
         assert_eq!(workspace_count(&conn), 0);
+    }
+
+    /// Title convergence from the agent's session_name must not disturb the
+    /// sidebar order (`updated_at` untouched), skip matching titles, and
+    /// reject empty titles.
+    #[test]
+    fn sync_thread_title_converges_without_touching_updated_at() {
+        let conn = test_conn();
+        let workspace = get_or_create_user_workspace_in(
+            &conn,
+            "Sync Workspace".to_string(),
+            PathBuf::from("/tmp/futureos-sync-ws"),
+            None,
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO threads (
+                 id, workspace_id, mode, title, status, pinned, readonly,
+                 agent_session_id, created_at, updated_at
+             ) VALUES ('thread_sync', ?1, 'chat', 'old', 'active', 0, 0, 'sess', 1, 42)",
+            params![workspace.id],
+        )
+        .unwrap();
+
+        // Matching title: no-op. New title: applied. Empty title: rejected.
+        assert!(!super::sync_thread_title_in(&conn, "thread_sync", "old").unwrap());
+        assert!(super::sync_thread_title_in(&conn, "thread_sync", "agent name").unwrap());
+        assert!(!super::sync_thread_title_in(&conn, "thread_sync", "   ").unwrap());
+
+        let (title, updated_at): (String, i64) = conn
+            .query_row(
+                "SELECT title, updated_at FROM threads WHERE id = 'thread_sync'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "agent name");
+        assert_eq!(updated_at, 42);
     }
 }

--- a/gui/src/components/layout/hooks/useApprovals.ts
+++ b/gui/src/components/layout/hooks/useApprovals.ts
@@ -38,6 +38,13 @@ export function useApprovals(activeThreadId: string | null): ApprovalsState {
     },
     [activeThreadId],
     NO_APPROVALS,
+    {
+      isEqual: (prev, next) =>
+        prev.length === next.length
+        && prev.every((item, idx) =>
+          item.id === next[idx]!.id && item.status === next[idx]!.status
+        ),
+    },
   );
 
   // No `activeThreadId` in the poll deps: useAsyncResource already reloads when

--- a/gui/src/components/layout/hooks/useApprovals.ts
+++ b/gui/src/components/layout/hooks/useApprovals.ts
@@ -42,7 +42,7 @@ export function useApprovals(activeThreadId: string | null): ApprovalsState {
       isEqual: (prev, next) =>
         prev.length === next.length
         && prev.every((item, idx) =>
-          item.id === next[idx]!.id && item.status === next[idx]!.status
+          item.id === next[idx]!.id && item.status === next[idx]!.status,
         ),
     },
   );

--- a/gui/src/components/layout/hooks/useThreadStore.ts
+++ b/gui/src/components/layout/hooks/useThreadStore.ts
@@ -206,7 +206,7 @@ export function useThreadStore(): ThreadStore {
     for (const thread of activeThreads) {
       next[thread.id] = streamingIds.has(thread.id);
     }
-    setThreadStreamingStatuses((prev) =>
+    setThreadStreamingStatuses(prev =>
       // Shallow-compare every key — skip the re-render when nothing streamed.
       Object.keys(next).length === Object.keys(prev).length
       && Object.keys(next).every(k => prev[k] === next[k])

--- a/gui/src/components/layout/hooks/useThreadStore.ts
+++ b/gui/src/components/layout/hooks/useThreadStore.ts
@@ -6,7 +6,7 @@ import { pollStreamingThreadIds, prefetchAgentState } from "../../../integration
 import {
   getRecentOrCreateDefaultThread,
   initializeAppStore,
-  listRuns,
+  listLatestRunInfos,
   listThreads,
   listWorkspaces,
 } from "../../../integrations/storage/threadStore";
@@ -87,28 +87,33 @@ export function useThreadStore(): ThreadStore {
     // must not reject the whole batch — that would blank every thread's run
     // indicator and surface an unhandled rejection. A failed thread keeps
     // its previous status and self-heals on the next 1.5s tick.
-    const entries = await Promise.all(
-      nextThreads.map(async (thread) => {
-        try {
-          const runs = await listRuns(thread.id);
-          const latest = runs[0];
-          const value = latest ? { endedAt: latest.endedAt ?? null, status: latest.status } : undefined;
-          return { id: thread.id, ok: true as const, value };
-        }
-        catch {
-          return { id: thread.id, ok: false as const };
-        }
-      }),
-    );
+    const ids = nextThreads.map(t => t.id);
+    let infos: Array<{ threadId: string; status: string; endedAt: number | null }> = [];
+    try {
+      infos = await listLatestRunInfos(ids);
+    }
+    catch {
+      // Transient error — keep previous statuses, retry next tick.
+    }
     if (generation !== runStatusGenRef.current) {
       return;
     }
+    const infoMap = new Map(infos.map(info => [info.threadId, info]));
     setThreadRunStatuses((previous) => {
+      let changed = false;
       const next: ThreadRunStatuses = {};
-      for (const entry of entries) {
-        next[entry.id] = entry.ok ? entry.value : previous[entry.id];
+      for (const thread of nextThreads) {
+        const info = infoMap.get(thread.id);
+        const value: ThreadRunInfo | undefined = info
+          ? { endedAt: info.endedAt ?? null, status: info.status as ThreadRunInfo["status"] }
+          : previous[thread.id]; // keep old if no new info
+        if (!changed) {
+          const prev = previous[thread.id];
+          changed = prev?.status !== value?.status || prev?.endedAt !== value?.endedAt;
+        }
+        next[thread.id] = value;
       }
-      return next;
+      return changed ? next : previous;
     });
   }, []);
 
@@ -201,7 +206,13 @@ export function useThreadStore(): ThreadStore {
     for (const thread of activeThreads) {
       next[thread.id] = streamingIds.has(thread.id);
     }
-    setThreadStreamingStatuses(next);
+    setThreadStreamingStatuses((prev) =>
+      // Shallow-compare every key — skip the re-render when nothing streamed.
+      Object.keys(next).length === Object.keys(prev).length
+      && Object.keys(next).every(k => prev[k] === next[k])
+        ? prev
+        : next,
+    );
   }, 1000, {
     enabled: activeThreads.length > 0,
     deps: [activeThreads],

--- a/gui/src/integrations/storage/runs.ts
+++ b/gui/src/integrations/storage/runs.ts
@@ -22,6 +22,13 @@ export async function listRuns(threadId: string) {
   return invokeCommand<StoredRun[]>("list_runs", { threadId });
 }
 
+export async function listLatestRunInfos(threadIds: string[]) {
+  return invokeCommand<Array<{ threadId: string; status: string; endedAt: number | null }>>(
+    "list_latest_run_infos",
+    { threadIds },
+  );
+}
+
 export async function updateRunStatus(input: {
   runId: string;
   status: StoredRun["status"];

--- a/gui/src/lib/useAsyncResource.ts
+++ b/gui/src/lib/useAsyncResource.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface AsyncResource<T> {
   data: T;
@@ -12,7 +12,7 @@ export interface UseAsyncResourceOptions<T> {
   /**
    * When supplied, a load result that is equal to the current `data` will
    * NOT trigger a re-render — `setState` is short-circuited. Equality is
-   * compared against the **previous** value (new vs. old), so the same array
+   * compared against the previous value (new vs. old), so the same array
    * identity check via `Object.is` is already free; pass this only for
    * structural comparison (e.g. arrays of records keyed by id).
    */
@@ -23,7 +23,7 @@ export interface UseAsyncResourceOptions<T> {
  * Loads an async resource with cancellation safety.  When deps change (e.g.
  * the active thread switched) a full fetch runs and `loading` flips to true.
  * When ONLY `reload()` is called (poll tick, deps unchanged) the fetch is
- * *silent* — `data` stays visible and `loading` stays false so the UI never
+ * silent — `data` stays visible and `loading` stays false so the UI never
  * shows a stale spinner mid-poll.
  */
 export function useAsyncResource<T>(
@@ -45,16 +45,13 @@ export function useAsyncResource<T>(
   }, []);
 
   // Track whether this load is a silent poll tick vs. a deps change (where
-  // `loading` should flip so the user sees a spinner).  Derived in the render
-  // so `useEffect` reads it synchronously — no extra render.
-  const depsChanged = useMemo(() => {
-    if (!mountedRef.current) {
-      return true; // initial mount always shows loading
-    }
-    return prevDepsRef.current.length !== deps.length
-      || prevDepsRef.current.some((dep, idx) => !Object.is(dep, deps[idx]));
-    // eslint-disable-next-line react/exhaustive-deps
-  }, deps);
+  // `loading` should flip so the user sees a spinner). Computed on EVERY
+  // render against the deps snapshotted by the last effect run — a useMemo
+  // keyed on `deps` would only recompute when deps change, so it could never
+  // observe an unchanged-deps poll tick and would stay `true` forever.
+  const depsChanged = !mountedRef.current
+    || prevDepsRef.current.length !== deps.length
+    || prevDepsRef.current.some((dep, idx) => !Object.is(dep, deps[idx]));
 
   useEffect(() => {
     // Snapshot deps for the *next* tick's comparison.

--- a/gui/src/lib/useAsyncResource.ts
+++ b/gui/src/lib/useAsyncResource.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface AsyncResource<T> {
   data: T;
@@ -8,38 +8,75 @@ export interface AsyncResource<T> {
   reload: () => void;
 }
 
+export interface UseAsyncResourceOptions<T> {
+  /**
+   * When supplied, a load result that is equal to the current `data` will
+   * NOT trigger a re-render — `setState` is short-circuited. Equality is
+   * compared against the **previous** value (new vs. old), so the same array
+   * identity check via `Object.is` is already free; pass this only for
+   * structural comparison (e.g. arrays of records keyed by id).
+   */
+  isEqual?: (previous: T, next: T) => boolean;
+}
+
 /**
- * Loads an async resource with cancellation safety: a load started by an
- * earlier render (or before `deps` changed, or before unmount) never overwrites
- * state with its late result. Replaces the hand-rolled `let cancelled = false`
- * effect pattern.
- *
- * `loader` is intentionally not part of the dependency list — pass the values
- * it closes over via `deps` so the caller controls exactly when a refetch runs.
+ * Loads an async resource with cancellation safety.  When deps change (e.g.
+ * the active thread switched) a full fetch runs and `loading` flips to true.
+ * When ONLY `reload()` is called (poll tick, deps unchanged) the fetch is
+ * *silent* — `data` stays visible and `loading` stays false so the UI never
+ * shows a stale spinner mid-poll.
  */
 export function useAsyncResource<T>(
   loader: () => Promise<T>,
   deps: React.DependencyList,
   initialData: T,
+  options: UseAsyncResourceOptions<T> = {},
 ): AsyncResource<T> {
+  const { isEqual } = options;
   const [data, setData] = useState<T>(initialData);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const prevDepsRef = useRef(deps);
+  const mountedRef = useRef(false);
 
   const reload = useCallback(() => {
     setReloadToken(token => token + 1);
   }, []);
 
+  // Track whether this load is a silent poll tick vs. a deps change (where
+  // `loading` should flip so the user sees a spinner).  Derived in the render
+  // so `useEffect` reads it synchronously — no extra render.
+  const depsChanged = useMemo(() => {
+    if (!mountedRef.current) {
+      return true; // initial mount always shows loading
+    }
+    return prevDepsRef.current.length !== deps.length
+      || prevDepsRef.current.some((dep, idx) => !Object.is(dep, deps[idx]));
+    // eslint-disable-next-line react/exhaustive-deps
+  }, deps);
+
   useEffect(() => {
+    // Snapshot deps for the *next* tick's comparison.
+    prevDepsRef.current = deps;
+    mountedRef.current = true;
+
     let cancelled = false;
-    setLoading(true);
+    const silent = !depsChanged;
+    if (!silent) {
+      setLoading(true);
+    }
     setError(null);
 
     loader()
       .then((result) => {
         if (!cancelled) {
-          setData(result);
+          setData((prev) => {
+            if (isEqual && prev !== initialData && isEqual(prev, result)) {
+              return prev; // structural equal — skip re-render
+            }
+            return result;
+          });
           setLoading(false);
         }
       })


### PR DESCRIPTION
- gRPC channel: cache single HTTP/2 connection (OnceCell + health check)
  instead of per-call TCP connect/teardown; pin channel driver on a
  process-lifetime runtime so it survives throwaway startup threads
  (fixes "Service was not ready: transport error" at startup).
- useAsyncResource: silent reload on poll ticks, skip re-render when
  data unchanged (optional isEqual comparator).
- Thread store: shallow-compare guards on streaming + run status
  setStates; replace N x listRuns fan-out with single batch
  list_latest_run_infos.
- Fix 3 Windows test failures: NUL excludesFile in shadow review,
  platform-aware path asserts in preview-link & markdown-refs tests.
- Converge GUI DB title toward the agent session_name (TUI /name
  never wrote the GUI DB, causing "name reverts after restart"):
  sync_thread_title (no updated_at bump), on-poll sync in
  get_thread_agent_state, and startup-import sync.
- Makefile: build-gui now produces standalone futureos.exe
  (build-gui-dist preserves the old frontend-only pass for check-gui),
  gui-sidecars target deduplicates binary copy in install-gui.
