### PR TITLE
perf(gui): windowed message rendering with paged history loading

### DIFF
--- a/gui/src/features/agent/AgentThread.tsx
+++ b/gui/src/features/agent/AgentThread.tsx
@@ -3,7 +3,7 @@ import type { AgentModelOption } from "../../integrations/agent/agentClient";
 import type { ApprovalTier } from "../../integrations/storage/appSettings";
 import type { StoredApprovalRequest, StoredThread } from "../../integrations/storage/threadStore";
 import type { AgentMessage, MessageAttachment } from "./agentThreadTypes";
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, History, Loader2 } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FloatingScrollbar } from "../../components/ui/FloatingScrollbar";
@@ -18,7 +18,11 @@ import { Composer } from "./Composer";
 import { MessageList } from "./MessageList";
 import { ThreadHeader } from "./ThreadHeader";
 import { useAgentThreadState } from "./useAgentThreadState";
+import { useMessagePaging } from "./useMessagePaging";
 import { useStickyAutoScroll } from "./useStickyAutoScroll";
+
+/** How many user turns one loaded page renders. */
+const PAGE_USER_TURNS = 10;
 
 interface AgentThreadProps {
   thread: StoredThread | null;
@@ -109,6 +113,30 @@ export function AgentThread({
     onScroll: handleScrollbarVisibility,
     onContentSettled: () => updateFloatingScrollbar(false),
   });
+
+  // Windowed rendering for long threads: only the last PAGE_USER_TURNS turns
+  // render; loading an older page is a sync window change (the full message
+  // list stays in memory) with scroll anchoring so the viewport never jumps.
+  const {
+    visibleMessages,
+    loadingOlder,
+    showLoadOlderHint,
+    handleScroll: handlePagingScroll,
+    loadOlder,
+  } = useMessagePaging({
+    messages,
+    scrollRef,
+    userTurnCount: PAGE_USER_TURNS,
+    resetKey: thread?.id ?? null,
+    onScroll: handleScroll,
+  });
+
+  // Compose scroll handling: sticky auto-scroll + floating scrollbar + paging
+  // top detection all observe the same container.
+  const combinedHandleScroll = useCallback(() => {
+    handlePagingScroll();
+    handleScroll();
+  }, [handlePagingScroll, handleScroll]);
 
   // When loading completes (initial load or thread switch), scroll to the
   // latest message.  useStickyAutoScroll's useLayoutEffect fires on contentKey
@@ -213,9 +241,28 @@ export function AgentThread({
             activeApproval ? "pb-112" : "pb-48",
           )}
           data-chat-scroll="true"
-          onScroll={handleScroll}
+          onScroll={combinedHandleScroll}
         >
           <div className="mx-auto w-full max-w-4xl">
+            {showLoadOlderHint
+              ? (
+                  <div className="flex justify-center py-3">
+                    <button
+                      type="button"
+                      onClick={loadOlder}
+                      disabled={loadingOlder}
+                      aria-label={t("thread.loadOlder")}
+                      title={t("thread.loadOlder")}
+                      className="flex items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink disabled:cursor-default disabled:opacity-70"
+                    >
+                      {loadingOlder
+                        ? <Loader2 className="size-3.5 animate-spin" />
+                        : <History className="size-3.5" />}
+                      {t("thread.loadOlder")}
+                    </button>
+                  </div>
+                )
+              : null}
             {loadingIndicator
               ? (
                   <div className="py-8 text-sm text-ink-soft">{t("thread.loading")}</div>
@@ -226,7 +273,7 @@ export function AgentThread({
                     )
                   : (
                       <MessageList
-                        messages={messages}
+                        messages={visibleMessages}
                         showThinking={showThinking}
                         workspaceId={renderWorkspace.workspaceId}
                         workspacePath={renderWorkspace.workspacePath}

--- a/gui/src/features/agent/AgentThread.tsx
+++ b/gui/src/features/agent/AgentThread.tsx
@@ -3,7 +3,7 @@ import type { AgentModelOption } from "../../integrations/agent/agentClient";
 import type { ApprovalTier } from "../../integrations/storage/appSettings";
 import type { StoredApprovalRequest, StoredThread } from "../../integrations/storage/threadStore";
 import type { AgentMessage, MessageAttachment } from "./agentThreadTypes";
-import { ArrowDown, History, Loader2 } from "lucide-react";
+import { ArrowDown, History } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FloatingScrollbar } from "../../components/ui/FloatingScrollbar";
@@ -117,9 +117,10 @@ export function AgentThread({
   // Windowed rendering for long threads: only the last PAGE_USER_TURNS turns
   // render; loading an older page is a sync window change (the full message
   // list stays in memory) with scroll anchoring so the viewport never jumps.
+  // The paging hook composes the sticky auto-scroll handler via `onScroll`, so
+  // one scroll event reaches both.
   const {
     visibleMessages,
-    loadingOlder,
     showLoadOlderHint,
     handleScroll: handlePagingScroll,
     loadOlder,
@@ -130,13 +131,6 @@ export function AgentThread({
     resetKey: thread?.id ?? null,
     onScroll: handleScroll,
   });
-
-  // Compose scroll handling: sticky auto-scroll + floating scrollbar + paging
-  // top detection all observe the same container.
-  const combinedHandleScroll = useCallback(() => {
-    handlePagingScroll();
-    handleScroll();
-  }, [handlePagingScroll, handleScroll]);
 
   // When loading completes (initial load or thread switch), scroll to the
   // latest message.  useStickyAutoScroll's useLayoutEffect fires on contentKey
@@ -240,14 +234,11 @@ export function AgentThread({
                 <button
                   type="button"
                   onClick={loadOlder}
-                  disabled={loadingOlder}
                   aria-label={t("thread.loadOlder")}
                   title={t("thread.loadOlder")}
-                  className="pointer-events-auto flex animate-pop-in items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink disabled:cursor-default disabled:opacity-70"
+                  className="pointer-events-auto flex animate-pop-in items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink"
                 >
-                  {loadingOlder
-                    ? <Loader2 className="size-3.5 animate-spin" />
-                    : <History className="size-3.5" />}
+                  <History className="size-3.5" />
                   {t("thread.loadOlder")}
                 </button>
               </div>
@@ -260,7 +251,7 @@ export function AgentThread({
             activeApproval ? "pb-112" : "pb-48",
           )}
           data-chat-scroll="true"
-          onScroll={combinedHandleScroll}
+          onScroll={handlePagingScroll}
         >
           <div className="mx-auto w-full max-w-4xl">
             {loadingIndicator

--- a/gui/src/features/agent/AgentThread.tsx
+++ b/gui/src/features/agent/AgentThread.tsx
@@ -234,6 +234,25 @@ export function AgentThread({
         onToggleLeftPanel={onToggleLeftPanel}
       />
       <div className="group relative min-h-0 flex-1 overflow-hidden">
+        {showLoadOlderHint
+          ? (
+              <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-8 pt-5">
+                <button
+                  type="button"
+                  onClick={loadOlder}
+                  disabled={loadingOlder}
+                  aria-label={t("thread.loadOlder")}
+                  title={t("thread.loadOlder")}
+                  className="pointer-events-auto flex animate-pop-in items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink disabled:cursor-default disabled:opacity-70"
+                >
+                  {loadingOlder
+                    ? <Loader2 className="size-3.5 animate-spin" />
+                    : <History className="size-3.5" />}
+                  {t("thread.loadOlder")}
+                </button>
+              </div>
+            )
+          : null}
         <div
           ref={scrollRef}
           className={cn(
@@ -244,25 +263,6 @@ export function AgentThread({
           onScroll={combinedHandleScroll}
         >
           <div className="mx-auto w-full max-w-4xl">
-            {showLoadOlderHint
-              ? (
-                  <div className="flex justify-center py-3">
-                    <button
-                      type="button"
-                      onClick={loadOlder}
-                      disabled={loadingOlder}
-                      aria-label={t("thread.loadOlder")}
-                      title={t("thread.loadOlder")}
-                      className="flex items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink disabled:cursor-default disabled:opacity-70"
-                    >
-                      {loadingOlder
-                        ? <Loader2 className="size-3.5 animate-spin" />
-                        : <History className="size-3.5" />}
-                      {t("thread.loadOlder")}
-                    </button>
-                  </div>
-                )
-              : null}
             {loadingIndicator
               ? (
                   <div className="py-8 text-sm text-ink-soft">{t("thread.loading")}</div>

--- a/gui/src/features/agent/MessageBlock.tsx
+++ b/gui/src/features/agent/MessageBlock.tsx
@@ -22,6 +22,8 @@ interface MessageBlockProps {
   message: AgentMessage;
   /** Whether this row is the hovered one (single-owner state in MessageList). */
   hovered: boolean;
+  /** Anchor for scroll restoration when an older page loads above this row. */
+  dataMessageId?: string;
   /** Whether this is the last message in the thread. */
   isLast?: boolean;
   recoverySource?: AgentMessage | null;
@@ -46,6 +48,7 @@ export const MessageBlock = memo(MessageBlockImpl);
 function MessageBlockImpl({
   message,
   hovered,
+  dataMessageId,
   isLast,
   recoverySource,
   showThinking,
@@ -104,7 +107,7 @@ function MessageBlockImpl({
   if (segments && segments.length === 1 && segments[0]!.kind === "compaction") {
     return (
       <article className="flex justify-center">
-        <div className="min-w-0 w-full max-w-3xl">
+        <div className="min-w-0 w-full max-w-3xl" data-message-id={dataMessageId}>
           <CompactionDivider tokensBefore={segments[0]!.tokensBefore} />
         </div>
       </article>
@@ -115,6 +118,7 @@ function MessageBlockImpl({
     <article className="flex justify-center">
       <div
         className="min-w-0 w-full max-w-3xl"
+        data-message-id={dataMessageId}
         onPointerLeave={() => onLeave(message.id)}
         onPointerOver={() => onHover(message.id)}
       >

--- a/gui/src/features/agent/MessageList.tsx
+++ b/gui/src/features/agent/MessageList.tsx
@@ -81,6 +81,7 @@ export function MessageList({ messages, showThinking, onContinue, onFork, onRetr
             key={message.id}
             message={message}
             hovered={hoveredId === message.id}
+            dataMessageId={message.id}
             isLast={isLast}
             recoverySource={recoverySource}
             showThinking={showThinking}

--- a/gui/src/features/agent/entryProjection.ts
+++ b/gui/src/features/agent/entryProjection.ts
@@ -126,8 +126,10 @@ function segId(): string {
   return `ep_${Date.now()}_${++_seq}`;
 }
 
-/** The agent replaces summarized history with a single user message
- * "[Context compaction: …]" (compaction/mod.rs). */
+/**
+ * The agent replaces summarized history with a single user message
+ * "[Context compaction: …]" (compaction/mod.rs).
+ */
 function isCompactionDivider(entry: SessionEntry): boolean {
   return entry.role === "user" && entry.content.startsWith("[Context compaction:");
 }

--- a/gui/src/features/agent/useMessagePaging.test.ts
+++ b/gui/src/features/agent/useMessagePaging.test.ts
@@ -1,0 +1,74 @@
+import type { AgentMessage } from "./agentThreadTypes";
+import { describe, expect, it } from "vitest";
+import { computePageStart } from "./useMessagePaging";
+
+function user(id: string): AgentMessage {
+  return { id, role: "user", authorKey: "author.you", content: id, status: "complete", createdAt: "2026-01-01T00:00:00Z" };
+}
+
+function assistant(id: string): AgentMessage {
+  return { id, role: "assistant", authorKey: "author.researchCopilot", content: id, status: "complete", createdAt: "2026-01-01T00:00:00Z" };
+}
+
+describe("computePageStart", () => {
+  it("returns 0 for an empty list", () => {
+    expect(computePageStart([], 10)).toBe(0);
+  });
+
+  it("returns 0 for a non-positive page size", () => {
+    expect(computePageStart([user("u1")], 0)).toBe(0);
+    expect(computePageStart([user("u1")], -3)).toBe(0);
+  });
+
+  it("renders everything when the thread has fewer turns than a page", () => {
+    const messages = [user("u1"), assistant("a1"), user("u2"), assistant("a2")];
+    expect(computePageStart(messages, 10)).toBe(0);
+  });
+
+  it("starts at the Nth user message from the end", () => {
+    // 3 turns: u1→a1, u2→a2, u3→a3. A 2-turn page starts at u2 (index 2).
+    const messages = [
+      user("u1"),
+      assistant("a1"),
+      user("u2"),
+      assistant("a2"),
+      user("u3"),
+      assistant("a3"),
+    ];
+    expect(computePageStart(messages, 2)).toBe(2);
+  });
+
+  it("starts at a user boundary even when the tail has orphan messages", () => {
+    // u1→a1, u2→a2, then a trailing assistant with no user (in-flight reply).
+    const messages = [
+      user("u1"),
+      assistant("a1"),
+      user("u2"),
+      assistant("a2"),
+      assistant("orphan"),
+    ];
+    // A 1-turn page must start at u2, keeping u2→a2→orphan together.
+    expect(computePageStart(messages, 1)).toBe(2);
+  });
+
+  it("does not count compaction dividers as user turns", () => {
+    const divider = assistant("divider");
+    // u1→a1, u2→a2, [divider], u3→a3.
+    const messages = [
+      user("u1"),
+      assistant("a1"),
+      user("u2"),
+      assistant("a2"),
+      divider,
+      user("u3"),
+      assistant("a3"),
+    ];
+    // A 2-turn page still starts at u2 — the divider sits inside the window.
+    expect(computePageStart(messages, 2)).toBe(2);
+  });
+
+  it("clamps to 0 when the requested page exceeds the whole thread", () => {
+    const messages = [user("u1"), assistant("a1")];
+    expect(computePageStart(messages, 5)).toBe(0);
+  });
+});

--- a/gui/src/features/agent/useMessagePaging.ts
+++ b/gui/src/features/agent/useMessagePaging.ts
@@ -46,7 +46,6 @@ interface UseMessagePagingInput {
 interface UseMessagePagingResult {
   visibleMessages: AgentMessage[];
   canLoadOlder: boolean;
-  loadingOlder: boolean;
   /** True when the user is pinned to the top and more history exists. */
   showLoadOlderHint: boolean;
   handleScroll: () => void;
@@ -84,40 +83,35 @@ export function useMessagePaging({
   onScroll,
 }: UseMessagePagingInput): UseMessagePagingResult {
   const [loadedPages, setLoadedPages] = useState(1);
-  const [loadingOlder, setLoadingOlder] = useState(false);
   const [atTop, setAtTop] = useState(false);
   const [topSettled, setTopSettled] = useState(false);
   const topSettleTimerRef = useRef<number | null>(null);
   const onScrollRef = useRef(onScroll);
   onScrollRef.current = onScroll;
 
-  // Synchronous re-entrancy guard. Unlike the `loadingOlder` state (which only
-  // flips after React commits), this ref is read in the same tick a wheel event
-  // fires, so a single scroll gesture can't queue a dozen page loads — and a
-  // trailing wheel event after the commit is swallowed by the cooldown stamp.
+  // Synchronous re-entrancy guard. This ref is read in the same tick a wheel
+  // event fires (a state flag would only flip after React commits), so a single
+  // scroll gesture can't queue a dozen page loads — and a trailing wheel event
+  // after the commit is swallowed by the cooldown stamp.
   const loadingOlderRef = useRef(false);
   const lastWheelAtRef = useRef(0);
 
-  const pageStart = computePageStart(messages, loadedPages * userTurnCount);
-  // Clamp to the current list (the list can shrink during an in-flight load)
-  // and never produce an empty window.
-  const clampedPageStart = Math.min(pageStart, messages.length);
-  const effectivePageStart = clampedPageStart >= messages.length
-    ? Math.max(0, messages.length - 1)
-    : clampedPageStart;
+  // computePageStart always returns a valid index (or 0 for an empty/short
+  // list), so no clamping is needed here.
+  const effectivePageStart = computePageStart(messages, loadedPages * userTurnCount);
   const visibleMessages = messages.slice(effectivePageStart);
   const canLoadOlder = effectivePageStart > 0;
   // The button only appears after the user has rested at the top for the settle
   // window — arriving at the top must not, by itself, ever trigger a load.
-  const showLoadOlderHint = canLoadOlder && atTop && topSettled && !loadingOlder;
+  const showLoadOlderHint = canLoadOlder && atTop && topSettled;
 
   // Pending scroll restore for the in-flight page load. Written synchronously in
   // `loadOlder`, consumed (and cleared) by the layout effect after commit.
   const restoreRef = useRef<{ anchor: Anchor | null } | null>(null);
 
   const loadOlder = useCallback(() => {
-    // The synchronous ref guard is the real re-entrancy fence; the `loadingOlder`
-    // state check only prevents the hint from looking "idle" mid-load.
+    // The synchronous ref guard is the real re-entrancy fence: it blocks every
+    // wheel event of the gesture until the restore effect clears it.
     if (loadingOlderRef.current)
       return;
     if (effectivePageStart <= 0)
@@ -130,7 +124,6 @@ export function useMessagePaging({
     restoreRef.current = {
       anchor: captureAnchor(scrollRef.current, "data-message-id"),
     };
-    setLoadingOlder(true);
     setLoadedPages(pages => pages + 1);
   }, [effectivePageStart, scrollRef]);
 
@@ -140,7 +133,6 @@ export function useMessagePaging({
   // read a pending anchor captured for the previous thread.
   useLayoutEffect(() => {
     setLoadedPages(1);
-    setLoadingOlder(false);
     setAtTop(false);
     setTopSettled(false);
     if (topSettleTimerRef.current !== null) {
@@ -163,7 +155,6 @@ export function useMessagePaging({
       return;
     restoreRef.current = null;
     loadingOlderRef.current = false;
-    setLoadingOlder(false);
     setTopSettled(false);
     const container = scrollRef.current;
     if (!container)
@@ -214,7 +205,7 @@ export function useMessagePaging({
   // the top can never auto-load — the pull must happen after the button shows.
   // The sync ref guard + cooldown stamp keep one gesture to one page load.
   useEffect(() => {
-    if (!canLoadOlder || !atTop || !topSettled || loadingOlder)
+    if (!canLoadOlder || !atTop || !topSettled)
       return;
     const container = scrollRef.current;
     if (!container)
@@ -231,12 +222,19 @@ export function useMessagePaging({
     };
     container.addEventListener("wheel", onWheel, { passive: true });
     return () => container.removeEventListener("wheel", onWheel);
-  }, [atTop, canLoadOlder, loadOlder, loadingOlder, scrollRef, topSettled]);
+  }, [atTop, canLoadOlder, loadOlder, scrollRef, topSettled]);
+
+  // Don't leave a pending settle timer firing setState after unmount.
+  useEffect(() => () => {
+    if (topSettleTimerRef.current !== null) {
+      window.clearTimeout(topSettleTimerRef.current);
+      topSettleTimerRef.current = null;
+    }
+  }, []);
 
   return {
     visibleMessages,
     canLoadOlder,
-    loadingOlder,
     showLoadOlderHint,
     handleScroll,
     loadOlder,

--- a/gui/src/features/agent/useMessagePaging.ts
+++ b/gui/src/features/agent/useMessagePaging.ts
@@ -1,0 +1,213 @@
+import type { RefObject } from "react";
+import type { AgentMessage } from "./agentThreadTypes";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * One rendered page of conversation history: a run of turns starting at a user
+ * message (a "turn" is one user question plus the reply that follows it). The
+ * window is defined by the index of its first user message, so the top of a
+ * loaded page is always a user bubble — the "must have a user question" rule.
+ * The tail beyond the window (streaming bubbles, replies whose user message
+ * landed inside the window) is always included.
+ */
+export function computePageStart(messages: AgentMessage[], userTurnCount: number): number {
+  if (userTurnCount <= 0 || messages.length === 0)
+    return 0;
+  // Walk backwards from the tail, counting user messages until the window is
+  // full; the page starts at that user's index.
+  let remaining = userTurnCount;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]!.role === "user") {
+      remaining -= 1;
+      if (remaining <= 0)
+        return index;
+    }
+  }
+  return 0;
+}
+
+interface UseMessagePagingInput {
+  messages: AgentMessage[];
+  /**
+   * Scroll container. The paging hook reads/writes its `scrollTop` to preserve
+   * the user's viewport across a page load. `scrollTop` stays `0` while the
+   * user is stuck at the top, so top-gesture detection must listen to `wheel`
+   * (see `handleScroll`).
+   */
+  scrollRef: RefObject<HTMLElement | null>;
+  /** How many user turns each page renders. The first page shows the last N. */
+  userTurnCount: number;
+  /** Changing this (the active thread id) resets the window to the latest page. */
+  resetKey: unknown;
+  /** Caller's scroll handler — composed in front of the paging handler. */
+  onScroll?: () => void;
+}
+
+interface UseMessagePagingResult {
+  visibleMessages: AgentMessage[];
+  canLoadOlder: boolean;
+  loadingOlder: boolean;
+  /** True when the user is pinned to the top and more history exists. */
+  showLoadOlderHint: boolean;
+  handleScroll: () => void;
+  loadOlder: () => void;
+}
+
+/** Distance from the top that counts as "at the top" for the load hint. */
+const TOP_THRESHOLD_PX = 8;
+
+/**
+ * Windowed rendering for long threads. `messages` stays fully loaded in memory
+ * (the agent session JSONL is projected once, cheaply); this hook only controls
+ * which slice renders. Pages are counted in user turns, so loading an older page
+ * never splits a user question from its reply.
+ *
+ * Scroll anchoring across a page load follows the same idea opencode uses: when
+ * a page is prepended, record the first visible message and its offset from the
+ * viewport top, then restore that exact offset in a layout effect (before the
+ * browser paints) — the viewport never visibly jumps.
+ */
+export function useMessagePaging({
+  messages,
+  scrollRef,
+  userTurnCount,
+  resetKey,
+  onScroll,
+}: UseMessagePagingInput): UseMessagePagingResult {
+  const [loadedPages, setLoadedPages] = useState(1);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [atTop, setAtTop] = useState(false);
+  const onScrollRef = useRef(onScroll);
+  onScrollRef.current = onScroll;
+
+  const pageStart = computePageStart(messages, loadedPages * userTurnCount);
+  // Clamp to the current list (the list can shrink during an in-flight load)
+  // and never produce an empty window.
+  const clampedPageStart = Math.min(pageStart, messages.length);
+  const effectivePageStart = clampedPageStart >= messages.length
+    ? Math.max(0, messages.length - 1)
+    : clampedPageStart;
+  const visibleMessages = messages.slice(effectivePageStart);
+  const canLoadOlder = effectivePageStart > 0;
+  const showLoadOlderHint = canLoadOlder && atTop && !loadingOlder;
+
+  // Pending scroll restore for the in-flight page load. Written synchronously in
+  // `loadOlder`, consumed (and cleared) by the layout effect after commit.
+  const restoreRef = useRef<{ anchor: Anchor | null } | null>(null);
+
+  const loadOlder = useCallback(() => {
+    if (loadingOlder)
+      return;
+    if (effectivePageStart <= 0)
+      return;
+    restoreRef.current = {
+      anchor: captureAnchor(scrollRef.current, "data-message-id"),
+    };
+    setLoadingOlder(true);
+    setLoadedPages(pages => pages + 1);
+  }, [effectivePageStart, loadingOlder, scrollRef]);
+
+  // Reset on thread switch: newest page, top hint hidden. A layout effect
+  // declared before the restore effect below, so on a reset that races an
+  // in-flight page load the reset's clear runs first and the restore can't
+  // read a pending anchor captured for the previous thread.
+  useLayoutEffect(() => {
+    setLoadedPages(1);
+    setLoadingOlder(false);
+    setAtTop(false);
+    restoreRef.current = null;
+    // `messages` isn't a dependency: the reset targets the thread change only.
+  }, [resetKey]);
+
+  // Restore the viewport after the new page renders, before paint. The anchor
+  // was captured relative to the container's viewport top; move the scroll
+  // offset by the anchor's new position so the user's reading position doesn't
+  // move. A lost anchor (ids regenerated on a reload) falls back to pinning the
+  // top of the freshly loaded page — the user was at the top when they asked.
+  useLayoutEffect(() => {
+    const pending = restoreRef.current;
+    if (!pending)
+      return;
+    restoreRef.current = null;
+    setLoadingOlder(false);
+    const container = scrollRef.current;
+    if (!container)
+      return;
+    if (pending.anchor) {
+      const target = container.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(pending.anchor.id)}"]`);
+      if (target) {
+        const containerRect = container.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        const delta = (targetRect.top - containerRect.top) - pending.anchor.offset;
+        container.scrollTop += delta;
+        return;
+      }
+    }
+    container.scrollTop = 0;
+  }, [scrollRef]);
+
+  // Compose the caller's scroll handling with top detection. `scrollTop === 0`
+  // means the user is at the very top of the thread.
+  const handleScroll = useCallback(() => {
+    onScrollRef.current?.();
+    const container = scrollRef.current;
+    if (container)
+      setAtTop(container.scrollTop <= TOP_THRESHOLD_PX);
+  }, [scrollRef]);
+
+  // Second channel for the load gesture: a wheel-scroll up while already stuck
+  // at the top fires the load, alongside clicking the hint button. The listener
+  // only mounts while the hint is live, so a single fast scroll-up can't fire
+  // two loads (the guard in `loadOlder` would ignore the second anyway).
+  useEffect(() => {
+    if (!canLoadOlder || !atTop || loadingOlder)
+      return;
+    const container = scrollRef.current;
+    if (!container)
+      return;
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0)
+        loadOlder();
+    };
+    container.addEventListener("wheel", onWheel, { passive: true });
+    return () => container.removeEventListener("wheel", onWheel);
+  }, [atTop, canLoadOlder, loadOlder, loadingOlder, scrollRef]);
+
+  return {
+    visibleMessages,
+    canLoadOlder,
+    loadingOlder,
+    showLoadOlderHint,
+    handleScroll,
+    loadOlder,
+  };
+}
+
+/** The first visible message's id + its offset from the viewport top. */
+interface Anchor {
+  id: string;
+  offset: number;
+}
+
+function captureAnchor(container: HTMLElement | null, attribute: string): Anchor | null {
+  if (!container)
+    return null;
+  const viewTop = container.getBoundingClientRect().top;
+  let best: Anchor | null = null;
+  let bestTop = Number.POSITIVE_INFINITY;
+  for (const element of container.querySelectorAll<HTMLElement>(`[${attribute}]`)) {
+    const rect = element.getBoundingClientRect();
+    // Only elements actually crossing the viewport top are candidates — the one
+    // with the smallest top (highest on screen) anchors the view.
+    if (rect.bottom <= viewTop)
+      continue;
+    const id = element.getAttribute(attribute);
+    if (!id)
+      continue;
+    if (rect.top < bestTop) {
+      bestTop = rect.top;
+      best = { id, offset: rect.top - viewTop };
+    }
+  }
+  return best;
+}

--- a/gui/src/features/agent/useMessagePaging.ts
+++ b/gui/src/features/agent/useMessagePaging.ts
@@ -57,6 +57,13 @@ interface UseMessagePagingResult {
 const TOP_THRESHOLD_PX = 8;
 /** Wheel events within this window after a load are ignored — one page per gesture. */
 const WHEEL_COOLDOWN_MS = 300;
+/**
+ * How long the user must rest at the top before the load button appears. This
+ * is the "confirm gate": the gesture that brought the user to the top ends
+ * while the timer runs, so its trailing wheel events can never auto-load — the
+ * button must be visibly settled before a pull counts.
+ */
+const TOP_SETTLE_MS = 350;
 
 /**
  * Windowed rendering for long threads. `messages` stays fully loaded in memory
@@ -79,6 +86,8 @@ export function useMessagePaging({
   const [loadedPages, setLoadedPages] = useState(1);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [atTop, setAtTop] = useState(false);
+  const [topSettled, setTopSettled] = useState(false);
+  const topSettleTimerRef = useRef<number | null>(null);
   const onScrollRef = useRef(onScroll);
   onScrollRef.current = onScroll;
 
@@ -98,7 +107,9 @@ export function useMessagePaging({
     : clampedPageStart;
   const visibleMessages = messages.slice(effectivePageStart);
   const canLoadOlder = effectivePageStart > 0;
-  const showLoadOlderHint = canLoadOlder && atTop && !loadingOlder;
+  // The button only appears after the user has rested at the top for the settle
+  // window — arriving at the top must not, by itself, ever trigger a load.
+  const showLoadOlderHint = canLoadOlder && atTop && topSettled && !loadingOlder;
 
   // Pending scroll restore for the in-flight page load. Written synchronously in
   // `loadOlder`, consumed (and cleared) by the layout effect after commit.
@@ -112,6 +123,10 @@ export function useMessagePaging({
     if (effectivePageStart <= 0)
       return;
     loadingOlderRef.current = true;
+    if (topSettleTimerRef.current !== null) {
+      window.clearTimeout(topSettleTimerRef.current);
+      topSettleTimerRef.current = null;
+    }
     restoreRef.current = {
       anchor: captureAnchor(scrollRef.current, "data-message-id"),
     };
@@ -127,6 +142,11 @@ export function useMessagePaging({
     setLoadedPages(1);
     setLoadingOlder(false);
     setAtTop(false);
+    setTopSettled(false);
+    if (topSettleTimerRef.current !== null) {
+      window.clearTimeout(topSettleTimerRef.current);
+      topSettleTimerRef.current = null;
+    }
     loadingOlderRef.current = false;
     restoreRef.current = null;
     // `messages` isn't a dependency: the reset targets the thread change only.
@@ -144,6 +164,7 @@ export function useMessagePaging({
     restoreRef.current = null;
     loadingOlderRef.current = false;
     setLoadingOlder(false);
+    setTopSettled(false);
     const container = scrollRef.current;
     if (!container)
       return;
@@ -161,20 +182,39 @@ export function useMessagePaging({
   }, [loadedPages, scrollRef]);
 
   // Compose the caller's scroll handling with top detection. `scrollTop === 0`
-  // means the user is at the very top of the thread.
+  // means the user is at the very top; resting there for the settle window turns
+  // the load button on. Any scroll away (or a load starting) cancels it — the
+  // button must re-settle before the next pull counts.
   const handleScroll = useCallback(() => {
     onScrollRef.current?.();
     const container = scrollRef.current;
-    if (container)
-      setAtTop(container.scrollTop <= TOP_THRESHOLD_PX);
+    if (!container)
+      return;
+    const isAtTop = container.scrollTop <= TOP_THRESHOLD_PX;
+    setAtTop(isAtTop);
+    if (!isAtTop) {
+      if (topSettleTimerRef.current !== null) {
+        window.clearTimeout(topSettleTimerRef.current);
+        topSettleTimerRef.current = null;
+      }
+      setTopSettled(false);
+      return;
+    }
+    if (topSettleTimerRef.current !== null)
+      return;
+    topSettleTimerRef.current = window.setTimeout(() => {
+      topSettleTimerRef.current = null;
+      setTopSettled(true);
+    }, TOP_SETTLE_MS);
   }, [scrollRef]);
 
-  // Second channel for the load gesture: a wheel-scroll up while already stuck
-  // at the top fires the load, alongside clicking the hint button. The listener
-  // only mounts while the hint is live; the sync ref guard + cooldown stamp keep
-  // one gesture to one page load.
+  // Second channel for the load gesture: a wheel-scroll up while the load button
+  // is visible fires the load, alongside clicking it. The listener only mounts
+  // once the button has settled (`topSettled`), so the gesture that arrived at
+  // the top can never auto-load — the pull must happen after the button shows.
+  // The sync ref guard + cooldown stamp keep one gesture to one page load.
   useEffect(() => {
-    if (!canLoadOlder || !atTop || loadingOlder)
+    if (!canLoadOlder || !atTop || !topSettled || loadingOlder)
       return;
     const container = scrollRef.current;
     if (!container)
@@ -191,7 +231,7 @@ export function useMessagePaging({
     };
     container.addEventListener("wheel", onWheel, { passive: true });
     return () => container.removeEventListener("wheel", onWheel);
-  }, [atTop, canLoadOlder, loadOlder, loadingOlder, scrollRef]);
+  }, [atTop, canLoadOlder, loadOlder, loadingOlder, scrollRef, topSettled]);
 
   return {
     visibleMessages,

--- a/gui/src/features/agent/useMessagePaging.ts
+++ b/gui/src/features/agent/useMessagePaging.ts
@@ -55,6 +55,8 @@ interface UseMessagePagingResult {
 
 /** Distance from the top that counts as "at the top" for the load hint. */
 const TOP_THRESHOLD_PX = 8;
+/** Wheel events within this window after a load are ignored — one page per gesture. */
+const WHEEL_COOLDOWN_MS = 300;
 
 /**
  * Windowed rendering for long threads. `messages` stays fully loaded in memory
@@ -80,6 +82,13 @@ export function useMessagePaging({
   const onScrollRef = useRef(onScroll);
   onScrollRef.current = onScroll;
 
+  // Synchronous re-entrancy guard. Unlike the `loadingOlder` state (which only
+  // flips after React commits), this ref is read in the same tick a wheel event
+  // fires, so a single scroll gesture can't queue a dozen page loads — and a
+  // trailing wheel event after the commit is swallowed by the cooldown stamp.
+  const loadingOlderRef = useRef(false);
+  const lastWheelAtRef = useRef(0);
+
   const pageStart = computePageStart(messages, loadedPages * userTurnCount);
   // Clamp to the current list (the list can shrink during an in-flight load)
   // and never produce an empty window.
@@ -96,16 +105,19 @@ export function useMessagePaging({
   const restoreRef = useRef<{ anchor: Anchor | null } | null>(null);
 
   const loadOlder = useCallback(() => {
-    if (loadingOlder)
+    // The synchronous ref guard is the real re-entrancy fence; the `loadingOlder`
+    // state check only prevents the hint from looking "idle" mid-load.
+    if (loadingOlderRef.current)
       return;
     if (effectivePageStart <= 0)
       return;
+    loadingOlderRef.current = true;
     restoreRef.current = {
       anchor: captureAnchor(scrollRef.current, "data-message-id"),
     };
     setLoadingOlder(true);
     setLoadedPages(pages => pages + 1);
-  }, [effectivePageStart, loadingOlder, scrollRef]);
+  }, [effectivePageStart, scrollRef]);
 
   // Reset on thread switch: newest page, top hint hidden. A layout effect
   // declared before the restore effect below, so on a reset that races an
@@ -115,6 +127,7 @@ export function useMessagePaging({
     setLoadedPages(1);
     setLoadingOlder(false);
     setAtTop(false);
+    loadingOlderRef.current = false;
     restoreRef.current = null;
     // `messages` isn't a dependency: the reset targets the thread change only.
   }, [resetKey]);
@@ -129,6 +142,7 @@ export function useMessagePaging({
     if (!pending)
       return;
     restoreRef.current = null;
+    loadingOlderRef.current = false;
     setLoadingOlder(false);
     const container = scrollRef.current;
     if (!container)
@@ -144,7 +158,7 @@ export function useMessagePaging({
       }
     }
     container.scrollTop = 0;
-  }, [scrollRef]);
+  }, [loadedPages, scrollRef]);
 
   // Compose the caller's scroll handling with top detection. `scrollTop === 0`
   // means the user is at the very top of the thread.
@@ -157,8 +171,8 @@ export function useMessagePaging({
 
   // Second channel for the load gesture: a wheel-scroll up while already stuck
   // at the top fires the load, alongside clicking the hint button. The listener
-  // only mounts while the hint is live, so a single fast scroll-up can't fire
-  // two loads (the guard in `loadOlder` would ignore the second anyway).
+  // only mounts while the hint is live; the sync ref guard + cooldown stamp keep
+  // one gesture to one page load.
   useEffect(() => {
     if (!canLoadOlder || !atTop || loadingOlder)
       return;
@@ -166,8 +180,14 @@ export function useMessagePaging({
     if (!container)
       return;
     const onWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0)
-        loadOlder();
+      if (event.deltaY >= 0)
+        return;
+      const now = performance.now();
+      // Swallow the tail of the same gesture so it can't queue a second page.
+      if (now - lastWheelAtRef.current < WHEEL_COOLDOWN_MS)
+        return;
+      lastWheelAtRef.current = now;
+      loadOlder();
     };
     container.addEventListener("wheel", onWheel, { passive: true });
     return () => container.removeEventListener("wheel", onWheel);

--- a/gui/src/i18n/locales/en/agent.json
+++ b/gui/src/i18n/locales/en/agent.json
@@ -34,6 +34,7 @@
     "loading": "Loading FutureOS thread...",
     "noActiveThread": "No active thread.",
     "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier messages",
     "defaultTitle": "FutureOS",
     "agentDoneNoText": "The assistant finished but returned no text.",
     "messagesLoadFailed": "Couldn't load this conversation. Please try again — if it keeps happening, restart FutureOS.",

--- a/gui/src/i18n/locales/zh/agent.json
+++ b/gui/src/i18n/locales/zh/agent.json
@@ -30,6 +30,7 @@
     "loading": "正在加载 FutureOS 对话…",
     "noActiveThread": "没有活动对话。",
     "jumpToLatest": "回到最新",
+    "loadOlder": "加载更早的对话",
     "defaultTitle": "FutureOS",
     "agentDoneNoText": "助手已完成回复，但没有返回内容。",
     "messagesLoadFailed": "对话记录加载失败，请稍后重试；如果反复出现，请重新打开 FutureOS。",

--- a/gui/src/styles/globals.css
+++ b/gui/src/styles/globals.css
@@ -1,6 +1,27 @@
 @import "tailwindcss";
 @config "../../tailwind.config.js";
 
+/* Load-older button entrance: a quick pop with a small overshoot bounce so the
+   "pause + confirm" affordance is unmissable when it settles at the top. */
+@keyframes pop-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.96);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(1px) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.animate-pop-in {
+  animation: pop-in 0.24s ease-out both;
+}
+
 :root {
   color: theme(colors.ink);
   background: theme(colors.canvas);


### PR DESCRIPTION
## Summary

- **Windowed rendering**: only the last 10 turns of a thread render at once; `messages` stays fully loaded in memory (projected once from the agent session JSONL), so paging is a pure render-window change — no refetch.
- **Paged history loading**: scrolling to the top pauses, a load-older button pops in after the user rests at the top, and a second pull (wheel up) or click prepends the next 10 turns. Arriving at the top never auto-loads.
- **Scroll anchoring**: the load captures the first visible message + its viewport offset and restores it in a layout effect (before paint), so the user's reading position never jumps. Anchor is the message, not a raw offset.
- **One page per gesture**: synchronous ref guard + wheel cooldown prevent a single scroll gesture from queuing multiple loads.

## Test plan

- [x] `cargo fmt --check` (workspace + gui/src-tauri)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] GUI: `tsc --noEmit`, `eslint`, `vitest run` (241 passed)
- [x] `gui/src-tauri cargo test --lib` (173 passed)
- [x] `cargo test` (agent)
- [ ] Manual: scroll to top → button pops in → second pull/click loads 10 turns with position preserved (pending real-machine verification)