### PR TITLE
feat(gui): refresh_skills on skills page view, startup, and agent reconnect

### DIFF
--- a/gui/src-tauri/src/commands/skills.rs
+++ b/gui/src-tauri/src/commands/skills.rs
@@ -8,6 +8,15 @@
 
 use crate::{agent_bridge, skills};
 
+/// Manually tell the agent to drop its skills cache and re-discover.
+/// Use when entering the Skills page or on app startup so the
+/// displayed list always reflects the current filesystem state.
+#[tauri::command]
+pub async fn refresh_skills() -> Result<(), crate::AppError> {
+    agent_bridge::refresh_skills().await;
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn list_installed_skills() -> Result<Vec<agent_bridge::InstalledSkill>, crate::AppError> {
     agent_bridge::list_installed_skills().await

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -456,6 +456,7 @@ pub fn run() {
             list_available_skills,
             install_skill,
             uninstall_skill,
+            refresh_skills,
             remote_start,
             remote_stop,
             remote_status

--- a/gui/src/components/layout/AppShell.tsx
+++ b/gui/src/components/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { RemoteView } from "../../features/remote/RemoteView";
 import { SettingsDialog } from "../../features/settings/SettingsDialog";
 import { SkillsView } from "../../features/skills/SkillsView";
 import { installAgentEventListener } from "../../integrations/agent/agentStateCache";
+import { refreshSkills } from "../../integrations/skills/skillsClient";
 import {
   createWorkspace,
   pinThread,
@@ -90,6 +91,12 @@ export function AppShell() {
     installAgentEventListener();
   }, []);
 
+  // On startup, tell the agent to re-scan skills so any skills installed
+  // outside the GUI (e.g. via CLI) are visible without a restart.
+  useEffect(() => {
+    void refreshSkills();
+  }, []);
+
   const {
     threads,
     workspaces,
@@ -132,6 +139,16 @@ export function AppShell() {
     setSelectedModelId,
     refreshAgentModels,
   } = useAgentConnection(appSettings.hiddenModels);
+
+  // When the agent becomes available (startup, restart, or recovery after
+  // a disconnect), re-trigger the skills scan.  The agent has a 5 s rate
+  // limit so rapid repeats are harmless.
+  useEffect(() => {
+    if (agentConnection.status === "connected") {
+      void refreshSkills();
+    }
+  }, [agentConnection.status]);
+
   const {
     selectedThinkingLevel,
     modelsEmptyReason,

--- a/gui/src/features/skills/SkillsView.tsx
+++ b/gui/src/features/skills/SkillsView.tsx
@@ -13,6 +13,7 @@ import {
   installSkill,
   listAvailableSkills,
   listInstalledSkills,
+  refreshSkills,
   uninstallSkill,
 } from "../../integrations/skills/skillsClient";
 import { cn } from "../../lib/cn";
@@ -141,7 +142,9 @@ export function SkillsView({ leftPanelExpanded, onToggleLeftPanel }: { leftPanel
   }, []);
 
   useEffect(() => {
-    void refresh();
+    // First tell the agent to re-scan skills so the installed list is fresh,
+    // then load both lists. refreshSkills is best-effort (agent may be down).
+    void refreshSkills().finally(() => void refresh());
   }, [refresh]);
 
   // The silent auto-upgrade installs newer versions out-of-band; reload so an

--- a/gui/src/integrations/skills/skillsClient.ts
+++ b/gui/src/integrations/skills/skillsClient.ts
@@ -40,3 +40,8 @@ export function installSkill(id: string, version: string): Promise<void> {
 export function uninstallSkill(id: string): Promise<boolean> {
   return invokeCommand<boolean>("uninstall_skill", { id });
 }
+
+/** Tell the agent to drop its skills cache and re-discover immediately. */
+export function refreshSkills(): Promise<void> {
+  return invokeCommand<void>("refresh_skills");
+}


### PR DESCRIPTION
﻿## Summary

Adds `refresh_skills` RPC calls at two new trigger points so the agent'"'"'s skill cache stays in sync with the filesystem without requiring an explicit install/uninstall:

1. **Entering the Skills page** — calls `refresh_skills` before fetching installed/available lists, ensuring the view always reflects the current state.
2. **GUI startup** — fire-and-forget call ensures skills installed via CLI or other tools are visible without a restart.
3. **Agent reconnect** — when the agent becomes available after a disconnect/restart, re-triggers the scan so a fresh agent instance (with empty cache) picks up installed skills.

The agent'"'"'s 5 s rate limit makes repeated calls within a short window harmless (returns `refreshed: false`).

### Changes

| File | Change |
|------|--------|
| `gui/src-tauri/src/commands/skills.rs` | New `refresh_skills` Tauri command wrapping `agent_bridge::refresh_skills()` |
| `gui/src-tauri/src/lib.rs` | Register the new command |
| `gui/src/integrations/skills/skillsClient.ts` | New `refreshSkills()` frontend function |
| `gui/src/features/skills/SkillsView.tsx` | Call `refreshSkills()` on mount before loading lists |
| `gui/src/components/layout/AppShell.tsx` | Call `refreshSkills()` on startup mount + on agent connection change |
