### PR TITLE
feat: add i18n model descriptions (description_en) across full chain

### DIFF
--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -150,6 +150,7 @@ struct FutureModelEntry {
     #[allow(dead_code)]
     provider: Option<String>,
     description: Option<String>,
+    description_en: Option<String>,
     recommended: Option<bool>,
 }
 
@@ -379,6 +380,7 @@ fn convert_future_model(entry: FutureModelEntry, base_url: &str) -> Model {
         headers: HashMap::new(),
         hide: false,
         description: entry.description,
+        description_en: entry.description_en,
         recommended: entry.recommended.unwrap_or(false),
     }
 }
@@ -655,6 +657,7 @@ mod tests {
             knowledge_cutoff: None,
             provider: None,
             description: None,
+            description_en: None,
             recommended: None,
         };
         let model = convert_future_model(entry, "https://api.example.com/v1");
@@ -674,6 +677,7 @@ mod tests {
             knowledge_cutoff: None,
             provider: None,
             description: None,
+            description_en: None,
             recommended: None,
         };
         let model = convert_future_model(entry, "https://api.example.com/v1");
@@ -696,6 +700,7 @@ mod tests {
             knowledge_cutoff: None,
             provider: None,
             description: None,
+            description_en: None,
             recommended: None,
         };
         let model = convert_future_model(entry, "https://api.example.com/v1");
@@ -724,6 +729,7 @@ mod tests {
             knowledge_cutoff: None,
             provider: None,
             description: None,
+            description_en: None,
             recommended: None,
         };
         let model = convert_future_model(entry, "https://api.example.com/v1");

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -50,6 +50,12 @@ pub struct Model {
     /// leave this as `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// English counterpart of `description` from the Future platform catalog
+    /// (e.g. "Budget-friendly edition, solid for daily coding and chat"). The GUI
+    /// shows this when the UI language is not Chinese. Built-in / user models
+    /// leave this as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description_en: Option<String>,
     /// Whether the Future platform flags this model as recommended. Defaults to
     /// `false` for built-in / user models and for catalog entries that omit it.
     #[serde(default)]
@@ -107,6 +113,7 @@ pub fn builtin_models() -> Vec<Model> {
             headers: serde_json::from_str(&m.headers_json).unwrap_or_default(),
             hide: m.hide,
             description: None,
+            description_en: None,
             recommended: false,
         })
         .collect()

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -767,6 +767,7 @@ fn list_models_response(id: &str, registry: &crate::models::Registry) -> String 
                 "contextWindow": model.context_window,
                 "isDefault": id == effective_default,
                 "description": model.description,
+                "descriptionEn": model.description_en,
                 "recommended": model.recommended,
             })
         })

--- a/gui/src-tauri/src/agent_bridge/models.rs
+++ b/gui/src-tauri/src/agent_bridge/models.rs
@@ -22,6 +22,11 @@ pub struct AgentModelOption {
     /// "经济实用版，日常编程和对话任务够用且实惠"). Absent for built-in / user models.
     #[serde(default)]
     description: Option<String>,
+    /// English counterpart of `description` (e.g. "Budget-friendly edition, solid
+    /// for daily coding and chat"); the GUI shows it when the UI language is not
+    /// Chinese. Absent for built-in / user models.
+    #[serde(default)]
+    description_en: Option<String>,
     /// Future-platform recommendation flag (drives the onboarding model picker).
     #[serde(default)]
     recommended: bool,

--- a/gui/src/components/layout/ActivityRail.tsx
+++ b/gui/src/components/layout/ActivityRail.tsx
@@ -16,6 +16,7 @@ import {
   Sparkles,
   SquarePen,
   Trash2,
+  Wallet,
   X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -754,6 +755,7 @@ function AccountMenuButton({
         ? (
             <MenuPanel className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden p-0">
               <MenuRow
+                icon={Settings}
                 label={t("activityRail.settings")}
                 onClick={() => {
                   onOpenSettings();
@@ -762,6 +764,7 @@ function AccountMenuButton({
               />
               <MenuRow
                 action={<ActionBadge>{t("userMenu.recharge")}</ActionBadge>}
+                icon={Wallet}
                 label={t("userMenu.balance", { credits: balance != null ? Math.trunc(balance) : "—" })}
                 onClick={() => {
                   onRecharge?.();
@@ -776,13 +779,14 @@ function AccountMenuButton({
 }
 
 /** A borderless row inside the account popover; the whole row is clickable. */
-function MenuRow({ action, label, onClick }: { action?: ReactNode; label: string; onClick: () => void }) {
+function MenuRow({ action, icon: Icon, label, onClick }: { action?: ReactNode; icon?: LucideIcon; label: string; onClick: () => void }) {
   return (
     <button
       className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-subtle"
       onClick={onClick}
       type="button"
     >
+      {Icon ? <Icon className="size-4 shrink-0 text-ink-soft" /> : null}
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {action ?? null}
     </button>

--- a/gui/src/components/layout/OnboardingGate.tsx
+++ b/gui/src/components/layout/OnboardingGate.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFutureLoginFlow } from "../../features/settings/useFutureLoginFlow";
 import { getLanguage, LANGUAGE_LABELS, setLanguage, SUPPORTED_LANGUAGES } from "../../i18n";
-import { loadAgentModelOptions, modelKey, rememberLastUsedModel, syncFutureModels } from "../../integrations/agent/agentClient";
+import { loadAgentModelOptions, localizedModelDescription, modelKey, rememberLastUsedModel, syncFutureModels } from "../../integrations/agent/agentClient";
 import { getFutureEnvironment } from "../../integrations/agent/providers";
 import { bootstrapBuiltinSkills } from "../../integrations/skills/skillsClient";
 import { invokeCommand } from "../../integrations/tauri/invoke";
@@ -64,7 +64,7 @@ export interface OnboardingGateProps {
  * Dev/test builds additionally show an environment switcher next to it.
  */
 export function OnboardingGate({ onEnableBYOK, onInitComplete, onCancelLogin, hasAnyProvider, modelsReady, initPending, autoLogin }: OnboardingGateProps) {
-  const { t } = useTranslation("layout");
+  const { t, i18n } = useTranslation("layout");
   const { phase, message, begin, cancel } = useFutureLoginFlow(() => {});
   const busy = phase === "starting" || phase === "waiting" || phase === "authorized";
   const failed = phase === "denied" || phase === "expired" || phase === "error";
@@ -345,6 +345,7 @@ export function OnboardingGate({ onEnableBYOK, onInitComplete, onCancelLogin, ha
                 {recommendedModels.map((model) => {
                   const key = modelKey(model);
                   const active = selectedModelId === key;
+                  const description = localizedModelDescription(model, i18n.language);
                   return (
                     <button
                       className={cn(
@@ -358,8 +359,8 @@ export function OnboardingGate({ onEnableBYOK, onInitComplete, onCancelLogin, ha
                       type="button"
                     >
                       <span className="text-lg font-semibold text-ink">{model.label}</span>
-                      {model.description
-                        ? <span className="line-clamp-2 text-xs text-ink-muted">{model.description}</span>
+                      {description
+                        ? <span className="line-clamp-2 text-xs text-ink-muted">{description}</span>
                         : null}
                     </button>
                   );

--- a/gui/src/features/agent/Composer.tsx
+++ b/gui/src/features/agent/Composer.tsx
@@ -9,7 +9,7 @@ import { ArrowUp, ChevronDown, Paperclip, ShieldCheck, ShieldOff, ShieldQuestion
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { SelectMenu, SelectMenuItem } from "../../components/ui/SelectMenu";
-import { modelKey, modelLabel, modelOption, normalizeThinkingLevel, thinkingLevels } from "../../integrations/agent/agentClient";
+import { localizedModelDescription, modelKey, modelLabel, modelOption, normalizeThinkingLevel, thinkingLevels } from "../../integrations/agent/agentClient";
 import { useProviderNames } from "../../integrations/agent/useProviderNames";
 import { listAvailableSkills, listInstalledSkills } from "../../integrations/skills/skillsClient";
 import { deleteTempAttachment, savePastedImage } from "../../integrations/storage/threadStore";
@@ -629,7 +629,7 @@ export function Composer({
                   onModelChange?.(modelKey(model));
                   setModelMenuOpen(false);
                 }}
-                title={model.description?.trim() || undefined}
+                title={localizedModelDescription(model, i18n.language) ?? undefined}
               >
                 <span className="min-w-0 flex-1 space-y-0.5">
                   <span className="block truncate font-medium leading-tight text-ink">{model.label}</span>

--- a/gui/src/features/settings/ModelsPage.tsx
+++ b/gui/src/features/settings/ModelsPage.tsx
@@ -2,7 +2,7 @@ import type { AgentModelOption } from "../../integrations/agent/agentClient";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TextInput } from "../../components/ui/TextInput";
-import { modelKey } from "../../integrations/agent/agentClient";
+import { localizedModelDescription, modelKey } from "../../integrations/agent/agentClient";
 import { useProviderNames } from "../../integrations/agent/useProviderNames";
 import { SettingsList, SettingsRow, SettingsSection, Switch } from "./SettingsPrimitives";
 
@@ -15,7 +15,7 @@ export function ModelsPage({
   modelOptions: AgentModelOption[];
   onChangeHidden: (next: string[]) => void;
 }) {
-  const { t } = useTranslation("settings");
+  const { t, i18n } = useTranslation("settings");
   const [query, setQuery] = useState("");
   const providerNames = useProviderNames();
   const hidden = useMemo(() => new Set(hiddenModels), [hiddenModels]);
@@ -104,8 +104,9 @@ export function ModelsPage({
           >
             <SettingsList>
               {models.map((model) => {
-                // Curated platform blurb; trimmed so whitespace-only counts as empty.
-                const description = model.description?.trim() || null;
+                // Curated platform blurb in the active UI language; trimmed so
+                // whitespace-only counts as empty (handled by the helper).
+                const description = localizedModelDescription(model, i18n.language);
                 return (
                   <SettingsRow
                     key={modelKey(model)}

--- a/gui/src/integrations/agent/agentClient.ts
+++ b/gui/src/integrations/agent/agentClient.ts
@@ -11,8 +11,10 @@ export interface AgentModelOption {
   thinkingLevel?: ThinkingLevel | string | null;
   contextWindow?: number | null;
   isDefault?: boolean;
-  /** Curated positioning blurb from the Future platform catalog; absent elsewhere. */
+  /** Curated positioning blurb (Chinese) from the Future platform catalog; absent elsewhere. */
   description?: string | null;
+  /** English counterpart of `description`; shown when the UI language is not Chinese. */
+  descriptionEn?: string | null;
   /** Future-platform recommendation flag (drives the onboarding model picker). */
   recommended?: boolean;
 }
@@ -111,6 +113,26 @@ function normalizeAgentModelOptions(models: AgentModelOption[]) {
  */
 export function modelKey(model: Pick<AgentModelOption, "id" | "provider">) {
   return model.provider ? `${model.provider}/${model.id}` : model.id;
+}
+
+/**
+ * Pick the catalog blurb that matches the UI language. The Future platform
+ * supplies a Chinese `description` and an English `descriptionEn`; return the
+ * variant matching `language` (everything except "en" is treated as Chinese,
+ * mirroring the `i18n.language !== "en"` convention used elsewhere), falling
+ * back to the other variant when the preferred one is missing so a model row is
+ * never left blank. Trimmed; `null` when neither variant is present.
+ *
+ * Pure on purpose: callers pass `i18n.language` in rather than this helper
+ * importing i18n, so it stays testable and side-effect free.
+ */
+export function localizedModelDescription(
+  model: Pick<AgentModelOption, "description" | "descriptionEn">,
+  language: string | undefined,
+): string | null {
+  const preferred = language === "en" ? model.descriptionEn : model.description;
+  const fallback = language === "en" ? model.description : model.descriptionEn;
+  return preferred?.trim() || fallback?.trim() || null;
 }
 
 /** Built-in Future provider id (display name "Future"). */


### PR DESCRIPTION
## Summary
- Platform models now carry **Chinese** (`description`) and **English** (`description_en`) blurbs.
- Field flows: agent `future.rs` → `Model` struct → `list_models` JSON → Tauri bridge → GUI `AgentModelOption.descriptionEn`.
- GUI picks the matching variant via `localizedModelDescription(model, i18n.language)`:
  - `en` → `descriptionEn`, falls back to `description`.
  - `zh` → `description`, falls back to `descriptionEn`.
- Updated 3 UI sites: **ModelsPage** (settings), **Composer** (model selector tooltip), **OnboardingGate** (onboarding model picker cards).
- Also added lucide `Wallet` / `Settings` icons to the account-menu popover rows that were missing them.
- Merged latest `origin/main`. All checks: `cargo fmt --check` + `cargo clippy` (agent/channels/tauri) clean, `tsc --noEmit` + `eslint` clean.

## Test plan
- [ ] English UI shows English model descriptions
- [ ] Chinese UI shows Chinese model descriptions
- [ ] Missing variant falls back to the other (no blank rows)
- [ ] Account popover shows Settings icon and Wallet icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)