### PR TITLE
feat(gui): batch delete conversations with file cleanup option

### DIFF
--- a/gui/src-tauri/src/commands/threads.rs
+++ b/gui/src-tauri/src/commands/threads.rs
@@ -144,8 +144,10 @@ pub fn restore_thread(thread_id: String) -> Result<store::ThreadRecord, crate::A
 }
 
 #[tauri::command]
-pub async fn delete_thread(thread_id: String) -> Result<store::ThreadRecord, crate::AppError> {
-    let thread = store::delete_thread(&thread_id)?;
+pub async fn delete_thread(
+    input: store::DeleteThreadInput,
+) -> Result<store::ThreadRecord, crate::AppError> {
+    let thread = store::delete_thread_with_files(&input.thread_id, input.delete_files)?;
     // Also delete the agent session JSONL (the source of truth) so the mirror and
     // the agent stay consistent. The session id mirrors the GUI's own resolution:
     // agent_session_id when set, else the thread id. Best-effort — a failure here
@@ -162,6 +164,47 @@ pub async fn delete_thread(thread_id: String) -> Result<store::ThreadRecord, cra
         let _ = client.execute_command(cmd).await;
     }
     Ok(thread)
+}
+
+/// Batch-delete multiple threads. For each thread, the DB row + children are
+/// hard-deleted and the agent session JSONL is removed. For chat-mode threads
+/// with `delete_files`, the temporary workspace directory on disk is also
+/// removed. Workspace-mode threads are never touched on disk regardless of
+/// `delete_files`. Returns a summary of deleted count and failures.
+#[tauri::command]
+pub async fn batch_delete_threads(
+    input: store::BatchDeleteThreadsInput,
+) -> Result<store::BatchDeleteResult, crate::AppError> {
+    // Pre-resolve session ids so we can delete agent JSONL files even for
+    // threads that fail the store delete (best-effort).
+    let session_info: Vec<(String, String)> = input
+        .thread_ids
+        .iter()
+        .filter_map(|tid| {
+            store::get_thread(tid).ok().flatten().map(|t| {
+                let sid = t
+                    .agent_session_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .unwrap_or(&t.id)
+                    .to_string();
+                (t.id.clone(), sid)
+            })
+        })
+        .collect();
+
+    let result = store::batch_delete_threads(&input)?;
+
+    // Delete agent session JSONLs for every thread (best-effort).
+    if let Ok(mut client) = crate::agent_bridge::connect_agent().await {
+        for (_, session_id) in &session_info {
+            let cmd = crate::agent_bridge::delete_session_command(session_id.clone());
+            let _ = client.execute_command(cmd).await;
+        }
+    }
+
+    Ok(result)
 }
 
 /// Bulk streaming-status query: ONE agent RPC (`list_streaming_sessions`,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -428,6 +428,7 @@ pub fn run() {
             archive_thread,
             restore_thread,
             delete_thread,
+            batch_delete_threads,
             fork_thread,
             get_session_entries,
             get_thread_agent_state,

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -61,10 +61,11 @@ pub use runs::{
     ToolOutputRecord,
 };
 pub use threads::{
-    archive_thread, create_thread, delete_thread, find_thread_by_agent_session, get_recent_thread,
-    get_thread, list_threads, move_thread_to_workspace, pin_thread, purge_soft_deleted_threads,
-    rename_thread, restore_thread, sync_thread_title, update_thread_model,
-    update_thread_session_id, update_thread_thinking_level, ThreadRecord,
+    archive_thread, batch_delete_threads, create_thread, delete_thread, delete_thread_with_files,
+    find_thread_by_agent_session, get_recent_thread, get_thread, list_threads,
+    move_thread_to_workspace, pin_thread, purge_soft_deleted_threads, rename_thread,
+    restore_thread, sync_thread_title, update_thread_model, update_thread_session_id,
+    update_thread_thinking_level, ThreadRecord,
 };
 pub use workspace_files::{search_workspace_files, WorkspaceFileResult, WorkspaceFileSearchInput};
 pub use workspaces::{

--- a/gui/src-tauri/src/store/records.rs
+++ b/gui/src-tauri/src/store/records.rs
@@ -266,6 +266,33 @@ pub struct PinThreadInput {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DeleteThreadInput {
+    pub thread_id: String,
+    /// For chat-mode threads only: also delete the temporary workspace
+    /// directory on disk. Ignored for workspace-mode threads.
+    #[serde(default)]
+    pub delete_files: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchDeleteThreadsInput {
+    pub thread_ids: Vec<String>,
+    /// For chat-mode threads only: also delete the temporary workspace
+    /// directory on disk. Ignored for workspace-mode threads.
+    #[serde(default)]
+    pub delete_files: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchDeleteResult {
+    pub deleted_count: usize,
+    pub failed: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RenameWorkspaceInput {
     pub workspace_id: String,
     pub name: String,

--- a/gui/src-tauri/src/store/threads.rs
+++ b/gui/src-tauri/src/store/threads.rs
@@ -361,7 +361,29 @@ pub(super) fn delete_thread_children_in(
 /// `commands::delete_thread`). Returns the pre-delete record so callers that
 /// expected the old soft-delete return value keep working. Temp chat workspaces
 /// are flagged for cleanup exactly as before.
+///
+/// When `delete_files` is true and the thread is chat-mode, the temporary
+/// workspace directory on disk is removed immediately instead of being flagged
+/// for background cleanup. Workspace-mode threads are never touched.
 pub fn delete_thread(thread_id: &str) -> Result<ThreadRecord, crate::AppError> {
+    delete_thread_inner(thread_id, false)
+}
+
+/// Like [`delete_thread`] but also removes the temporary chat workspace
+/// directory on disk when `delete_files` is true. Workspace-mode threads
+/// are never touched on disk regardless of this flag.
+pub fn delete_thread_with_files(
+    thread_id: &str,
+    delete_files: bool,
+) -> Result<ThreadRecord, crate::AppError> {
+    delete_thread_inner(thread_id, delete_files)
+}
+
+/// Internal helper with the `delete_files` flag (see [`delete_thread`]).
+pub(crate) fn delete_thread_inner(
+    thread_id: &str,
+    delete_files: bool,
+) -> Result<ThreadRecord, crate::AppError> {
     let now = now_millis();
     let mut conn = connect()?;
     let thread = loaded(get_thread(thread_id)?, "Thread")?;
@@ -372,21 +394,94 @@ pub fn delete_thread(thread_id: &str) -> Result<ThreadRecord, crate::AppError> {
     delete_thread_children_in(&tx, thread_id)?;
 
     if thread.mode == "chat" {
-        tx.execute(
-            "UPDATE workspaces
-             SET cleanup_status = 'pending_cleanup',
-                 cleanup_requested_at = COALESCE(cleanup_requested_at, ?1),
-                 updated_at = ?1
-             WHERE id = ?2
-               AND kind = 'temporary'
-               AND cleanup_status = 'active'",
-            params![now, thread.workspace_id],
-        )?;
+        if delete_files {
+            // Mark cleaned immediately (skip the pending_cleanup phase) so
+            // orphans reconcilers won't re-attempt the now-removed directory.
+            tx.execute(
+                "UPDATE workspaces
+                 SET cleanup_status = 'cleaned',
+                     cleanup_requested_at = COALESCE(cleanup_requested_at, ?1),
+                     cleaned_at = ?1,
+                     updated_at = ?1
+                 WHERE id = ?2
+                   AND kind = 'temporary'",
+                params![now, thread.workspace_id],
+            )?;
+        } else {
+            tx.execute(
+                "UPDATE workspaces
+                 SET cleanup_status = 'pending_cleanup',
+                     cleanup_requested_at = COALESCE(cleanup_requested_at, ?1),
+                     updated_at = ?1
+                 WHERE id = ?2
+                   AND kind = 'temporary'
+                   AND cleanup_status = 'active'",
+                params![now, thread.workspace_id],
+            )?;
+        }
     }
     tx.execute("DELETE FROM threads WHERE id = ?1", params![thread_id])?;
     tx.commit()?;
 
+    // Remove the directory on disk AFTER the transaction commits — if the
+    // directory deletion fails the DB row is already gone, which is the safer
+    // failure mode (side-effect-last).
+    if delete_files && thread.mode == "chat" {
+        // The workspace path for chat threads is the chat-workspace dir named
+        // after either the agent session id or the thread id.
+        let dir_key = thread
+            .agent_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .unwrap_or(thread_id);
+        let dir = super::db::chat_workspace_path(dir_key)?;
+        if dir.exists() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        // Also remove the legacy directory named after the thread id if it
+        // differs from the session id (migration edge case).
+        if dir_key != thread_id {
+            let legacy_dir = super::db::chat_workspace_path(thread_id)?;
+            if legacy_dir.exists() {
+                let _ = std::fs::remove_dir_all(&legacy_dir);
+            }
+        }
+    }
+
     Ok(thread)
+}
+
+/// Batch-delete multiple threads. For each thread:
+/// - The DB row and children are hard-deleted.
+/// - For chat-mode threads with `delete_files`, the temporary workspace
+///   directory on disk is removed.
+/// - For workspace-mode threads, only the DB row is deleted; files are never
+///   touched regardless of `delete_files`.
+///
+/// Each thread delete is independent — one failure does not roll back
+/// already-deleted siblings. Returns a summary.
+pub fn batch_delete_threads(
+    input: &super::records::BatchDeleteThreadsInput,
+) -> Result<super::records::BatchDeleteResult, crate::AppError> {
+    let mut deleted_count = 0usize;
+    let mut failed: Vec<String> = Vec::new();
+
+    for thread_id in &input.thread_ids {
+        match delete_thread_inner(thread_id, input.delete_files) {
+            Ok(_) => {
+                deleted_count += 1;
+            }
+            Err(error) => {
+                failed.push(format!("{thread_id}: {error}"));
+            }
+        }
+    }
+
+    Ok(super::records::BatchDeleteResult {
+        deleted_count,
+        failed,
+    })
 }
 
 /// Defensive / one-time sweep: hard-delete any threads still parked in the

--- a/gui/src/components/layout/ActivityRail.tsx
+++ b/gui/src/components/layout/ActivityRail.tsx
@@ -13,8 +13,10 @@ import {
   Smartphone,
   Sparkles,
   SquarePen,
+  Trash2,
+  X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useBuildInfo } from "../../integrations/tauri/useBuildInfo";
 import { cn } from "../../lib/cn";
@@ -22,9 +24,10 @@ import { isMacOS } from "../../lib/platform";
 import { useFloatingScrollbar } from "../../lib/useFloatingScrollbar";
 import { useIsFullscreen } from "../../lib/useIsFullscreen";
 import { startWindowDrag } from "../../lib/windowDrag";
+import { Button } from "../ui/Button";
 import { FloatingScrollbar } from "../ui/FloatingScrollbar";
 import { IconButton } from "../ui/IconButton";
-import { WorkspaceHeaderMenu } from "./ActivityRailMenus";
+import { ChatSectionMenu, WorkspaceHeaderMenu } from "./ActivityRailMenus";
 import { ThreadListItem } from "./ThreadListItem";
 
 export type ActivitySection = "chat" | "workspace" | "skill" | "remote" | "settings";
@@ -41,6 +44,7 @@ interface ActivityRailProps {
   unreadThreadIds: Set<string>;
   workspaces: StoredWorkspace[];
   onChange: (section: ActivitySection) => void;
+  onBatchDeleteThreads: (threads: StoredThread[]) => void;
   onDeleteThread: (thread: StoredThread) => void;
   onNewChat: (workspaceId?: string) => void;
   onOpenModels: () => void;
@@ -79,6 +83,7 @@ export function ActivityRail({
   unreadThreadIds,
   workspaces,
   onChange,
+  onBatchDeleteThreads,
   onDeleteThread,
   onNewChat,
   onOpenModels,
@@ -111,6 +116,12 @@ export function ActivityRail({
   // independent of the per-workspace group collapse above.
   const [workspaceSectionCollapsed, setWorkspaceSectionCollapsed] = useState(false);
   const [chatSectionCollapsed, setChatSectionCollapsed] = useState(false);
+  // Batch selection mode.
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectionScope, setSelectionScope] = useState<"chat" | string>("chat");
+  const [selectedThreadIds, setSelectedThreadIds] = useState<Set<string>>(() => new Set());
+  // Chat section header menu.
+  const [chatSectionMenuOpen, setChatSectionMenuOpen] = useState(false);
 
   function toggleWorkspaceCollapsed(workspaceId: string) {
     setCollapsedWorkspaces((current) => {
@@ -122,9 +133,88 @@ export function ActivityRail({
       return next;
     });
   }
+
+  function toggleThreadSelection(thread: StoredThread) {
+    setSelectedThreadIds((current) => {
+      const next = new Set(current);
+      if (next.has(thread.id)) {
+        next.delete(thread.id);
+      }
+      else {
+        next.add(thread.id);
+      }
+      return next;
+    });
+  }
+
+  function exitSelectionMode() {
+    setSelectionMode(false);
+    setSelectedThreadIds(new Set());
+  }
+
+  // Esc key exits selection mode.
+  useEffect(() => {
+    if (!selectionMode)
+      return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        exitSelectionMode();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectionMode]);
+
   const visibleThreads = sortThreads(
     threads.filter(thread => thread.status === "active"),
   );
+
+  // Scope-filtered threads for the current selection mode.
+  const scopedThreads = visibleThreads.filter((thread) => {
+    if (selectionScope === "chat")
+      return thread.mode === "chat";
+    return thread.mode === "workspace" && thread.workspaceId === selectionScope;
+  });
+
+  function enterChatSelectionMode() {
+    setSelectionScope("chat");
+    setSelectedThreadIds(new Set());
+    setSelectionMode(true);
+  }
+
+  function enterWorkspaceSelectionMode(workspaceId: string) {
+    setSelectionScope(workspaceId);
+    setSelectedThreadIds(new Set());
+    setSelectionMode(true);
+  }
+
+  function selectAll() {
+    setSelectedThreadIds(new Set(scopedThreads.map(t => t.id)));
+  }
+
+  function deselectAll() {
+    setSelectedThreadIds(new Set());
+  }
+
+  /** Whether a thread is selectable in the current selection scope. */
+  function isThreadInScope(thread: StoredThread) {
+    if (selectionScope === "chat")
+      return thread.mode === "chat";
+    return thread.mode === "workspace" && thread.workspaceId === selectionScope;
+  }
+
+  /** Whether this thread should show a selection checkbox. */
+  function threadSelectionMode(thread: StoredThread): boolean {
+    return selectionMode && isThreadInScope(thread);
+  }
+
+  function handleStartBatchDelete() {
+    const selectedThreads = visibleThreads.filter(t => selectedThreadIds.has(t.id));
+    if (selectedThreads.length === 0)
+      return;
+    onBatchDeleteThreads(selectedThreads);
+    exitSelectionMode();
+  }
   // Pinned threads are hoisted into a single global section (regardless of
   // workspace/chat); the per-group lists show only the unpinned rest.
   const pinnedThreads = visibleThreads.filter(thread => thread.pinned);
@@ -222,14 +312,17 @@ export function ActivityRail({
                                 key={thread.id}
                                 menuOpen={openThreadMenuId === thread.id}
                                 runStatus={threadRunStatuses[thread.id]}
+                                selected={selectedThreadIds.has(thread.id)}
+                                selectionMode={threadSelectionMode(thread)}
                                 thread={thread}
                                 unread={unreadThreadIds.has(thread.id)}
                                 onDeleteThread={onDeleteThread}
                                 onMenuOpenChange={open => setOpenThreadMenuId(open ? thread.id : null)}
                                 onRenameThread={onRenameThread}
                                 onRestoreThread={onRestoreThread}
-                                onSelectThread={onSelectThread}
+                                onSelectThread={selectionMode ? (isThreadInScope(thread) ? () => toggleThreadSelection(thread) : () => {}) : onSelectThread}
                                 onTogglePinThread={onTogglePinThread}
+                                onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
                               />
                             ))}
                           </div>
@@ -300,6 +393,7 @@ export function ActivityRail({
                                 onDelete={onDeleteWorkspace}
                                 onOpenChange={open => setOpenWorkspaceMenuId(open ? workspace.id : null)}
                                 onRename={onRenameWorkspace}
+                                onSelect={selectionMode ? undefined : () => enterWorkspaceSelectionMode(workspace.id)}
                               />
                               <button
                                 aria-label={t("activityRail.newChatInWorkspace", { name: workspace.name })}
@@ -321,6 +415,8 @@ export function ActivityRail({
                                         key={thread.id}
                                         menuOpen={openThreadMenuId === thread.id}
                                         runStatus={threadRunStatuses[thread.id]}
+                                        selected={selectedThreadIds.has(thread.id)}
+                                        selectionMode={threadSelectionMode(thread)}
                                         thread={thread}
                                         unread={unreadThreadIds.has(thread.id)}
                                         compact
@@ -328,8 +424,9 @@ export function ActivityRail({
                                         onMenuOpenChange={open => setOpenThreadMenuId(open ? thread.id : null)}
                                         onRenameThread={onRenameThread}
                                         onRestoreThread={onRestoreThread}
-                                        onSelectThread={onSelectThread}
+                                        onSelectThread={selectionMode ? (isThreadInScope(thread) ? () => toggleThreadSelection(thread) : () => {}) : onSelectThread}
                                         onTogglePinThread={onTogglePinThread}
+                                        onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
                                       />
                                     ))}
                                   </div>
@@ -350,6 +447,15 @@ export function ActivityRail({
                               : t("activityRail.collapseChatSection")}
                             onToggle={() => setChatSectionCollapsed(value => !value)}
                           />
+                          {!selectionMode
+                            ? (
+                                <ChatSectionMenu
+                                  open={chatSectionMenuOpen}
+                                  onOpenChange={setChatSectionMenuOpen}
+                                  onSelect={enterChatSelectionMode}
+                                />
+                              )
+                            : null}
                           <button
                             aria-label={t("activityRail.newChatShort")}
                             className="inline-flex size-5 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
@@ -372,17 +478,65 @@ export function ActivityRail({
                           menuOpen={openThreadMenuId === thread.id}
                           runStatus={threadRunStatuses[thread.id]}
                           isStreaming={threadStreamingStatuses[thread.id]}
+                          selected={selectedThreadIds.has(thread.id)}
+                          selectionMode={threadSelectionMode(thread)}
                           thread={thread}
                           unread={unreadThreadIds.has(thread.id)}
                           onDeleteThread={onDeleteThread}
                           onMenuOpenChange={open => setOpenThreadMenuId(open ? thread.id : null)}
                           onRenameThread={onRenameThread}
                           onRestoreThread={onRestoreThread}
-                          onSelectThread={onSelectThread}
+                          onSelectThread={selectionMode ? (isThreadInScope(thread) ? () => toggleThreadSelection(thread) : () => {}) : onSelectThread}
                           onTogglePinThread={onTogglePinThread}
+                          onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
                         />
                       ))}
                     </div>
+                    {/* Batch selection action bar. */}
+                    {selectionMode
+                      ? (
+                          <div className="sticky bottom-0 z-10 -mx-2 -mb-0.5 border-t border-line-soft bg-surface px-2 py-2">
+                            <div className="flex items-center gap-2">
+                              <SelectAllCheckbox
+                                checked={scopedThreads.length > 0 && selectedThreadIds.size === scopedThreads.length}
+                                indeterminate={selectedThreadIds.size > 0 && selectedThreadIds.size < scopedThreads.length}
+                                onChange={() => {
+                                  if (selectedThreadIds.size === scopedThreads.length) {
+                                    deselectAll();
+                                  }
+                                  else {
+                                    selectAll();
+                                  }
+                                }}
+                              />
+                              <span className="flex-1 text-xs text-ink-soft">
+                                {selectedThreadIds.size > 0
+                                  ? t("activityRail.threadsSelected", { count: selectedThreadIds.size })
+                                  : t("activityRail.selectAll")}
+                              </span>
+                              <Button
+                                disabled={selectedThreadIds.size === 0}
+                                leftIcon={<Trash2 className="size-3.5" />}
+                                onClick={handleStartBatchDelete}
+                                size="sm"
+                                type="button"
+                                variant="danger"
+                              >
+                                {t("activityRail.deleteSelected")}
+                              </Button>
+                              <Button
+                                leftIcon={<X className="size-3.5" />}
+                                onClick={exitSelectionMode}
+                                size="sm"
+                                type="button"
+                                variant="secondary"
+                              >
+                                {t("common:cancel")}
+                              </Button>
+                            </div>
+                          </div>
+                        )
+                      : null}
                   </div>
                   <FloatingScrollbar
                     scrollbar={listScrollbar.scrollbar}
@@ -491,6 +645,32 @@ function sortThreads(items: StoredThread[]) {
 
 function threadSortTime(thread: StoredThread) {
   return thread.lastMessageAt ?? thread.lastOpenedAt ?? thread.updatedAt ?? thread.createdAt;
+}
+
+/** Tri-state checkbox for select-all / deselect-all in the selection action bar. */
+function SelectAllCheckbox({
+  checked,
+  indeterminate,
+  onChange,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current)
+      ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      checked={checked}
+      className="size-4 shrink-0 rounded border-line accent-accent"
+      onChange={onChange}
+      type="checkbox"
+    />
+  );
 }
 
 /**

--- a/gui/src/components/layout/ActivityRailMenus.tsx
+++ b/gui/src/components/layout/ActivityRailMenus.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { StoredWorkspace } from "../../integrations/storage/threadStore";
-import { Archive, FolderOpen, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react";
+import { Archive, CheckSquare, FolderOpen, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { openPath } from "../../integrations/storage/files";
 import { cn } from "../../lib/cn";
@@ -61,9 +61,8 @@ export function ThreadItemMenu({
 }
 
 /**
- * Workspace-header actions dropdown (rename / reveal in file manager / delete).
- * Open state is controlled by the caller so the same menu can be triggered from
- * either the `...` button or a right-click on the workspace row.
+ * Workspace-header actions dropdown (rename / reveal in file manager /
+ * select conversations / delete).
  */
 export function WorkspaceHeaderMenu({
   workspace,
@@ -71,16 +70,16 @@ export function WorkspaceHeaderMenu({
   onDelete,
   onOpenChange,
   onRename,
+  onSelect,
 }: {
   workspace: StoredWorkspace;
   open: boolean;
   onDelete: (workspace: StoredWorkspace) => void;
   onOpenChange: (open: boolean) => void;
   onRename: (workspace: StoredWorkspace) => void;
+  onSelect?: () => void;
 }) {
   const { t } = useTranslation("layout");
-  // Label follows OS convention: Finder (macOS) / File Explorer (Windows) /
-  // File Manager (Linux and other).
   const revealLabel = t("activityRail.revealInFinder");
   const layerRef = useDismissableLayer<HTMLDivElement>({ enabled: open, onDismiss: () => onOpenChange(false) });
   const { menuRef, dropUp } = useDropUpMenu(open);
@@ -117,8 +116,64 @@ export function WorkspaceHeaderMenu({
               <ThreadMenuItem icon={<FolderOpen className="size-3.5" />} onClick={() => void openPath(workspace.path).catch(() => {})} onClose={() => onOpenChange(false)}>
                 {revealLabel}
               </ThreadMenuItem>
+              {onSelect
+                ? (
+                    <ThreadMenuItem icon={<CheckSquare className="size-3.5" />} onClick={onSelect} onClose={() => onOpenChange(false)}>
+                      {t("activityRail.selectThreads")}
+                    </ThreadMenuItem>
+                  )
+                : null}
               <ThreadMenuItem danger icon={<Trash2 className="size-3.5" />} onClick={() => onDelete(workspace)} onClose={() => onOpenChange(false)}>
                 {t("activityRail.delete")}
+              </ThreadMenuItem>
+            </MenuPanel>
+          )
+        : null}
+    </div>
+  );
+}
+
+/**
+ * Chat section header menu: select conversations for batch deletion.
+ */
+export function ChatSectionMenu({
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: () => void;
+}) {
+  const { t } = useTranslation("layout");
+  const layerRef = useDismissableLayer<HTMLDivElement>({ enabled: open, onDismiss: () => onOpenChange(false) });
+  const { menuRef, dropUp } = useDropUpMenu(open);
+
+  return (
+    <div className="relative" ref={layerRef}>
+      <button
+        aria-label={t("activityRail.chatSectionActions")}
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenChange(!open);
+        }}
+        title={t("activityRail.chatSectionActions")}
+        type="button"
+      >
+        <MoreHorizontal className="size-3.5" />
+      </button>
+      {open
+        ? (
+            <MenuPanel
+              ref={menuRef}
+              className={cn(
+                "absolute right-0 z-40 w-max min-w-36 p-1",
+                dropUp ? "bottom-7" : "top-7",
+              )}
+            >
+              <ThreadMenuItem icon={<CheckSquare className="size-3.5" />} onClick={onSelect} onClose={() => onOpenChange(false)}>
+                {t("activityRail.selectThreads")}
               </ThreadMenuItem>
             </MenuPanel>
           )

--- a/gui/src/components/layout/AppShell.tsx
+++ b/gui/src/components/layout/AppShell.tsx
@@ -180,12 +180,16 @@ export function AppShell() {
   const {
     renameDialog,
     deleteDialog,
+    batchDeleteDialog,
     setRenameDialog,
     setDeleteDialog,
+    setBatchDeleteDialog,
     openRename,
     confirmRename,
     openDelete,
     confirmDelete,
+    openBatchDelete,
+    confirmBatchDelete,
   } = useThreadDialogs({ activeThreadId, refreshStore });
   const {
     renameDialog: workspaceRenameDialog,
@@ -348,6 +352,7 @@ export function AppShell() {
     onOpenModels: handleOpenModels,
     onNewChat: handleOpenNewChat,
     onNewWorkspace: handleOpenNewWorkspace,
+    onBatchDeleteThreads: openBatchDelete,
     onDeleteThread: openDelete,
     onRenameThread: openRename,
     onDeleteWorkspace: openWorkspaceDelete,
@@ -476,10 +481,13 @@ export function AppShell() {
         ? <div className="fixed inset-0 z-50 cursor-ew-resize select-none" />
         : null}
       <AppShellDialogs
+        batchDeleteDialog={batchDeleteDialog}
         deleteDialog={deleteDialog}
         renameDialog={renameDialog}
+        setBatchDeleteDialog={setBatchDeleteDialog}
         setDeleteDialog={setDeleteDialog}
         setRenameDialog={setRenameDialog}
+        onConfirmBatchDeleteThread={() => void confirmBatchDelete()}
         onConfirmDeleteThread={() => void confirmDelete()}
         onConfirmRenameThread={() => void confirmRename()}
       />

--- a/gui/src/components/layout/AppShellDialogs.tsx
+++ b/gui/src/components/layout/AppShellDialogs.tsx
@@ -18,20 +18,35 @@ export interface RenameDialogState {
   value: string;
 }
 
+export interface BatchDeleteDialogState {
+  error: string | null;
+  submitting: boolean;
+  deleteFiles: boolean;
+  threads: StoredThread[];
+  chatThreadCount: number;
+  workspaceThreadCount: number;
+}
+
 interface AppShellDialogsProps {
+  batchDeleteDialog: BatchDeleteDialogState | null;
   deleteDialog: DeleteDialogState | null;
+  onConfirmBatchDeleteThread: () => void;
   onConfirmDeleteThread: () => void;
   onConfirmRenameThread: () => void;
   renameDialog: RenameDialogState | null;
+  setBatchDeleteDialog: Dispatch<SetStateAction<BatchDeleteDialogState | null>>;
   setDeleteDialog: Dispatch<SetStateAction<DeleteDialogState | null>>;
   setRenameDialog: Dispatch<SetStateAction<RenameDialogState | null>>;
 }
 
 export function AppShellDialogs({
+  batchDeleteDialog,
   deleteDialog,
+  onConfirmBatchDeleteThread,
   onConfirmDeleteThread,
   onConfirmRenameThread,
   renameDialog,
+  setBatchDeleteDialog,
   setDeleteDialog,
   setRenameDialog,
 }: AppShellDialogsProps) {
@@ -71,6 +86,62 @@ export function AppShellDialogs({
             : null}
         </div>
       </ConfirmDeleteDialog>
+      <ConfirmDeleteDialog
+        description={batchDeleteDialog ? batchDeleteDescription(batchDeleteDialog, t) : undefined}
+        error={batchDeleteDialog?.error ?? null}
+        onClose={() => setBatchDeleteDialog(null)}
+        onConfirm={onConfirmBatchDeleteThread}
+        open={Boolean(batchDeleteDialog)}
+        submitting={batchDeleteDialog?.submitting ?? false}
+        title={t("appShellDialogs.batchDeleteTitle")}
+      >
+        {batchDeleteDialog
+          ? (
+              <div className="space-y-3">
+                <div className="rounded-md border border-line-soft bg-surface-subtle p-3 text-sm text-ink">
+                  <div className="mb-1 font-medium">{t("appShellDialogs.batchDeleteSummary", { count: batchDeleteDialog.threads.length })}</div>
+                  <ul className="list-inside list-disc space-y-0.5 text-ink-soft">
+                    {batchDeleteDialog.threads.slice(0, 5).map(thread => (
+                      <li key={thread.id} className="truncate">{thread.title}</li>
+                    ))}
+                    {batchDeleteDialog.threads.length > 5
+                      ? (
+                          <li className="text-ink-muted">
+                            {t("appShellDialogs.andMore", { count: batchDeleteDialog.threads.length - 5 })}
+                          </li>
+                        )
+                      : null}
+                  </ul>
+                </div>
+                {batchDeleteDialog.workspaceThreadCount > 0
+                  ? (
+                      <div className="rounded-md border border-line-soft bg-surface px-3 py-2 text-xs text-ink-soft">
+                        {t("appShellDialogs.workspaceFilesUnaffected", { count: batchDeleteDialog.workspaceThreadCount })}
+                      </div>
+                    )
+                  : null}
+                {batchDeleteDialog.chatThreadCount > 0
+                  ? (
+                      <label className="flex cursor-pointer items-center gap-2 rounded-md border border-line-soft bg-surface px-3 py-2">
+                        <input
+                          checked={batchDeleteDialog.deleteFiles}
+                          className="size-4 shrink-0 rounded border-line accent-accent"
+                          disabled={batchDeleteDialog.submitting}
+                          onChange={event =>
+                            setBatchDeleteDialog(current =>
+                              current ? { ...current, deleteFiles: event.target.checked } : current)}
+                          type="checkbox"
+                        />
+                        <span className="text-sm text-ink-soft">
+                          {t("appShellDialogs.deleteAssociatedFiles", { count: batchDeleteDialog.chatThreadCount })}
+                        </span>
+                      </label>
+                    )
+                  : null}
+              </div>
+            )
+          : null}
+      </ConfirmDeleteDialog>
     </>
   );
 }
@@ -85,10 +156,23 @@ function ArtifactCount({ count }: { count: number }) {
   );
 }
 
-function deleteThreadDescription(thread: StoredThread, t: (key: string) => string) {
+function deleteThreadDescription(thread: StoredThread, t: (key: string, options?: Record<string, unknown>) => string) {
   if (thread.mode === "workspace") {
     return t("appShellDialogs.deleteWorkspaceDescription");
   }
 
+  return t("appShellDialogs.deleteChatDescription");
+}
+
+function batchDeleteDescription(state: BatchDeleteDialogState, t: (key: string, options?: Record<string, unknown>) => string) {
+  if (state.workspaceThreadCount > 0 && state.chatThreadCount > 0) {
+    return t("appShellDialogs.batchDeleteMixedDescription", {
+      chatCount: state.chatThreadCount,
+      wsCount: state.workspaceThreadCount,
+    });
+  }
+  if (state.workspaceThreadCount > 0) {
+    return t("appShellDialogs.deleteWorkspaceDescription");
+  }
   return t("appShellDialogs.deleteChatDescription");
 }

--- a/gui/src/components/layout/ThreadListItem.tsx
+++ b/gui/src/components/layout/ThreadListItem.tsx
@@ -7,7 +7,10 @@ import { cn } from "../../lib/cn";
 import { useDismissableLayer } from "../../lib/useDismissableLayer";
 import { ThreadItemMenu } from "./ActivityRailMenus";
 
-/** A single sidebar thread row: title, run/unread indicator, and actions menu. */
+/**
+ * A single sidebar thread row: title, run/unread indicator, and actions menu.
+ * When the sidebar is in selection mode, a checkbox replaces the run indicator.
+ */
 export function ThreadListItem({
   active,
   archived,
@@ -15,6 +18,8 @@ export function ThreadListItem({
   isStreaming,
   menuOpen,
   runStatus,
+  selected,
+  selectionMode,
   thread,
   unread,
   onDeleteThread,
@@ -23,6 +28,7 @@ export function ThreadListItem({
   onRestoreThread,
   onSelectThread,
   onTogglePinThread,
+  onToggleSelection,
 }: {
   active: boolean;
   archived?: boolean;
@@ -31,6 +37,8 @@ export function ThreadListItem({
   isStreaming?: boolean;
   menuOpen: boolean;
   runStatus?: ThreadRunInfo;
+  selected?: boolean;
+  selectionMode?: boolean;
   thread: StoredThread;
   unread?: boolean;
   onDeleteThread: (thread: StoredThread) => void;
@@ -39,6 +47,7 @@ export function ThreadListItem({
   onRestoreThread: (thread: StoredThread) => void;
   onSelectThread: (thread: StoredThread) => void;
   onTogglePinThread: (thread: StoredThread) => void;
+  onToggleSelection?: (thread: StoredThread) => void;
 }) {
   const { t } = useTranslation("layout");
   const menuRef = useDismissableLayer<HTMLDivElement>({
@@ -102,24 +111,53 @@ export function ThreadListItem({
         {displayTitle}
       </span>
       {archived ? <span className="pointer-events-none shrink-0 text-[11px] text-ink-muted group-hover/thread:hidden">{t("activityRail.archived")}</span> : null}
-      <span className="pointer-events-none flex shrink-0">
-        <ThreadRunIndicator status={effectiveRunStatus} unread={unread} />
-      </span>
-      <button
-        aria-label={t("activityRail.threadActions", { title: displayTitle })}
-        className={cn(
-          "relative z-10 hidden size-5 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft group-hover/thread:inline-flex",
-          menuOpen && "inline-flex",
-        )}
-        onClick={(event) => {
-          event.stopPropagation();
-          onMenuOpenChange(!menuOpen);
-        }}
-        title={t("activityRail.threadActions", { title: displayTitle })}
-        type="button"
-      >
-        <MoreHorizontal className="size-3.5" />
-      </button>
+      {selectionMode
+        ? (
+            <button
+              aria-label={t("activityRail.selectThread", { title: displayTitle })}
+              className={cn(
+                "relative z-10 flex size-5 shrink-0 items-center justify-center rounded transition-colors",
+                selected
+                  ? "bg-accent text-white"
+                  : "border border-line-soft text-transparent hover:border-line",
+              )}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleSelection?.(thread);
+              }}
+              type="button"
+            >
+              {selected
+                ? (
+                    <svg className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )
+                : null}
+            </button>
+          )
+        : (
+            <>
+              <span className="pointer-events-none flex shrink-0">
+                <ThreadRunIndicator status={effectiveRunStatus} unread={unread} />
+              </span>
+              <button
+                aria-label={t("activityRail.threadActions", { title: displayTitle })}
+                className={cn(
+                  "relative z-10 hidden size-5 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft group-hover/thread:inline-flex",
+                  menuOpen && "inline-flex",
+                )}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onMenuOpenChange(!menuOpen);
+                }}
+                title={t("activityRail.threadActions", { title: displayTitle })}
+                type="button"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </button>
+            </>
+          )}
       {menuOpen
         ? (
             <ThreadItemMenu

--- a/gui/src/components/layout/hooks/useThreadDialogs.ts
+++ b/gui/src/components/layout/hooks/useThreadDialogs.ts
@@ -1,10 +1,10 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { StoredThread } from "../../../integrations/storage/threadStore";
-import type { DeleteDialogState, RenameDialogState } from "../AppShellDialogs";
+import type { BatchDeleteDialogState, DeleteDialogState, RenameDialogState } from "../AppShellDialogs";
 import { useState } from "react";
 import i18n from "../../../i18n";
 import { invalidateAgentState, prefetchAgentState } from "../../../integrations/agent/agentStateCache";
-import { deleteThread, getThreadCleanupSummary, renameThread } from "../../../integrations/storage/threadStore";
+import { batchDeleteThreads, deleteThread, getThreadCleanupSummary, renameThread } from "../../../integrations/storage/threadStore";
 import { errorMessage } from "../../../lib/errors";
 
 interface UseThreadDialogsParams {
@@ -15,12 +15,16 @@ interface UseThreadDialogsParams {
 export interface ThreadDialogs {
   renameDialog: RenameDialogState | null;
   deleteDialog: DeleteDialogState | null;
+  batchDeleteDialog: BatchDeleteDialogState | null;
   setRenameDialog: Dispatch<SetStateAction<RenameDialogState | null>>;
   setDeleteDialog: Dispatch<SetStateAction<DeleteDialogState | null>>;
+  setBatchDeleteDialog: Dispatch<SetStateAction<BatchDeleteDialogState | null>>;
   openRename: (thread: StoredThread) => void;
   confirmRename: () => Promise<void>;
   openDelete: (thread: StoredThread) => void;
   confirmDelete: () => Promise<void>;
+  openBatchDelete: (threads: StoredThread[]) => void;
+  confirmBatchDelete: () => Promise<void>;
 }
 
 /**
@@ -31,6 +35,7 @@ export interface ThreadDialogs {
 export function useThreadDialogs({ activeThreadId, refreshStore }: UseThreadDialogsParams): ThreadDialogs {
   const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState | null>(null);
   const [renameDialog, setRenameDialog] = useState<RenameDialogState | null>(null);
+  const [batchDeleteDialog, setBatchDeleteDialog] = useState<BatchDeleteDialogState | null>(null);
 
   function openRename(thread: StoredThread) {
     setRenameDialog({
@@ -110,7 +115,7 @@ export function useThreadDialogs({ activeThreadId, refreshStore }: UseThreadDial
 
     setDeleteDialog(current => current ? { ...current, error: null, submitting: true } : current);
     try {
-      await deleteThread(deleteDialog.thread.id);
+      await deleteThread({ threadId: deleteDialog.thread.id, deleteFiles: false });
       await refreshStore(deleteDialog.thread.id === activeThreadId ? undefined : activeThreadId ?? undefined);
       setDeleteDialog(null);
     }
@@ -127,14 +132,62 @@ export function useThreadDialogs({ activeThreadId, refreshStore }: UseThreadDial
     }
   }
 
+  function openBatchDelete(threads: StoredThread[]) {
+    const chatThreads = threads.filter(t => t.mode === "chat");
+    const workspaceThreads = threads.filter(t => t.mode === "workspace");
+    setBatchDeleteDialog({
+      error: null,
+      submitting: false,
+      deleteFiles: false,
+      threads,
+      chatThreadCount: chatThreads.length,
+      workspaceThreadCount: workspaceThreads.length,
+    });
+  }
+
+  async function confirmBatchDelete() {
+    if (!batchDeleteDialog || batchDeleteDialog.submitting)
+      return;
+
+    setBatchDeleteDialog(current => current ? { ...current, error: null, submitting: true } : current);
+    try {
+      const threadIds = batchDeleteDialog.threads.map(t => t.id);
+      await batchDeleteThreads({
+        threadIds,
+        deleteFiles: batchDeleteDialog.deleteFiles,
+      });
+      // Invalidate caches for all deleted threads.
+      for (const threadId of threadIds) {
+        invalidateAgentState(threadId);
+      }
+      await refreshStore();
+      setBatchDeleteDialog(null);
+    }
+    catch (error) {
+      setBatchDeleteDialog(current =>
+        current
+          ? {
+              ...current,
+              error: errorMessage(error),
+              submitting: false,
+            }
+          : current,
+      );
+    }
+  }
+
   return {
     renameDialog,
     deleteDialog,
+    batchDeleteDialog,
     setRenameDialog,
     setDeleteDialog,
+    setBatchDeleteDialog,
     openRename,
     confirmRename,
     openDelete,
     confirmDelete,
+    openBatchDelete,
+    confirmBatchDelete,
   };
 }

--- a/gui/src/features/agent/AgentActivityList.tsx
+++ b/gui/src/features/agent/AgentActivityList.tsx
@@ -209,13 +209,21 @@ function labelForActivity(item: AgentActivityItem) {
 
   switch (item.kind) {
     case "read":
-      return i18n.t("agent:activity.read", { prefix });
+      return item.status === "completed"
+        ? i18n.t("agent:activity.readCompleted")
+        : i18n.t("agent:activity.read", { prefix });
     case "shell":
-      return i18n.t("agent:activity.run", { prefix });
+      return item.status === "completed"
+        ? i18n.t("agent:activity.runCompleted")
+        : i18n.t("agent:activity.run", { prefix });
     case "write":
-      return i18n.t("agent:activity.write", { prefix });
+      return item.status === "completed"
+        ? i18n.t("agent:activity.writeCompleted")
+        : i18n.t("agent:activity.write", { prefix });
     case "edit":
-      return i18n.t("agent:activity.edit", { prefix });
+      return item.status === "completed"
+        ? i18n.t("agent:activity.editCompleted")
+        : i18n.t("agent:activity.edit", { prefix });
   }
 }
 

--- a/gui/src/features/agent/buildContinuePrompt.ts
+++ b/gui/src/features/agent/buildContinuePrompt.ts
@@ -11,23 +11,15 @@ import { previousUserMessageBefore } from "./agentMessageFormatters";
  */
 export function buildContinuePrompt({
   message,
-  runId,
+  runId: _runId,
   summary,
 }: {
   message?: AgentMessage;
   runId?: string;
   summary?: string;
 }) {
-  const effectiveRunId = runId ?? message?.runId ?? null;
-  const lines = [
-    "继续上一个任务。",
-    "请基于当前线程、最近一次运行状态和工作区当前文件状态继续推进。",
-    "不要重复执行已经成功完成的副作用操作；如果需要再次写入、删除、执行复杂命令，请先说明原因并遵守审批策略。",
-  ];
+  const lines = ["继续上一个任务。"];
 
-  if (effectiveRunId) {
-    lines.push("", `最近 Run: ${effectiveRunId}`);
-  }
   if (message?.content?.trim()) {
     lines.push("", "上一条失败消息摘要:", truncate(message.content.trim(), 1200));
   }

--- a/gui/src/i18n/locales/en/agent.json
+++ b/gui/src/i18n/locales/en/agent.json
@@ -1,7 +1,7 @@
 {
   "author": {
     "you": "You",
-    "researchCopilot": "Future Copilot",
+    "researchCopilot": "FutureOS",
     "system": "FutureOS"
   },
   "activity": {
@@ -18,10 +18,14 @@
     "editFiles_other": "{{prefix}}{{count}} files edited",
     "readFiles_one": "{{prefix}}{{count}} file read",
     "readFiles_other": "{{prefix}}{{count}} files read",
-    "read": "{{prefix}}read",
-    "run": "{{prefix}}run",
-    "write": "{{prefix}}write",
-    "edit": "{{prefix}}edit",
+    "read": "{{prefix}}reading",
+    "run": "{{prefix}}command",
+    "write": "{{prefix}}writing",
+    "edit": "{{prefix}}editing",
+    "readCompleted": "Read a file",
+    "runCompleted": "Ran a command",
+    "writeCompleted": "Wrote a file",
+    "editCompleted": "Edited a file",
     "failed": {
       "shell": "Command failed",
       "edit": "Edit failed",
@@ -76,7 +80,7 @@
     }
   },
   "composer": {
-    "placeholder": "Ask Future Copilot to plan, research, analyze, edit, or prepare a workflow...",
+    "placeholder": "Ask FutureOS to plan, research, analyze, edit, or prepare a workflow...",
     "attachFiles": "Attach files",
     "attachFilesHint": "Attach files (images, PDF, text)",
     "attachLimitReached": "Attachment limit reached (4 per turn)",
@@ -130,7 +134,7 @@
     "headerTitle": "New conversation",
     "chatSubtitle": "Chat",
     "welcome": "Welcome",
-    "placeholder": "Ask Future Copilot to plan, research, analyze, edit, or prepare a workflow...",
+    "placeholder": "Ask FutureOS to plan, research, analyze, edit, or prepare a workflow...",
     "workspace": "Workspace",
     "noWorkspaces": "No workspaces yet.",
     "openExisting": "Open workspace",

--- a/gui/src/i18n/locales/en/layout.json
+++ b/gui/src/i18n/locales/en/layout.json
@@ -41,7 +41,14 @@
     "delete": "Delete",
     "revealInFinder": "Open Folder",
     "workspaceActions": "Workspace actions for {{name}}",
-    "pinnedHeader": "Pinned"
+    "pinnedHeader": "Pinned",
+    "selectThreads": "Select conversations...",
+    "selectThread": "Select {{title}}",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "chatSectionActions": "Chat section actions",
+    "threadsSelected": "{{count}} selected",
+    "deleteSelected": "Delete selected"
   },
   "appShell": {
     "storeInitFailed": "FutureOS local storage failed to initialize: ",
@@ -58,7 +65,14 @@
     "deleting": "Deleting...",
     "artifacts": "Artifacts",
     "deleteWorkspaceDescription": "This removes only the chat. Workspace files will not be changed.",
-    "deleteChatDescription": "This chat will be removed from the sidebar."
+    "deleteChatDescription": "This chat will be removed from the sidebar.",
+    "batchDeleteTitle": "Delete Conversations",
+    "batchDeleteSummary": "{{count}} conversation(s) selected",
+    "batchDeleteMixedDescription": "{{chatCount}} chat(s) and {{wsCount}} workspace conversation(s) will be removed from the sidebar. Workspace files are not affected.",
+    "andMore": "and {{count}} more",
+    "workspaceFilesUnaffected": "{{count}} workspace conversation(s): files on disk will not be deleted.",
+    "deleteAssociatedFiles": "Also delete associated file content for {{count}} chat(s)",
+    "deleteAssociatedFiles_other": "Also delete associated file content for {{count}} chat(s)"
   },
   "contextPanel": {
     "runs": "Runs",

--- a/gui/src/i18n/locales/zh/agent.json
+++ b/gui/src/i18n/locales/zh/agent.json
@@ -18,6 +18,10 @@
     "run": "{{prefix}}运行",
     "write": "{{prefix}}写入",
     "edit": "{{prefix}}编辑",
+    "readCompleted": "已读取",
+    "runCompleted": "已运行",
+    "writeCompleted": "已写入",
+    "editCompleted": "已编辑",
     "failed": {
       "shell": "运行失败",
       "edit": "编辑失败",

--- a/gui/src/i18n/locales/zh/layout.json
+++ b/gui/src/i18n/locales/zh/layout.json
@@ -41,7 +41,14 @@
     "delete": "删除",
     "revealInFinder": "打开文件夹",
     "workspaceActions": "{{name}} 的操作",
-    "pinnedHeader": "置顶"
+    "pinnedHeader": "置顶",
+    "selectThreads": "选择对话…",
+    "selectThread": "选择 {{title}}",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "chatSectionActions": "对话区操作",
+    "threadsSelected": "已选择 {{count}} 个",
+    "deleteSelected": "删除所选"
   },
   "appShell": {
     "storeInitFailed": "FutureOS 本地存储初始化失败：",
@@ -58,7 +65,14 @@
     "deleting": "删除中…",
     "artifacts": "Artifacts",
     "deleteWorkspaceDescription": "仅删除此对话，工作区文件不会被更改。",
-    "deleteChatDescription": "此对话将从侧边栏移除。"
+    "deleteChatDescription": "此对话将从侧边栏移除。",
+    "batchDeleteTitle": "删除对话",
+    "batchDeleteSummary": "已选择 {{count}} 个对话",
+    "batchDeleteMixedDescription": "{{chatCount}} 个普通对话和 {{wsCount}} 个工作区对话将从侧边栏移除。工作区文件不受影响。",
+    "andMore": "以及其他 {{count}} 个",
+    "workspaceFilesUnaffected": "{{count}} 个工作区对话：磁盘上的文件不会被删除。",
+    "deleteAssociatedFiles": "同时删除 {{count}} 个对话的相关文件内容",
+    "deleteAssociatedFiles_other": "同时删除 {{count}} 个对话的相关文件内容"
   },
   "contextPanel": {
     "runs": "运行",

--- a/gui/src/integrations/storage/threads.ts
+++ b/gui/src/integrations/storage/threads.ts
@@ -111,8 +111,12 @@ export async function restoreThread(threadId: string) {
   return invokeCommand<StoredThread>("restore_thread", { threadId });
 }
 
-export async function deleteThread(threadId: string) {
-  return invokeCommand<StoredThread>("delete_thread", { threadId });
+export async function deleteThread(input: { threadId: string; deleteFiles?: boolean }) {
+  return invokeCommand<StoredThread>("delete_thread", { input });
+}
+
+export async function batchDeleteThreads(input: { threadIds: string[]; deleteFiles?: boolean }) {
+  return invokeCommand<{ deletedCount: number; failed: string[] }>("batch_delete_threads", { input });
 }
 
 export async function getThreadCleanupSummary(threadId: string) {


### PR DESCRIPTION
## Summary

- **Batch delete**: Select multiple conversations in the sidebar via section header menus, scoped to chat or workspace threads. Bottom action bar with tri-state select-all checkbox, delete button, and cancel (Esc).
- **File cleanup**: Backend `delete_thread` accepts `deleteFiles` flag. `batch_delete_threads` deletes multiple threads + agent sessions at once. When checked, the temp workspace directory (`~/.future/workspaces/chat/<id>/`) is removed.
- **Continue prompt**: Simplified to single line — "Continue the previous task."
- **English labels**: Fixed awkward tool-call labels ("Ran run" → "Ran a command", etc.). AI author name changed from "Future Copilot" to "FutureOS".
- **i18n**: New keys added to both en/zh locales.