### PR TITLE
perf(gui): incremental preview, IPC batching, crash recovery, TUI session switch fix

### DIFF
--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -791,10 +791,17 @@ impl Loop {
                     args: tc.function.arguments.clone(),
                 });
             }
-            // Skip empty assistant messages — the LLM API rejects them
-            // ("content or tool_calls must be set").  This happens when the
-            // model returns only thinking with no text and no tool calls.
-            if !assistant_msg.content.is_empty() || !assistant_msg.tool_calls.is_empty() {
+            // Skip truly empty assistant messages — the LLM API rejects them
+            // ("content or tool_calls must be set").  However, a message that
+            // has reasoning_content (thinking) is NOT empty: the thinking
+            // content was already streamed to the client, and dropping it here
+            // loses the entire response (the GUI shows "没有返回文本").
+            // convert_messages_to_openai sends reasoning_content even when the
+            // content field is omitted, matching the tool_calls-only pattern.
+            if !assistant_msg.content.is_empty()
+                || !assistant_msg.tool_calls.is_empty()
+                || !assistant_msg.thinking.is_empty()
+            {
                 messages.push(assistant_msg);
                 // Persist the assistant response immediately so it survives a
                 // crash mid-run, even if no tools were called in this turn.

--- a/agent/src/llm/helpers.rs
+++ b/agent/src/llm/helpers.rs
@@ -42,17 +42,17 @@ impl Client {
         }
 
         let effective_format_str = effective_format.as_str();
+        let reasoning_enabled = *thinking_level != "off";
+        let mut level_value = thinking_level.clone();
+
+        let thinking_level_map = self.thinking_level_map.read();
+        if let Some(mapped) = thinking_level_map.get(&*thinking_level) {
+            level_value = mapped.clone();
+        }
+        drop(thinking_level_map);
+        drop(thinking_level);
+
         if !effective_format.is_empty() {
-            let reasoning_enabled = *thinking_level != "off";
-            let mut level_value = thinking_level.clone();
-
-            let thinking_level_map = self.thinking_level_map.read();
-            if let Some(mapped) = thinking_level_map.get(&*thinking_level) {
-                level_value = mapped.clone();
-            }
-            drop(thinking_level_map);
-            drop(thinking_level);
-
             match effective_format_str {
                 "zai" => {
                     body["enable_thinking"] = serde_json::json!(reasoning_enabled);
@@ -66,7 +66,10 @@ impl Client {
                     } else {
                         body["enable_thinking"] = serde_json::json!(reasoning_enabled);
                     }
-                    if reasoning_enabled && *self.compat_supports_reasoning_effort.read() {
+                    // reasoning_effort is always supported on dashscope/aliyuncs
+                    // (qwen format) — send it unconditionally, matching the
+                    // deepseek format which also has no compat gate.
+                    if reasoning_enabled {
                         body["reasoning_effort"] = serde_json::json!(level_value);
                     }
                 }
@@ -107,9 +110,20 @@ impl Client {
                 }
                 _ => {}
             }
+        } else if reasoning_enabled {
+            // No compat thinking format is configured (effective_format is
+            // empty), but the user has explicitly set a non-"off" thinking
+            // level.  The provider is likely an OpenAI-compatible gateway
+            // (FutureAPI, CrossModel, OpenRouter, etc.) that passes
+            // reasoning_effort through to the upstream model.  Send it via
+            // the standard OpenAI parameter so the thinking level takes
+            // effect — without this, the provider defaults to its own
+            // (usually low) thinking budget and long reasoning gets cut off.
+            // When thinking is "off" we intentionally send nothing so the
+            // model doesn't reason at all (OpenAI-compatible models don't
+            // reason unless instructed).
+            body["reasoning_effort"] = serde_json::json!(level_value);
         }
-        // When effective_format is empty (no compat thinking format configured),
-        // don't add any thinking parameters — provider doesn't support it.
     }
 
     pub(super) fn convert_messages_to_openai(

--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -19,6 +19,20 @@ const DEFAULT_TIMEOUT_SECS: u64 = 600;
 const STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
 const STREAM_TOOL_CALL_IDLE_TIMEOUT_SECS: u64 = 15;
 
+/// Why the LLM SSE read loop exited before seeing a genuine terminal signal
+/// (`[DONE]` or `finish_reason`). Distinguishes abort/disconnect (expected —
+/// log at INFO) from provider-side drops (actionable — log at WARN).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamExitCause {
+    /// The consumer (run loop) dropped the receiver — user abort or client
+    /// disconnect. Expected truncation, not a provider failure.
+    ConsumerDropped,
+    /// The provider closed the HTTP connection without a terminal signal.
+    UpstreamEof,
+    /// No SSE data arrived within the idle window.
+    IdleTimeout,
+}
+
 // ─── LLM Client ────────────────────────────────────────────────────────────
 
 pub struct Client {
@@ -378,7 +392,9 @@ impl crate::types::LLMProvider for Client {
             // leave an actionable trace instead of a silent truncation.
             let stream_started_at = std::time::Instant::now();
             let mut total_bytes: usize = 0;
-            let mut idle_timed_out = false;
+            // Why the read loop exited (only consulted when !saw_terminal).
+            // Set at every break point; early returns skip the WARN block.
+            let exit_cause: StreamExitCause;
 
             // Helper to emit events from a parsed SSE data line, handling
             // thinking/tool-call bookending (matches original per-line logic).
@@ -513,16 +529,23 @@ impl crate::types::LLMProvider for Client {
                     // and the run loop abandoned this stream. Stop reading right
                     // away instead of draining the HTTP body until the idle
                     // timeout, which leaked a live connection for up to 45s on
-                    // every interrupt.
-                    _ = tx.closed() => break,
+                    // every interrupt. This is an expected exit, not a provider
+                    // failure — recorded so the end-of-stream log stays quiet.
+                    _ = tx.closed() => {
+                        exit_cause = StreamExitCause::ConsumerDropped;
+                        break;
+                    },
                     res = tokio::time::timeout(
                         std::time::Duration::from_secs(idle_timeout_secs),
                         stream.next(),
                     ) => match res {
                         Ok(Some(chunk_result)) => chunk_result,
-                        Ok(None) => break,
+                        Ok(None) => {
+                            exit_cause = StreamExitCause::UpstreamEof;
+                            break;
+                        }
                         Err(_) => {
-                            idle_timed_out = true;
+                            exit_cause = StreamExitCause::IdleTimeout;
                             break;
                         }
                     },
@@ -632,25 +655,38 @@ impl crate::types::LLMProvider for Client {
             }
 
             // If we never saw a genuine terminal signal, the read loop exited
-            // via idle timeout or a premature EOF — the response is a truncated
-            // prefix. Mark the synthetic stop so the run loop can distinguish it
-            // from a clean completion instead of persisting a cut-off reply as a
-            // success.
+            // via consumer drop, idle timeout, or a premature EOF. Only the
+            // last two are provider issues worth a WARN — a consumer drop is
+            // an expected abort/disconnect and logs at INFO instead.
             let stop_reason = if saw_terminal {
                 String::new()
             } else {
-                warn!(
-                    elapsed_ms = stream_started_at.elapsed().as_millis() as u64,
-                    bytes = total_bytes,
-                    in_tool_call = in_tool_call,
-                    cause = if idle_timed_out {
-                        "idle_timeout"
-                    } else {
-                        "upstream_eof"
-                    },
-                    "LLM stream ended without a terminal signal ([DONE]/finish_reason \
-                     missing) — response truncated mid-flight"
-                );
+                match exit_cause {
+                    StreamExitCause::ConsumerDropped => {
+                        info!(
+                            elapsed_ms = stream_started_at.elapsed().as_millis() as u64,
+                            bytes = total_bytes,
+                            in_tool_call = in_tool_call,
+                            "LLM stream dropped by consumer (abort/disconnect)"
+                        );
+                    }
+                    StreamExitCause::IdleTimeout | StreamExitCause::UpstreamEof => {
+                        warn!(
+                            elapsed_ms = stream_started_at.elapsed().as_millis() as u64,
+                            bytes = total_bytes,
+                            in_tool_call = in_tool_call,
+                            cause = match exit_cause {
+                                StreamExitCause::IdleTimeout => "idle_timeout",
+                                StreamExitCause::UpstreamEof => "upstream_eof",
+                                // Unreachable: ConsumerDropped is dispatched
+                                // above; included for match exhaustiveness.
+                                StreamExitCause::ConsumerDropped => "unknown",
+                            },
+                            "LLM stream ended without a terminal signal ([DONE]/finish_reason \
+                             missing) — response truncated mid-flight"
+                        );
+                    }
+                }
                 "truncated".to_string()
             };
             let _ = tx

--- a/gui/package.json
+++ b/gui/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "tsc && vite build",
-    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" && npm run typecheck",
     "test": "vitest run",
     "stylelint": "stylelint \"src/**/*.css\"",
     "preview": "vite preview --host 127.0.0.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -64,6 +64,10 @@ windows = { version = "0.61", features = [
 
 # Stripped symbols + no debug info: smaller desktop binary and less link/scan
 # I/O, negligible runtime cost for a Tauri shell. See ../../.cargo/config.toml.
+# Thin LTO: cross-crate inlining for a few % runtime win and a smaller binary.
+# codegen-units stays at the default (16) — 1 would squeeze a bit more but
+# multiplies release build time, which CI pays on every tag.
 [profile.release]
 debug = false
 strip = true
+lto = "thin"

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -494,33 +494,58 @@ async fn check_and_reanimate_run(session_id: &str, run_id: &str) -> Result<(), S
 async fn collect_reanimated_run(session_id: &str, run_id: &str) -> Result<(), String> {
     let mut client = connect_agent().await.map_err(|e| format!("connect: {e}"))?;
 
-    // Backfill: the agent's event buffer holds the whole current-run log.
-    // Drop the local log first — it ends at the crash point, and the
-    // backfill covers everything from turn-start, so keeping both would
-    // double the event log. After clearing, replay from the agent so
-    // the local log is complete and matches the single-source-of-truth
-    // shape `collect_remote_stream` expects for a fresh run.
-    crate::store::clear_run_event_buffer(run_id);
-    crate::store::delete_run_events_file(run_id);
+    // Backfill: fetch the agent's buffered events FIRST. Only replace the
+    // local log after the fetch succeeds with non-empty events — clearing
+    // before fetching would destroy the pre-crash history on failure.
+    let backfill_events: Vec<(String, String)> = if let Ok(backfill) =
+        get_events_since(session_id.to_string(), run_id.to_string(), -1).await
+    {
+        backfill
+            .get("events")
+            .and_then(|v| v.as_array())
+            .map(|events| {
+                events
+                    .iter()
+                    .map(|item| {
+                        let t = item
+                            .get("type")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let d = item
+                            .get("data")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        (t, d)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
     let mut sequence = 0i64;
-    if let Ok(backfill) = get_events_since(session_id.to_string(), run_id.to_string(), -1).await {
-        if let Some(events) = backfill.get("events").and_then(|v| v.as_array()) {
-            for item in events {
-                let evt_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                let evt_data = item.get("data").and_then(|v| v.as_str()).unwrap_or("");
-                crate::store::append_run_event(crate::store::AppendRunEventInput {
-                    run_id: run_id.to_string(),
-                    event_type: evt_type.to_string(),
-                    payload: if evt_data.is_empty() {
-                        None
-                    } else {
-                        Some(evt_data.to_string())
-                    },
-                    sequence,
-                })
-                .map_err(|e| format!("append_backfill: {e}"))?;
-                sequence += 1;
-            }
+    if !backfill_events.is_empty() {
+        // The backfill covers the entire turn-from-start, so the pre-crash
+        // local log (which ends at the crash point) would duplicate events.
+        // Safe to replace now that we know the agent delivered.
+        crate::store::clear_run_event_buffer(run_id);
+        crate::store::delete_run_events_file(run_id);
+        for (evt_type, evt_data) in backfill_events {
+            crate::store::append_run_event(crate::store::AppendRunEventInput {
+                run_id: run_id.to_string(),
+                event_type: evt_type,
+                payload: if evt_data.is_empty() {
+                    None
+                } else {
+                    Some(evt_data)
+                },
+                sequence,
+            })
+            .map_err(|e| format!("append_backfill: {e}"))?;
+            sequence += 1;
         }
     }
 

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -493,6 +493,37 @@ async fn check_and_reanimate_run(session_id: &str, run_id: &str) -> Result<(), S
 
 async fn collect_reanimated_run(session_id: &str, run_id: &str) -> Result<(), String> {
     let mut client = connect_agent().await.map_err(|e| format!("connect: {e}"))?;
+
+    // Backfill: the agent's event buffer holds the whole current-run log.
+    // Drop the local log first — it ends at the crash point, and the
+    // backfill covers everything from turn-start, so keeping both would
+    // double the event log. After clearing, replay from the agent so
+    // the local log is complete and matches the single-source-of-truth
+    // shape `collect_remote_stream` expects for a fresh run.
+    crate::store::clear_run_event_buffer(run_id);
+    crate::store::delete_run_events_file(run_id);
+    let mut sequence = 0i64;
+    if let Ok(backfill) = get_events_since(session_id.to_string(), run_id.to_string(), -1).await {
+        if let Some(events) = backfill.get("events").and_then(|v| v.as_array()) {
+            for item in events {
+                let evt_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                let evt_data = item.get("data").and_then(|v| v.as_str()).unwrap_or("");
+                crate::store::append_run_event(crate::store::AppendRunEventInput {
+                    run_id: run_id.to_string(),
+                    event_type: evt_type.to_string(),
+                    payload: if evt_data.is_empty() {
+                        None
+                    } else {
+                        Some(evt_data.to_string())
+                    },
+                    sequence,
+                })
+                .map_err(|e| format!("append_backfill: {e}"))?;
+                sequence += 1;
+            }
+        }
+    }
+
     let mut stream = client
         .stream_events(StreamRequest {
             event_types: vec![],
@@ -501,8 +532,6 @@ async fn collect_reanimated_run(session_id: &str, run_id: &str) -> Result<(), St
         .await
         .map_err(|e| format!("stream_events: {e}"))?
         .into_inner();
-
-    let mut sequence = 0i64;
 
     loop {
         let event = tokio::time::timeout(std::time::Duration::from_secs(600), stream.message())

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -697,6 +697,22 @@ static OBSERVER_CANCEL: Mutex<Option<oneshot::Sender<()>>> = Mutex::new(None);
 
 /// Start observing a session's settings changes in the background.  Subscribes
 /// to the agent's StreamEvents and forwards settings-change events to the
+/// Event types the session observer forwards to the webview. Whitelist, kept
+/// in sync with the frontend consumers: `user_message` (zero-latency user
+/// bubble in useThreadMessages) plus the settings-change set applied by
+/// agentStateCache (`applySettingsEvent`). Everything else — in particular the
+/// per-token `text_chunk`/`thinking_delta`/`tool_*` stream — is dropped here,
+/// before the JSON rebuild + Tauri emit, because no frontend listener reads it.
+const OBSERVER_FORWARDED_EVENTS: &[&str] = &[
+    "user_message",
+    "model_changed",
+    "thinking_level_changed",
+    "permission_level_changed",
+    "session_name_changed",
+    "cwd_changed",
+    "config_reloaded",
+];
+
 /// frontend via Tauri `agent-event` events so the UI reflects model /
 /// thinking / name / cwd changes in near real-time (< 1s).
 ///
@@ -757,10 +773,16 @@ pub fn start_observing_session(session_id: String) {
                             _ => break, // stream ended or error — reconnect
                         };
 
-                        // Forward ALL events to the frontend so content
-                        // (user_message, text_chunk, agent_start, etc.) and
-                        // settings changes are received in real-time without
-                        // polling.  The frontend dispatches by event type.
+                        // Forward only the events the frontend actually
+                        // consumes (see OBSERVER_FORWARDED_EVENTS). Per-token
+                        // content events (text_chunk, thinking_delta, tool_*)
+                        // used to be JSON-rebuilt and emitted across IPC on
+                        // every token only to be discarded by the single
+                        // listener — the frontend renders content from the
+                        // persisted run-event log instead.
+                        if !OBSERVER_FORWARDED_EVENTS.contains(&event.r#type.as_str()) {
+                            continue;
+                        }
                         if let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(&event.data) {
                             if let serde_json::Value::Object(ref mut map) = payload {
                                 map.insert("sessionId".to_string(),

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -21,7 +21,7 @@ pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, Prepared
 pub(crate) use self::import::import_missing_sessions;
 pub use self::models::{list_agent_models, AgentModelOption};
 pub use self::run_control::abort_run;
-pub(crate) use self::run_control::abort_session;
+pub(crate) use self::run_control::{abort_session, wait_for_agent_idle};
 pub use self::session::fork_agent_session;
 pub use self::skills::{list_installed_skills, refresh_skills, InstalledSkill};
 pub use review::retry as retry_run_review;
@@ -34,7 +34,7 @@ use std::{
 
 pub use self::client::AttachmentInput;
 use self::client::{base_command, prompt_command};
-use self::run_control::{mark_run_failed_if_active, wait_for_agent_idle};
+use self::run_control::mark_run_failed_if_active;
 use self::session::{
     ensure_agent_session, is_chat_thread, set_agent_permission_level, set_agent_sandbox_policy,
     workspace_path_for_thread,

--- a/gui/src-tauri/src/agent_bridge/models.rs
+++ b/gui/src-tauri/src/agent_bridge/models.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::client::{base_command, connect_agent, RpcResponseExt};
+use super::client::{base_command, connect_agent, map_rpc_error, RpcResponseExt};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -31,7 +31,7 @@ pub async fn list_agent_models() -> Result<Vec<AgentModelOption>, crate::AppErro
     let response = client
         .execute_command(base_command("list_models", String::new()))
         .await
-        .map_err(|error| format!("Unable to load Future Agent models: {error}"))?
+        .map_err(|status| map_rpc_error("Unable to load Future Agent models", status))?
         .into_inner()
         .ok_or_rpc_error("Future Agent rejected the model list request.")?;
 

--- a/gui/src-tauri/src/agent_bridge/run_control.rs
+++ b/gui/src-tauri/src/agent_bridge/run_control.rs
@@ -90,8 +90,8 @@ pub(crate) async fn wait_for_agent_idle(session_id: &str) {
     let Ok(mut client) = connect_agent().await else {
         return;
     };
-    // ~3s budget at 200ms intervals.
-    for _ in 0..15 {
+    // ~5s budget at 200ms intervals.
+    for _ in 0..25 {
         match client
             .execute_command(get_state_command(session_id.to_string()))
             .await

--- a/gui/src-tauri/src/agent_bridge/run_control.rs
+++ b/gui/src-tauri/src/agent_bridge/run_control.rs
@@ -86,12 +86,12 @@ pub(super) fn mark_run_failed_if_active(run_id: Option<&str>, error: &str) {
 /// Poll the Agent's `get_state.isStreaming` until it reports idle (or a short
 /// timeout / the agent disappears). Best-effort confirmation that the Agent has
 /// stopped writing files before the after snapshot (§6.2).
-pub(super) async fn wait_for_agent_idle(session_id: &str) {
+pub(crate) async fn wait_for_agent_idle(session_id: &str) {
     let Ok(mut client) = connect_agent().await else {
         return;
     };
-    // ~5s budget at 200ms intervals.
-    for _ in 0..25 {
+    // ~3s budget at 200ms intervals.
+    for _ in 0..15 {
         match client
             .execute_command(get_state_command(session_id.to_string()))
             .await

--- a/gui/src-tauri/src/agent_supervisor.rs
+++ b/gui/src-tauri/src/agent_supervisor.rs
@@ -215,10 +215,18 @@ pub fn confirm_quit(app: AppHandle) {
         // Abort each running session best-effort — an unreachable agent or a
         // session that finished in the meantime is a harmless no-op.
         tauri::async_runtime::block_on(async {
-            for session in sessions {
-                if let Err(error) = crate::agent_bridge::abort_session(&session).await {
+            for session in &sessions {
+                if let Err(error) = crate::agent_bridge::abort_session(session).await {
                     eprintln!("FutureOS: failed to abort session {session} on quit: {error}");
                 }
+            }
+            // Give the agent a moment for its abort to settle before the process
+            // exits or kills the sidecar. Without this the agent's LLM stream is
+            // torn down while it's still processing the abort interrupt, leaving a
+            // "LLM stream ended without a terminal signal" WARN in the agent log.
+            // Best-effort: an unreachable agent returns immediately.
+            for session in &sessions {
+                crate::agent_bridge::wait_for_agent_idle(session).await;
             }
         });
         // Kill the bundled sidecar if we own it (no-op for an external agent).

--- a/gui/src-tauri/src/agent_supervisor.rs
+++ b/gui/src-tauri/src/agent_supervisor.rs
@@ -215,19 +215,28 @@ pub fn confirm_quit(app: AppHandle) {
         // Abort each running session best-effort — an unreachable agent or a
         // session that finished in the meantime is a harmless no-op.
         tauri::async_runtime::block_on(async {
-            for session in &sessions {
-                if let Err(error) = crate::agent_bridge::abort_session(session).await {
-                    eprintln!("FutureOS: failed to abort session {session} on quit: {error}");
-                }
-            }
+            // Abort all sessions in parallel, then wait for all to go idle.
+            // Sequential waits would make force-quit take 3s per session;
+            // concurrent gRPC calls over the shared channel complete together.
+            let abort_futs: Vec<_> = sessions
+                .iter()
+                .map(|session| async move {
+                    if let Err(error) = crate::agent_bridge::abort_session(session).await {
+                        eprintln!("FutureOS: failed to abort session {session} on quit: {error}");
+                    }
+                })
+                .collect();
+            futures::future::join_all(abort_futs).await;
             // Give the agent a moment for its abort to settle before the process
             // exits or kills the sidecar. Without this the agent's LLM stream is
             // torn down while it's still processing the abort interrupt, leaving a
             // "LLM stream ended without a terminal signal" WARN in the agent log.
             // Best-effort: an unreachable agent returns immediately.
-            for session in &sessions {
-                crate::agent_bridge::wait_for_agent_idle(session).await;
-            }
+            let wait_futs: Vec<_> = sessions
+                .iter()
+                .map(|session| crate::agent_bridge::wait_for_agent_idle(session))
+                .collect();
+            futures::future::join_all(wait_futs).await;
         });
         // Kill the bundled sidecar if we own it (no-op for an external agent).
         shutdown_agent();

--- a/gui/src-tauri/src/commands/runs.rs
+++ b/gui/src-tauri/src/commands/runs.rs
@@ -13,6 +13,20 @@ pub fn list_runs(thread_id: String) -> Result<Vec<store::RunRecord>, crate::AppE
     store::list_runs(&thread_id)
 }
 
+/// The thread's most recent run, or None. Powers the 1.5s recent-run poll
+/// during an active run — one row instead of the thread's full run history.
+#[tauri::command]
+pub fn get_latest_run(thread_id: String) -> Result<Option<store::RunRecord>, crate::AppError> {
+    store::latest_run(&thread_id)
+}
+
+/// A single run by id — direct primary-key lookup for the send pipeline's
+/// settle checks (was a full per-thread list + client-side find).
+#[tauri::command]
+pub fn get_run(run_id: String) -> Result<Option<store::RunRecord>, crate::AppError> {
+    store::get_run(&run_id)
+}
+
 /// Batch query: the latest run's (status, ended_at) for each thread in one IPC.
 /// Replaces the per-thread [`list_runs`] fan-out that powered the thread-list
 /// run-indicator poll (N connections, N full row-sets 6+ times per second).
@@ -55,15 +69,52 @@ pub async fn list_run_events(
     if !local.is_empty() {
         return Ok(local);
     }
-    let Some(run) = store::get_run(&run_id).ok().flatten() else {
+    agent_events_fallback(&run_id, -1).await
+}
+
+/// Incremental variant of [`list_run_events`] for the 220ms live-preview poll:
+/// returns only events with `sequence > since_sequence`. A run's event log
+/// grows monotonically, so the steady-state payload is a handful of events
+/// instead of the whole log crossing IPC (and being re-parsed) every tick.
+#[tauri::command]
+pub async fn list_run_events_since(
+    run_id: String,
+    since_sequence: i64,
+) -> Result<Vec<store::RunEventRecord>, crate::AppError> {
+    if since_sequence < 0 {
+        return list_run_events(run_id).await;
+    }
+    let local = store::list_run_events_since(&run_id, since_sequence)?;
+    // An empty tail usually means "no new events this tick" — but when the
+    // local log is entirely cold (post-restart) AND the run is still active,
+    // the events only exist agent-side (the earlier full fetch came from the
+    // agent and was never persisted locally), so keep falling back with the
+    // same incremental query the agent natively supports.
+    if !local.is_empty() || store::has_run_events(&run_id) {
         return Ok(local);
+    }
+    agent_events_fallback(&run_id, since_sequence).await
+}
+
+/// Pull an active run's events from the agent (authoritative while streaming,
+/// survives GUI restarts) when the local log is cold. `since_sequence` is
+/// passed through to the agent's native incremental query (-1 = whole run).
+/// Returns an empty vec for settled runs, unknown runs, or an unreachable
+/// agent — the caller's empty local result is the right answer in all three.
+async fn agent_events_fallback(
+    run_id: &str,
+    since_sequence: i64,
+) -> Result<Vec<store::RunEventRecord>, crate::AppError> {
+    let empty = Vec::new();
+    let Some(run) = store::get_run(run_id).ok().flatten() else {
+        return Ok(empty);
     };
     if matches!(run.status.as_str(), "completed" | "failed" | "cancelled") {
-        return Ok(local);
+        return Ok(empty);
     }
     // Active run — pull events from the agent
     let Some(thread) = store::get_thread(&run.thread_id).ok().flatten() else {
-        return Ok(local);
+        return Ok(empty);
     };
     let sid = thread
         .agent_session_id
@@ -71,12 +122,13 @@ pub async fn list_run_events(
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .unwrap_or_else(|| run.thread_id.clone());
-    let agent_json = match agent_bridge::get_events_since(sid, run_id.clone(), -1).await {
-        Ok(v) => v,
-        Err(_) => return Ok(local),
-    };
+    let agent_json =
+        match agent_bridge::get_events_since(sid, run_id.to_string(), since_sequence).await {
+            Ok(v) => v,
+            Err(_) => return Ok(empty),
+        };
     let Some(events) = agent_json.get("events").and_then(|v| v.as_array()) else {
-        return Ok(local);
+        return Ok(empty);
     };
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -87,7 +139,7 @@ pub async fn list_run_events(
         .enumerate()
         .map(|(i, e)| store::RunEventRecord {
             id: format!("agent_{run_id}_{i}"),
-            run_id: run_id.clone(),
+            run_id: run_id.to_string(),
             event_type: e
                 .get("type")
                 .and_then(|v| v.as_str())
@@ -101,11 +153,7 @@ pub async fn list_run_events(
             created_at: now,
         })
         .collect();
-    if records.is_empty() {
-        Ok(local)
-    } else {
-        Ok(records)
-    }
+    Ok(records)
 }
 
 #[tauri::command]
@@ -118,6 +166,15 @@ pub fn list_run_events_bulk(
 #[tauri::command]
 pub fn list_tool_calls(run_id: String) -> Result<Vec<store::ToolCallRecord>, crate::AppError> {
     store::list_tool_calls(&run_id)
+}
+
+/// Batch variant: the context panel's 1.5s poll needs tool calls for every
+/// run of the thread — one IPC round-trip instead of N.
+#[tauri::command]
+pub fn list_tool_calls_bulk(
+    run_ids: Vec<String>,
+) -> Result<Vec<(String, Vec<store::ToolCallRecord>)>, crate::AppError> {
+    store::list_tool_calls_bulk(&run_ids)
 }
 
 #[tauri::command]

--- a/gui/src-tauri/src/git_review.rs
+++ b/gui/src-tauri/src/git_review.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::store;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitReview {
     is_git_workspace: bool,
@@ -32,6 +32,23 @@ pub struct GitReviewFile {
     diff: String,
 }
 
+/// Cache of the last computed review per (workspace, base, custom_base), keyed
+/// by a cheap fingerprint. The Review tab polls every 1.5s; an uncached fetch
+/// spawns 6+ git processes (incl. the full `--unified=80` patch) and reads
+/// every untracked file into memory. The fingerprint costs two small spawns
+/// (rev-parse + status) plus a metadata stat per changed file, and skips the
+/// whole computation while nothing relevant moved.
+/// (workspace_id, base, custom_base) → (fingerprint, review).
+type ReviewCacheKey = (String, String, String);
+type ReviewCacheEntry = (String, GitReview);
+
+static REVIEW_CACHE: std::sync::LazyLock<
+    std::sync::Mutex<HashMap<ReviewCacheKey, ReviewCacheEntry>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Bound the cache (one entry per workspace/base combo in practice).
+const REVIEW_CACHE_MAX: usize = 32;
+
 pub fn get_git_review(
     workspace_id: String,
     base: Option<String>,
@@ -52,6 +69,20 @@ pub fn get_git_review(
             deletions: 0,
             files: Vec::new(),
         });
+    }
+
+    let cache_key = (
+        workspace_id.clone(),
+        base.clone().unwrap_or_default(),
+        custom_base.clone().unwrap_or_default(),
+    );
+    let fingerprint = review_fingerprint(&workspace_path);
+    if let Ok(cache) = REVIEW_CACHE.lock() {
+        if let Some((cached_fingerprint, review)) = cache.get(&cache_key) {
+            if *cached_fingerprint == fingerprint {
+                return Ok(review.clone());
+            }
+        }
     }
 
     let branch = git_output(&workspace_path, ["branch", "--show-current"])
@@ -81,7 +112,7 @@ pub fn get_git_review(
     let additions = files.iter().map(|file| file.additions).sum();
     let deletions = files.iter().map(|file| file.deletions).sum();
 
-    Ok(GitReview {
+    let review = GitReview {
         is_git_workspace: true,
         workspace_path: workspace.path,
         branch,
@@ -91,10 +122,118 @@ pub fn get_git_review(
         additions,
         deletions,
         files,
-    })
+    };
+
+    if let Ok(mut cache) = REVIEW_CACHE.lock() {
+        if cache.len() >= REVIEW_CACHE_MAX {
+            cache.clear();
+        }
+        cache.insert(cache_key, (fingerprint, review.clone()));
+    }
+    Ok(review)
 }
 
+/// A cheap staleness signal for the review cache. Components:
+/// - HEAD sha (commits, checkouts to a different commit);
+/// - the `.git/HEAD` file content (`git checkout -b` switches branches at the
+///   SAME commit — the sha is unchanged but the branch label in the review
+///   must update);
+/// - the status output (staging, new/deleted files);
+/// - the git index mtime (re-staging identical content);
+/// - FETCH_HEAD / packed-refs mtimes (a `git fetch` moves upstream refs
+///   without touching HEAD, index, or the working tree — the upstream and
+///   merge-base diff bases would otherwise serve stale results);
+/// - the size+mtime of every file the status lists (edits to an
+///   already-modified file don't change the status text, so without this the
+///   main "agent keeps editing a file" flow would serve stale diffs).
+///
+/// Two small git spawns + a few metadata stats — no patch generation, no file
+/// content reads. Known gap: a force-updated LOOSE ref (`git branch -f`) that
+/// touches neither packed-refs nor FETCH_HEAD stays stale until any other
+/// input moves; acceptable for a 1.5s-refresh UI cache.
+fn review_fingerprint(workspace_path: &Path) -> String {
+    use std::fmt::Write;
+    let head = git_output(workspace_path, ["rev-parse", "HEAD"]).unwrap_or_default();
+    let status = git_output(
+        workspace_path,
+        ["status", "--short", "--untracked-files=all"],
+    )
+    .unwrap_or_default();
+    let git_dir = workspace_path.join(".git");
+    let mut fingerprint = String::with_capacity(head.len() + status.len() + 256);
+    fingerprint.push_str(head.trim());
+    fingerprint.push('\n');
+    fingerprint.push_str(&status);
+
+    if let Ok(head_ref) = fs::read_to_string(git_dir.join("HEAD")) {
+        let _ = write!(fingerprint, "\nHEAD:{}", head_ref.trim());
+    }
+    for meta_file in ["index", "FETCH_HEAD", "packed-refs"] {
+        if let Ok(mtime) = fs::metadata(git_dir.join(meta_file)).and_then(|meta| meta.modified()) {
+            let _ = write!(fingerprint, "\n{meta_file}:{mtime:?}");
+        }
+    }
+
+    for path in status_paths(&status) {
+        if let Ok(meta) = fs::metadata(workspace_path.join(&path)) {
+            let mtime = meta.modified().ok();
+            let _ = write!(fingerprint, "\n{path}:{}:{mtime:?}", meta.len());
+        }
+    }
+    fingerprint
+}
+
+/// The paths listed by `git status --short` (renames resolve to the new path).
+fn status_paths(status: &str) -> Vec<String> {
+    status
+        .lines()
+        .filter_map(|line| {
+            if line.len() < 4 {
+                return None;
+            }
+            let raw_path = line[3..].trim();
+            Some(
+                raw_path
+                    .rsplit_once(" -> ")
+                    .map(|(_, next)| next)
+                    .unwrap_or(raw_path)
+                    .to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Short-TTL cache for [`is_git_workspace`]: the check forks `git rev-parse`
+/// and sits on the artifact-persist path (every write/edit tool_end) plus the
+/// review poll. A workspace's git-ness changes only via an external
+/// `git init`/deletion of `.git`, so 30s of staleness is harmless.
+static GIT_WORKSPACE_CACHE: std::sync::LazyLock<
+    std::sync::Mutex<HashMap<PathBuf, (bool, std::time::Instant)>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+const GIT_WORKSPACE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const GIT_WORKSPACE_CACHE_MAX: usize = 64;
+
 pub fn is_git_workspace(path: &Path) -> bool {
+    let key = canonical_or_raw(path);
+    if let Ok(cache) = GIT_WORKSPACE_CACHE.lock() {
+        if let Some((result, at)) = cache.get(&key) {
+            if at.elapsed() < GIT_WORKSPACE_CACHE_TTL {
+                return *result;
+            }
+        }
+    }
+    let result = is_git_workspace_uncached(path);
+    if let Ok(mut cache) = GIT_WORKSPACE_CACHE.lock() {
+        if cache.len() >= GIT_WORKSPACE_CACHE_MAX {
+            cache.clear();
+        }
+        cache.insert(key, (result, std::time::Instant::now()));
+    }
+    result
+}
+
+fn is_git_workspace_uncached(path: &Path) -> bool {
     let Ok(root) = git_output(path, ["rev-parse", "--show-toplevel"]) else {
         return false;
     };
@@ -314,4 +453,29 @@ fn git_output<const N: usize>(
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::status_paths;
+
+    #[test]
+    fn status_paths_extracts_plain_and_renamed_paths() {
+        let status = " M src/a.ts\n?? src/new file.md\nR  old.ts -> src/renamed.ts\nA  added.rs\n";
+        assert_eq!(
+            status_paths(status),
+            vec![
+                "src/a.ts".to_string(),
+                "src/new file.md".to_string(),
+                "src/renamed.ts".to_string(),
+                "added.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn status_paths_skips_short_and_empty_lines() {
+        assert!(status_paths("").is_empty());
+        assert!(status_paths("##\n M").is_empty());
+    }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -325,7 +325,12 @@ pub fn run() {
             // machine). Runs off the launch path — failures are logged but the
             // UI renders immediately. The store must be initialized first.
             std::thread::spawn(|| {
-                let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+                // Single-threaded runtime: `Runtime::new()` is multi_thread and
+                // would spawn num_cpus workers for this one-shot task.
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tokio runtime");
                 rt.block_on(async {
                     if let Err(error) = agent_bridge::import_missing_sessions().await {
                         eprintln!("FutureOS session import failed: {error}");
@@ -355,7 +360,12 @@ pub fn run() {
             // streaming (the agent survived a GUI crash). Spawned off the launch
             // path so it never delays the window.
             std::thread::spawn(|| {
-                let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+                // Single-threaded runtime: `Runtime::new()` is multi_thread and
+                // would spawn num_cpus workers for this one-shot task.
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tokio runtime");
                 rt.block_on(async {
                     // Give the agent a few seconds to come up; then test.
                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -429,13 +439,17 @@ pub fn run() {
             list_messages,
             append_message,
             create_run,
+            get_latest_run,
+            get_run,
             list_runs,
             list_latest_run_infos,
             update_run_status,
             abort_run,
             list_run_events,
             list_run_events_bulk,
+            list_run_events_since,
             list_tool_calls,
+            list_tool_calls_bulk,
             list_tool_outputs,
             list_approval_requests,
             decide_approval_request,

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -50,10 +50,13 @@ pub use review_snapshots::{
     mark_snapshot_failed, prune_thread_changesets, upsert_run_changeset, ReviewChangesetRecord,
     ReviewFileChangeRecord, ReviewSnapshotRecord,
 };
+#[cfg(test)]
+pub(crate) use runs::flush_run_event_log_for_test;
 pub use runs::{
     active_run_sessions, append_run_event, clear_all_run_events_files, clear_run_event_buffer,
-    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input, latest_run_infos,
-    list_run_events, list_run_events_bulk, list_runs, list_tool_calls, list_tool_outputs,
+    create_run, delete_run_events_file, fail_run_if_active, get_tool_call_input, has_run_events,
+    latest_run, latest_run_infos, list_run_events, list_run_events_bulk, list_run_events_since,
+    list_runs, list_tool_calls, list_tool_calls_bulk, list_tool_outputs,
     update_run_status_if_active, LatestRunInfo, RunEventRecord, RunRecord, ToolCallRecord,
     ToolOutputRecord,
 };

--- a/gui/src-tauri/src/store/cleanup.rs
+++ b/gui/src-tauri/src/store/cleanup.rs
@@ -614,6 +614,9 @@ mod tests {
             sequence: 1,
         })
         .expect("append event");
+        // Disk writes are async (single writer thread) — flush before
+        // asserting on the file.
+        crate::store::flush_run_event_log_for_test(&run.id);
         let log_path = PathBuf::from(
             crate::store::app_data_path()
                 .expect("app data path")

--- a/gui/src-tauri/src/store/db.rs
+++ b/gui/src-tauri/src/store/db.rs
@@ -72,15 +72,84 @@ pub(super) fn ensure_app_dirs() -> Result<(), crate::AppError> {
     fs::create_dir_all(chat_workspaces_root()?).map_err(crate::AppError::from)
 }
 
-pub(super) fn connect() -> Result<Connection, crate::AppError> {
+/// Maximum idle connections kept warm in the pool. WAL allows one writer plus
+/// concurrent readers, and the store's queries are all small, so a handful of
+/// connections covers every poll path without queueing.
+const POOL_MAX_IDLE: usize = 4;
+
+/// Process-wide connection pool. Previously every store call opened a fresh
+/// SQLite connection (file open + 3 PRAGMAs + WAL handshake) — several times
+/// per second on the 1.5s poll paths, and 3× per artifact write. Connections
+/// are keyed to the current db path: tests that override HOME get a fresh pool
+/// instead of stale connections into the previous HOME's database.
+static POOL: std::sync::LazyLock<std::sync::Mutex<(std::path::PathBuf, Vec<Connection>)>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new((std::path::PathBuf::new(), Vec::new())));
+
+/// A connection checked out from [`POOL`]; returns to the pool on drop.
+/// Derefs to [`Connection`], so existing call sites (queries, prepared
+/// statements, `transaction()` via `DerefMut`) work unchanged.
+pub(super) struct PooledConnection {
+    conn: Option<Connection>,
+}
+
+impl std::ops::Deref for PooledConnection {
+    type Target = Connection;
+    fn deref(&self) -> &Connection {
+        self.conn
+            .as_ref()
+            .expect("pooled connection live until drop")
+    }
+}
+
+impl std::ops::DerefMut for PooledConnection {
+    fn deref_mut(&mut self) -> &mut Connection {
+        self.conn
+            .as_mut()
+            .expect("pooled connection live until drop")
+    }
+}
+
+impl Drop for PooledConnection {
+    fn drop(&mut self) {
+        let Some(conn) = self.conn.take() else {
+            return;
+        };
+        let Ok(path) = db_path() else {
+            return;
+        };
+        if let Ok(mut pool) = POOL.lock() {
+            // Return only if the pool still points at this database (a HOME
+            // override mid-process swaps the path) and it has room.
+            if pool.0 == path && pool.1.len() < POOL_MAX_IDLE {
+                pool.1.push(conn);
+            }
+        }
+    }
+}
+
+pub(super) fn connect() -> Result<PooledConnection, crate::AppError> {
+    let path = db_path()?;
+    if let Ok(mut pool) = POOL.lock() {
+        if pool.0 != path {
+            // HOME changed (test override) — drop connections into the old
+            // database and re-key the pool.
+            pool.1.clear();
+            pool.0 = path.clone();
+        }
+        if let Some(conn) = pool.1.pop() {
+            // Directory creation is skipped on the pooled path — the dirs
+            // provably existed when the pooled connection was first opened.
+            return Ok(PooledConnection { conn: Some(conn) });
+        }
+    }
     ensure_app_dirs()?;
-    let conn = Connection::open(db_path()?)?;
+    let conn = Connection::open(path)?;
     conn.execute_batch(
         "PRAGMA foreign_keys = ON;
          PRAGMA busy_timeout = 5000;
          PRAGMA journal_mode = WAL;",
     )?;
-    Ok(conn)
+    Ok(PooledConnection { conn: Some(conn) })
 }
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {

--- a/gui/src-tauri/src/store/review_snapshots.rs
+++ b/gui/src-tauri/src/store/review_snapshots.rs
@@ -453,7 +453,8 @@ pub fn prune_thread_changesets(
 /// `NOT EXISTS(after)` dropped it, leaving such Runs permanently
 /// changeset-less.
 pub fn list_unmaterialized_runs() -> Result<Vec<(String, String, String)>, crate::AppError> {
-    list_unmaterialized_runs_in(&connect()?)
+    let conn = connect()?;
+    list_unmaterialized_runs_in(&conn)
 }
 
 fn list_unmaterialized_runs_in(

--- a/gui/src-tauri/src/store/runs.rs
+++ b/gui/src-tauri/src/store/runs.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::PathBuf;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use super::db::*;
@@ -43,7 +43,7 @@ pub struct RunEventRecord {
     pub created_at: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub struct ToolCallRecord {
@@ -132,6 +132,26 @@ pub fn list_runs(thread_id: &str) -> Result<Vec<RunRecord>, crate::AppError> {
     let rows = stmt.query_map(params![thread_id], run_from_row)?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(crate::AppError::from)
+}
+
+/// The thread's single most recent run (same ordering/tiebreak as
+/// [`latest_run_infos`]). Backs the 1.5s recent-run poll during an active run,
+/// which used to transfer the thread's entire run history every tick.
+pub fn latest_run(thread_id: &str) -> Result<Option<RunRecord>, crate::AppError> {
+    let conn = connect()?;
+    conn.query_row(
+        &format!(
+            "SELECT {RUN_COLUMNS}
+                 FROM runs
+                 WHERE thread_id = ?1
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1"
+        ),
+        params![thread_id],
+        run_from_row,
+    )
+    .optional()
+    .map_err(crate::AppError::from)
 }
 
 /// The single latest run's basic info for each of `thread_ids`. Powers the
@@ -321,6 +341,50 @@ pub fn list_run_events(run_id: &str) -> Result<Vec<RunEventRecord>, crate::AppEr
     Ok(read_run_events(run_id))
 }
 
+/// The tail of a run's events with `sequence > since_sequence`, in append
+/// order. Backs the frontend's 220ms live-preview poll: instead of cloning and
+/// re-serializing the whole log every tick (O(n) per tick → O(n²) over a run),
+/// only the events the caller hasn't seen cross IPC. `since_sequence < 0`
+/// returns the full log (same as [`list_run_events`]).
+pub fn list_run_events_since(
+    run_id: &str,
+    since_sequence: i64,
+) -> Result<Vec<RunEventRecord>, crate::AppError> {
+    if since_sequence < 0 {
+        return Ok(read_run_events(run_id));
+    }
+    // Filter rather than slice: every buffer writer today appends in
+    // monotonically increasing sequence order (one collector per run), but
+    // that invariant is implicit — a scan keeps the tail correct even if a
+    // future writer appends out of order, and still clones only the new
+    // events. The scan is integer compares; the clone was the real cost.
+    if let Ok(buf) = RUN_EVENT_BUFFER.lock() {
+        if let Some(events) = buf.get(run_id) {
+            return Ok(events
+                .iter()
+                .filter(|event| event.sequence > since_sequence)
+                .cloned()
+                .collect());
+        }
+    }
+    Ok(read_events_from_disk(run_id)
+        .into_iter()
+        .filter(|event| event.sequence > since_sequence)
+        .collect())
+}
+
+/// Whether any events for `run_id` exist locally (buffer or persisted log).
+/// Cheap — no event cloning — so the incremental-read command can decide
+/// whether an empty tail means "no new events" or "cold buffer, ask the agent".
+pub fn has_run_events(run_id: &str) -> bool {
+    if let Ok(buf) = RUN_EVENT_BUFFER.lock() {
+        if buf.get(run_id).is_some_and(|events| !events.is_empty()) {
+            return true;
+        }
+    }
+    run_events_path(run_id).is_some_and(|path| path.exists())
+}
+
 pub fn list_run_events_bulk(
     run_ids: &[String],
 ) -> Result<Vec<(String, Vec<RunEventRecord>)>, crate::AppError> {
@@ -343,6 +407,146 @@ static RUN_EVENT_BUFFER: std::sync::LazyLock<
     std::sync::Mutex<HashMap<String, Vec<RunEventRecord>>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 
+// ── Async disk writer ─────────────────────────────────────────────────
+// Run events are appended to a per-run JSONL log so the Runs panel survives
+// an app restart. Writes go through a single background thread holding one
+// open BufWriter per active run, coalescing bursts into one flush — previously
+// every event did its own open/append/close syscall trio, several times per
+// second while streaming.
+enum WriterMsg {
+    Event(RunEventRecord),
+    /// Flush and close the run's writer, then ack. Sent before the run's log
+    /// is read from disk (settle) or deleted: the ack guarantees the file is
+    /// complete and closed before the caller proceeds (Windows also refuses
+    /// to delete an open file).
+    Close {
+        run_id: String,
+        ack: std::sync::mpsc::Sender<()>,
+    },
+    /// Flush and close every writer (clear_all_data), then ack.
+    CloseAll {
+        ack: std::sync::mpsc::Sender<()>,
+    },
+}
+
+static DISK_WRITER: std::sync::LazyLock<std::sync::mpsc::Sender<WriterMsg>> =
+    std::sync::LazyLock::new(spawn_disk_writer);
+
+fn spawn_disk_writer() -> std::sync::mpsc::Sender<WriterMsg> {
+    let (tx, rx) = std::sync::mpsc::channel::<WriterMsg>();
+    std::thread::Builder::new()
+        .name("run-event-writer".to_string())
+        .spawn(move || {
+            let mut writers: HashMap<String, std::io::BufWriter<std::fs::File>> = HashMap::new();
+            while let Ok(msg) = rx.recv() {
+                match msg {
+                    WriterMsg::Event(first) => {
+                        write_event(&mut writers, &first);
+                        // Coalesce a burst into one flush. Close messages are
+                        // handled inline — a try_recv that consumed one must
+                        // not drop it.
+                        loop {
+                            match rx.try_recv() {
+                                Ok(WriterMsg::Event(record)) => {
+                                    write_event(&mut writers, &record);
+                                }
+                                Ok(WriterMsg::Close { run_id, ack }) => {
+                                    if let Some(mut writer) = writers.remove(&run_id) {
+                                        let _ = writer.flush();
+                                    }
+                                    let _ = ack.send(());
+                                }
+                                Ok(WriterMsg::CloseAll { ack }) => {
+                                    for (_, mut writer) in writers.drain() {
+                                        let _ = writer.flush();
+                                    }
+                                    let _ = ack.send(());
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        for writer in writers.values_mut() {
+                            let _ = writer.flush();
+                        }
+                    }
+                    WriterMsg::Close { run_id, ack } => {
+                        if let Some(mut writer) = writers.remove(&run_id) {
+                            let _ = writer.flush();
+                        }
+                        let _ = ack.send(());
+                    }
+                    WriterMsg::CloseAll { ack } => {
+                        for (_, mut writer) in writers.drain() {
+                            let _ = writer.flush();
+                        }
+                        let _ = ack.send(());
+                    }
+                }
+            }
+        })
+        .expect("spawn run-event writer thread");
+    tx
+}
+
+fn write_event(
+    writers: &mut HashMap<String, std::io::BufWriter<std::fs::File>>,
+    record: &RunEventRecord,
+) {
+    let writer = match writers.entry(record.run_id.clone()) {
+        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let Some(path) = run_events_path(&record.run_id) else {
+                return;
+            };
+            let Ok(file) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+            else {
+                return;
+            };
+            entry.insert(std::io::BufWriter::new(file))
+        }
+    };
+    if let Ok(line) = serde_json::to_string(record) {
+        let _ = writeln!(writer, "{line}");
+    }
+}
+
+/// Flush + close the run's writer on the disk-writer thread and wait for the
+/// ack (bounded), so a following disk read sees the complete log and a
+/// following delete doesn't hit an open handle.
+fn close_disk_writer(run_id: &str) {
+    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+    if DISK_WRITER
+        .send(WriterMsg::Close {
+            run_id: run_id.to_string(),
+            ack: ack_tx,
+        })
+        .is_ok()
+    {
+        let _ = ack_rx.recv_timeout(std::time::Duration::from_secs(2));
+    }
+}
+
+/// Flush + close every writer and wait for the ack (bounded).
+fn close_all_disk_writers() {
+    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+    if DISK_WRITER
+        .send(WriterMsg::CloseAll { ack: ack_tx })
+        .is_ok()
+    {
+        let _ = ack_rx.recv_timeout(std::time::Duration::from_secs(2));
+    }
+}
+
+/// Force the async disk writer to flush a run's log — synchronization point
+/// for tests that assert on the log file's existence.
+#[cfg(test)]
+pub(crate) fn flush_run_event_log_for_test(run_id: &str) {
+    close_disk_writer(run_id);
+}
+
 /// Directory holding per-run event logs: `~/.future/app/run_events/`.
 fn run_events_dir() -> Option<PathBuf> {
     let dir = app_dir().ok()?.join("run_events");
@@ -363,22 +567,11 @@ fn run_events_path(run_id: &str) -> Option<PathBuf> {
     Some(run_events_dir()?.join(format!("{run_id}.jsonl")))
 }
 
-/// Append one event as a JSON line to the run's log (best-effort; a failed
-/// write just means that event won't survive a restart).
-fn persist_event_to_disk(record: &RunEventRecord) {
-    let Some(path) = run_events_path(&record.run_id) else {
-        return;
-    };
-    let Ok(line) = serde_json::to_string(record) else {
-        return;
-    };
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
-        let _ = writeln!(file, "{line}");
-    }
+/// Queue one event for the run's JSONL log (best-effort; a dead writer thread
+/// just means that event won't survive a restart — same contract as the old
+/// synchronous write, whose errors were also dropped).
+fn persist_event_to_disk(record: RunEventRecord) {
+    let _ = DISK_WRITER.send(WriterMsg::Event(record));
 }
 
 /// Read a run's events from the persisted log (one JSON object per line).
@@ -423,105 +616,200 @@ pub fn append_run_event(input: AppendRunEventInput) -> Result<RunEventRecord, cr
             .or_default()
             .push(record.clone());
     }
-    persist_event_to_disk(&record);
+    persist_event_to_disk(record.clone());
     Ok(record)
 }
 
 /// Drop a settled run's in-memory events (called on `agent_end`). The persisted
 /// log stays, so reads still work — this only bounds memory so a long-lived app
-/// doesn't accumulate every run's events forever.
+/// doesn't accumulate every run's events forever. The disk writer is flushed
+/// FIRST (its ack guarantees the log is complete), so the post-clear disk
+/// reads see every event the buffer held.
 pub fn clear_run_event_buffer(run_id: &str) {
+    close_disk_writer(run_id);
     if let Ok(mut buf) = RUN_EVENT_BUFFER.lock() {
         buf.remove(run_id);
     }
 }
 
 /// Delete a run's persisted event log (called when the run/thread is deleted).
+/// The writer is closed first — Windows refuses to delete an open file.
 pub fn delete_run_events_file(run_id: &str) {
+    close_disk_writer(run_id);
     if let Some(path) = run_events_path(run_id) {
         let _ = std::fs::remove_file(path);
+    }
+    if let Ok(mut cache) = TOOL_PROJECTION_CACHE.lock() {
+        cache.remove(run_id);
     }
 }
 
 /// Remove the whole run-events directory (called by `clear_all_data`).
 pub fn clear_all_run_events_files() {
+    close_all_disk_writers();
     if let Ok(dir) = app_dir() {
         let _ = std::fs::remove_dir_all(dir.join("run_events"));
     }
     if let Ok(mut buf) = RUN_EVENT_BUFFER.lock() {
         buf.clear();
     }
+    if let Ok(mut cache) = TOOL_PROJECTION_CACHE.lock() {
+        cache.clear();
+    }
 }
 
+/// Per-run incremental tool-call projection. The context panel polls tool
+/// calls for every run every 1.5s; rebuilding from the full event log each
+/// time costs O(events) per run per poll (clone + JSON parse of every event).
+/// Events are append-only, so the projection can advance over just the new
+/// tail instead. State survives the run settling (the events are then
+/// immutable on disk) and is dropped only when the run's log is deleted.
+struct ToolProjectionState {
+    tools: Vec<ToolCallRecord>,
+    index_by_id: HashMap<String, usize>,
+    /// Highest event sequence folded into `tools` so far.
+    last_sequence: i64,
+}
+
+static TOOL_PROJECTION_CACHE: std::sync::LazyLock<
+    std::sync::Mutex<HashMap<String, ToolProjectionState>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Bound the cache (entries are small: one record per tool call).
+const TOOL_PROJECTION_CACHE_MAX: usize = 64;
+
 pub fn list_tool_calls(run_id: &str) -> Result<Vec<ToolCallRecord>, crate::AppError> {
-    // Reconstruct each tool call from its tool_start / tool_end events (the
-    // tool_calls table was dropped). Both events carry the agent's stable tool
-    // id, so pair by id — a single "current" slot would mispair overlapping
-    // (parallel) tool calls.
-    let events = read_run_events(run_id);
+    Ok(tool_calls_for_run(run_id))
+}
 
-    let mut tools: Vec<ToolCallRecord> = Vec::new();
-    let mut index_by_id: HashMap<String, usize> = HashMap::new();
+/// Tool calls for many runs in one call — backs the context panel's poll,
+/// which used to fan out one IPC round-trip per run every 1.5s. Every run id
+/// appears in the result (with an empty vec when it has no tool activity) so
+/// the caller's `Object.fromEntries` shape is unchanged.
+pub fn list_tool_calls_bulk(
+    run_ids: &[String],
+) -> Result<Vec<(String, Vec<ToolCallRecord>)>, crate::AppError> {
+    Ok(run_ids
+        .iter()
+        .map(|run_id| (run_id.clone(), tool_calls_for_run(run_id)))
+        .collect())
+}
 
-    for event in &events {
-        match event.event_type.as_str() {
-            "tool_start" | "toolcall_start" => {
-                // Use the same fallback as the frontend (agentActivity.ts:445):
-                // `${toolName}_${sequence}`.  When the payload lacks an explicit
-                // tool_id, the front-end generates this synthetic id — we must
-                // match it so the tool detail lookup succeeds.
-                let id = event_tool_id(event).unwrap_or_else(|| {
-                    let (name, _, _) = parse_tool_start_payload(event.payload.as_deref());
-                    let seq = event.sequence;
-                    if name.is_empty() {
-                        event.id.clone()
-                    } else {
-                        format!("{name}_{seq}")
-                    }
-                });
-                let (name, kind, input) = parse_tool_start_payload(event.payload.as_deref());
-                if let Some(&idx) = index_by_id.get(&id) {
-                    // The same call announced twice: `toolcall_start` fires first
-                    // with empty args (they stream in via toolcall_delta), then
-                    // the execution `tool_start` carries the complete args. Enrich
-                    // the existing record rather than adding an empty duplicate.
-                    if input.as_deref().is_some_and(|s| !s.is_empty()) {
-                        tools[idx].input = input;
-                    }
-                    if !name.is_empty() {
-                        tools[idx].name = name;
-                        tools[idx].kind = kind;
-                    }
-                } else {
-                    index_by_id.insert(id.clone(), tools.len());
-                    tools.push(ToolCallRecord {
-                        id,
-                        run_id: event.run_id.clone(),
-                        name,
-                        kind,
-                        input,
-                        status: "running".to_string(),
-                        started_at: Some(event.created_at),
-                        ended_at: None,
-                        created_at: event.created_at,
-                    });
-                }
-            }
-            "tool_end" | "tool_result" => {
-                let idx = event_tool_id(event)
-                    .as_deref()
-                    .and_then(|id| index_by_id.get(id).copied());
-                if let Some(idx) = idx {
-                    let command = shell_command_from_input(tools[idx].input.as_deref());
-                    tools[idx].status =
-                        tool_end_status(event.payload.as_deref(), command.as_deref());
-                    tools[idx].ended_at = Some(event.created_at);
-                }
-            }
-            _ => {}
+/// The run's tool calls, advancing the cached projection over only the events
+/// appended since the last call. The cache mutex is held across the event
+/// read — the lock order (tool cache → event buffer) is used nowhere in
+/// reverse, so there's no deadlock cycle, and holding it prevents two
+/// concurrent pollers from double-applying the same tail.
+fn tool_calls_for_run(run_id: &str) -> Vec<ToolCallRecord> {
+    let Ok(mut cache) = TOOL_PROJECTION_CACHE.lock() else {
+        // Poisoned lock: fall back to a one-shot full rebuild.
+        return tool_calls_from_events(&read_run_events(run_id));
+    };
+    if cache.len() >= TOOL_PROJECTION_CACHE_MAX && !cache.contains_key(run_id) {
+        cache.clear();
+    }
+    let last_sequence = cache
+        .get(run_id)
+        .map(|state| state.last_sequence)
+        .unwrap_or(-1);
+    let new_events = list_run_events_since(run_id, last_sequence).unwrap_or_default();
+    if new_events.is_empty() {
+        return cache
+            .get(run_id)
+            .map(|state| state.tools.clone())
+            .unwrap_or_default();
+    }
+    let state = cache
+        .entry(run_id.to_string())
+        .or_insert_with(|| ToolProjectionState {
+            tools: Vec::new(),
+            index_by_id: HashMap::new(),
+            last_sequence: -1,
+        });
+    for event in &new_events {
+        apply_tool_event(state, event);
+        if event.sequence > state.last_sequence {
+            state.last_sequence = event.sequence;
         }
     }
-    Ok(tools)
+    state.tools.clone()
+}
+
+/// Reconstruct each tool call from its tool_start / tool_end events (the
+/// tool_calls table was dropped). Both events carry the agent's stable tool
+/// id, so pair by id — a single "current" slot would mispair overlapping
+/// (parallel) tool calls.
+fn tool_calls_from_events(events: &[RunEventRecord]) -> Vec<ToolCallRecord> {
+    let mut state = ToolProjectionState {
+        tools: Vec::new(),
+        index_by_id: HashMap::new(),
+        last_sequence: -1,
+    };
+    for event in events {
+        apply_tool_event(&mut state, event);
+    }
+    state.tools
+}
+
+/// Fold one event into the tool-call projection (see [`tool_calls_from_events`]).
+fn apply_tool_event(state: &mut ToolProjectionState, event: &RunEventRecord) {
+    let tools = &mut state.tools;
+    let index_by_id = &mut state.index_by_id;
+    match event.event_type.as_str() {
+        "tool_start" | "toolcall_start" => {
+            // Use the same fallback as the frontend (agentActivity.ts:445):
+            // `${toolName}_${sequence}`.  When the payload lacks an explicit
+            // tool_id, the front-end generates this synthetic id — we must
+            // match it so the tool detail lookup succeeds.
+            let id = event_tool_id(event).unwrap_or_else(|| {
+                let (name, _, _) = parse_tool_start_payload(event.payload.as_deref());
+                let seq = event.sequence;
+                if name.is_empty() {
+                    event.id.clone()
+                } else {
+                    format!("{name}_{seq}")
+                }
+            });
+            let (name, kind, input) = parse_tool_start_payload(event.payload.as_deref());
+            if let Some(&idx) = index_by_id.get(&id) {
+                // The same call announced twice: `toolcall_start` fires first
+                // with empty args (they stream in via toolcall_delta), then
+                // the execution `tool_start` carries the complete args. Enrich
+                // the existing record rather than adding an empty duplicate.
+                if input.as_deref().is_some_and(|s| !s.is_empty()) {
+                    tools[idx].input = input;
+                }
+                if !name.is_empty() {
+                    tools[idx].name = name;
+                    tools[idx].kind = kind;
+                }
+            } else {
+                index_by_id.insert(id.clone(), tools.len());
+                tools.push(ToolCallRecord {
+                    id,
+                    run_id: event.run_id.clone(),
+                    name,
+                    kind,
+                    input,
+                    status: "running".to_string(),
+                    started_at: Some(event.created_at),
+                    ended_at: None,
+                    created_at: event.created_at,
+                });
+            }
+        }
+        "tool_end" | "tool_result" => {
+            let idx = event_tool_id(event)
+                .as_deref()
+                .and_then(|id| index_by_id.get(id).copied());
+            if let Some(idx) = idx {
+                let command = shell_command_from_input(tools[idx].input.as_deref());
+                tools[idx].status = tool_end_status(event.payload.as_deref(), command.as_deref());
+                tools[idx].ended_at = Some(event.created_at);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// The agent's stable tool-call id from a buffered tool event payload
@@ -767,6 +1055,111 @@ mod tests {
             params![id, status],
         )
         .expect("insert run");
+    }
+
+    /// Seed the process-global event buffer directly (no disk writes) with
+    /// `count` events sequenced 0..count, returning the unique run id used.
+    /// `tag` keeps concurrently-running tests off each other's buffer entry.
+    fn seed_event_buffer(tag: &str, count: i64) -> String {
+        let run_id = format!("test_since_{tag}_{}", std::process::id());
+        let mut buf = RUN_EVENT_BUFFER.lock().expect("lock event buffer");
+        let events = buf.entry(run_id.clone()).or_default();
+        events.clear();
+        for sequence in 0..count {
+            events.push(RunEventRecord {
+                id: format!("e{sequence}"),
+                run_id: run_id.clone(),
+                event_type: "text_chunk".to_string(),
+                payload: None,
+                sequence,
+                created_at: sequence,
+            });
+        }
+        run_id
+    }
+
+    #[test]
+    fn list_run_events_since_returns_only_the_unseen_tail() {
+        let run_id = seed_event_buffer("tail", 10);
+
+        let tail = list_run_events_since(&run_id, 4).expect("tail read");
+        assert_eq!(tail.len(), 5, "sequences 5..=9");
+        assert_eq!(tail[0].sequence, 5);
+        assert_eq!(tail[8 - 5].sequence, 8);
+
+        // At the watermark: nothing new.
+        assert!(list_run_events_since(&run_id, 9)
+            .expect("no new")
+            .is_empty());
+        // Beyond the watermark (caller ahead of the log): still nothing.
+        assert!(list_run_events_since(&run_id, 100)
+            .expect("ahead")
+            .is_empty());
+        // Negative watermark: the full log, matching list_run_events.
+        assert_eq!(list_run_events_since(&run_id, -1).expect("full").len(), 10);
+
+        clear_run_event_buffer(&run_id);
+    }
+
+    #[test]
+    fn has_run_events_tracks_buffer_contents() {
+        let run_id = seed_event_buffer("has", 3);
+        assert!(has_run_events(&run_id));
+        clear_run_event_buffer(&run_id);
+        // Buffer entry gone; no disk log was written by the seed, so absent.
+        assert!(!has_run_events(&run_id));
+    }
+
+    /// Push one event into the process-global buffer (no disk writes).
+    fn push_tool_event(run_id: &str, event_type: &str, payload: &str, sequence: i64) {
+        let mut buf = RUN_EVENT_BUFFER.lock().expect("lock event buffer");
+        buf.entry(run_id.to_string())
+            .or_default()
+            .push(RunEventRecord {
+                id: format!("e{sequence}"),
+                run_id: run_id.to_string(),
+                event_type: event_type.to_string(),
+                payload: Some(payload.to_string()),
+                sequence,
+                created_at: sequence,
+            });
+    }
+
+    #[test]
+    fn tool_calls_advance_incrementally_without_duplicates() {
+        let run_id = format!("test_tools_{}", std::process::id());
+        push_tool_event(
+            &run_id,
+            "tool_start",
+            r#"{"tool_id":"t1","tool_name":"read","tool_args":"{\"path\":\"/a.ts\"}"}"#,
+            0,
+        );
+        push_tool_event(&run_id, "tool_end", r#"{"tool_id":"t1","text":"ok"}"#, 1);
+
+        let first = list_tool_calls(&run_id).expect("first read");
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].status, "completed");
+
+        // A second identical read must not duplicate the already-folded events.
+        let second = list_tool_calls(&run_id).expect("second read");
+        assert_eq!(second.len(), 1);
+
+        // A later event is folded in on the next read.
+        push_tool_event(
+            &run_id,
+            "tool_start",
+            r#"{"tool_id":"t2","tool_name":"edit","tool_args":"{\"path\":\"/b.ts\"}"}"#,
+            2,
+        );
+        let third = list_tool_calls(&run_id).expect("third read");
+        assert_eq!(third.len(), 2);
+        assert_eq!(third[1].name, "edit");
+        assert_eq!(third[1].status, "running");
+
+        clear_run_event_buffer(&run_id);
+        if let Ok(mut cache) = TOOL_PROJECTION_CACHE.lock() {
+            cache.remove(&run_id);
+        }
     }
 
     fn insert_thread(conn: &Connection, id: &str, agent_session_id: Option<&str>) {

--- a/gui/src/components/layout/hooks/useAgentConnection.ts
+++ b/gui/src/components/layout/hooks/useAgentConnection.ts
@@ -37,9 +37,15 @@ function classifyAgentConnectionError(message: string): AgentConnectionState["ki
   if (normalized.includes("unable to connect to future agent")) {
     return "agent_unavailable";
   }
+  // "Unable to load Future Agent models" surfaces when the gRPC call itself
+  // fails (agent unreachable), not a model-data problem.
+  if (normalized.includes("unable to load future agent models")) {
+    return "agent_unavailable";
+  }
+  // Genuine model errors: agent returned but data is invalid / request rejected.
   if (
-    normalized.includes("unable to load future agent models")
-    || normalized.includes("model")
+    normalized.includes("invalid model data")
+    || normalized.includes("rejected the model list")
     || normalized.includes("list_models")
   ) {
     return "model_error";

--- a/gui/src/components/layout/hooks/useContextData.ts
+++ b/gui/src/components/layout/hooks/useContextData.ts
@@ -2,6 +2,7 @@ import type { ReviewBase } from "../../../integrations/storage/review";
 import type { GitReview, StoredArtifact, StoredRun, StoredThread, StoredToolCall } from "../../../integrations/storage/threadStore";
 import type { WorkspaceReviewCapabilities } from "../../../integrations/storage/types";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { matchesSettledRun } from "../../../features/agent/agentMessageFormatters";
 import { upsertFutureReferenceEntries } from "../../../features/markdown/futureReferenceStore";
 import {
   ensureWorkspaceGit,
@@ -9,7 +10,7 @@ import {
   getWorkspaceReviewCapabilities,
   listArtifacts,
   listRuns,
-  listToolCalls,
+  listToolCallsBulk,
 } from "../../../integrations/storage/threadStore";
 import { usePolling } from "../../../lib/usePolling";
 
@@ -107,7 +108,8 @@ export function useContextData({
       ]);
       // Only chat threads use Artifacts; workspace threads show Review (§14.6).
       const nextArtifacts = activeThreadMode === "workspace" ? [] : await listArtifacts(activeThreadId);
-      const toolEntries = await Promise.all(nextRuns.map(async run => [run.id, await listToolCalls(run.id)] as const));
+      // One batched IPC for all runs' tool calls (was one round-trip per run).
+      const toolEntries = await listToolCallsBulk(nextRuns.map(run => run.id));
 
       if (!isCurrentRefresh())
         return;
@@ -209,11 +211,17 @@ export function useContextData({
     // eslint-disable-next-line react/exhaustive-deps
   }, [activeTab, reviewBase, debouncedReviewCustomBase]);
 
-  usePolling(() => refreshContextRef.current(), 1500, {
+  // Poll cadence follows activity: fast while a run is live (tool calls and
+  // statuses accumulate in near real time), slow once everything settles —
+  // idle-panel data (git review, artifacts) moves rarely, and the expensive
+  // queries behind it are already cached/batched. External changes (another
+  // client driving the session) surface within the slow tick.
+  const hasActiveRun = runs.some(run => !matchesSettledRun(run.status));
+  usePolling(() => refreshContextRef.current(), hasActiveRun ? 1500 : 5000, {
     enabled: Boolean(activeThreadId) && expanded,
     // Intentionally no refreshContext dep: the parameter-driven effect above
     // owns param-change fetches; the poll only needs to tick periodically.
-    deps: [],
+    deps: [hasActiveRun],
   });
 
   return {

--- a/gui/src/features/agent/MessageBlock.tsx
+++ b/gui/src/features/agent/MessageBlock.tsx
@@ -77,6 +77,21 @@ function MessageBlockImpl({
   // A local narrowed to the non-empty segment array (or null) so the render can
   // map over it without a non-null assertion.
   const segments = !isUser && message.segments && message.segments.length > 0 ? message.segments : null;
+  // While streaming, only the LAST text/thinking segment is still growing —
+  // mark it `live` so its code blocks skip re-highlighting on every 220ms
+  // poll tick (O(block) per tick → O(n²) over the reply). Closed segments
+  // keep full rendering. Once the run settles, `streaming` flips off and the
+  // tail re-renders fully highlighted.
+  const liveSegmentId = streaming && segments
+    ? (() => {
+        for (let index = segments.length - 1; index >= 0; index--) {
+          const segment = segments[index]!;
+          if (segment.kind === "text" || segment.kind === "thinking")
+            return segment.id;
+        }
+        return null;
+      })()
+    : null;
   // Plain-text payload for the copy button: joined text slices when the reply is
   // segmented, otherwise the raw content. Activity lines are excluded.
   const copyableText = (segments
@@ -131,6 +146,7 @@ function MessageBlockImpl({
                         <MarkdownContent
                           content={segment.text}
                           key={segment.id}
+                          live={segment.id === liveSegmentId}
                           workspaceId={workspaceId}
                         />
                       );
@@ -142,6 +158,7 @@ function MessageBlockImpl({
                         ? (
                             <ThinkingBlock
                               key={segment.id}
+                              live={segment.id === liveSegmentId}
                               text={segment.text}
                               workspaceId={workspaceId}
                             />
@@ -158,7 +175,7 @@ function MessageBlockImpl({
             : message.content
               ? isUser
                 ? <UserMessageText content={message.content} />
-                : <MarkdownContent content={message.content} workspaceId={workspaceId} />
+                : <MarkdownContent content={message.content} workspaceId={workspaceId} live={streaming} />
               : null}
           {message.attachments && message.attachments.length > 0
             ? (

--- a/gui/src/features/agent/ThinkingBlock.tsx
+++ b/gui/src/features/agent/ThinkingBlock.tsx
@@ -9,9 +9,12 @@ import { MarkdownContent } from "../markdown/MarkdownContent";
 export function ThinkingBlock({
   text,
   workspaceId,
+  live,
 }: {
   text: string;
   workspaceId?: string | null;
+  /** True while this reasoning block is the growing tail of a streaming reply. */
+  live?: boolean;
 }) {
   return (
     <div
@@ -22,7 +25,7 @@ export function ThinkingBlock({
         "[&_*]:text-ink-muted",
       )}
     >
-      <MarkdownContent content={text} workspaceId={workspaceId} />
+      <MarkdownContent content={text} workspaceId={workspaceId} live={live} />
     </div>
   );
 }

--- a/gui/src/features/agent/agentActivity.test.ts
+++ b/gui/src/features/agent/agentActivity.test.ts
@@ -1,6 +1,6 @@
 import type { StoredRunEvent } from "../../integrations/storage/threadStore";
 import { describe, expect, it } from "vitest";
-import { buildAssistantRunProjection, isSoftExit, nonZeroExitCode } from "./agentActivity";
+import { buildAssistantRunProjection, createRunProjector, isSoftExit, nonZeroExitCode } from "./agentActivity";
 
 function events(list: Array<[string, Record<string, unknown>]>): StoredRunEvent[] {
   return list.map(([eventType, payload], index) => ({
@@ -307,5 +307,70 @@ describe("nonZeroExitCode", () => {
     expect(isSoftExit(1, "grep foo file")).toBe(true);
     // A real command-not-found (exit 1, first token not a soft-fail program) stays a failure.
     expect(isSoftExit(1, "future tools call parse_doc")).toBe(false);
+  });
+});
+
+describe("createRunProjector incremental ingestion", () => {
+  const full = events([
+    ["thinking_start", {}],
+    ["thinking_delta", { text: "reasoning " }],
+    ["thinking_delta", { text: "more" }],
+    ["thinking_end", {}],
+    ["text_chunk", { text: "First. " }],
+    ["tool_start", read("t1", "/a.ts")[0]],
+    ["toolcall_delta", { text: "{\"path\":\"/a" }],
+    ["toolcall_delta", { text: ".ts\"}" }],
+    ["tool_end", read("t1", "/a.ts")[0]],
+    ["text_chunk", { text: "Second." }],
+    ["usage", { usage: { completion_tokens: 42 } }],
+    ["agent_end", { usage: { completion_tokens: 99 } }],
+  ]);
+
+  it("matches the one-shot projection when fed in chunks", () => {
+    const expected = buildAssistantRunProjection(full);
+    const projector = createRunProjector();
+
+    // Feed in uneven chunks, as the 220ms incremental poll would deliver them.
+    let projection = projector.ingest(full.slice(0, 3));
+    projection = projector.ingest(full.slice(3, 6));
+    projection = projector.ingest(full.slice(6));
+
+    expect(projection).toEqual(expected);
+    expect(projector.lastSequence).toBe(full.length - 1);
+  });
+
+  it("skips already-ingested events in overlapping batches", () => {
+    const expected = buildAssistantRunProjection(full);
+    const projector = createRunProjector();
+
+    projector.ingest(full.slice(0, 6));
+    // Overlapping redelivery (events 4-7) must not double-apply text/tools.
+    const projection = projector.ingest(full.slice(4));
+
+    expect(projection).toEqual(expected);
+  });
+
+  it("processes two events sharing one sequence within a single batch", () => {
+    const projector = createRunProjector();
+    const batch = events([
+      ["text_chunk", { text: "a" }],
+      ["text_chunk", { text: "b" }],
+    ]).map(event => ({ ...event, sequence: 7 }));
+
+    const projection = projector.ingest(batch);
+
+    expect(projection.content).toBe("ab");
+    expect(projector.lastSequence).toBe(7);
+    // ...but a later batch re-delivering that watermark is deduped.
+    expect(projector.ingest(batch).content).toBe("ab");
+  });
+
+  it("returns a stable empty snapshot before any event lands", () => {
+    const projector = createRunProjector();
+    const projection = projector.ingest([]);
+
+    expect(projection.content).toBe("");
+    expect(projection.segments).toHaveLength(0);
+    expect(projector.lastSequence).toBe(-1);
   });
 });

--- a/gui/src/features/agent/agentActivity.test.ts
+++ b/gui/src/features/agent/agentActivity.test.ts
@@ -331,9 +331,9 @@ describe("createRunProjector incremental ingestion", () => {
     const projector = createRunProjector();
 
     // Feed in uneven chunks, as the 220ms incremental poll would deliver them.
-    let projection = projector.ingest(full.slice(0, 3));
-    projection = projector.ingest(full.slice(3, 6));
-    projection = projector.ingest(full.slice(6));
+    projector.ingest(full.slice(0, 3));
+    projector.ingest(full.slice(3, 6));
+    const projection = projector.ingest(full.slice(6));
 
     expect(projection).toEqual(expected);
     expect(projector.lastSequence).toBe(full.length - 1);

--- a/gui/src/features/agent/agentActivity.ts
+++ b/gui/src/features/agent/agentActivity.ts
@@ -11,7 +11,7 @@ import {
   targetFromArgs,
 } from "./toolActivityModel";
 
-interface AssistantRunProjection {
+export interface AssistantRunProjection {
   activityItems: AgentActivityItem[];
   content: string;
   /** Text and activity in chronological order — drives inline rendering. */
@@ -55,8 +55,25 @@ interface ToolActivity {
   order: number;
 }
 
-export function buildAssistantRunProjection(events: StoredRunEvent[]): AssistantRunProjection {
-  const sortedEvents = [...events].sort((a, b) => a.sequence - b.sequence);
+/**
+ * A stateful, incremental projector over a run's event log. The live-preview
+ * poll fetches only the events it hasn't seen (`list_run_events_since`) and
+ * ingests them here, so each tick costs O(new events) for parsing plus
+ * O(slots) for the snapshot — instead of re-parsing and re-projecting the
+ * whole log every 220ms (O(n) per tick, O(n²) over a run).
+ */
+export interface RunProjector {
+  /** Highest event sequence ingested so far (-1 when none). */
+  readonly lastSequence: number;
+  /**
+   * Ingest a batch of events and return the current projection snapshot.
+   * Batches are sorted by sequence internally; events already ingested
+   * (sequence <= lastSequence) are skipped, so overlapping batches are safe.
+   */
+  ingest: (events: StoredRunEvent[]) => AssistantRunProjection;
+}
+
+export function createRunProjector(): RunProjector {
   const toolActivities = new Map<string, ToolActivity>();
   // Ordered timeline of the turn. Text accumulates into the open text slot;
   // each tool call pins a slot at the point it started.
@@ -75,19 +92,20 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
   let usageOutputSum = 0;
   let sawUsageEvent = false;
   let agentEndOutput = 0;
+  let lastSequence = -1;
 
-  for (const event of sortedEvents) {
+  function processEvent(event: StoredRunEvent) {
     const payload = parseEventPayload(event.payload);
 
     if (event.eventType === "usage") {
       usageOutputSum += usageOutputTokens(payload);
       sawUsageEvent = true;
-      continue;
+      return;
     }
 
     if (event.eventType === "agent_end") {
       agentEndOutput = usageOutputTokens(payload);
-      continue;
+      return;
     }
 
     if (event.eventType === "text_chunk") {
@@ -103,7 +121,7 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
       if (text.trim()) {
         sawVisibleWork = true;
       }
-      continue;
+      return;
     }
 
     if (event.eventType === "thinking_start") {
@@ -113,7 +131,7 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
       openThinking = { type: "thinking", text: "" };
       slots.push(openThinking);
       openText = null;
-      continue;
+      return;
     }
 
     if (event.eventType === "thinking_delta") {
@@ -127,13 +145,13 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
         }
         openThinking.text += text;
       }
-      continue;
+      return;
     }
 
     if (event.eventType === "thinking_end") {
       thinking = false;
       openThinking = null;
-      continue;
+      return;
     }
 
     // Context compaction ran this turn (usually at the top, before any text).
@@ -149,7 +167,7 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
         openText = null;
         openThinking = null;
       }
-      continue;
+      return;
     }
 
     if (event.eventType === "toolcall_start" || event.eventType === "tool_start") {
@@ -171,16 +189,16 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
         openThinking = null;
         sawVisibleWork = true;
       }
-      continue;
+      return;
     }
 
     if (event.eventType === "toolcall_delta") {
       if (!activeToolCallId)
-        continue;
+        return;
 
       const existing = toolActivities.get(activeToolCallId);
       if (!existing)
-        continue;
+        return;
 
       const nextArgsText = `${existing.argsText ?? ""}${textFromPayload(payload)}`;
       const target = targetFromToolArgs(existing.kind, nextArgsText);
@@ -194,13 +212,13 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
             }
           : {}),
       });
-      continue;
+      return;
     }
 
     if (event.eventType === "tool_end" || event.eventType === "tool_result") {
       const tool = toolFromPayload(payload, event.sequence);
       if (!tool)
-        continue;
+        return;
 
       const toolId = explicitToolId(payload) ?? latestRunningToolId(toolActivities, tool.kind) ?? tool.id;
       const existing = toolActivities.get(toolId);
@@ -227,30 +245,58 @@ export function buildAssistantRunProjection(events: StoredRunEvent[]): Assistant
     }
   }
 
-  const segments = buildSegments(slots, toolActivities);
+  function snapshot(): AssistantRunProjection {
+    const segments = buildSegments(slots, toolActivities);
 
-  // Flat activity list kept for back-compat (legacy render path / callers).
-  const items = collapseToolActivities([...toolActivities.values()].sort((a, b) => a.order - b.order));
-  // Mid-reasoning with nothing visible yet. Reported as a flag (consumed by the
-  // footer hint) rather than injected as a top-of-message "thinking" activity.
-  const thinkingActive = Boolean(thinking) && !content.trim() && !sawVisibleWork;
+    // Flat activity list kept for back-compat (legacy render path / callers).
+    const items = collapseToolActivities([...toolActivities.values()].sort((a, b) => a.order - b.order));
+    // Mid-reasoning with nothing visible yet. Reported as a flag (consumed by the
+    // footer hint) rather than injected as a top-of-message "thinking" activity.
+    const thinkingActive = Boolean(thinking) && !content.trim() && !sawVisibleWork;
 
-  // Concatenated reasoning (blocks joined by blank lines) — the inline segments
-  // carry the ordered form; this is the whole-turn text for any non-inline use.
-  const thinkingText = slots
-    .filter((slot): slot is Extract<Slot, { type: "thinking" }> => slot.type === "thinking")
-    .map(slot => slot.text.trim())
-    .filter(Boolean)
-    .join("\n\n");
+    // Concatenated reasoning (blocks joined by blank lines) — the inline segments
+    // carry the ordered form; this is the whole-turn text for any non-inline use.
+    const thinkingText = slots
+      .filter((slot): slot is Extract<Slot, { type: "thinking" }> => slot.type === "thinking")
+      .map(slot => slot.text.trim())
+      .filter(Boolean)
+      .join("\n\n");
+
+    return {
+      activityItems: items,
+      content,
+      segments,
+      outputTokens: sawUsageEvent ? usageOutputSum : agentEndOutput,
+      thinking: thinkingText,
+      thinkingActive,
+    };
+  }
 
   return {
-    activityItems: items,
-    content,
-    segments,
-    outputTokens: sawUsageEvent ? usageOutputSum : agentEndOutput,
-    thinking: thinkingText,
-    thinkingActive,
+    get lastSequence() {
+      return lastSequence;
+    },
+    ingest(events) {
+      const sorted = [...events].sort((a, b) => a.sequence - b.sequence);
+      for (const event of sorted) {
+        // Skip already-ingested events (overlapping batches), but compare
+        // against the pre-batch watermark so two events sharing one sequence
+        // within a single batch are both processed.
+        if (event.sequence <= lastSequence)
+          continue;
+        processEvent(event);
+      }
+      if (sorted.length > 0) {
+        lastSequence = Math.max(lastSequence, sorted[sorted.length - 1]!.sequence);
+      }
+      return snapshot();
+    },
   };
+}
+
+/** One-shot full projection (settle path, tests): project the entire log. */
+export function buildAssistantRunProjection(events: StoredRunEvent[]): AssistantRunProjection {
+  return createRunProjector().ingest(events);
 }
 
 function numberFromPayload(payload: unknown, keys: string[]): number {

--- a/gui/src/features/agent/sendPipeline.ts
+++ b/gui/src/features/agent/sendPipeline.ts
@@ -174,7 +174,7 @@ export async function runSendPipeline(
     // images already had their temp original moved into the thread's origin dir
     // by persistImageAttachments (which deletes the temp copy).
 
-    const currentRun = await loadCurrentRun(thread.id, run.id);
+    const currentRun = await loadCurrentRun(run.id);
     if (currentRun && matchesSettledRun(currentRun.status)) {
       // The run settled while we awaited the agent. For a user abort
       // (`cancelled`) the agent stopped mid-reply: keep the partial text so it
@@ -288,7 +288,7 @@ export async function runSendPipeline(
       await safeListRunEvents(run.id),
       storedAssistantMessage.content,
     );
-    const settledRun = await loadCurrentRun(thread.id, run.id);
+    const settledRun = await loadCurrentRun(run.id);
     const durationMs = runDurationMs(settledRun, runStartAnchorMs);
 
     if (isCurrentSend()) {
@@ -311,7 +311,7 @@ export async function runSendPipeline(
 
     const message = errorMessage(error);
     if (run) {
-      const currentRun = await loadCurrentRun(thread.id, run.id);
+      const currentRun = await loadCurrentRun(run.id);
       if (!currentRun || !matchesSettledRun(currentRun.status)) {
         await updateRunStatusSafe(run.id, "failed", message);
       }

--- a/gui/src/features/agent/threadRunProjection.ts
+++ b/gui/src/features/agent/threadRunProjection.ts
@@ -1,9 +1,10 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { StoredRun, StoredRunEvent } from "../../integrations/storage/threadStore";
+import type { AssistantRunProjection, RunProjector } from "./agentActivity";
 import type { AgentMessage, MessageSegment } from "./agentThreadTypes";
-import { listRunEvents, listRunEventsBulk, listRuns, storedTimeToIso } from "../../integrations/storage/threadStore";
+import { getRun, listRunEvents, listRunEventsBulk, listRunEventsSince, storedTimeToIso } from "../../integrations/storage/threadStore";
 import { emitFutureEvent } from "../../lib/futureEvents";
-import { buildAssistantRunProjection } from "./agentActivity";
+import { buildAssistantRunProjection, createRunProjector } from "./agentActivity";
 import { matchesSettledRun } from "./agentMessageFormatters";
 
 /** Apply a patch to the single message with `id`, leaving the rest untouched. */
@@ -21,8 +22,25 @@ export function patchMessage(
   );
 }
 
+// ── Incremental live-preview projection ──────────────────────────────────
+// The 220ms live-preview poll used to fetch the run's ENTIRE event log every
+// tick and re-project it from scratch (O(n) per tick → O(n²) over a run, with
+// every payload re-parsed and re-serialized across IPC). Instead, each run
+// keeps a stateful projector here; every tick fetches only the events with
+// `sequence > lastSequence` and ingests just those.
+interface LiveProjectionEntry {
+  projector: RunProjector;
+  /** Null only between projector creation and the first ingest (same tick). */
+  projection: AssistantRunProjection | null;
+}
+
+/** Max cached runs before evicting the least-recently-used projector. */
+const LIVE_PROJECTION_CACHE_MAX = 8;
+
+const liveProjectionCache = new Map<string, LiveProjectionEntry>();
+
 /**
- * Fetch a run's events and project them for a live preview, honoring the
+ * Fetch a run's unseen events and advance its cached projector, honoring the
  * `shouldApply` guard (a stale async result is dropped by returning null). Emits
  * `file-tree-refresh` when tool activity appears — the agent may have created or
  * modified files. Shared prologue of the two live-preview writers below.
@@ -30,14 +48,42 @@ export function patchMessage(
 async function projectRunForLivePreview(
   runId: string,
   shouldApply: () => boolean,
-): Promise<ReturnType<typeof buildAssistantRunProjection> | null> {
-  const events = await listRunEvents(runId);
+): Promise<AssistantRunProjection | null> {
+  const cached = liveProjectionCache.get(runId) ?? null;
+  const since = cached?.projector.lastSequence ?? -1;
+  let events = await listRunEventsSince(runId, since);
   if (!shouldApply())
     return null;
-  const projection = buildAssistantRunProjection(events);
-  if (projection.activityItems.length > 0)
+
+  if (cached && events.length > 0 && events[0]!.sequence <= since) {
+    // Sequence regressed under us — the agent realigned mid-stream (e.g. its
+    // fallback restarted the event log for a new run). The incremental tail is
+    // meaningless against the old projector: drop it and rebuild from the
+    // full log once.
+    liveProjectionCache.delete(runId);
+    events = await listRunEventsSince(runId, -1);
+    if (!shouldApply())
+      return null;
+  }
+
+  let entry = liveProjectionCache.get(runId);
+  if (!entry) {
+    entry = { projector: createRunProjector(), projection: null };
+  }
+  // LRU touch; bound the cache so long sessions don't accumulate projectors.
+  liveProjectionCache.delete(runId);
+  liveProjectionCache.set(runId, entry);
+  while (liveProjectionCache.size > LIVE_PROJECTION_CACHE_MAX) {
+    const oldest = liveProjectionCache.keys().next().value;
+    if (oldest === undefined)
+      break;
+    liveProjectionCache.delete(oldest);
+  }
+
+  entry.projection = entry.projector.ingest(events);
+  if (entry.projection.activityItems.length > 0)
     emitFutureEvent("file-tree-refresh", undefined);
-  return projection;
+  return entry.projection;
 }
 
 /**
@@ -408,10 +454,13 @@ export function clientId(prefix: string) {
   return `${prefix}_${Date.now()}_${clientIdCounter}`;
 }
 
-export async function loadCurrentRun(threadId: string, runId: string) {
+/**
+ * A run's current record by id (settle checks) — direct PK lookup, not a
+ * full per-thread list.
+ */
+export async function loadCurrentRun(runId: string) {
   try {
-    const runs = await listRuns(threadId);
-    return runs.find(run => run.id === runId) ?? null;
+    return await getRun(runId);
   }
   catch {
     return null;

--- a/gui/src/features/agent/useThreadMessages.ts
+++ b/gui/src/features/agent/useThreadMessages.ts
@@ -2,7 +2,7 @@ import type { StoredRun } from "../../integrations/storage/threadStore";
 import type { AgentMessage } from "./agentThreadTypes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import i18n from "../../i18n";
-import { getSessionEntries, listRuns } from "../../integrations/storage/threadStore";
+import { getLatestRun, getSessionEntries, listRuns } from "../../integrations/storage/threadStore";
 import { invokeCommand } from "../../integrations/tauri/invoke";
 import { errorMessage } from "../../lib/errors";
 import { usePolling } from "../../lib/usePolling";
@@ -94,11 +94,12 @@ export function useThreadMessages({ threadId, workspaceId, agentSessionId }: Use
   const refreshRecentRun = useCallback(async (targetThreadId: string, targetWorkspaceId?: string | null) => {
     const generation = ++recentRunGenRef.current;
     try {
-      const runs = await listRuns(targetThreadId);
+      // One row, not the thread's whole run history — this fires every 1.5s
+      // while a run is active.
+      const latestRun = await getLatestRun(targetThreadId);
       if (generation !== recentRunGenRef.current) {
         return;
       }
-      const latestRun = runs[0] ?? null;
       if (targetThreadId === activeThreadIdRef.current) {
         setRecentRun(latestRun);
       }

--- a/gui/src/features/artifacts/ArtifactDetailPanel.tsx
+++ b/gui/src/features/artifacts/ArtifactDetailPanel.tsx
@@ -2,7 +2,7 @@ import type { StoredArtifact } from "../../integrations/storage/threadStore";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
 import { ArrowLeft, Download, ExternalLink, Maximize2, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/ui/Button";
 import { CopyButton } from "../../components/ui/CopyButton";
@@ -23,7 +23,12 @@ import { pathBasename } from "../../lib/workspacePath";
 import { FilePreviewOverlay } from "../filepreview/FilePreviewOverlay";
 import { previewKindForPath } from "../filepreview/previewKind";
 import { MarkdownContent } from "../markdown/MarkdownContent";
-import { PdfPreview } from "./PdfPreview";
+
+// pdfjs-dist is ~500KB of the main bundle's eager parse cost while PDF preview
+// is a rare path — split it out and load it on first use.
+const PdfPreview = lazy(() =>
+  import("./PdfPreview").then(module => ({ default: module.PdfPreview })),
+);
 
 interface ArtifactDetailPanelProps {
   artifact: StoredArtifact;
@@ -235,7 +240,9 @@ export function ArtifactDetailPanel({ artifact, onBack, onChanged }: ArtifactDet
         {!fileMissing && shouldShowPdfPreview
           ? (
               <div className="mt-3">
-                <PdfPreview path={artifact.path!} />
+                <Suspense fallback={null}>
+                  <PdfPreview path={artifact.path!} />
+                </Suspense>
               </div>
             )
           : null}

--- a/gui/src/features/markdown/LiveMarkdownContext.ts
+++ b/gui/src/features/markdown/LiveMarkdownContext.ts
@@ -1,0 +1,17 @@
+import { createContext, use } from "react";
+
+/**
+ * Marks a markdown block as the still-growing tail of a streaming reply.
+ * Expensive renderers (shiki code highlighting) degrade to plain text inside
+ * a live block: re-tokenizing a growing code block every 220ms poll tick is
+ * O(block) per tick → O(n²) over a reply. Once the segment closes (or the run
+ * settles), the same content re-renders fully highlighted.
+ */
+const LiveMarkdownContext = createContext(false);
+
+export const LiveMarkdownProvider = LiveMarkdownContext.Provider;
+
+/** True when this block is the live tail of a streaming reply. */
+export function useLiveMarkdown(): boolean {
+  return use(LiveMarkdownContext);
+}

--- a/gui/src/features/markdown/MarkdownContent.tsx
+++ b/gui/src/features/markdown/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import type { StoredFile } from "../../integrations/storage/types";
 import type { FutureReference, InlineNode, MarkdownNode } from "./futureMarkdownTypes";
 import { useMemo } from "react";
 import { useFutureReference, useFutureReferences } from "./futureReferenceStore";
+import { LiveMarkdownProvider } from "./LiveMarkdownContext";
 import { parseFutureMarkdown } from "./parseFutureMarkdown";
 import { PreviewMarkdownContext, usePreviewMarkdown } from "./PreviewMarkdownContext";
 import { CodeBlock } from "./renderers/CodeBlock";
@@ -23,13 +24,22 @@ interface MarkdownContentProps {
    * The chat stream omits it, keeping its link behavior unchanged.
    */
   basePath?: string;
+  /**
+   * True for the still-growing tail of a streaming reply (see
+   * `LiveMarkdownContext`): code blocks render plain until the segment closes.
+   */
+  live?: boolean;
 }
 
-export function MarkdownContent({ content, workspaceId, basePath }: MarkdownContentProps) {
+export function MarkdownContent({ content, workspaceId, basePath, live }: MarkdownContentProps) {
   const document = useMemo(() => parseFutureMarkdown(content), [content]);
   useFutureReferences(workspaceId, document.references);
 
-  const body = <div className="space-y-3">{document.nodes.map((node, index) => renderBlock(node, workspaceId, `b${index}`))}</div>;
+  const body = (
+    <LiveMarkdownProvider value={Boolean(live)}>
+      <div className="space-y-3">{document.nodes.map((node, index) => renderBlock(node, workspaceId, `b${index}`))}</div>
+    </LiveMarkdownProvider>
+  );
   if (basePath)
     return <PreviewMarkdownContext value={{ basePath }}>{body}</PreviewMarkdownContext>;
   return body;

--- a/gui/src/features/markdown/renderers/CodeBlock.tsx
+++ b/gui/src/features/markdown/renderers/CodeBlock.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CopyButton } from "../../../components/ui/CopyButton";
 import { useCopyState } from "../../../components/ui/useCopyState";
+import { useLiveMarkdown } from "../LiveMarkdownContext";
 import { useCodeHighlighter } from "../useCodeHighlighter";
 
 export function CodeBlock({
@@ -14,7 +15,14 @@ export function CodeBlock({
   const { t } = useTranslation("markdown");
   const { copiedKey, copy } = useCopyState();
   const { highlight, isLoaded } = useCodeHighlighter();
-  const highlighted = useMemo(() => highlight(code, language), [highlight, code, language]);
+  // The live tail of a streaming reply renders plain: re-tokenizing a growing
+  // code block on every 220ms poll tick is O(block) per tick → O(n²) over the
+  // reply. Full highlighting returns when the segment closes / the run settles.
+  const live = useLiveMarkdown();
+  const highlighted = useMemo(
+    () => (live ? null : highlight(code, language)),
+    [highlight, code, language, live],
+  );
 
   // Fallback to plain text if highlighter not loaded or language not supported
   if (!isLoaded || !highlighted) {

--- a/gui/src/integrations/storage/runs.ts
+++ b/gui/src/integrations/storage/runs.ts
@@ -22,6 +22,16 @@ export async function listRuns(threadId: string) {
   return invokeCommand<StoredRun[]>("list_runs", { threadId });
 }
 
+/** The thread's most recent run, or null (recent-run poll — one row). */
+export async function getLatestRun(threadId: string) {
+  return invokeCommand<StoredRun | null>("get_latest_run", { threadId });
+}
+
+/** A single run by id (settle checks — direct PK lookup). */
+export async function getRun(runId: string) {
+  return invokeCommand<StoredRun | null>("get_run", { runId });
+}
+
 export async function listLatestRunInfos(threadIds: string[]) {
   return invokeCommand<Array<{ threadId: string; status: string; endedAt: number | null }>>(
     "list_latest_run_infos",
@@ -49,6 +59,14 @@ export async function listRunEvents(runId: string) {
   return invokeCommand<StoredRunEvent[]>("list_run_events", { runId });
 }
 
+/**
+ * Incremental variant for the live-preview poll: only events with
+ * `sequence > sinceSequence` cross IPC. Pass -1 for the full log.
+ */
+export async function listRunEventsSince(runId: string, sinceSequence: number) {
+  return invokeCommand<StoredRunEvent[]>("list_run_events_since", { runId, sinceSequence });
+}
+
 /** Fetch run events for multiple runs in a single IPC call. */
 export async function listRunEventsBulk(runIds: string[]) {
   return invokeCommand<[string, StoredRunEvent[]][]>("list_run_events_bulk", { runIds });
@@ -56,6 +74,11 @@ export async function listRunEventsBulk(runIds: string[]) {
 
 export async function listToolCalls(runId: string) {
   return invokeCommand<StoredToolCall[]>("list_tool_calls", { runId });
+}
+
+/** Tool calls for many runs in a single IPC call (context panel poll). */
+export async function listToolCallsBulk(runIds: string[]) {
+  return invokeCommand<[string, StoredToolCall[]][]>("list_tool_calls_bulk", { runIds });
 }
 
 export async function listToolOutputs(runId: string, toolCallId: string) {

--- a/gui/src/lib/useNow.ts
+++ b/gui/src/lib/useNow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 /**
  * Returns `Date.now()` and re-renders the caller every `intervalMs` so that
@@ -6,20 +6,54 @@ import { useEffect, useState } from "react";
  * A static clock timestamp never needs this; a relative one does, since it
  * silently goes stale between renders.
  *
- * Keep the interval coarse (default 60s) — relative labels only change at the
- * minute granularity, so ticking faster just wastes renders.
+ * All subscribers share ONE global 1s ticker (previously every MessageBlock
+ * installed its own interval — hundreds of timers on long threads). A
+ * subscriber re-renders only when its own bucket (`floor(now / intervalMs)`)
+ * changes, so a 60s relative-timestamp subscriber sleeps through the 1s
+ * ticks a streaming elapsed timer needs.
  *
- * Pass `enabled: false` to freeze the clock (no interval, no re-renders) — e.g.
- * a live elapsed timer that should only tick while its run is streaming.
+ * Pass `enabled: false` to freeze the clock (no subscription, no re-renders)
+ * — e.g. a live elapsed timer that should only tick while its run streams.
  */
+
+const TICK_MS = 1000;
+const listeners = new Set<() => void>();
+let timer: number | null = null;
+// Updated only on ticks (and on subscribe), so getSnapshot is stable between
+// notifications — no mid-render tearing.
+let currentTick = Date.now();
+
+function subscribe(listener: () => void): () => void {
+  currentTick = Date.now();
+  listeners.add(listener);
+  if (timer === null) {
+    timer = window.setInterval(() => {
+      currentTick = Date.now();
+      for (const listener of listeners) {
+        listener();
+      }
+    }, TICK_MS);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      window.clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+function noopSubscribe(): () => void {
+  return () => {};
+}
+
 export function useNow(intervalMs: number = 60_000, enabled: boolean = true): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (!enabled)
-      return;
-    setNow(Date.now());
-    const id = setInterval(() => setNow(Date.now()), intervalMs);
-    return () => clearInterval(id);
-  }, [intervalMs, enabled]);
-  return now;
+  const bucket = useSyncExternalStore(
+    enabled ? subscribe : noopSubscribe,
+    enabled ? () => Math.floor(currentTick / intervalMs) : () => 0,
+    () => 0,
+  );
+  // Disabled: no subscription; the value refreshes whenever the component
+  // re-renders for other reasons (it isn't displayed while disabled anyway).
+  return enabled ? bucket * intervalMs : Date.now();
 }

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -465,6 +465,9 @@ export class App extends Container {
         if (e.text && this.chat) {
           this.chat.updateLastMessage(e.text);
         }
+        // Mark the assistant message as complete so pending→false and the
+        // full markdown render replaces the streaming (prefix-cached) render.
+        this.chat.markLastMessageComplete();
         // Refresh state to update context percentage, token totals, etc.
         this.refresh().then(() => this.requestRender());
         break;

--- a/tui/src/rpc/grpc-client.ts
+++ b/tui/src/rpc/grpc-client.ts
@@ -604,6 +604,12 @@ export class GrpcClient {
     }, 5000);
 
     call.on("data", (response: any) => {
+      // Discard events from a stale stream — when connectEvents() cancels an
+      // old stream and creates a new one, buffered data events from the old
+      // stream can still arrive asynchronously.  Without this guard those
+      // events leak into the new session's chat, corrupting messages and
+      // leaving the streaming indicator stuck on.
+      if (this.streamCall !== call) return;
       if (connectWatchdog) { clearTimeout(connectWatchdog); connectWatchdog = null; }
       if (!this.connected) {
         this.connected = true;


### PR DESCRIPTION
## Summary

6 commits improving GUI performance and reliability, plus a TUI session-switching bug fix.

---

### 66014d7 — perf(gui): incremental preview, IPC reduction, connection/event/write batching

**P0: streaming preview O(n²) → O(n)**
- `observe_session`: whitelist forwarded events (6 settings types + user_message), drop per-token text_chunk/thinking_*/tool_* — no frontend listener reads them
- Incremental event fetch: `list_run_events_since(run_id, sequence)` returns only unseen tail; frontend `RunProjector` caches state and ingests per-tick
- `agent_events_fallback` supports `since_idx` passthrough for post-restart recovery

**P1: store/IPC/git batching**
- SQLite connection pool (4 idle conns, path-keyed for test HOME overrides) replaces per-call open/PRAGMA/handshake
- `list_tool_calls_bulk`: one IPC round-trip for all runs (was N); incremental `ToolProjectionState` cache per run
- Git review fingerprint cache: HEAD+status+index/FETCH/packed-refs+stat per changed file; skips full `--unified=80` diff + untracked content reads on hit

**Lazy code-highlight + reduced polling**
- `LiveMarkdownContext` defers shiki tokenize for growing streaming tail — was O(block) per 220ms tick → skipped until segment closes or run settles
- pdfjs-dist static import → React.lazy (427KB chunk, index.js -34%)
- `get_latest_run` / `get_run` commands: recent-run poll & settle checks use LIMIT 1 / PK lookup
- `useContextData` poll cadence: 1.5s while runs active, 5s when idle

**Disk writer & runtime & misc**
- Single background thread + BufWriter per run: sequential open/append/close per event → coalesced flush
- `spawn_blocking` startup tasks: `Runtime::new()` (multi_thread×num_cpus) → `new_current_thread()`
- `is_git_workspace`: 30s TTL cache
- `useNow`: global 1s ticker + `useSyncExternalStore` bucket detection (one timer instead of one per MessageBlock)
- release: `lto="thin"`; build: split typecheck from vite build

---

### 7ccd73e — fix(gui): wait for agent to settle before exit on force-quit

When the user force-quits the GUI while a conversation is running, the quit guard called `abort_session` on every active session but immediately followed with `shutdown_agent` / `exit(0)`. For an externally managed agent this dropped the gRPC connection while the agent was still tearing down its LLM stream, leaving a "LLM stream ended without a terminal signal" WARN.

After aborting, now poll the agent until it reports idle (`isStreaming` false, up to 3s per session) before killing the sidecar/exiting.

---

### e9f9aa7 — fix(gui): backfill agent events when recovering a crashed run

`collect_reanimated_run` (crash-recovery collector) subscribed to the agent's `StreamEvents` stream without a backfill — events emitted between the crash and reconnection were permanently lost, and the frontend saw a streaming bubble starting mid-reply.

Replicates the `collect_remote_stream` pattern: clear the incomplete local log, replay the agent's buffered events via `get_events_since`, then continue with live streaming.

---

### d76e59f — fix(gui): safe backfill order, restore wait budget, parallel quit waits

- **Bug 1:** crash-recovery cleared the local event log BEFORE calling `get_events_since` — if the backfill failed, pre-crash history was destroyed. Now fetch first, replace only on success.
- **Bug 2:** quit wait iteration reduction (5s→3s) was too aggressive and also affected the shadow-review snapshot path. Reverted.
- **Bug 3:** sequential abort+wait per session made force-quit take 3s per active session. Parallelized with `join_all`.

---

### 1cf0a25 — fix(agent): suppress LLM truncation WARN on consumer abort

The LLM SSE read loop exited via three paths but only distinguished two (`idle_timeout` vs `upstream_eof`). The third — `tx.closed()` when the consumer drops the receiver (user abort, GUI disconnect) — hit the same "stream ended without a terminal signal" WARN as a genuine provider-side drop, flooding logs on every user abort.

Introduce `StreamExitCause` to track the exit path: `ConsumerDropped` → INFO, `UpstreamEof`/`IdleTimeout` → WARN.

---

### 588c564 — fix(tui): discard stale stream events on session switch, clear pending on agent_end

Two fixes for a session-switching bug where switching away from a streaming session and back shows partial/stale content with the streaming indicator stuck on.

1. **gRPC stale stream guard** (`grpc-client.ts`): add `if (this.streamCall !== call) return` to the `data` event handler, matching existing guards in `end`/`error`/watchdog handlers. Without this, buffered data events from a cancelled old-session stream could arrive asynchronously and leak into the new session's chat.

2. **agent_end pending cleanup** (`app.ts`): call `markLastMessageComplete()` in the `agent_end` handler. This method existed but was never called, so the `pending` flag on the last assistant message was never cleared after streaming finished. Clicking pause worked around this because `handleInterrupt` calls `markLastAssistantStopped` which also clears `pending`.