### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/tui/scripts/generate-proto.ts
+++ b/tui/scripts/generate-proto.ts
@@ -16,6 +16,7 @@ const clientPaths = [
 ];
 
 const proto = fs.readFileSync(protoPath, "utf-8")
+  .replace(/\\/g, "\\\\")
   .replace(/`/g, "\\`")
   .replace(/\$\{/g, "\\${");
 


### PR DESCRIPTION
Potential fix for [https://github.com/futuregene/future-os/security/code-scanning/11](https://github.com/futuregene/future-os/security/code-scanning/11)

General fix: when embedding arbitrary text into a template literal, escape **backslashes first**, then escape template-literal metacharacters (backticks and `${`). Escaping backslashes first avoids creating/altering escape sequences that can interfere with later escaping.

Best single fix here: in `tui/scripts/generate-proto.ts`, update the `proto` construction (lines 18–20 region) to add `.replace(/\\/g, "\\\\")` before the existing replacements. Keep current behavior otherwise unchanged.

No new imports, methods, or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
