### PR TITLE
fix(gui,agent,mobile): close the event-ordering and message-identity gaps

### DIFF
--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -113,13 +113,26 @@ impl ServerSession {
         run_loop
             .stream_incomplete
             .store(false, std::sync::atomic::Ordering::SeqCst);
-        user_message
-            .metadata
-            .get_or_insert_with(serde_json::Map::new)
-            .insert(
+        // Stamp run + turn identity on the message itself, not just the
+        // journal entry: the terminal history rewrite regenerates entries from
+        // the in-memory messages, so identity injected only at the entry layer
+        // would be lost there. Every user message opens a turn; assistant and
+        // tool entries inherit the current one (see save_closure/user_msg_cb).
+        let initial_turn_id = format!("turn_{}", crate::utils::generate_entry_id());
+        let current_turn_id = Arc::new(std::sync::Mutex::new(initial_turn_id.clone()));
+        {
+            let metadata = user_message
+                .metadata
+                .get_or_insert_with(serde_json::Map::new);
+            metadata.insert(
                 "run_id".to_string(),
                 serde_json::Value::String(run_lease.run_id.clone()),
             );
+            metadata.insert(
+                "turn_id".to_string(),
+                serde_json::Value::String(initial_turn_id),
+            );
+        }
         self.messages.write().push(user_message);
 
         // Log the user message so the run log shows the question alongside
@@ -227,20 +240,44 @@ impl ServerSession {
         let save_messages = messages_arc.clone();
         let save_persistence = self.persistence.clone();
         let persisted_run_id = run_lease.run_id.clone();
+        let save_turn_id = current_turn_id.clone();
         let save_closure: crate::agent::PersistCallback =
             Arc::new(move |msg: &crate::types::AgentMessage| {
                 if is_ephemeral {
                     return;
                 }
                 let mut persisted = msg.clone();
-                if persisted.role == "assistant" {
-                    persisted
-                        .metadata
-                        .get_or_insert_with(serde_json::Map::new)
-                        .insert(
-                            "run_id".to_string(),
-                            serde_json::Value::String(persisted_run_id.clone()),
-                        );
+                // Every entry of this run carries its run identity — not just
+                // assistant entries — so a message's home run never has to be
+                // re-derived from journal position. Assistant/tool entries join
+                // the turn the last user message opened; a user message
+                // reaching this path (the interrupt-save loop) opens a fresh
+                // turn, mirroring user_msg_cb. Existing ids win — a re-saved
+                // message must keep the identity it was first journaled with.
+                let metadata = persisted.metadata.get_or_insert_with(serde_json::Map::new);
+                metadata
+                    .entry("run_id".to_string())
+                    .or_insert_with(|| serde_json::Value::String(persisted_run_id.clone()));
+                if persisted.role == "user" {
+                    let turn_id = metadata
+                        .get("turn_id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| {
+                            let fresh = format!("turn_{}", crate::utils::generate_entry_id());
+                            metadata.insert(
+                                "turn_id".to_string(),
+                                serde_json::Value::String(fresh.clone()),
+                            );
+                            fresh
+                        });
+                    if let Ok(mut current) = save_turn_id.lock() {
+                        *current = turn_id;
+                    }
+                } else if let Ok(current) = save_turn_id.lock() {
+                    metadata
+                        .entry("turn_id".to_string())
+                        .or_insert_with(|| serde_json::Value::String(current.clone()));
                 }
                 save_messages.write().push(persisted.clone());
                 let entry = crate::session::agent_message_to_entry(&persisted);
@@ -261,9 +298,37 @@ impl ServerSession {
             let b = broadcaster.clone();
             let persistence = self.persistence.clone();
             let rewrite_required = in_run_user_message_seen.clone();
+            let user_msg_run_id = run_lease.run_id.clone();
+            let user_msg_turn = current_turn_id.clone();
             Arc::new(move |msg: &crate::types::AgentMessage| {
                 rewrite_required.store(true, std::sync::atomic::Ordering::SeqCst);
-                let entry = crate::session::agent_message_to_entry(msg);
+                // An in-run user message (follow-up/steer) opens a new turn.
+                // Adopt a pre-stamped turn id when the construction site set
+                // one, so the journal entry and the in-memory history copy
+                // share the same identity.
+                let mut persisted = msg.clone();
+                let turn_id = {
+                    let metadata = persisted.metadata.get_or_insert_with(serde_json::Map::new);
+                    metadata
+                        .entry("run_id".to_string())
+                        .or_insert_with(|| serde_json::Value::String(user_msg_run_id.clone()));
+                    metadata
+                        .get("turn_id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| {
+                            let fresh = format!("turn_{}", crate::utils::generate_entry_id());
+                            metadata.insert(
+                                "turn_id".to_string(),
+                                serde_json::Value::String(fresh.clone()),
+                            );
+                            fresh
+                        })
+                };
+                if let Ok(mut current) = user_msg_turn.lock() {
+                    *current = turn_id;
+                }
+                let entry = crate::session::agent_message_to_entry(&persisted);
                 if let Err(error) = persistence.append(vec![entry]) {
                     tracing::error!("Failed to enqueue in-run user message: {error}");
                 }
@@ -438,10 +503,29 @@ impl ServerSession {
                                     return Ok(current_messages);
                                 }
                                 for msg in follow_ups {
-                                    let follow_up = crate::types::AgentMessage::new_user(
+                                    let mut follow_up = crate::types::AgentMessage::new_user(
                                         "user",
                                         serde_json::json!([{"type": "text", "text": msg}]),
                                     );
+                                    // Stamp identity before the callback fires
+                                    // so the journal entry and the in-memory
+                                    // history copy carry the same ids.
+                                    {
+                                        let metadata = follow_up
+                                            .metadata
+                                            .get_or_insert_with(serde_json::Map::new);
+                                        metadata.insert(
+                                            "run_id".to_string(),
+                                            serde_json::Value::String(task_lease.run_id.clone()),
+                                        );
+                                        metadata.insert(
+                                            "turn_id".to_string(),
+                                            serde_json::Value::String(format!(
+                                                "turn_{}",
+                                                crate::utils::generate_entry_id()
+                                            )),
+                                        );
+                                    }
                                     if let Some(ref on_user_message) = stream_ctx.on_user_message {
                                         on_user_message(&follow_up);
                                     }
@@ -478,19 +562,7 @@ impl ServerSession {
 
             let run_error = match result {
                 Ok(mut final_messages) => {
-                    if let Some(last_assistant) = final_messages
-                        .iter_mut()
-                        .rev()
-                        .find(|message| message.role == "assistant")
-                    {
-                        last_assistant
-                            .metadata
-                            .get_or_insert_with(serde_json::Map::new)
-                            .insert(
-                                "run_id".to_string(),
-                                serde_json::Value::String(task_lease.run_id.clone()),
-                            );
-                    }
+                    reconcile_run_identity(&mut final_messages, &task_lease.run_id);
                     // Update shared messages so next prompt includes the full context
                     *messages_arc.write() = final_messages;
                     None
@@ -1185,6 +1257,72 @@ impl ServerSession {
             parent_session_id.to_string(),
             entries,
         )
+    }
+}
+
+/// Reconcile run/turn identity across a run's final in-memory history before
+/// it replaces the shared session messages (and before any terminal rewrite
+/// regenerates journal entries from it). The run loop builds its own
+/// un-stamped message copies (assistant/tool results, steering-drained user
+/// messages), while the journal entries persisted mid-run were stamped at
+/// save time — without this pass the rewrite would diverge from them.
+///
+/// The sweep covers only this run's messages: it starts at the run's opening
+/// user message, which was stamped before the run began, and never touches
+/// earlier turns — their entries carry their own runs' identities (or, for
+/// legacy journals, none at all, and they must stay that way). Existing ids
+/// win: a message first journaled with a turn id keeps it.
+fn reconcile_run_identity(messages: &mut [crate::types::AgentMessage], run_id: &str) {
+    let start = messages
+        .iter()
+        .position(|message| {
+            message.role == "user"
+                && message
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("run_id"))
+                    .and_then(|value| value.as_str())
+                    == Some(run_id)
+        })
+        .unwrap_or(messages.len());
+    let mut current_turn: Option<String> = None;
+    for message in &mut messages[start..] {
+        let metadata = message.metadata.get_or_insert_with(serde_json::Map::new);
+        metadata
+            .entry("run_id".to_string())
+            .or_insert_with(|| serde_json::Value::String(run_id.to_string()));
+        if message.role == "user" {
+            let turn_id = metadata
+                .get("turn_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    let fresh = format!("turn_{}", crate::utils::generate_entry_id());
+                    metadata.insert(
+                        "turn_id".to_string(),
+                        serde_json::Value::String(fresh.clone()),
+                    );
+                    fresh
+                });
+            current_turn = Some(turn_id);
+        } else if let Some(turn_id) = &current_turn {
+            metadata
+                .entry("turn_id".to_string())
+                .or_insert_with(|| serde_json::Value::String(turn_id.clone()));
+        }
+    }
+    // The run's final assistant reply is always attributable to it, even when
+    // a compaction rewrite cost the opening user message its stamp.
+    if let Some(last_assistant) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.role == "assistant")
+    {
+        last_assistant
+            .metadata
+            .get_or_insert_with(serde_json::Map::new)
+            .entry("run_id".to_string())
+            .or_insert_with(|| serde_json::Value::String(run_id.to_string()));
     }
 }
 

--- a/agent/src/rpc/session_prompt/tests.rs
+++ b/agent/src/rpc/session_prompt/tests.rs
@@ -1,4 +1,4 @@
-﻿use super::*;
+use super::*;
 use std::path::PathBuf;
 
 use crate::{
@@ -259,4 +259,97 @@ fn session_info_session_name_never_empty() {
         })
         .unwrap_or_default();
     assert!(fallback.is_empty()); // no user = empty, not crash
+}
+
+// ── Run/turn identity reconciliation ─────────────────────────────────────
+
+fn stamped_message(role: &str, run_id: Option<&str>, turn_id: Option<&str>) -> AgentMessage {
+    let metadata = if run_id.is_some() || turn_id.is_some() {
+        let mut map = serde_json::Map::new();
+        if let Some(id) = run_id {
+            map.insert(
+                "run_id".to_string(),
+                serde_json::Value::String(id.to_string()),
+            );
+        }
+        if let Some(id) = turn_id {
+            map.insert(
+                "turn_id".to_string(),
+                serde_json::Value::String(id.to_string()),
+            );
+        }
+        Some(map)
+    } else {
+        None
+    };
+    AgentMessage {
+        role: role.to_string(),
+        content: vec![crate::types::ContentBlock::text("x")],
+        metadata,
+        ..Default::default()
+    }
+}
+
+fn meta_str(message: &AgentMessage, key: &str) -> Option<String> {
+    message
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(key))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+#[test]
+fn reconcile_run_identity_stamps_run_messages_and_spares_prior_turns() {
+    let mut messages = vec![
+        stamped_message("user", None, None), // legacy prior turn
+        stamped_message("assistant", Some("run-old"), None), // prior run's reply
+        stamped_message("user", Some("run-new"), Some("turn-1")), // this run's opener
+        stamped_message("assistant", None, None),
+        stamped_message("tool", None, None),
+        stamped_message("user", Some("run-new"), Some("turn-2")), // follow-up
+        stamped_message("assistant", None, None),
+    ];
+
+    reconcile_run_identity(&mut messages, "run-new");
+
+    // Prior turns are never touched.
+    assert!(messages[0].metadata.is_none());
+    assert_eq!(meta_str(&messages[1], "run_id").as_deref(), Some("run-old"));
+    assert_eq!(meta_str(&messages[1], "turn_id"), None);
+    // This run: every entry carries run_id; turn membership follows the user
+    // messages, and a follow-up keeps the turn it was journaled with.
+    assert_eq!(meta_str(&messages[2], "turn_id").as_deref(), Some("turn-1"));
+    assert_eq!(meta_str(&messages[3], "run_id").as_deref(), Some("run-new"));
+    assert_eq!(meta_str(&messages[3], "turn_id").as_deref(), Some("turn-1"));
+    assert_eq!(meta_str(&messages[4], "turn_id").as_deref(), Some("turn-1"));
+    assert_eq!(meta_str(&messages[5], "turn_id").as_deref(), Some("turn-2"));
+    assert_eq!(meta_str(&messages[6], "turn_id").as_deref(), Some("turn-2"));
+}
+
+#[test]
+fn reconcile_run_identity_mints_turns_and_falls_back_to_last_assistant() {
+    let mut messages = vec![
+        stamped_message("user", Some("run-x"), None),
+        stamped_message("assistant", None, None),
+    ];
+    reconcile_run_identity(&mut messages, "run-x");
+    let minted = meta_str(&messages[0], "turn_id").expect("turn minted for the opener");
+    assert!(minted.starts_with("turn_"));
+    assert_eq!(
+        meta_str(&messages[1], "turn_id").as_deref(),
+        Some(minted.as_str()),
+        "the reply joins the opener's minted turn"
+    );
+
+    // No stamped opener (a compaction rewrite dropped it): the sweep leaves
+    // the unidentified prefix alone, but the run's final assistant reply is
+    // still attributable.
+    let mut messages = vec![
+        stamped_message("user", None, None),
+        stamped_message("assistant", None, None),
+    ];
+    reconcile_run_identity(&mut messages, "run-y");
+    assert_eq!(meta_str(&messages[0], "run_id"), None);
+    assert_eq!(meta_str(&messages[1], "run_id").as_deref(), Some("run-y"));
 }

--- a/gui/src-tauri/src/agent_bridge/mod.rs
+++ b/gui/src-tauri/src/agent_bridge/mod.rs
@@ -500,10 +500,20 @@ async fn agent_prompt_inner(
     // Save the message for auto-naming after the prompt completes.
     let user_message = message.clone();
 
-    // Subscribe BEFORE the prompt reaches the agent: the session observer is
+    // Resolve the run identity and register single-writer ownership BEFORE the
+    // prompt reaches the agent. The session observer subscribes first (it is
     // the sole NATS publisher and the fallback event projector, so it must
-    // exist before the run starts (its atomic-attach replay covers the small
-    // subscribe window, but registering first keeps that window minimal).
+    // exist before the run starts); with the lease already held it recognizes
+    // this run as pipeline-owned from its very first event — closing the ack
+    // window where an early event (e.g. `user_message`) could otherwise be
+    // persisted by both the observer and this collector.
+    let run_id = match run_id.filter(|id| !id.trim().is_empty()) {
+        Some(id) => id,
+        None => crate::store::create_id("run"),
+    };
+    let replica_lease = AGENT_REPLICAS
+        .acquire(&run_id)
+        .map_err(crate::AppError::from)?;
     observer::ensure_observer(&session_id);
 
     let prompt_response = command_client
@@ -511,7 +521,7 @@ async fn agent_prompt_inner(
             message,
             session_id.clone(),
             attachments.unwrap_or_default(),
-            run_id.clone(),
+            Some(run_id.clone()),
         )?)
         .await
         .map_err(|error| format!("Unable to send prompt to Future Agent: {error}"))?
@@ -528,25 +538,14 @@ async fn agent_prompt_inner(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "Future Agent prompt acknowledgement omitted run_id.".to_string())?
         .to_string();
-    if let Some(requested_run_id) = run_id.as_deref() {
-        if canonical_run_id != requested_run_id {
-            return Err(format!(
-                "Future Agent adopted run id {canonical_run_id}, expected {requested_run_id}"
-            )
-            .into());
-        }
+    if canonical_run_id != run_id {
+        return Err(
+            format!("Future Agent adopted run id {canonical_run_id}, expected {run_id}").into(),
+        );
     }
-    let replica_lease = AGENT_REPLICAS
-        .acquire(&canonical_run_id)
-        .map_err(crate::AppError::from)?;
 
     match replica_lease
-        .collect(
-            run_id.as_deref(),
-            &canonical_run_id,
-            &session_id,
-            &thread_id,
-        )
+        .collect(Some(&run_id), &canonical_run_id, &session_id, &thread_id)
         .await
     {
         Ok(response) => {

--- a/gui/src-tauri/src/agent_bridge/observer.rs
+++ b/gui/src-tauri/src/agent_bridge/observer.rs
@@ -11,12 +11,16 @@
 //!    restart), the observer creates the local run row (id == the agent's
 //!    canonical run id, so the existing crash-reconcile machinery matches it)
 //!    and projects events into the run-event log. Runs owned by a pipeline
-//!    collector are persisted by that collector — `append_run_event` does not
-//!    dedupe, so exactly one writer per run, enforced via the replica lease
-//!    registry.
+//!    collector are persisted by that collector — exactly one writer per run:
+//!    the pipeline registers its lease before the prompt ever reaches the
+//!    agent, and `append_run_event`'s sequence guard absorbs any residual
+//!    replay overlap.
 //! 2. **NATS mirroring** — the sole publisher for the remote bridge. The
 //!    collector deliberately does not publish; the observer's atomic-attach
-//!    replay guarantees the mirrored sequence has no holes.
+//!    replay guarantees the mirrored sequence has no holes. Events are
+//!    validated against the run cursor BEFORE any fan-out (persistence,
+//!    webview forward, mirror publish), so the mirrored sequence stays
+//!    in-order and duplicate-free across re-attaches.
 //! 3. **Frontend invalidation** — `thread-runtime-updated` for persisted runs,
 //!    plus whitelisted settings events (`agent-event`) for every session, so
 //!    model/thinking/title changes land in the sidebar cache live.
@@ -344,11 +348,14 @@ fn bind_run(session_id: &str, canonical_run_id: &str, local_run_id: &str) {
 // ── Observer task ──────────────────────────────────────────────────────────
 
 /// Task-local stream bookkeeping: per-run event cursors (idx dedup + gap
-/// detection) and the session's currently-active run, if any.
+/// detection), the session's currently-active run (if any), and the most
+/// recently settled run — the broadcaster keeps stamping its identity onto
+/// between-runs settings events until the next run starts.
 #[derive(Default)]
 struct ObserverState {
     cursors: HashMap<String, i64>,
     active_run: Option<String>,
+    last_settled_run: Option<String>,
 }
 
 fn spawn_observer(session_id: String, shared: Arc<ObserverShared>, cancel: oneshot::Receiver<()>) {
@@ -384,7 +391,14 @@ async fn run_observer(
         // run starting in the probe→subscribe gap is caught by gap detection.
         let active_run = probe_active_run(&mut client, session_id).await;
         let mut stream = if let Some(run_id) = active_run {
-            let cursor = attach_cursor(session_id, &run_id).await;
+            // Resume from the in-memory cursor on re-attach: events at or
+            // below it were already persisted and mirrored, so replaying them
+            // would only duplicate the NATS mirror. The persisted-store cursor
+            // is the resume point for a fresh attach (startup, first sight).
+            let cursor = match state.cursors.get(&run_id) {
+                Some(&cursor) => cursor,
+                None => attach_cursor(session_id, &run_id).await,
+            };
             state.cursors.insert(run_id.clone(), cursor);
             match client
                 .stream_events(StreamRequest {
@@ -549,6 +563,12 @@ async fn attach_cursor(session_id: &str, canonical_run_id: &str) -> i64 {
 
 /// Process one event. Returns false when the run's idx sequence broke — the
 /// caller re-attaches, and the replay/projection snapshot heals the gap.
+///
+/// Ordering rule: an event is validated against its run cursor BEFORE any
+/// fan-out (persistence, webview forward, NATS mirror). The observer is the
+/// sole NATS publisher, so nothing unvalidated may be mirrored — otherwise a
+/// gap-triggered re-attach would re-publish replayed events and remote
+/// clients would see the run out of order and duplicated.
 async fn handle_event(
     session_id: &str,
     shared: &Arc<ObserverShared>,
@@ -558,18 +578,19 @@ async fn handle_event(
     let event_type = event.r#type.as_str();
     let run_id = event.run_id.as_str();
 
-    // Settings fan-out for every observed session (sidebar cache, open thread).
-    if FORWARDED_EVENTS.contains(&event_type) {
-        forward_settings_event(session_id, event_type, &event.data);
-    }
-    // Sole NATS publisher (no-op when no remote is connected).
-    crate::remote::publish_event(session_id, event_type, &event.data, run_id, event.idx);
-
+    // Session-level event (no run scope): no cursor to validate against —
+    // forward and mirror directly.
     if run_id.is_empty() {
-        return true; // session-level event — no run bookkeeping
+        if FORWARDED_EVENTS.contains(&event_type) {
+            forward_settings_event(session_id, event_type, &event.data);
+        }
+        crate::remote::publish_event(session_id, event_type, &event.data, run_id, event.idx);
+        return true;
     }
 
-    // Projection snapshots replace the run's local replica wholesale.
+    // Projection snapshots replace the run's local replica wholesale. The
+    // snapshot IS the healing mechanism, so it bypasses the continuity check:
+    // its cursor is the new position, locally and on the mirror.
     if event.projection_snapshot {
         state
             .cursors
@@ -606,18 +627,56 @@ async fn handle_event(
                 note_run_settled(shared, state, run_id);
             }
         }
+        // Mirror the snapshot AFTER the local replace has landed — a remote
+        // client healing from this signal reads back the store we just wrote.
+        // Folded events cannot be applied incrementally, so this goes out as a
+        // wholesale-replacement signal, not as individual events.
+        crate::remote::publish_snapshot(
+            session_id,
+            run_id,
+            event.snapshot_cursor,
+            &event.snapshot_events,
+        );
         return true;
     }
 
-    // idx bookkeeping per run. Replay overlap is skipped; a break in the
-    // sequence (missed head on first sight, or a mid-run hole) forces a
-    // re-attach so persistence and the NATS mirror stay gap-free.
-    let last = state.cursors.get(run_id).copied().unwrap_or(-1);
-    if event.idx <= last {
-        return true;
-    }
-    if event.idx != last.saturating_add(1) {
-        return false;
+    // Run-scoped event: validate ordering first. Replays (idx <= cursor) and
+    // gaps (idx skips ahead) are settled here — neither may reach the stores,
+    // the webview, or the mirror.
+    match state.cursors.get(run_id).copied() {
+        Some(last) => {
+            if event.idx <= last {
+                return true; // replay overlap — already persisted and mirrored
+            }
+            if event.idx != last.saturating_add(1) {
+                return false; // mid-run hole — re-attach for replay/snapshot healing
+            }
+        }
+        None => {
+            if event.idx != 0 {
+                if state.last_settled_run.as_deref() == Some(run_id) {
+                    // The broadcaster keeps the settled run's identity until
+                    // the next `start_run`, so between-runs settings changes
+                    // (model, thinking level, …) arrive stamped with it at the
+                    // idx the run ended on. They are session fan-out, not run
+                    // content: forward and mirror without cursor bookkeeping —
+                    // treating them as gaps would force a pointless re-attach
+                    // on every settings change.
+                    if FORWARDED_EVENTS.contains(&event_type) {
+                        forward_settings_event(session_id, event_type, &event.data);
+                    }
+                    crate::remote::publish_event(
+                        session_id,
+                        event_type,
+                        &event.data,
+                        run_id,
+                        event.idx,
+                    );
+                    return true;
+                }
+                return false; // missed head on first sight — re-attach for replay
+            }
+        }
     }
     state.cursors.insert(run_id.to_string(), event.idx);
     note_run_active(shared, state, run_id);
@@ -627,41 +686,45 @@ async fn handle_event(
     let is_terminal = matches!(event_type, "agent_end" | "error");
 
     // Pipeline-owned runs are persisted by their collector; the observer only
-    // mirrors/forwards those. Everything else is ours to project.
-    let Some((thread_id, local_run_id)) = observer_run(session_id, shared, run_id).await else {
-        if is_terminal {
-            note_run_settled(shared, state, run_id);
-        }
-        return true;
-    };
-    stream::persist_run_event_off_thread(
-        &thread_id,
-        Some(&local_run_id),
-        event_type.to_string(),
-        event.data.clone(),
-        event.idx,
-    )
-    .await;
+    // mirrors/forwards those. Everything else is ours to project — persisted
+    // BEFORE fan-out, so the mirror never announces what the store lacks.
+    if let Some((thread_id, local_run_id)) = observer_run(session_id, shared, run_id).await {
+        stream::persist_run_event_off_thread(
+            &thread_id,
+            Some(&local_run_id),
+            event_type.to_string(),
+            event.data.clone(),
+            event.idx,
+        )
+        .await;
 
-    match event_type {
-        "agent_end" => {
-            if stream::agent_end_incomplete(&event.data) {
-                mark_run_failed_if_active(
-                    Some(&local_run_id),
-                    "Future Agent response ended before a clean terminal.",
-                );
-            } else {
-                mark_run_completed_if_active(Some(&local_run_id));
+        match event_type {
+            "agent_end" => {
+                if stream::agent_end_incomplete(&event.data) {
+                    mark_run_failed_if_active(
+                        Some(&local_run_id),
+                        "Future Agent response ended before a clean terminal.",
+                    );
+                } else {
+                    mark_run_completed_if_active(Some(&local_run_id));
+                }
+                crate::store::clear_run_event_buffer(&local_run_id);
+                note_run_settled(shared, state, run_id);
             }
-            crate::store::clear_run_event_buffer(&local_run_id);
-            note_run_settled(shared, state, run_id);
+            "error" => {
+                mark_run_failed_if_active(Some(&local_run_id), "Future Agent reported an error.");
+                note_run_settled(shared, state, run_id);
+            }
+            _ => {}
         }
-        "error" => {
-            mark_run_failed_if_active(Some(&local_run_id), "Future Agent reported an error.");
-            note_run_settled(shared, state, run_id);
-        }
-        _ => {}
+    } else if is_terminal {
+        note_run_settled(shared, state, run_id);
     }
+
+    if FORWARDED_EVENTS.contains(&event_type) {
+        forward_settings_event(session_id, event_type, &event.data);
+    }
+    crate::remote::publish_event(session_id, event_type, &event.data, run_id, event.idx);
     true
 }
 
@@ -676,6 +739,7 @@ fn note_run_settled(shared: &Arc<ObserverShared>, state: &mut ObserverState, run
         shared.has_active_run.store(false, Ordering::Relaxed);
     }
     state.cursors.remove(run_id);
+    state.last_settled_run = Some(run_id.to_string());
     if let Ok(mut bindings) = shared.run_bindings.lock() {
         bindings.remove(run_id);
     }
@@ -826,5 +890,142 @@ mod tests {
             quiet_idle.should_sleep(),
             "long-quiet + no active run → sleep"
         );
+    }
+
+    // ── Ordering: validation before fan-out ─────────────────────────────
+
+    fn stream_event(event_type: &str, run_id: &str, idx: i64) -> crate::agent_proto::StreamEvent {
+        crate::agent_proto::StreamEvent {
+            r#type: event_type.to_string(),
+            data: "{}".to_string(),
+            run_id: run_id.to_string(),
+            idx,
+            projection_snapshot: false,
+            snapshot_events: vec![],
+            snapshot_cursor: 0,
+            session_id: "sess-order".to_string(),
+            epoch: 1,
+        }
+    }
+
+    /// Lease the run so `observer_run` short-circuits as pipeline-owned and
+    /// `handle_event` never touches the store. Fan-out ends at no-op sinks
+    /// (no APP_HANDLE, no remote pairing) — what these tests assert is the
+    /// cursor bookkeeping that gates it.
+    fn lease_run(run_id: &str) -> super::super::replica::ReplicaLease {
+        super::super::replica::AGENT_REPLICAS
+            .acquire(run_id)
+            .expect("lease")
+    }
+
+    #[tokio::test]
+    async fn gap_event_is_rejected_without_advancing_the_cursor() {
+        let _lease = lease_run("run-gap");
+        let shared = Arc::new(ObserverShared::new());
+        let mut state = ObserverState::default();
+
+        assert!(
+            handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("text_chunk", "run-gap", 0)
+            )
+            .await,
+            "in-order first event accepted"
+        );
+        assert!(
+            handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("text_chunk", "run-gap", 0)
+            )
+            .await,
+            "replay overlap is a no-op, not a gap"
+        );
+        assert!(
+            !handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("text_chunk", "run-gap", 2)
+            )
+            .await,
+            "idx skipping ahead breaks the stream for re-attach"
+        );
+        assert_eq!(
+            state.cursors.get("run-gap"),
+            Some(&0),
+            "a rejected gap event must not advance the cursor — the re-attach replay covers it"
+        );
+        assert!(
+            handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("text_chunk", "run-gap", 1)
+            )
+            .await,
+            "the replayed continuation validates against the untouched cursor"
+        );
+        assert_eq!(state.cursors.get("run-gap"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn missed_head_on_first_sight_forces_reattach() {
+        let shared = Arc::new(ObserverShared::new());
+        let mut state = ObserverState::default();
+
+        assert!(
+            !handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("text_chunk", "run-late", 3)
+            )
+            .await,
+            "a run first seen above idx 0 means the head was missed — re-attach"
+        );
+        assert!(
+            state.cursors.get("run-late").is_none(),
+            "no cursor bookkeeping before the replay heals the head"
+        );
+    }
+
+    #[tokio::test]
+    async fn settled_run_stragglers_fan_out_without_bookkeeping() {
+        let _lease = lease_run("run-fresh");
+        let shared = Arc::new(ObserverShared::new());
+        let mut state = ObserverState {
+            last_settled_run: Some("run-settled".to_string()),
+            ..ObserverState::default()
+        };
+        // Between-runs settings events keep the settled run's stamped identity;
+        // they must forward/mirror without cursor bookkeeping or a re-attach.
+        assert!(
+            handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("model_changed", "run-settled", 47)
+            )
+            .await
+        );
+        assert!(
+            state.cursors.get("run-settled").is_none(),
+            "a straggler must not open cursor bookkeeping for the settled run"
+        );
+        // A genuinely new run still starts at idx 0.
+        assert!(
+            handle_event(
+                "sess-order",
+                &shared,
+                &mut state,
+                stream_event("agent_start", "run-fresh", 0)
+            )
+            .await
+        );
+        assert_eq!(state.cursors.get("run-fresh"), Some(&0));
     }
 }

--- a/gui/src-tauri/src/agent_bridge/observer.rs
+++ b/gui/src-tauri/src/agent_bridge/observer.rs
@@ -988,7 +988,7 @@ mod tests {
             "a run first seen above idx 0 means the head was missed — re-attach"
         );
         assert!(
-            state.cursors.get("run-late").is_none(),
+            !state.cursors.contains_key("run-late"),
             "no cursor bookkeeping before the replay heals the head"
         );
     }
@@ -1013,7 +1013,7 @@ mod tests {
             .await
         );
         assert!(
-            state.cursors.get("run-settled").is_none(),
+            !state.cursors.contains_key("run-settled"),
             "a straggler must not open cursor bookkeeping for the settled run"
         );
         // A genuinely new run still starts at idx 0.

--- a/gui/src-tauri/src/remote/mod.rs
+++ b/gui/src-tauri/src/remote/mod.rs
@@ -452,6 +452,33 @@ pub fn publish_event(session_id: &str, event_type: &str, data: &str, run_id: &st
     }
 }
 
+/// Mirror a run's projection snapshot as a wholesale-replacement signal. The
+/// snapshot's folded events cannot be applied incrementally — a coalesced
+/// chunk's payload spans idx values the client already applied — so this goes
+/// out as a single `run_snapshot` event and the client heals by resyncing
+/// rather than folding. The folded events ride along in `data` for consumers
+/// that can apply a snapshot directly.
+pub fn publish_snapshot(
+    session_id: &str,
+    run_id: &str,
+    snapshot_cursor: i64,
+    snapshot_events: &[crate::agent_proto::ProjectedRunEvent],
+) {
+    let events: Vec<serde_json::Value> = snapshot_events
+        .iter()
+        .map(|event| {
+            json!({
+                "type": event.r#type,
+                "data": serde_json::from_str::<serde_json::Value>(&event.data)
+                    .unwrap_or(serde_json::Value::Null),
+                "idx": event.idx,
+            })
+        })
+        .collect();
+    let data = json!({ "snapshotEvents": events, "snapshotCursor": snapshot_cursor }).to_string();
+    publish_event(session_id, "run_snapshot", &data, run_id, snapshot_cursor);
+}
+
 /// Return `data` unchanged when it fits the payload budget, else a well-formed
 /// JSON placeholder that keeps the event renderable and tells the client where
 /// the full content lives (the persisted run history via `get_messages`). The

--- a/gui/src-tauri/src/store.rs
+++ b/gui/src-tauri/src/store.rs
@@ -62,7 +62,7 @@ pub use threads::{
     restore_thread, sync_thread_title, update_thread_model, update_thread_session_id,
     update_thread_thinking_level, ThreadRecord,
 };
-pub use util::take_catalog_dirty;
+pub use util::{create_id, take_catalog_dirty};
 pub use workspace_files::{search_workspace_files, WorkspaceFileResult, WorkspaceFileSearchInput};
 pub use workspaces::{
     create_workspace, delete_workspace, get_or_create_chat_workspace, get_workspace,

--- a/gui/src-tauri/src/store/runs.rs
+++ b/gui/src-tauri/src/store/runs.rs
@@ -593,6 +593,25 @@ fn read_run_events(run_id: &str) -> Vec<RunEventRecord> {
 }
 
 pub fn append_run_event(input: AppendRunEventInput) -> Result<RunEventRecord, crate::AppError> {
+    // Re-delivery guard: a run's events arrive in strictly increasing sequence
+    // from its single writer, so a sequence at/below the buffered high-water
+    // mark is a replay overlap or a cross-writer race duplicate — return the
+    // already-stored record instead of appending a second copy. (The
+    // projection-snapshot replace path clears the buffer first, so it
+    // re-appends from an empty slate and is unaffected.)
+    if let Ok(buf) = RUN_EVENT_BUFFER.lock() {
+        if let Some(events) = buf.get(&input.run_id) {
+            if let Some(last) = events.last() {
+                if input.sequence <= last.sequence {
+                    if let Some(existing) =
+                        events.iter().find(|event| event.sequence == input.sequence)
+                    {
+                        return Ok(existing.clone());
+                    }
+                }
+            }
+        }
+    }
     let id = create_id("event");
     let now = now_millis();
     let record = RunEventRecord {
@@ -1300,5 +1319,35 @@ mod tests {
             )
             .unwrap();
         assert_eq!(approval_status, "cancelled");
+    }
+
+    #[test]
+    fn append_run_event_dedups_replayed_sequences() {
+        let run_id = format!("test_dedup_{}", std::process::id());
+        let input = |sequence: i64| AppendRunEventInput {
+            run_id: run_id.clone(),
+            event_type: "text_chunk".to_string(),
+            payload: Some(format!(r#"{{"text":"s{sequence}"}}"#)),
+            sequence,
+        };
+
+        let first = append_run_event(input(0)).expect("first append");
+        let replay = append_run_event(input(0)).expect("replay tolerated");
+        assert_eq!(
+            first.id, replay.id,
+            "a replayed sequence returns the already-stored record"
+        );
+        append_run_event(input(1)).expect("advancing append");
+        append_run_event(input(1)).expect("second replay tolerated");
+
+        let events = list_run_events(&run_id).expect("list events");
+        assert_eq!(
+            events.len(),
+            2,
+            "replayed sequences must not duplicate the log"
+        );
+        assert_eq!(events[0].sequence, 0);
+        assert_eq!(events[1].sequence, 1);
+        clear_run_event_buffer(&run_id);
     }
 }

--- a/gui/src/features/agent/agentThreadTypes.ts
+++ b/gui/src/features/agent/agentThreadTypes.ts
@@ -47,6 +47,8 @@ export interface MessageAttachment {
 export interface AgentMessage {
   id: string;
   runId?: string | null;
+  /** Conversation-turn identity from the agent journal (`meta.turn_id`). */
+  turnId?: string | null;
   role: MessageRole;
   /**
    * i18n key (in the `agent` namespace) for the author, e.g. `author.you`. It is

--- a/gui/src/features/agent/entryProjection.test.ts
+++ b/gui/src/features/agent/entryProjection.test.ts
@@ -208,4 +208,50 @@ describe("entriesToMessages", () => {
     // The compaction text must not appear as a user bubble.
     expect(messages.some(message => message.role === "user" && message.content.startsWith("[Context compaction:"))).toBe(false);
   });
+
+  it("groups reordered entries by turn_id when the journal carries turn identity", () => {
+    // A steered follow-up is journaled ahead of the turn it interrupted (the
+    // terminal rewrite heals order): positionally, assistant "first answer"
+    // would land in the follow-up's turn. Turn ids re-attribute it correctly.
+    const entries: SessionEntry[] = [
+      { id: "u1", role: "user", content: "first question", meta: { run_id: "run-1", turn_id: "turn-1" } },
+      { id: "u2", role: "user", content: "steered follow-up", meta: { run_id: "run-1", turn_id: "turn-2" } },
+      { id: "a1", role: "assistant", content: "first answer", meta: { run_id: "run-1", turn_id: "turn-1" } },
+      { id: "a2", role: "assistant", content: "follow-up answer", meta: { run_id: "run-1", turn_id: "turn-2" } },
+    ];
+
+    const messages = entriesToMessages(entries);
+
+    expect(messages.map(m => [m.role, m.content])).toEqual([
+      ["user", "first question"],
+      ["assistant", "first answer"],
+      ["user", "steered follow-up"],
+      ["assistant", "follow-up answer"],
+    ]);
+    expect(messages[0]?.turnId).toBe("turn-1");
+    expect(messages[1]?.turnId).toBe("turn-1");
+    expect(messages[2]?.turnId).toBe("turn-2");
+    expect(messages[3]?.turnId).toBe("turn-2");
+    // Run identity still only marks the settled assistant bubbles.
+    expect(messages[0]?.runId).toBeUndefined();
+    expect(messages[1]?.runId).toBe("run-1");
+  });
+
+  it("keeps positional grouping for legacy journals without turn ids", () => {
+    const entries: SessionEntry[] = [
+      { id: "u1", role: "user", content: "first question" },
+      { id: "u2", role: "user", content: "follow-up" },
+      { id: "a1", role: "assistant", content: "answer" },
+    ];
+
+    const messages = entriesToMessages(entries);
+
+    // Positional: the assistant follows the most recent user message.
+    expect(messages.map(m => [m.role, m.content])).toEqual([
+      ["user", "first question"],
+      ["user", "follow-up"],
+      ["assistant", "answer"],
+    ]);
+    expect(messages.every(m => m.turnId == null)).toBe(true);
+  });
 });

--- a/gui/src/features/agent/entryProjection.ts
+++ b/gui/src/features/agent/entryProjection.ts
@@ -29,6 +29,8 @@ export interface SessionEntry {
   meta?: {
     /** Canonical Agent run identity (new entries; absent in legacy JSONL). */
     run_id?: string;
+    /** Conversation-turn identity (new entries; absent in legacy JSONL). */
+    turn_id?: string;
     attachments?: Array<{
       path: string;
       kind?: "image" | "file" | null;
@@ -62,6 +64,8 @@ interface TurnAcc {
   durationMs?: number;
   /** Set only from an assistant entry finalized by the Agent. */
   runId?: string;
+  /** The turn this accumulator groups, when the journal carries turn ids. */
+  turnId?: string;
   /**
    * Tool activities awaiting their result entry, in call order. A `tool` result
    * entry updates the oldest one's status (the agent executes and appends
@@ -122,143 +126,232 @@ function segId(): string {
   return `ep_${Date.now()}_${++_seq}`;
 }
 
+/** The agent replaces summarized history with a single user message
+ * "[Context compaction: …]" (compaction/mod.rs). */
+function isCompactionDivider(entry: SessionEntry): boolean {
+  return entry.role === "user" && entry.content.startsWith("[Context compaction:");
+}
+
+/** Render a compaction marker as a divider, not as a user bubble / new turn. */
+function dividerMessage(entry: SessionEntry, now: string): AgentMessage {
+  return {
+    id: segId(),
+    role: "assistant",
+    authorKey: "author.researchCopilot",
+    content: "",
+    status: "complete",
+    createdAt: entry.timestamp ?? now,
+    segments: [{ id: segId(), kind: "compaction" }],
+  };
+}
+
+function newTurnAcc(): TurnAcc {
+  return { segments: [], finalText: "", pendingTools: [] };
+}
+
+function userMessageFromEntry(entry: SessionEntry, now: string): AgentMessage {
+  return {
+    id: segId(),
+    role: "user",
+    authorKey: "author.you",
+    content: entry.content,
+    status: "complete",
+    createdAt: entry.timestamp ?? now,
+    attachments: attachmentsFromMeta(entry),
+    // Run identity stays off the user bubble on purpose: runId-on-assistant is
+    // the convention applyRunMetadata / streamingBubbleBase use to tell
+    // settled turns from in-flight ones — a stamped user message would
+    // suppress the live streaming bubble after a mid-run reload. The turn id
+    // carries the message's journal identity instead.
+    turnId: entry.meta?.turn_id ?? null,
+  };
+}
+
+/** Fold one assistant entry into a turn's accumulator. */
+function foldAssistantEntry(acc: TurnAcc, entry: SessionEntry) {
+  // Last assistant entry of the turn carries the reply's time + usage.
+  if (entry.timestamp)
+    acc.assistantCreatedAt = entry.timestamp;
+  if (typeof entry.output_tokens === "number")
+    acc.outputTokens = entry.output_tokens;
+  if (typeof entry.duration_ms === "number")
+    acc.durationMs = entry.duration_ms;
+  if (typeof entry.meta?.run_id === "string" && entry.meta.run_id)
+    acc.runId = entry.meta.run_id;
+  if (entry.thinking) {
+    acc.segments.push({ id: segId(), kind: "thinking", text: entry.thinking });
+  }
+  // Text (any preamble) comes before the tool calls it introduces — that's
+  // the order the model emits within a message, and the order the live path
+  // shows. Pushing tools first put "Read config.toml" above "Let me check
+  // the config".
+  if (entry.content?.trim()) {
+    acc.segments.push({ id: segId(), kind: "text", text: entry.content });
+    acc.finalText = entry.content;
+  }
+  if (entry.tool_calls) {
+    for (const tc of entry.tool_calls) {
+      const kind = asToolKind(tc.function.name);
+      const target = targetFromArgs(kind, normalizeArgs(tc.function.arguments));
+      const item: AgentActivityItem = {
+        // Use the LLM's tool call id (call_00_xxx) so it matches the
+        // stored tool call records in the runs panel.
+        id: tc.id || segId(),
+        kind,
+        status: "completed",
+        target,
+        // The path/command, not the raw args blob — matches the live path and
+        // keeps a write's hover from being its entire file content.
+        detail: target,
+      };
+      acc.segments.push({ id: segId(), kind: "activity", item });
+      acc.pendingTools.push(item);
+    }
+  }
+}
+
+/**
+ * A `tool` result entry doesn't get its own row (the assistant's
+ * `tool_calls` already produced one — rendering it too duplicated the row
+ * as a blank activity). Use it only to mark that call failed, matching the
+ * tool_calls in order (the agent executes and appends results in order).
+ */
+function foldToolEntry(acc: TurnAcc | null, entry: SessionEntry) {
+  const item = acc?.pendingTools.shift();
+  if (item) {
+    const command = item.kind === "shell" ? item.target : undefined;
+    if (toolResultFailed(entry.content, command))
+      item.status = "failed";
+  }
+}
+
+/** Emit a completed turn as 1 user message + (when non-empty) 1 assistant. */
+function flushAcc(messages: AgentMessage[], acc: TurnAcc) {
+  if (!acc.userMessage)
+    return;
+  messages.push(acc.userMessage);
+  const textSegments = acc.segments.filter(s => s.kind === "text") as { kind: "text"; id: string; text: string }[];
+  // Collapse same-kind tool bursts only after statuses are final (a failing
+  // tool result, processed later, must break the group).
+  const segments = collapseActivitySegments(acc.segments);
+  // Skip assistant message for incomplete turns — the user message is the last
+  // entry and the assistant reply hasn't been written to the JSONL yet (the
+  // agent is still streaming). An empty completed bubble would steal the runId
+  // in applyRunMetadata and block upsertStreamingPreview from inserting the
+  // live preview when the user returns to this thread.
+  const hasContent = acc.finalText
+    || textSegments.length > 0
+    || segments.length > 0
+    || acc.outputTokens !== undefined
+    || acc.durationMs !== undefined;
+  if (hasContent) {
+    messages.push({
+      id: segId(),
+      role: "assistant",
+      authorKey: "author.researchCopilot",
+      content: acc.finalText || textSegments.map(s => s.text).join("\n"),
+      segments: segments.length > 0 ? segments : undefined,
+      status: "complete",
+      // An aborted turn has no assistant entry, so no recorded reply time — fall
+      // back to the turn's user time (a real timestamp) rather than `now`, which
+      // would re-stamp the reply "just now" on every reload.
+      createdAt: acc.assistantCreatedAt ?? acc.userMessage.createdAt,
+      outputTokens: acc.outputTokens,
+      durationMs: acc.durationMs,
+      runId: acc.runId,
+      turnId: acc.turnId ?? null,
+    });
+  }
+}
+
 /**
  * Convert raw agent session entries into AgentMessage[] for the GUI pipeline.
  * Each user→assistant turn yields 1 user + 1 assistant message with segments
  * for thinking, tool activity, and text.
+ *
+ * Two grouping strategies: when the journal carries turn ids on every turn
+ * entry (current agents), entries are grouped by `turn_id`, so an in-run
+ * follow-up/steer whose journal order differs from conversation order still
+ * attributes content to the right turn. Legacy journals (no turn ids) group
+ * positionally — a user entry always opens a turn.
  */
 export function entriesToMessages(entries: SessionEntry[]): AgentMessage[] {
   const messages: AgentMessage[] = [];
   const now = new Date().toISOString();
-  let acc: TurnAcc | null = null;
+  const keyed = entries.length > 0 && entries
+    .filter(e => !isCompactionDivider(e) && e.role !== "tool")
+    .every(e => typeof e.meta?.turn_id === "string" && e.meta.turn_id);
 
-  function flush() {
-    if (!acc?.userMessage)
-      return;
-    messages.push(acc.userMessage);
-    const textSegments = acc.segments.filter(s => s.kind === "text") as { kind: "text"; id: string; text: string }[];
-    // Collapse same-kind tool bursts only after statuses are final (a failing
-    // tool result, processed later, must break the group).
-    const segments = collapseActivitySegments(acc.segments);
-    // Skip assistant message for incomplete turns — the user message is the last
-    // entry and the assistant reply hasn't been written to the JSONL yet (the
-    // agent is still streaming). An empty completed bubble would steal the runId
-    // in applyRunMetadata and block upsertStreamingPreview from inserting the
-    // live preview when the user returns to this thread.
-    const hasContent = acc.finalText
-      || textSegments.length > 0
-      || segments.length > 0
-      || acc.outputTokens !== undefined
-      || acc.durationMs !== undefined;
-    if (hasContent) {
-      messages.push({
-        id: segId(),
-        role: "assistant",
-        authorKey: "author.researchCopilot",
-        content: acc.finalText || textSegments.map(s => s.text).join("\n"),
-        segments: segments.length > 0 ? segments : undefined,
-        status: "complete",
-        // An aborted turn has no assistant entry, so no recorded reply time — fall
-        // back to the turn's user time (a real timestamp) rather than `now`, which
-        // would re-stamp the reply "just now" on every reload.
-        createdAt: acc.assistantCreatedAt ?? acc.userMessage.createdAt,
-        outputTokens: acc.outputTokens,
-        durationMs: acc.durationMs,
-        runId: acc.runId,
-      });
+  if (keyed) {
+    const accs = new Map<string, TurnAcc>();
+    const ordered: TurnAcc[] = [];
+    let open: TurnAcc | null = null;
+    const accFor = (turnId: string | undefined): TurnAcc => {
+      if (turnId === undefined) {
+        // Only reachable for a stray tool entry — attach to the open turn.
+        if (!open) {
+          open = newTurnAcc();
+          ordered.push(open);
+        }
+        return open;
+      }
+      let acc = accs.get(turnId);
+      if (!acc) {
+        acc = newTurnAcc();
+        acc.turnId = turnId;
+        accs.set(turnId, acc);
+        ordered.push(acc);
+      }
+      open = acc;
+      return acc;
+    };
+    for (const entry of entries) {
+      if (isCompactionDivider(entry)) {
+        messages.push(dividerMessage(entry, now));
+        continue;
+      }
+      if (entry.role === "user")
+        accFor(entry.meta?.turn_id).userMessage = userMessageFromEntry(entry, now);
+      else if (entry.role === "assistant")
+        foldAssistantEntry(accFor(entry.meta?.turn_id), entry);
+      else if (entry.role === "tool")
+        foldToolEntry(accFor(entry.meta?.turn_id), entry);
     }
-    acc = null;
+    for (const acc of ordered)
+      flushAcc(messages, acc);
+    return messages;
   }
 
+  // Positional grouping (legacy journals, mixed files, compaction rewrites).
+  let acc: TurnAcc | null = null;
   for (const entry of entries) {
-    // The agent replaces summarized history with a single user message
-    // "[Context compaction: …]" (compaction/mod.rs). Render it as a divider
-    // marking where history was summarized, not as a user bubble / new turn.
-    if (entry.role === "user" && entry.content.startsWith("[Context compaction:")) {
-      if (acc)
-        flush();
-      messages.push({
-        id: segId(),
-        role: "assistant",
-        authorKey: "author.researchCopilot",
-        content: "",
-        status: "complete",
-        createdAt: entry.timestamp ?? now,
-        segments: [{ id: segId(), kind: "compaction" }],
-      });
+    if (isCompactionDivider(entry)) {
+      if (acc) {
+        flushAcc(messages, acc);
+        acc = null;
+      }
+      messages.push(dividerMessage(entry, now));
       continue;
     }
     if (entry.role === "user") {
-      if (acc)
-        flush();
-      acc = { segments: [], finalText: "", pendingTools: [] };
-      acc.userMessage = {
-        id: segId(),
-        role: "user",
-        authorKey: "author.you",
-        content: entry.content,
-        status: "complete",
-        createdAt: entry.timestamp ?? now,
-        attachments: attachmentsFromMeta(entry),
-      };
+      if (acc) {
+        flushAcc(messages, acc);
+        acc = null;
+      }
+      acc = newTurnAcc();
+      acc.turnId = entry.meta?.turn_id;
+      acc.userMessage = userMessageFromEntry(entry, now);
     }
     else if (entry.role === "assistant") {
       if (!acc)
-        acc = { segments: [], finalText: "", pendingTools: [] };
-      // Last assistant entry of the turn carries the reply's time + usage.
-      if (entry.timestamp)
-        acc.assistantCreatedAt = entry.timestamp;
-      if (typeof entry.output_tokens === "number")
-        acc.outputTokens = entry.output_tokens;
-      if (typeof entry.duration_ms === "number")
-        acc.durationMs = entry.duration_ms;
-      if (typeof entry.meta?.run_id === "string" && entry.meta.run_id)
-        acc.runId = entry.meta.run_id;
-      if (entry.thinking) {
-        acc.segments.push({ id: segId(), kind: "thinking", text: entry.thinking });
-      }
-      // Text (any preamble) comes before the tool calls it introduces — that's
-      // the order the model emits within a message, and the order the live path
-      // shows. Pushing tools first put "Read config.toml" above "Let me check
-      // the config".
-      if (entry.content?.trim()) {
-        acc.segments.push({ id: segId(), kind: "text", text: entry.content });
-        acc.finalText = entry.content;
-      }
-      if (entry.tool_calls) {
-        for (const tc of entry.tool_calls) {
-          const kind = asToolKind(tc.function.name);
-          const target = targetFromArgs(kind, normalizeArgs(tc.function.arguments));
-          const item: AgentActivityItem = {
-            // Use the LLM's tool call id (call_00_xxx) so it matches the
-            // stored tool call records in the runs panel.
-            id: tc.id || segId(),
-            kind,
-            status: "completed",
-            target,
-            // The path/command, not the raw args blob — matches the live path and
-            // keeps a write's hover from being its entire file content.
-            detail: target,
-          };
-          acc.segments.push({ id: segId(), kind: "activity", item });
-          acc.pendingTools.push(item);
-        }
-      }
+        acc = newTurnAcc();
+      foldAssistantEntry(acc, entry);
     }
     else if (entry.role === "tool") {
-      // A `tool` result entry doesn't get its own row (the assistant's
-      // `tool_calls` already produced one — rendering it too duplicated the row
-      // as a blank activity). Use it only to mark that call failed, matching the
-      // tool_calls in order (the agent executes and appends results in order).
-      const item = acc?.pendingTools.shift();
-      if (item) {
-        const command = item.kind === "shell" ? item.target : undefined;
-        if (toolResultFailed(entry.content, command))
-          item.status = "failed";
-      }
+      foldToolEntry(acc, entry);
     }
   }
   if (acc)
-    flush();
+    flushAcc(messages, acc);
   return messages;
 }

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -251,6 +251,15 @@ export function RemoteProvider({ children }: PropsWithChildren) {
         pendingRef.current.push({ event, sessionId });
         return;
       }
+      if (event.type === "run_snapshot") {
+        // The host replaced this run's replica with a folded projection (its
+        // event ring overflowed). Folded events cannot be applied
+        // incrementally — a coalesced chunk's text spans idx values already
+        // applied — so heal wholesale: recover resyncs history + live tail,
+        // rebuilds the cursor, and folds buffered events.
+        void recoverRef.current();
+        return;
+      }
       const verdict = nextEvent(cursorRef.current, event.runId, event.idx);
       if (verdict.kind === "dup") return;
       if (verdict.kind === "gap") {


### PR DESCRIPTION
## Summary

三个结构性修复，来自多会话架构评审的三个 P1 项（P0 agent daemon 化按约定不在本次范围）：

- **Writer 仲裁**：prompt 前先解析 run id（调用方没传则 GUI 生成）并注册 replica lease，observer 从 run 首个事件起即认定 pipeline-owned，消除 ack 窗口内 observer/collector 双写；`append_run_event` 增加单调序列去重护栏作兜底。
- **Observer 顺序**：`handle_event` 先验证 cursor 再持久化/转发/发布，重连续传用内存 cursor 避免重放二次发布；跨 run 设置事件走 `last_settled_run` 豁免不再触发重连；snapshot 以 `run_snapshot` 整体替换信号镜像，mobile 走 recover 全量愈合。
- **消息身份**：journal 所有条目带 `run_id`，每条 user 消息开 `turn_id` 由其 assistant/tool 继承，终态 reconcile sweep 对齐内存副本；GUI 投影按 turn_id 分组（legacy 回退位置分组）。

## Test plan

- [x] agent: `cargo test` 全量 + workspace clippy（CI 旗标 `--workspace --all-targets -D warnings`）+ fmt
- [x] gui/src-tauri: `cargo test --lib` + clippy + fmt
- [x] gui: `tsc --noEmit` / `eslint` / `vitest` 230 通过
- [x] mobile: typecheck / eslint / jest 42 通过

## Reviewer notes

- GUI 投影里 user 消息的 `runId` 保持为空是刻意行为：`runId`-on-assistant 是流式气泡守护（`streamingBubbleBase` / `applyRunMetadata`）依赖的"已完结 turn"约定；turn 级身份由 `turnId` 承载。
- 已 fast-forward 合并到本地 `dev` 供手工测试（同一提交 `89e1d964`）。
- 依赖一个 Agent 侧既有行为：broadcaster 在 run 结束后不清除 run identity，跨 run 的设置事件仍盖旧 run id——本次以 observer 的 `last_settled_run` 豁免消费它，未改 agent 广播层。

🤖 Generated with [Claude Code](https://claude.com/claude-code)