### PR TITLE
fix(agent): skills install/uninstall now refresh; harden sessionless dispatch

### DIFF
--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -56,6 +56,12 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         "delete_session" => return cmd_delete_session(state, &cmd, id),
         "get_fork_messages" => return cmd_get_fork_messages(state, &cmd, id),
         "get_commands" => return cmd_get_commands(id),
+        // System-wide, no session needed: invalidates the skills discovery
+        // cache. Must stay sessionless — the GUI/CLI call it right after
+        // install/uninstall without a session_id, and a "session not found"
+        // here silently left the cache stale (the installed list never
+        // refreshed until restart / TTL expiry).
+        "refresh_skills" => return cmd_refresh_skills(id),
         "set_enabled_models" => {
             // Scoped models are managed entirely by the TUI/client; the agent
             // returns all available models. Kept as a no-op for compatibility.
@@ -501,7 +507,6 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             RpcResponse::ok(id, "export_html", serde_json::json!({"path": output_path}))
         }
         "reload_config" => cmd_reload_config(state, &session, id),
-        "refresh_skills" => cmd_refresh_skills(id),
         "set_cwd" => {
             // Trim trailing whitespace / separators so the saved cwd is
             // always a clean directory path — "project/ " produces a
@@ -1556,6 +1561,24 @@ mod tests {
             resp["data"]["skills"].as_array().unwrap().len() as u64
         );
         assert!(resp["data"]["refreshed"].is_boolean());
+    }
+
+    #[test]
+    fn refresh_skills_works_without_session_id() {
+        // Regression: refresh_skills is sessionless. The GUI/CLI fire it right
+        // after install/uninstall with NO session_id; when it lived in the
+        // session-scoped branch this returned "session not found", the skills
+        // cache was never invalidated, and the installed list stayed stale
+        // until restart / TTL expiry. make_cmd() always injects a session id,
+        // so it hid this — build the command by hand with an empty session.
+        let state = make_app_state();
+        let cmd: RpcCommand =
+            serde_json::from_str(r#"{"id":"test_cmd","type":"refresh_skills","sessionId":""}"#)
+                .unwrap();
+        assert!(cmd.session_id.is_empty());
+        let resp = parse_response(&handle_command_internal(&state, cmd));
+        assert_eq!(resp["success"], true);
+        assert_eq!(resp["command"], "refresh_skills");
     }
 
     #[test]

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -181,7 +181,9 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
                 Err(error) => RpcResponse::build_fail(id, "approval_decision", &error),
             }
         }
-        "new_session" => cmd_new_session(state, &cmd, id),
+        // NOTE: `new_session` is intentionally NOT matched here — it is handled
+        // in the sessionless branch above (a new session has no existing session
+        // to resolve). An arm here would be unreachable dead code.
         "get_state" => match get_state_internal(state, &cmd.session_id) {
             Some(state_val) => RpcResponse::ok(id, "get_state", state_val),
             None => RpcResponse::build_fail(id, "get_state", "session not found"),
@@ -402,10 +404,6 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         "abort_retry" => {
             rlock!(session, id).abort();
             RpcResponse::ok(id, "abort_retry", serde_json::json!({}))
-        }
-        "abort_shell" => {
-            // Shell abort is handled by the agent loop
-            RpcResponse::ok(id, "abort_shell", serde_json::json!({}))
         }
         "cycle_model" => {
             // Cycle to next available model.  Scoping is client-side (TUI/GUI).
@@ -1582,6 +1580,59 @@ mod tests {
     }
 
     #[test]
+    fn sessionless_commands_do_not_require_session_id() {
+        // Regression: every sessionless command must be dispatched WITHOUT
+        // resolving a session. If one is accidentally moved into the
+        // session-scoped branch, an empty session_id trips the resolution gate
+        // and the caller gets "session not found — pass a valid session_id..."
+        // (that exact phrase is unique to the gate). make_cmd() always injects
+        // a session id so it can't catch this — build each command by hand with
+        // an empty session and assert we never hit the gate.
+        //
+        // `reload_auth` and `shutdown` are deliberately excluded: they carry
+        // process-global side effects (credential reload / shutdown flag) that
+        // don't belong in a swept table.
+        let sessionless = [
+            "get_agent_info",
+            "list_models",
+            "list_sessions",
+            "list_streaming_sessions",
+            "new_session",
+            "switch_session",
+            "delete_session",
+            "get_fork_messages",
+            "get_commands",
+            "refresh_skills",
+            "set_enabled_models",
+        ];
+        for cmd_type in sessionless {
+            let state = make_app_state();
+            let cmd: RpcCommand = serde_json::from_str(&format!(
+                r#"{{"id":"test_cmd","type":"{cmd_type}","sessionId":""}}"#
+            ))
+            .unwrap();
+            assert!(cmd.session_id.is_empty());
+            let resp = parse_response(&handle_command_internal(&state, cmd));
+            let error = resp["error"].as_str().unwrap_or("");
+            // The command must actually exist (the fallback echoes cmd_type, so
+            // a successful dispatch and a typo both return command == cmd_type —
+            // "unknown command" in the error is the real tell).
+            assert!(
+                !error.contains("unknown command"),
+                "sessionless cmd {cmd_type} is not a known command: {error}"
+            );
+            // And it must not have failed at the session-resolution gate. A
+            // command may still fail for its own reasons (e.g. switch_session
+            // with an empty target) — that's fine; only the gate phrase is a
+            // regression signal.
+            assert!(
+                !error.contains("pass a valid session_id"),
+                "sessionless cmd {cmd_type} required a session: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn shutdown_sets_flag() {
         let state = make_app_state();
         let cmd = make_cmd("shutdown");
@@ -1802,14 +1853,6 @@ mod tests {
     fn abort_retry_works() {
         let state = make_app_state();
         let cmd = make_cmd("abort_retry");
-        let resp = parse_response(&handle_command_internal(&state, cmd));
-        assert_eq!(resp["success"], true);
-    }
-
-    #[test]
-    fn abort_shell_works() {
-        let state = make_app_state();
-        let cmd = make_cmd("abort_shell");
         let resp = parse_response(&handle_command_internal(&state, cmd));
         assert_eq!(resp["success"], true);
     }

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -1299,42 +1299,23 @@ fn cmd_clone(
     RpcResponse::ok(id, "clone", serde_json::json!({"cancelled": false}))
 }
 
-/// Minimum interval between forced skills-cache refreshes. CLI/GUI fire one
-/// notification per install/uninstall operation, so a burst of operations
-/// (or several frontends at once) must not trigger repeated disk scans —
-/// requests inside this window are served from the still-fresh cache.
-const SKILLS_REFRESH_MIN_INTERVAL_SECS: u64 = 5;
-
 fn cmd_refresh_skills(id: &str) -> String {
-    use std::sync::Mutex;
-    use std::time::{Duration, Instant};
-
-    static LAST_REFRESH: Mutex<Option<Instant>> = Mutex::new(None);
-
-    // Rate-limit: only invalidate + rescan when the last forced refresh is
-    // older than the minimum interval. Otherwise keep the cache as-is;
-    // `discover_skills_cached` will serve it (it is fresh by construction).
-    let now = Instant::now();
-    let refreshed = {
-        let mut last = LAST_REFRESH.lock().unwrap();
-        match *last {
-            Some(t)
-                if now.duration_since(t)
-                    < Duration::from_secs(SKILLS_REFRESH_MIN_INTERVAL_SECS) =>
-            {
-                false
-            }
-            _ => {
-                *last = Some(now);
-                true
-            }
-        }
-    };
-    if refreshed {
-        // Invalidate the skills cache so freshly installed skills are
-        // visible on the next prompt without waiting for the 60s TTL.
-        crate::skills::invalidate_skills_cache();
-    }
+    // Always invalidate the cache. install/uninstall write to disk *after* the
+    // previous scan, so the cache is stale for them no matter how recently it
+    // was refreshed; invalidation is O(1) and the rescan below repopulates it
+    // (and warms the cache so the GUI's follow-up get_commands hits the fast
+    // path with the new state).
+    //
+    // This used to be gated behind a 5 s minimum-interval rate limit, but that
+    // limit was process-global and kept getting consumed by the harmless scan
+    // the GUI fires on startup / page open / agent (re)connect. The invalidation
+    // that actually matters — the one right after a write — then landed inside
+    // the window and was silently skipped, so get_commands kept returning the
+    // pre-install cache and the Skills view showed the old installed/uninstalled
+    // state until the app was restarted (which resets the limit and forces a
+    // scan). Burst protection is not needed here: invalidation has no I/O cost,
+    // and a rescan is a cheap local walk of two directories.
+    crate::skills::invalidate_skills_cache();
     let skills = crate::skills::discover_skills_cached(&crate::skills::global_skill_dirs());
     let skill_names: Vec<String> = skills.iter().map(|s| s.name.clone()).collect();
     RpcResponse::ok(
@@ -1343,9 +1324,7 @@ fn cmd_refresh_skills(id: &str) -> String {
         serde_json::json!({
             "skills_count": skill_names.len(),
             "skills": skill_names,
-            // false when served from cache due to the minimum-interval
-            // rate limit — callers can log this for debugging.
-            "refreshed": refreshed,
+            "refreshed": true,
         }),
     )
 }
@@ -1577,19 +1556,6 @@ mod tests {
             resp["data"]["skills"].as_array().unwrap().len() as u64
         );
         assert!(resp["data"]["refreshed"].is_boolean());
-    }
-
-    #[test]
-    fn refresh_skills_rate_limits_bursts() {
-        // A second call within the minimum interval must be served from the
-        // cache (`refreshed: false`) instead of rescanning the skill dirs.
-        // Robust against test ordering: any earlier refresh within the
-        // window only makes `refreshed: false` more likely.
-        let state = make_app_state();
-        handle_command_internal(&state, make_cmd("refresh_skills"));
-        let resp = parse_response(&handle_command_internal(&state, make_cmd("refresh_skills")));
-        assert_eq!(resp["success"], true);
-        assert_eq!(resp["data"]["refreshed"], false);
     }
 
     #[test]


### PR DESCRIPTION
## 问题

GUI「全部技能」点击「安装」/「卸载」后，按钮状态不更新，只有重启才显示正确状态。安装/卸载本身是成功的（磁盘已写入），纯粹是展示层没刷新。

## 根因（两个叠加的 bug）

1. **`refresh_skills` 被错误地放进 session-scoped 分支。** GUI/CLI 在安装/卸载后会立即调用 `refresh_skills` 且**不带 session_id**，于是它撞上 session 解析门、返回 "session not found"。GUI 的 `agent_bridge::refresh_skills` 是 best-effort（`let _ =` 吞掉错误），所以这个失败完全静默 —— 缓存从未失效，已安装列表直到重启 / TTL 过期才更新。
2. **旧的 5 秒限流。** 即使 (1) 修好，`cmd_refresh_skills` 里的进程级 5s 限流也会被启动 / 打开页面时的扫描消耗掉，导致安装/卸载后的那次失效被跳过。

## 修复

- `refresh_skills` 移到 sessionless 分支（与 `get_commands` 并列），无需 session 即可失效缓存。
- `cmd_refresh_skills` 改为无条件失效缓存：安装/卸载是在上次扫描**之后**写盘的，缓存对它们必然是脏的；失效是 O(1)，随后的重扫会重新填充（并预热缓存，让 GUI 紧接着的 `get_commands` 命中快路径拿到新状态）。删除限流常量与 `LAST_REFRESH` 静态量。

## 审计收尾（防止同类问题）

- 删除 session-scoped 分支里不可达的 `new_session` 死分支（它在上方 sessionless 分支已处理），留 NOTE 防止被「好心」加回。
- 删除空壳命令 `abort_shell` 及其测试：全仓（agent/TUI/GUI/CLI/channels）零调用方，且 handler 什么都不做只返回 ok —— 真正的 shell 终止走 agent loop 的 `abort` 命令（GUI runs 面板的终止按钮用的就是它）。让一个未实现的命令静默返回 ok 会误导调用方。
- 新增表驱动回归测试 `sessionless_commands_do_not_require_session_id`：`make_cmd()` 总会注入 session id，恰好掩盖了 refresh_skills 这类「sessionless 命令被误挪进 session-scoped 分支」的 bug。该测试用空 session 构造每个 sessionless 命令，断言它既不撞 session 解析门（唯一的 "pass a valid session_id" 措辞）、也是已知命令。

## 验证

`cargo fmt --check` / `cargo clippy --all-targets -D warnings` / `cargo test --lib` 全部通过（765 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)