### PR TITLE
fix(gui,agent): unify chat workspace naming and restore workspace access

### DIFF
--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -1225,6 +1225,7 @@ mod tests {
     #[tokio::test]
     async fn active_run_uses_snapshot_and_leaves_next_run_config_writable() {
         let cwd = test_workspace();
+        std::fs::create_dir_all(&cwd).unwrap();
         let started = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
         let shared_loop = Arc::new(tokio::sync::RwLock::new(Loop::new(

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -17,7 +17,10 @@ impl ServerSession {
         client_request_id: Option<&str>,
     ) -> Result<crate::runtime::RunLease> {
         let cwd_path = std::path::Path::new(&self.cwd);
-        crate::utils::ensure_workspace_accessible(cwd_path, crate::utils::is_future_managed_dir(cwd_path))?;
+        crate::utils::ensure_workspace_accessible(
+            cwd_path,
+            crate::utils::is_future_managed_dir(cwd_path),
+        )?;
         let (system_prompt, verbose, mut run_loop) = {
             let mut shared = self
                 .agent_loop

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -16,7 +16,8 @@ impl ServerSession {
         requested_run_id: Option<&str>,
         client_request_id: Option<&str>,
     ) -> Result<crate::runtime::RunLease> {
-        crate::utils::ensure_workspace_accessible(std::path::Path::new(&self.cwd))?;
+        let cwd_path = std::path::Path::new(&self.cwd);
+        crate::utils::ensure_workspace_accessible(cwd_path, crate::utils::is_future_managed_dir(cwd_path))?;
         let (system_prompt, verbose, mut run_loop) = {
             let mut shared = self
                 .agent_loop

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -16,7 +16,7 @@ impl ServerSession {
         requested_run_id: Option<&str>,
         client_request_id: Option<&str>,
     ) -> Result<crate::runtime::RunLease> {
-        std::fs::create_dir_all(&self.cwd)?;
+        crate::utils::ensure_workspace_accessible(std::path::Path::new(&self.cwd))?;
         let (system_prompt, verbose, mut run_loop) = {
             let mut shared = self
                 .agent_loop

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -360,7 +360,8 @@ mod util_tests {
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
         // Repair is best-effort: it works when the test runs as the owner.
         let result = ensure_workspace_accessible(dir.path(), true);
-        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _ =
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         if result.is_ok() {
             let mode = std::fs::metadata(dir.path()).unwrap().permissions().mode();
             assert_ne!(mode & 0o700, 0, "owner bits should have been restored");
@@ -374,7 +375,8 @@ mod util_tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
         let result = ensure_workspace_accessible(dir.path(), false);
-        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _ =
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         // auto_repair=false must surface the write failure, not repair.
         assert!(result.is_err());
     }
@@ -391,11 +393,19 @@ mod util_tests {
     #[test]
     fn is_future_managed_dir_detects_future_root() {
         let home = dirs::home_dir().unwrap();
-        assert!(is_future_managed_dir(&home.join(".future").join("workspaces").join("chat").join("x")));
+        assert!(is_future_managed_dir(
+            &home
+                .join(".future")
+                .join("workspaces")
+                .join("chat")
+                .join("x")
+        ));
         assert!(is_future_managed_dir(&home.join(".future/agent/workspace")));
         // A sibling dir like ~/.futureworks or a user project is NOT managed.
         assert!(!is_future_managed_dir(&home.join(".futureworks")));
-        assert!(!is_future_managed_dir(Path::new("/home/user/projects/my-app")));
+        assert!(!is_future_managed_dir(Path::new(
+            "/home/user/projects/my-app"
+        )));
     }
 
     #[test]

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -180,6 +180,25 @@ pub fn is_tty() -> bool {
     std::io::stdin().is_terminal()
 }
 
+/// Ensure a workspace directory exists, is readable, and is writable.
+/// Creates the directory (and parents) if missing. Returns an error when
+/// the path exists but is not a directory, or when it can't be written to.
+pub fn ensure_workspace_accessible(path: &Path) -> Result<(), std::io::Error> {
+    std::fs::create_dir_all(path)?;
+    let meta = std::fs::metadata(path)?;
+    if !meta.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotADirectory,
+            format!("workspace path is not a directory: {}", path.display()),
+        ));
+    }
+    // Verify writability with a test file.
+    let test = path.join(".future_write_test");
+    std::fs::write(&test, b"")?;
+    std::fs::remove_file(&test)?;
+    Ok(())
+}
+
 /// ANSI color codes (matching Go constants)
 pub mod ansi {
     pub const RESET: &str = "\x1b[0m";

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -360,8 +360,7 @@ mod util_tests {
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
         // Repair is best-effort: it works when the test runs as the owner.
         let result = ensure_workspace_accessible(dir.path(), true);
-        let _ =
-            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         if result.is_ok() {
             let mode = std::fs::metadata(dir.path()).unwrap().permissions().mode();
             assert_ne!(mode & 0o700, 0, "owner bits should have been restored");
@@ -375,8 +374,7 @@ mod util_tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
         let result = ensure_workspace_accessible(dir.path(), false);
-        let _ =
-            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         // auto_repair=false must surface the write failure, not repair.
         assert!(result.is_err());
     }

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -221,7 +221,7 @@ pub fn ensure_workspace_accessible(path: &Path, auto_repair: bool) -> Result<(),
             // managed dirs, repair owner permissions and retry once (e.g. a
             // workspace chmod'ed read-only by a previous session). A user
             // workspace is left untouched — the caller surfaces the error.
-            Err(error) if auto_repair => {
+            Err(_error) if auto_repair => {
                 repair_dir_permissions(path)?;
                 std::fs::write(&test, b"")?;
                 let _ = std::fs::remove_file(&test);

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -180,22 +180,83 @@ pub fn is_tty() -> bool {
     std::io::stdin().is_terminal()
 }
 
-/// Ensure a workspace directory exists, is readable, and is writable.
-/// Creates the directory (and parents) if missing. Returns an error when
-/// the path exists but is not a directory, or when it can't be written to.
-pub fn ensure_workspace_accessible(path: &Path) -> Result<(), std::io::Error> {
-    std::fs::create_dir_all(path)?;
-    let meta = std::fs::metadata(path)?;
-    if !meta.is_dir() {
+/// True when `path` lives under the FutureOS-managed data root
+/// (`~/.future/`). These directories (chat temp workspaces, the agent's
+/// default workspace) are owned by FutureOS, so the agent may auto-create and
+/// repair them. A user-chosen workspace directory never qualifies — it must
+/// not be silently recreated or chmod'ed.
+pub fn is_future_managed_dir(path: &Path) -> bool {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    path.starts_with(home.join(".future"))
+}
+
+/// Ensure a workspace directory exists and is writable. Creates the directory
+/// (and parents) if missing. When the directory exists but is not writable and
+/// `auto_repair` is true, attempts a permission repair on Unix (grant owner
+/// read/write/execute) before retrying once. `auto_repair` should only be true
+/// for FutureOS-managed directories (see [`is_future_managed_dir`]); a user
+/// workspace that is missing or blocked returns an error so the caller can
+/// surface it instead of silently rebuilding the user's project dir. Returns an
+/// error when the path is not a directory or a write test still fails.
+pub fn ensure_workspace_accessible(path: &Path, auto_repair: bool) -> Result<(), std::io::Error> {
+    // A plain file at the workspace path is never recoverable — reject it
+    // before create_dir_all (which would fail with AlreadyExists anyway).
+    if path.exists() && !path.is_dir() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotADirectory,
             format!("workspace path is not a directory: {}", path.display()),
         ));
     }
-    // Verify writability with a test file.
-    let test = path.join(".future_write_test");
-    std::fs::write(&test, b"")?;
-    std::fs::remove_file(&test)?;
+    // FutureOS-managed dirs are auto-created when missing; a user workspace
+    // that vanished is an error the caller surfaces (never silently rebuilt).
+    if path.exists() {
+        // Verify writability with a test file.
+        let test = path.join(".future_write_test");
+        return match std::fs::write(&test, b"") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&test);
+                Ok(())
+            }
+            // Directory exists but the process can't write it. For FutureOS-
+            // managed dirs, repair owner permissions and retry once (e.g. a
+            // workspace chmod'ed read-only by a previous session). A user
+            // workspace is left untouched — the caller surfaces the error.
+            Err(error) if auto_repair => {
+                repair_dir_permissions(path)?;
+                std::fs::write(&test, b"")?;
+                let _ = std::fs::remove_file(&test);
+                Ok(())
+            }
+            Err(error) => Err(error),
+        };
+    }
+    if auto_repair {
+        std::fs::create_dir_all(path)?;
+        let test = path.join(".future_write_test");
+        std::fs::write(&test, b"")?;
+        let _ = std::fs::remove_file(&test);
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("workspace path does not exist: {}", path.display()),
+        ))
+    }
+}
+
+/// Grant the owner read/write/execute on `dir` (Unix only; a no-op elsewhere).
+fn repair_dir_permissions(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let current = std::fs::metadata(dir)?.permissions();
+        let mode = current.mode();
+        // Add owner rwx — never strip any existing bits.
+        let repaired = mode | 0o700;
+        if repaired != mode {
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(repaired))?;
+        }
+    }
     Ok(())
 }
 
@@ -264,6 +325,77 @@ mod util_tests {
         assert_ne!(id1, id2);
         assert!(id1.contains('-'));
         assert!(id1.len() > 12);
+    }
+
+    #[test]
+    fn ensure_workspace_accessible_creates_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nested").join("workspace");
+        ensure_workspace_accessible(&missing, true).unwrap();
+        assert!(missing.is_dir());
+    }
+
+    #[test]
+    fn ensure_workspace_accessible_does_not_create_without_repair() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nested").join("workspace");
+        let err = ensure_workspace_accessible(&missing, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(!missing.exists(), "user workspace must not be auto-created");
+    }
+
+    #[test]
+    fn ensure_workspace_accessible_accepts_writable_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(ensure_workspace_accessible(dir.path(), true).is_ok());
+        assert!(ensure_workspace_accessible(dir.path(), false).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_workspace_accessible_repairs_readonly_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        // chmod 000 — directory still exists but the test file write must fail.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Repair is best-effort: it works when the test runs as the owner.
+        let result = ensure_workspace_accessible(dir.path(), true);
+        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        if result.is_ok() {
+            let mode = std::fs::metadata(dir.path()).unwrap().permissions().mode();
+            assert_ne!(mode & 0o700, 0, "owner bits should have been restored");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_workspace_accessible_does_not_repair_without_flag() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = ensure_workspace_accessible(dir.path(), false);
+        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        // auto_repair=false must surface the write failure, not repair.
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ensure_workspace_accessible_rejects_plain_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-dir");
+        std::fs::write(&file, b"x").unwrap();
+        let err = ensure_workspace_accessible(&file, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn is_future_managed_dir_detects_future_root() {
+        let home = dirs::home_dir().unwrap();
+        assert!(is_future_managed_dir(&home.join(".future").join("workspaces").join("chat").join("x")));
+        assert!(is_future_managed_dir(&home.join(".future/agent/workspace")));
+        // A sibling dir like ~/.futureworks or a user project is NOT managed.
+        assert!(!is_future_managed_dir(&home.join(".futureworks")));
+        assert!(!is_future_managed_dir(Path::new("/home/user/projects/my-app")));
     }
 
     #[test]

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -1393,7 +1393,7 @@ dependencies = [
  "nkeys",
  "open",
  "prost",
- "rand 0.10.2",
+ "rand 0.8.7",
  "reqwest",
  "rusqlite",
  "serde",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -638,8 +638,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -1383,6 +1385,7 @@ version = "0.0.0"
 dependencies = [
  "async-nats",
  "base64 0.22.1",
+ "chrono",
  "futures",
  "fuzzy-matcher",
  "ignore",
@@ -1390,6 +1393,7 @@ dependencies = [
  "nkeys",
  "open",
  "prost",
+ "rand 0.10.2",
  "reqwest",
  "rusqlite",
  "serde",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -49,6 +49,8 @@ image = { version = "0.25", default-features = false, features = [
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 sha2 = "0.10"
 zip = { version = "8", default-features = false, features = ["deflate"] }
+chrono = "0.4"
+rand = "0.10"
 # Workspace file `@`-mention picker: gitignore-aware directory walk + fuzzy rank.
 ignore = "0.4"
 fuzzy-matcher = "0.3"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -50,7 +50,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 sha2 = "0.10"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 chrono = "0.4"
-rand = "0.10"
+rand = "0.8"
 # Workspace file `@`-mention picker: gitignore-aware directory walk + fuzzy rank.
 ignore = "0.4"
 fuzzy-matcher = "0.3"

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -431,10 +431,7 @@ async fn agent_prompt_inner(
         .unwrap_or_default();
     let mut command_client = connect_agent().await?;
 
-    // Create (or reuse) the agent session.  For brand-new threads the session
-    // is created with whatever cwd the workspace already has; we'll fix it up
-    // once we know the agent-generated session id so the directory can be named
-    // after it.
+    // Create (or reuse) the agent session.
     let existing_cwd = workspace_path_for_thread(&thread_id)?;
     let ensured = ensure_agent_session(
         &mut command_client,
@@ -457,22 +454,9 @@ async fn agent_prompt_inner(
     set_agent_permission_level(&mut command_client, &session_id, "workspace").await?;
     set_agent_sandbox_policy(&mut command_client, &session_id, &thread_id).await?;
 
-    // For a new chat-thread session, rename the workspace directory to match
-    // the agent-generated session id.  Workspace threads already have the
-    // correct cwd (the user's project directory).
+    // Persist the agent-generated session id for new threads.
     if session_id != stored_session_id {
         let _ = crate::store::update_thread_session_id(&thread_id, &session_id);
-        if is_chat_thread(&thread_id) {
-            let new_cwd =
-                crate::store::chat_workspace_path(&session_id).map(|p| p.display().to_string())?;
-            if new_cwd != existing_cwd {
-                std::fs::create_dir_all(&new_cwd)?;
-                let _ = crate::store::update_chat_workspace_path(&thread_id, &new_cwd);
-                let _ = command_client
-                    .execute_command(set_cwd_command(new_cwd, session_id.clone()))
-                    .await;
-            }
-        }
     }
 
     // Apply the prompt's model / thinking level ONLY when this call created a

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use self::client::raw_agent_addr;
 pub use self::client::{
     connect_agent, delete_session_command, get_available_models_command, get_run_state_command,
     get_session_entries_command, get_state_command, list_streaming_sessions_command, map_rpc_error,
-    set_cwd_command, set_default_model_command, set_model_command, set_session_name_command,
+    set_default_model_command, set_model_command, set_session_name_command,
     set_thinking_level_command, RpcResponseExt,
 };
 pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, PreparedPrompt};
@@ -37,7 +37,7 @@ use self::client::{base_command, prompt_command};
 use self::replica::AGENT_REPLICAS;
 use self::run_control::{mark_run_completed_if_active, mark_run_failed_if_active};
 use self::session::{
-    ensure_agent_session, is_chat_thread, set_agent_permission_level, set_agent_sandbox_policy,
+    ensure_agent_session, set_agent_permission_level, set_agent_sandbox_policy,
     workspace_path_for_thread,
 };
 

--- a/gui/src-tauri/src/agent_bridge/session.rs
+++ b/gui/src-tauri/src/agent_bridge/session.rs
@@ -139,15 +139,6 @@ pub(super) fn workspace_path_for_thread(thread_id: &str) -> Result<String, crate
     Ok(workspace.path)
 }
 
-/// Returns `true` when the thread is a chat-mode thread (not workspace-bound).
-pub(super) fn is_chat_thread(thread_id: &str) -> bool {
-    store::get_thread(thread_id)
-        .ok()
-        .flatten()
-        .map(|t| t.mode == "chat")
-        .unwrap_or(true)
-}
-
 /// Fork a session at the given user message. Returns the new GUI thread id.
 ///
 /// Creates a dedicated chat workspace named after the forked session id, copies

--- a/gui/src-tauri/src/agent_bridge/session.rs
+++ b/gui/src-tauri/src/agent_bridge/session.rs
@@ -298,10 +298,6 @@ pub async fn fork_agent_session(
 
     // ── create workspace + thread ──────────────────────────────────────
 
-    // Let create_thread handle workspace creation — for chat threads it
-    // always creates a fresh workspace keyed by the new thread id.
-    // create_thread ignores the passed workspace_id for chat mode, so
-    // any workspace we pre-created would be orphaned.
     let new_thread = store::create_thread(store::CreateThreadInput {
         mode: thread.mode.clone(),
         title: Some(session_name),

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -37,8 +37,7 @@ pub use cleanup::{
     ActiveRun,
 };
 pub use db::{
-    app_images_root, chat_workspace_path, future_dir, get_approval_request, get_run,
-    thread_images_dir,
+    app_images_root, future_dir, get_approval_request, get_run, thread_images_dir,
 };
 pub use markdown_refs::resolve_markdown_references;
 pub use records::*;

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -36,9 +36,7 @@ pub use cleanup::{
     reconcile_orphan_images, reconcile_orphan_review_repos, settle_interrupted_run_from_agent,
     ActiveRun,
 };
-pub use db::{
-    app_images_root, future_dir, get_approval_request, get_run, thread_images_dir,
-};
+pub use db::{app_images_root, future_dir, get_approval_request, get_run, thread_images_dir};
 pub use markdown_refs::resolve_markdown_references;
 pub use records::*;
 pub use review_snapshots::{

--- a/gui/src-tauri/src/store/cleanup.rs
+++ b/gui/src-tauri/src/store/cleanup.rs
@@ -280,11 +280,17 @@ fn live_thread_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
     rows.collect()
 }
 
-/// Live chat workspace directory names: every non-deleted thread id.
-/// Directories under `~/.future/workspaces/chat/` are named after the thread
-/// id (never the agent session id), so a live thread's dir is always kept.
+/// Live chat workspace directory names: both thread ids (legacy) and agent
+/// session ids (current).  Directories under `~/.future/workspaces/chat/` are
+/// named after the thread id, but older ones may still use the session id.
 fn live_chat_workspace_dir_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
-    let mut stmt = conn.prepare("SELECT id FROM threads WHERE status != 'deleted'")?;
+    let mut stmt = conn.prepare(
+        "SELECT id FROM threads WHERE status != 'deleted'
+         UNION
+         SELECT agent_session_id FROM threads
+         WHERE agent_session_id IS NOT NULL AND agent_session_id != ''
+           AND status != 'deleted'",
+    )?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
     rows.collect()
 }

--- a/gui/src-tauri/src/store/cleanup.rs
+++ b/gui/src-tauri/src/store/cleanup.rs
@@ -285,13 +285,7 @@ fn live_thread_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
 /// session ids (current).  Directories under `~/.future/workspaces/chat/` are
 /// now named after the session id, but older ones may still use the thread id.
 fn live_chat_workspace_dir_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT id FROM threads WHERE status != 'deleted'
-         UNION
-         SELECT agent_session_id FROM threads
-         WHERE agent_session_id IS NOT NULL AND agent_session_id != ''
-           AND status != 'deleted'",
-    )?;
+    let mut stmt = conn.prepare("SELECT id FROM threads WHERE status != 'deleted'")?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
     rows.collect()
 }

--- a/gui/src-tauri/src/store/cleanup.rs
+++ b/gui/src-tauri/src/store/cleanup.rs
@@ -280,9 +280,9 @@ fn live_thread_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
     rows.collect()
 }
 
-/// Live chat workspace directory names: both thread ids (legacy) and agent
-/// session ids (current).  Directories under `~/.future/workspaces/chat/` are
-/// now named after the session id, but older ones may still use the thread id.
+/// Live chat workspace directory names: every non-deleted thread id.
+/// Directories under `~/.future/workspaces/chat/` are named after the thread
+/// id (never the agent session id), so a live thread's dir is always kept.
 fn live_chat_workspace_dir_ids(conn: &Connection) -> rusqlite::Result<HashSet<String>> {
     let mut stmt = conn.prepare("SELECT id FROM threads WHERE status != 'deleted'")?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;

--- a/gui/src-tauri/src/store/threads.rs
+++ b/gui/src-tauri/src/store/threads.rs
@@ -111,12 +111,7 @@ pub fn create_thread(input: CreateThreadInput) -> Result<ThreadRecord, crate::Ap
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
     let workspace = if mode == "chat" {
-        // Use the agent session ID when it's known (fork, import) so the
-        // workspace path matches the agent's session dir; otherwise fall
-        // back to the thread ID (new chat threads get the session ID on
-        // the first prompt via update_chat_workspace_path).
-        let ws_key = agent_session_id.as_deref().unwrap_or(&thread_id);
-        get_or_create_chat_workspace_in(&tx, ws_key, Some(title.clone()))?
+        get_or_create_chat_workspace_in(&tx, &thread_id, Some(title.clone()))?
     } else if let Some(workspace_id) = input.workspace_id {
         loaded(get_workspace_in(&tx, &workspace_id)?, "Workspace")?
     } else {
@@ -436,25 +431,9 @@ pub(crate) fn delete_thread_inner(
     // directory deletion fails the DB row is already gone, which is the safer
     // failure mode (side-effect-last).
     if delete_files && thread.mode == "chat" {
-        // The workspace path for chat threads is the chat-workspace dir named
-        // after either the agent session id or the thread id.
-        let dir_key = thread
-            .agent_session_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|id| !id.is_empty())
-            .unwrap_or(thread_id);
-        let dir = super::db::chat_workspace_path(dir_key)?;
+        let dir = super::db::chat_workspace_path(thread_id)?;
         if dir.exists() {
             let _ = std::fs::remove_dir_all(&dir);
-        }
-        // Also remove the legacy directory named after the thread id if it
-        // differs from the session id (migration edge case).
-        if dir_key != thread_id {
-            let legacy_dir = super::db::chat_workspace_path(thread_id)?;
-            if legacy_dir.exists() {
-                let _ = std::fs::remove_dir_all(&legacy_dir);
-            }
         }
     }
 

--- a/gui/src-tauri/src/store/util.rs
+++ b/gui/src-tauri/src/store/util.rs
@@ -5,9 +5,11 @@ use std::{
     collections::HashSet,
     fs,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use rand::RngCore;
 
 /// Prefix each column in a `", "`-separated `*_COLUMNS` constant with a table
 /// alias, e.g. `qualify_columns("r", "id, status")` → `"r.id, r.status"`. Used
@@ -54,13 +56,13 @@ pub(super) fn workspace_name_from_path(path: &Path) -> String {
 }
 
 pub fn create_id(prefix: &str) -> String {
-    static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let counter = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{prefix}_{nanos}_{counter}")
+    let now = chrono::Local::now();
+    let ts = now.format("%Y%m%d-%H%M%S").to_string();
+    let mut rng = rand::thread_rng();
+    let mut buf = [0u8; 3];
+    rng.fill_bytes(&mut buf);
+    let hex: String = buf.iter().map(|b| format!("{:02x}", b)).collect();
+    format!("{prefix}-{ts}-{hex}")
 }
 
 pub(super) fn now_millis() -> i64 {

--- a/gui/src/i18n/locales/en/agent.json
+++ b/gui/src/i18n/locales/en/agent.json
@@ -39,7 +39,8 @@
     "messagesLoadFailed": "Couldn't load this conversation. Please try again — if it keeps happening, restart FutureOS.",
     "alreadyRunning": "A response is already in progress for this conversation.",
     "sessionRecreated": "The previous background record of this conversation was lost, so a fresh one was started. The history above is kept, but the assistant can no longer see it.",
-    "responseInterrupted": "The response was interrupted before it finished."
+    "responseInterrupted": "The response was interrupted before it finished.",
+    "workspaceAccessError": "The workspace directory is not accessible ({{message}}). Please check its path and permissions, then try again."
   },
   "failure": {
     "connect": "Couldn't connect to the FutureOS background service.\n\nPlease quit FutureOS completely, reopen it, and try again.",

--- a/gui/src/i18n/locales/zh/agent.json
+++ b/gui/src/i18n/locales/zh/agent.json
@@ -35,7 +35,8 @@
     "messagesLoadFailed": "对话记录加载失败，请稍后重试；如果反复出现，请重新打开 FutureOS。",
     "alreadyRunning": "该对话已有一个回复正在进行中。",
     "sessionRecreated": "此对话之前的后台记录已丢失，已自动开始新的对话。上方的历史消息仍然保留，但助手已经看不到它们了。",
-    "responseInterrupted": "回复在完成前被中断。"
+    "responseInterrupted": "回复在完成前被中断。",
+    "workspaceAccessError": "工作区目录无法访问（{{message}}）。请检查其路径和权限后重试。"
   },
   "failure": {
     "connect": "无法连接 FutureOS 后台服务。\n\n请完全退出 FutureOS 后重新打开，然后再试一次。",

--- a/gui/src/integrations/agent/agentStateCache.ts
+++ b/gui/src/integrations/agent/agentStateCache.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore } from "react";
 
 // ── Real-time agent state updates via Tauri events ──────────────────────
 
+import i18n from "../../i18n";
 import { emitFutureEvent } from "../../lib/futureEvents";
 import { invokeCommand } from "../tauri/invoke";
 
@@ -265,7 +266,7 @@ function applySettingsEvent(
       window.dispatchEvent(new CustomEvent("future:cwd-changed"));
     }).catch((error: unknown) => {
       emitFutureEvent("toast", {
-        message: `Workspace directory is no longer accessible: ${String(error)}`,
+        message: i18n.t("agent:thread.workspaceAccessError", { message: String(error) }),
         tone: "error",
       });
     });

--- a/gui/src/integrations/agent/agentStateCache.ts
+++ b/gui/src/integrations/agent/agentStateCache.ts
@@ -3,8 +3,8 @@ import { useSyncExternalStore } from "react";
 
 // ── Real-time agent state updates via Tauri events ──────────────────────
 
-import { invokeCommand } from "../tauri/invoke";
 import { emitFutureEvent } from "../../lib/futureEvents";
+import { invokeCommand } from "../tauri/invoke";
 
 /** Agent-side session state, fetched via get_state RPC. */
 export interface AgentSessionState {

--- a/gui/src/integrations/agent/agentStateCache.ts
+++ b/gui/src/integrations/agent/agentStateCache.ts
@@ -4,6 +4,7 @@ import { useSyncExternalStore } from "react";
 // ── Real-time agent state updates via Tauri events ──────────────────────
 
 import { invokeCommand } from "../tauri/invoke";
+import { emitFutureEvent } from "../../lib/futureEvents";
 
 /** Agent-side session state, fetched via get_state RPC. */
 export interface AgentSessionState {
@@ -262,7 +263,12 @@ function applySettingsEvent(
       cwd: p.cwd,
     }).then(() => {
       window.dispatchEvent(new CustomEvent("future:cwd-changed"));
-    }).catch(() => {});
+    }).catch((error: unknown) => {
+      emitFutureEvent("toast", {
+        message: `Workspace directory is no longer accessible: ${String(error)}`,
+        tone: "error",
+      });
+    });
   }
 
   for (const [threadId, entry] of cache) {


### PR DESCRIPTION
## Summary

Two related fixes for chat workspace directories under `~/.future/workspaces/chat/`:

### 1. Unify workspace directory naming
Chat workspace directories were renamed from the thread id to the agent session id on first prompt — but only the new dir was created, never the old one removed, leaking orphan dirs. The rename was also unnecessary (the agent accepts any cwd). Now:
- `create_id` produces readable IDs: `thread-YYYYMMDD-HHMMSS-hex` (was `thread_<nanos>_<counter>`)
- Chat workspace dirs are always named after the thread id, never renamed
- `live_chat_workspace_dir_ids` cleanup query simplified

### 2. Restore workspace access before each prompt
Every prompt now calls `ensure_workspace_accessible`:
- **FutureOS-managed dirs** (`~/.future/`): auto-created when missing, owner-rwx permission-repaired when read-only, silently recovered
- **User workspace dirs**: never silently rebuilt or chmod'ed — a missing/blocked dir returns an error that surfaces as a localized toast

Also reverts an over-aggressive cleanup simplification that would delete legacy session-id-named chat workspace dirs (a startup reconciler data-loss bug found during testing).

## Test plan
- [x] New chat: dir is `thread-<timestamp>-<hex>`, unchanged after first prompt
- [x] `chmod 000` a chat dir → prompt auto-repairs owner perms and succeeds
- [x] Workspace thread pointing at a deleted dir → toast "工作区目录无法访问"
- [x] Legacy session-id dirs no longer deleted at startup
- [x] agent: 801 tests, GUI Rust: 166 tests, GUI tsc/eslint/vitest: 227 tests
- [x] cargo fmt + clippy clean (agent + GUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)