### PR TITLE
fix(agent): silence unused-variable warning in repair_dir_permissions on Windows

### DIFF
--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -257,6 +257,8 @@ fn repair_dir_permissions(dir: &Path) -> std::io::Result<()> {
             std::fs::set_permissions(dir, std::fs::Permissions::from_mode(repaired))?;
         }
     }
+    #[cfg(not(unix))]
+    let _ = dir;
     Ok(())
 }
 


### PR DESCRIPTION
`make build-agent` emitted one warning on Windows:

`
warning: unused variable: `dir`
   --> agent\src\utils\mod.rs:248:27
`

`repair_dir_permissions` only uses `dir` inside `#[cfg(unix)]`; on Windows the parameter is unused. Fix: add `#[cfg(not(unix))] let _ = dir;` — cross-platform signature and Unix behavior unchanged, Windows build is now warning-free (verified with `make build-agent`).