### PR TITLE
fix(gui): keep failure bubble when a session's first run fails

### DIFF
--- a/gui/src/features/agent/threadRunProjection.test.ts
+++ b/gui/src/features/agent/threadRunProjection.test.ts
@@ -398,6 +398,25 @@ describe("recoverFailedRuns", () => {
     expect(result.map(m => m.id)).toEqual(["u1", "a1", "u2", "failed_r2", "u3", "a3"]);
   });
 
+  it("appends a failure bubble when the FIRST run of the session failed (no assistant entry at all)", () => {
+    // The "prompt acknowledgement omitted run_id" case: the run failed before
+    // the agent saved anything — the user's message is the only turn inside the
+    // run's window, so the trust guard must not require an assistant turn.
+    const result = recoverFailedRuns([
+      user("u1", { createdAt: "2026-07-01T10:00:00.000Z" }),
+    ], [
+      run("r1", { status: "failed", errorMessage: "Future Agent prompt acknowledgement omitted run_id.", ...r1Window }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      id: "failed_r1",
+      role: "assistant",
+      runId: "r1",
+      status: "failed",
+    });
+    expect(result[1]!.content.trim()).not.toBe("");
+  });
+
   it("leaves messages unchanged when the failed run already owns a projected turn", () => {
     const messages = [
       user("u1", { createdAt: "2026-07-01T10:00:00.000Z" }),

--- a/gui/src/features/agent/threadRunProjection.ts
+++ b/gui/src/features/agent/threadRunProjection.ts
@@ -511,6 +511,23 @@ function runMatchesAnyTurn(run: StoredRun, messages: AgentMessage[]): boolean {
 }
 
 /**
+ * Whether the run's window covers a projected user turn. A session whose FIRST
+ * run failed has no assistant entry at all — the only message inside the run's
+ * window is the user's — so window trust must not require an assistant turn.
+ */
+function runMatchesUserTurn(run: StoredRun, messages: AgentMessage[]): boolean {
+  const window = runWindow(run);
+  if (!window)
+    return false;
+  return messages.some((message) => {
+    if (message.role !== "user")
+      return false;
+    const at = Date.parse(message.createdAt);
+    return Number.isFinite(at) && at >= window.start && at <= window.end;
+  });
+}
+
+/**
  * A settled run that produced NO assistant turn in the session JSONL — e.g. the
  * very first LLM call failed (insufficient credit, auth) or the run died before
  * any entry was saved. Positional newest-first pairing would stamp such a run
@@ -597,7 +614,10 @@ export function recoverFailedRuns(messages: AgentMessage[], runs: StoredRun[]): 
   // backfilled by the agent), every run would look like an orphan, and bubbles
   // would be spliced to the wrong end of history. Skip recovery there — it
   // degrades to main's behavior instead of inventing misplaced bubbles.
-  if (!runs.some(run => runMatchesAnyTurn(run, messages)))
+  // A user turn counts as trust evidence too: a session whose FIRST run failed
+  // (the "prompt acknowledgement omitted run_id" case) has no assistant entry
+  // at all — the user's message is the only turn inside the run's window.
+  if (!runs.some(run => runMatchesAnyTurn(run, messages) || runMatchesUserTurn(run, messages)))
     return messages;
   const orphans = runs.filter(run =>
     run.status === "failed"


### PR DESCRIPTION
## Summary

When a prompt fails at the acknowledgement stage (the GUI received a success response whose `data` lacked `run_id` — e.g. a version-skewed agent ack), the send pipeline wrote a failure bubble, but the settle-time reload immediately wiped it: the page flashed the error then went blank, so the user had to screenshot to capture it.

Root cause: `recoverFailedRuns` trusted run-window matching only when *some* run covered an **assistant** turn. A run that fails before the agent saved any assistant entry produces a session with user turns only (first message of a fresh conversation, or an early failure), so the guard bailed and the failure bubble — which the live pipeline had shown — was never rebuilt from the `runs` table on reload.

## Change

- `gui/src/features/agent/threadRunProjection.ts`: add `runMatchesUserTurn` and accept a user turn inside a run's window as trust evidence in `recoverFailedRuns`' guard. The orphan check (`isOrphanRun`) is unchanged — a bubble is only spliced in when **no** assistant turn carries the failed run's id or falls in its window. `runMatchesAnyTurn` is untouched, so `applyRunMetadata`'s pairing behavior is unaffected.
- `gui/src/features/agent/threadRunProjection.test.ts`: new case covering a session whose **first** run failed (user turn only) — previously the guard bailed and no bubble was recovered.

## Notes for reviewers

- This only *widens* recovery: every previously-recovered case behaves identically; the change adds the "user turn is window-trust evidence" case.
- The failure bubble is idempotently rebuilt from the `runs` table (`status=failed` + `errorMessage`), so it survives thread switches, the settle watchdog, and app restarts — matching the existing `recoverFailedRuns` design.
- Residual edge (pre-existing, unchanged): a failed run whose window happens to cover a prior assistant turn (retry within ~30s) is not treated as an orphan and shows no bubble.

## Test plan

- `npx vitest run src/features/agent/threadRunProjection.test.ts` — 49 passed (incl. new case)
- Full agent suite — 136 passed
- `tsc --noEmit` clean, eslint clean
- Manual: reproduce the "prompt acknowledgement omitted run_id" error (version-skewed agent) → failure bubble persists after settle, across thread switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)