### PR TITLE
fix: resolve default model for sessions created before login

### DIFF
--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -158,7 +158,7 @@ impl AppState {
                 // Session created before login — resolve and apply default model.
                 // Re-check emptiness inside the write lock to avoid TOCTOU: another
                 // thread may have set a model between our read and write locks.
-                if let Ok(mut session) = sess.try_write() {
+                if let Some(mut session) = sess.try_write() {
                     if session.model.is_empty() {
                         let registry = self.model_registry.read();
                         let default_model =

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -146,10 +146,34 @@ impl AppState {
     /// running session keeps using a stale key. Sessions actively streaming are
     /// skipped by `reload_credentials` and pick up the new key on their next
     /// `set_model`.
+    ///
+    /// Sessions that were created before any credentials existed (model is empty)
+    /// get a default model resolved and applied, so the user can prompt immediately
+    /// after login without switching threads.
     pub fn reload_all_credentials(&self) {
         let sessions = self.sessions.read();
         for sess in sessions.values() {
-            sess.read().reload_credentials();
+            let model_is_empty = { sess.read().model.is_empty() };
+            if model_is_empty {
+                // Session created before login — resolve and apply default model.
+                // Re-check emptiness inside the write lock to avoid TOCTOU: another
+                // thread may have set a model between our read and write locks.
+                if let Ok(mut session) = sess.try_write() {
+                    if session.model.is_empty() {
+                        let registry = self.model_registry.read();
+                        let default_model =
+                            crate::models::get_default_model_with(&registry).unwrap_or_default();
+                        if !default_model.is_empty() {
+                            let _ = session.set_model(&default_model);
+                        }
+                    } else {
+                        // Model was set concurrently — just refresh credentials
+                        session.reload_credentials();
+                    }
+                }
+            } else {
+                sess.read().reload_credentials();
+            }
         }
     }
 }


### PR DESCRIPTION
## 问题

GUI 客户端首次登录后，默认打开的会话对话提示「密钥无效或已过期」。切换到其他会话正常。

## 根因

时序问题：

1. Agent 启动时无 auth.json → 创建默认 session（model 为空）
2. 用户登录 → auth.json 写入 → `reload_agent_credentials()` 调用
3. `reload_credentials()` 对空 model session 直接 return（跳过刷新）
4. 用户发消息 → session 已存在 → `set_model` 不触发 → 无 API key → 报错

## 修复

`reload_all_credentials()` 中，对 model 为空的 session 不再跳过，而是解析默认模型并调 `set_model`（完整走 API key 解析路径）。

写锁内重新检查 `model.is_empty()` 防止 TOCTOU 竞态。

## 改动

`agent/src/rpc/mod.rs` — `reload_all_credentials()` 方法