### PR TITLE
feat: inject session ID into system prompt for model self-awareness

### DIFF
--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -85,9 +85,9 @@ pub fn build_prompt(opts: &PromptOptions) -> String {
         sections.push(opts.append_prompt.clone());
     }
 
-    // 6. Environment: date, working directory, and host platform — always
-    //    included so the model generates platform-appropriate shell commands
-    //    and paths.
+    // 6. Environment: date, working directory, host platform, and session info
+    //    — always included so the model generates platform-appropriate shell
+    //    commands, paths, and can self-identify its own session.
     {
         let mut info = vec!["# Environment".to_string(), String::new()];
         if !opts.date.is_empty() {
@@ -102,6 +102,15 @@ pub fn build_prompt(opts: &PromptOptions) -> String {
                 "When looking for a file, search within the current working directory \
                  first; only widen the search to the rest of the filesystem if it is \
                  clearly not there. Avoid scanning the entire filesystem up front."
+                    .to_string(),
+            );
+        }
+        if !opts.session_id.is_empty() {
+            info.push(format!("Current session ID: {}", opts.session_id));
+            info.push(
+                "You can reference this session ID when you need to identify or \
+                 report which conversation you are part of. This is your own \
+                 session — you are self-aware of this identifier."
                     .to_string(),
             );
         }
@@ -126,6 +135,9 @@ pub struct PromptOptions {
     pub memory_content: String,
     pub append_prompt: String,
     pub prompt_guidelines: Vec<String>,
+    /// Session ID — injected into the environment section so the model can
+    /// self-identify and reference its own conversation.
+    pub session_id: String,
 }
 
 // ─── Identity Section ───────────────────────────────────────────────────────

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -1368,7 +1368,11 @@ fn cmd_reload_config(
                 );
             }
         };
-        (sess.cwd.clone(), loop_.tools.clone(), sess.session_id.clone())
+        (
+            sess.cwd.clone(),
+            loop_.tools.clone(),
+            sess.session_id.clone(),
+        )
     };
 
     // Re-discover skills (blocking I/O, no locks held).  Invalidate the

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -1356,7 +1356,7 @@ fn cmd_reload_config(
     id: &str,
 ) -> String {
     // Re-discover skills and re-read context files, then rebuild system prompt.
-    let (cwd, tools) = {
+    let (cwd, tools, session_id) = {
         let sess = rlock!(session, id);
         let loop_ = match sess.agent_loop.try_read() {
             Ok(l) => l,
@@ -1368,7 +1368,7 @@ fn cmd_reload_config(
                 );
             }
         };
-        (sess.cwd.clone(), loop_.tools.clone())
+        (sess.cwd.clone(), loop_.tools.clone(), sess.session_id.clone())
     };
 
     // Re-discover skills (blocking I/O, no locks held).  Invalidate the
@@ -1402,6 +1402,7 @@ fn cmd_reload_config(
         tools: tools.clone(),
         skills: skills.clone(),
         agent_content: agent_content.clone(),
+        session_id: session_id.clone(),
         ..Default::default()
     });
 

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -735,6 +735,7 @@ impl ServerSession {
             skills,
             agent_content,
             memory_content,
+            session_id: self.session_id.clone(),
             prompt_guidelines: vec![
                 // The write-via-shell prohibition is platform-neutral, but its
                 // examples must name the redirection forms the host's shell


### PR DESCRIPTION
## Summary

Add `session_id` to system prompt so the model can self-identify its own conversation session.

## Changes

- **`agent/src/prompt/mod.rs`**: Add `session_id` field to `PromptOptions` and inject it into the Environment section of the system prompt
- **`agent/src/rpc/commands.rs`**: Pass `session_id` when rebuilding prompt in `cmd_reload_config`
- **`agent/src/rpc/session_prompt.rs`**: Pass `self.session_id` when constructing prompt options

## Motivation

This allows the model to reference its own session ID when needed (e.g., for debugging, logging, or identifying the conversation context).