### PR TITLE
feat(agent): add runtime metrics and fault coverage

### DIFF
--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -13,6 +13,7 @@ use crate::rpc::{handle_command_internal, AppState};
 use anyhow::Result;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 
@@ -51,6 +52,44 @@ pub async fn serve(state: AppState, host: &str, port: u16) -> Result<()> {
 #[derive(Clone)]
 struct FutureAgentService {
     state: AppState,
+}
+
+#[allow(clippy::result_large_err)] // tonic stream items require `tonic::Status` directly.
+fn map_broadcast_event(
+    result: Result<crate::rpc::SseEvent, BroadcastStreamRecvError>,
+    broadcaster: &crate::rpc::SseBroadcaster,
+    session_id: &str,
+) -> Result<proto::StreamEvent, tonic::Status> {
+    match result {
+        Ok(event) => Ok(proto::StreamEvent {
+            r#type: event.event_type,
+            data: event.data,
+            run_id: event.run_id,
+            idx: event.idx,
+            projection_snapshot: false,
+            snapshot_events: Vec::new(),
+            snapshot_cursor: 0,
+            session_id: session_id.to_string(),
+            epoch: event.epoch,
+        }),
+        Err(error) => {
+            // Non-atomic observers can remain subscribed across multiple runs,
+            // so resolve the canonical run at the moment lag is observed rather
+            // than freezing the run that happened to be active at subscribe.
+            let run_id = broadcaster.current_run_id();
+            let count = broadcaster.record_lag();
+            tracing::warn!(
+                session_id,
+                run_id = %run_id,
+                lag_count = count,
+                error = %error,
+                "SSE stream lagged; terminating for cursor resume"
+            );
+            Err(tonic::Status::data_loss(format!(
+                "event stream gap for session {session_id}, run {run_id}; reconnect with atomic attach"
+            )))
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -234,7 +273,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                 "session {session_id} not found"
             )));
         };
-        let (rx, mut initial_events) = {
+        let (rx, mut initial_events, lag_broadcaster) = {
             let sess = session.read();
             if self.state.verbose {
                 tracing::debug!(
@@ -286,7 +325,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                             epoch: event.epoch,
                         }),
                 );
-                (attachment.receiver, initial)
+                (attachment.receiver, initial, sess.broadcaster.clone())
             } else {
                 (
                     sess.broadcaster.subscribe(),
@@ -301,6 +340,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                         session_id: session_id.clone(),
                         epoch: 0,
                     }],
+                    sess.broadcaster.clone(),
                 )
             }
         };
@@ -325,37 +365,49 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                 }
                 match r {
                     Ok(event) => event_types.contains(&event.event_type),
-                    // Never terminate the stream on lag — the receiver can
-                    // continue after a lag, but a tonic error ends the gRPC
-                    // stream and the client must reconnect, missing every
-                    // event in between (including critical settings-change
-                    // events like model_changed).
+                    // Lag must bypass event-type filtering so the mapper below
+                    // can terminate the gRPC stream explicitly. The client then
+                    // reconnects with atomic attach and recovers from its cursor.
                     Err(_) => true,
                 }
             })
-            .filter_map(move |r| match r {
-                Ok(event) => Some(Ok(proto::StreamEvent {
-                    r#type: event.event_type,
-                    data: event.data,
-                    run_id: event.run_id,
-                    idx: event.idx,
-                    projection_snapshot: false,
-                    snapshot_events: Vec::new(),
-                    snapshot_cursor: 0,
-                    session_id: lag_session_id.clone(),
-                    epoch: event.epoch,
-                })),
-                Err(e) => {
-                    tracing::warn!(
-                        "SSE stream lagged (session={lag_session_id}): {e} — terminating for cursor resume"
-                    );
-                    Some(Err(tonic::Status::data_loss(format!(
-                        "event stream gap for session {lag_session_id}; reconnect with atomic attach"
-                    ))))
-                }
-            });
+            .map(move |result| map_broadcast_event(result, &lag_broadcaster, &lag_session_id));
         let stream = snapshot.chain(events);
 
         Ok(tonic::Response::new(Box::pin(stream)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::{SseBroadcaster, SseEvent};
+
+    #[tokio::test]
+    async fn broadcast_overflow_records_lag_through_grpc_mapper() {
+        let broadcaster = SseBroadcaster::new();
+        broadcaster.start_run("run-lag".to_string(), 7);
+        let receiver = broadcaster.subscribe();
+
+        // The production broadcast channel holds 256 events. Keeping this
+        // receiver idle while publishing more than that deterministically
+        // produces BroadcastStreamRecvError::Lagged on its first read.
+        for idx in 0..300 {
+            broadcaster.broadcast(SseEvent::new(
+                "text_chunk",
+                serde_json::json!({"text": idx.to_string()}),
+            ));
+        }
+        let result = BroadcastStream::new(receiver)
+            .next()
+            .await
+            .expect("lagged stream yields an item");
+        assert!(matches!(&result, Err(BroadcastStreamRecvError::Lagged(_))));
+
+        let status = map_broadcast_event(result, &broadcaster, "session-lag").unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+        assert!(status.message().contains("session-lag"));
+        assert!(status.message().contains("run-lag"));
+        assert_eq!(broadcaster.lag_count(), 1);
     }
 }

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -395,6 +395,10 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             let stats = rlock!(session, id).get_session_stats();
             RpcResponse::ok(id, "get_session_stats", stats)
         }
+        "get_runtime_metrics" => {
+            let metrics = rlock!(session, id).get_runtime_metrics();
+            RpcResponse::ok(id, "get_runtime_metrics", metrics)
+        }
         "fork" => cmd_fork(state, &session, &cmd, id),
         "get_session_entries" => {
             // Must not fall back to a different session when the requested id
@@ -2000,6 +2004,32 @@ mod tests {
         let resp = parse_response(&handle_command_internal(&state, cmd));
         assert_eq!(resp["success"], true);
         assert!(resp["data"]["sessionId"].is_string());
+    }
+
+    #[test]
+    fn get_runtime_metrics_exposes_five_observability_values() {
+        let state = make_app_state();
+        let session = state.get_session("default").unwrap();
+        let (runtime, broadcaster) = {
+            let session = session.read();
+            (session.runtime.clone(), session.broadcaster.clone())
+        };
+        let lease = runtime.begin(Some("run-metrics"), None).unwrap();
+        broadcaster.record_lag();
+
+        let cmd = make_cmd("get_runtime_metrics");
+        let resp = parse_response(&handle_command_internal(&state, cmd));
+        assert_eq!(resp["success"], true);
+        assert!(resp["data"]["sessionId"].is_string());
+        assert_eq!(resp["data"]["activeRunGauge"], 1);
+        assert_eq!(resp["data"]["activeRunId"], "run-metrics");
+        assert_eq!(resp["data"]["broadcastLag"], 1);
+        for field in ["staleEpochDrops", "persistenceDegraded", "ringTruncations"] {
+            assert_eq!(resp["data"][field], 0, "unexpected {field}");
+        }
+
+        assert!(runtime.begin_finalizing(&lease));
+        assert!(runtime.finish(&lease));
     }
 
     #[test]

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -174,6 +174,16 @@ pub struct RunProjectionSnapshot {
 pub struct SseBroadcaster {
     tx: broadcast::Sender<SseEvent>,
     run: std::sync::Arc<parking_lot::Mutex<RunState>>,
+    /// Number of times a consumer's cursor predates the replay ring (ring
+    /// truncation / idx gap), forcing a resync via the projection snapshot.
+    /// Observability metric for the "ring truncation must be explicitly
+    /// visible" acceptance criterion; expected to stay 0 in healthy runs.
+    truncation_count: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    /// Number of times a live subscriber fell behind the broadcast channel
+    /// (tokio `RecvError::Lagged`) and the gRPC stream was terminated for cursor
+    /// resume. Observability metric for the "broadcast lag" criterion; a spike
+    /// means a client couldn't keep up with the event rate.
+    lag_count: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl SseBroadcaster {
@@ -192,6 +202,8 @@ impl SseBroadcaster {
                 events: Vec::new(),
                 projection_events: Vec::new(),
             })),
+            truncation_count: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            lag_count: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -202,6 +214,33 @@ impl SseBroadcaster {
 
     pub fn last_idx(&self) -> i64 {
         self.run.lock().idx.saturating_sub(1)
+    }
+
+    pub fn current_run_id(&self) -> String {
+        self.run.lock().run_id.clone()
+    }
+
+    /// Count of ring-truncation resyncs: times a consumer's cursor fell behind
+    /// the replay ring and had to recover via the projection snapshot.
+    /// Observability metric; expected to stay 0 in healthy runs (a non-zero
+    /// value means a client lagged far enough to lose the incremental tail).
+    pub fn truncation_count(&self) -> u64 {
+        self.truncation_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Record that a live subscriber lagged behind the broadcast channel (the
+    /// gRPC layer calls this when it observes `RecvError::Lagged`).
+    pub fn record_lag(&self) -> u64 {
+        self.lag_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1
+    }
+
+    /// Count of live-subscriber lag events (see `record_lag`). Observability
+    /// metric; expected to stay 0 unless a client can't keep up with the rate.
+    pub fn lag_count(&self) -> u64 {
+        self.lag_count.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Atomically register a receiver and snapshot the requested run tail.
@@ -215,6 +254,19 @@ impl SseBroadcaster {
         let receiver = self.tx.subscribe();
         let min_idx = run.events.first().map(|event| event.idx).unwrap_or(run.idx);
         let truncated = after_idx.saturating_add(1) < min_idx;
+        if truncated {
+            let count = self
+                .truncation_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                + 1;
+            tracing::warn!(
+                run_id,
+                requested_after_idx = after_idx,
+                min_available_idx = min_idx,
+                truncation_count = count,
+                "run replay ring truncated; returning projection snapshot"
+            );
+        }
         let events = run
             .events
             .iter()
@@ -289,6 +341,19 @@ impl SseBroadcaster {
         }
         let min_idx = run.events.first().map(|e| e.idx).unwrap_or(0);
         let truncated = since_idx.saturating_add(1) < min_idx;
+        if truncated {
+            let count = self
+                .truncation_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                + 1;
+            tracing::warn!(
+                run_id,
+                requested_after_idx = since_idx,
+                min_available_idx = min_idx,
+                truncation_count = count,
+                "run event query crossed replay-ring boundary; returning projection snapshot"
+            );
+        }
         let events = run
             .events
             .iter()
@@ -730,6 +795,98 @@ mod tests {
             Some(live.idx)
         );
         assert!(b.attach("run2", -1).is_err());
+    }
+
+    #[test]
+    fn truncation_counter_tracks_ring_overflow_resyncs() {
+        let b = SseBroadcaster::new();
+        b.start_run("run1".to_string(), 1);
+        assert_eq!(b.truncation_count(), 0);
+
+        // Within the ring: a full backfill is NOT a truncation.
+        for idx in 0..10 {
+            b.broadcast(SseEvent::new(
+                "text_chunk",
+                serde_json::json!({"text": idx.to_string()}),
+            ));
+        }
+        let _ = b.events_since("run1", -1).unwrap();
+        assert_eq!(
+            b.truncation_count(),
+            0,
+            "in-ring backfill is not a truncation"
+        );
+
+        // Overflow the ring; now a backfill whose cursor predates the ring is a
+        // truncation, and each such resync is counted (attach + events_since).
+        for idx in 0..=MAX_RUN_EVENTS {
+            b.broadcast(SseEvent::new(
+                "text_chunk",
+                serde_json::json!({"text": idx.to_string()}),
+            ));
+        }
+        let attachment = b.attach("run1", -1).unwrap();
+        assert!(attachment.truncated);
+        assert_eq!(b.truncation_count(), 1);
+        let _ = b.events_since("run1", -1).unwrap();
+        assert_eq!(
+            b.truncation_count(),
+            2,
+            "events_since truncation is counted too"
+        );
+    }
+
+    #[test]
+    fn lag_counter_is_observable_and_starts_at_zero() {
+        let b = SseBroadcaster::new();
+        assert_eq!(b.lag_count(), 0);
+        b.record_lag();
+        b.record_lag();
+        assert_eq!(b.lag_count(), 2);
+        // The counter is shared across clones (the gRPC layer holds a clone).
+        let clone = b.clone();
+        clone.record_lag();
+        assert_eq!(b.lag_count(), 3);
+    }
+
+    #[test]
+    fn concurrent_broadcasts_to_one_broadcaster_yield_contiguous_idx() {
+        use std::sync::Arc;
+        use std::thread;
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 250; // 8 * 250 = 2000 == MAX_RUN_EVENTS (no overflow)
+        let b = Arc::new(SseBroadcaster::new());
+        b.start_run("run1".to_string(), 1);
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let b = b.clone();
+                thread::spawn(move || {
+                    for n in 0..PER_THREAD {
+                        b.broadcast(SseEvent::new("text_chunk", serde_json::json!({"text": n})));
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        // The single stamping lock serializes concurrent broadcasts: every event
+        // got a unique, contiguous idx (no gaps, no duplicates) under contention.
+        let total = (THREADS * PER_THREAD) as i64;
+        assert_eq!(b.last_idx(), total - 1);
+        assert_eq!(b.truncation_count(), 0);
+        let (run_id, events, min_idx, projection) =
+            b.events_since("run1", total - 1 - 100).unwrap();
+        assert_eq!(run_id, "run1");
+        assert_eq!(min_idx, 0);
+        assert!(projection.is_none());
+        let expected_start = total - 100; // first idx > (total - 1 - 100)
+        assert_eq!(events.len(), 100);
+        for (i, event) in events.iter().enumerate() {
+            assert_eq!(event.idx, expected_start + i as i64, "contiguous, no gaps");
+            assert_eq!(event.run_id, "run1");
+            assert_eq!(event.epoch, 1);
+        }
     }
 
     #[test]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -628,6 +628,22 @@ impl ServerSession {
         })
     }
 
+    /// Operational lifecycle/event metrics for this live session. These values
+    /// are intentionally monotonic for the lifetime of the session runtime
+    /// (except `activeRunGauge`, which is a point-in-time gauge) and are exposed
+    /// through `get_runtime_metrics` for diagnostics and acceptance tests.
+    pub fn get_runtime_metrics(&self) -> serde_json::Value {
+        serde_json::json!({
+            "sessionId": self.session_id(),
+            "activeRunGauge": self.runtime.active_task_count(),
+            "staleEpochDrops": self.runtime.stale_epoch_drop_count(),
+            "persistenceDegraded": self.runtime.persistence_degraded_count(),
+            "broadcastLag": self.broadcaster.lag_count(),
+            "ringTruncations": self.broadcaster.truncation_count(),
+            "activeRunId": self.runtime.snapshot().map(|run| run.run_id),
+        })
+    }
+
     pub fn list_sessions(&self) -> Result<Vec<serde_json::Value>> {
         // Lightweight summaries: scans each JSONL without deserializing
         // large tool/assistant payloads, so listing stays fast even with

--- a/agent/src/runtime/run_state.rs
+++ b/agent/src/runtime/run_state.rs
@@ -68,6 +68,10 @@ pub struct RunControl {
     is_streaming: Arc<AtomicBool>,
     active_tasks: AtomicUsize,
     stale_epoch_drops: AtomicU64,
+    /// Count of runs that entered PersistenceDegraded (a run terminal could not
+    /// be committed). Observability metric for the "persistence degraded"
+    /// acceptance criterion; expected to stay 0 on healthy storage.
+    persistence_degraded: AtomicU64,
 }
 
 impl RunControl {
@@ -77,6 +81,7 @@ impl RunControl {
             is_streaming,
             active_tasks: AtomicUsize::new(0),
             stale_epoch_drops: AtomicU64::new(0),
+            persistence_degraded: AtomicU64::new(0),
         }
     }
 
@@ -284,7 +289,11 @@ impl RunControl {
         if active.lease != *lease {
             return false;
         }
+        if active.phase == RunPhase::PersistenceDegraded {
+            return true;
+        }
         active.phase = RunPhase::PersistenceDegraded;
+        self.persistence_degraded.fetch_add(1, Ordering::Relaxed);
         tracing::error!(
             run_id = %lease.run_id,
             run_epoch = lease.epoch,
@@ -353,14 +362,16 @@ impl RunControl {
             })
     }
 
-    #[cfg(test)]
     pub fn active_task_count(&self) -> usize {
         self.active_tasks.load(Ordering::Relaxed)
     }
 
-    #[cfg(test)]
     pub fn stale_epoch_drop_count(&self) -> u64 {
         self.stale_epoch_drops.load(Ordering::Relaxed)
+    }
+
+    pub fn persistence_degraded_count(&self) -> u64 {
+        self.persistence_degraded.load(Ordering::Relaxed)
     }
 
     fn stale(&self, lease: &RunLease, operation: &'static str) -> bool {
@@ -450,6 +461,14 @@ mod tests {
         assert!(streaming.load(Ordering::Acquire));
         assert!(control.begin(Some("run-b"), Some("request-b")).is_err());
         assert_eq!(control.active_task_count(), 1);
+        // The degraded transition is counted for observability.
+        assert_eq!(control.persistence_degraded_count(), 1);
+        assert!(control.mark_persistence_degraded(&lease, "same failure reported twice"));
+        assert_eq!(
+            control.persistence_degraded_count(),
+            1,
+            "one run entering degraded state is counted once"
+        );
     }
 
     #[test]

--- a/agent/src/runtime/session_runtime.rs
+++ b/agent/src/runtime/session_runtime.rs
@@ -212,9 +212,16 @@ impl SessionRuntime {
             .is_some_and(|active| active.lease == *lease)
     }
 
-    #[cfg(test)]
     pub(crate) fn active_task_count(&self) -> usize {
         self.control.active_task_count()
+    }
+
+    pub(crate) fn stale_epoch_drop_count(&self) -> u64 {
+        self.control.stale_epoch_drop_count()
+    }
+
+    pub(crate) fn persistence_degraded_count(&self) -> u64 {
+        self.control.persistence_degraded_count()
     }
 }
 


### PR DESCRIPTION
## Summary
- expose five runtime observability metrics through the session command surface
- make persistence degradation counting transition-based and add run/session context to broadcast diagnostics
- cover broadcast overflow and gRPC DataLoss mapping with deterministic tests

## Validation
- cargo fmt --check -p future-agent
- cargo clippy -p future-agent --all-targets -- -D warnings
- cargo test -p future-agent --quiet

The architecture review plan document is intentionally not included.