### PR TITLE
fix(loop): project-local state, CLI surface restore, layout/token cleanup + README overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ channel/
 .codex/
 .future/loop/
 gui/node_modules
+FUTURE.md

--- a/README.md
+++ b/README.md
@@ -13,22 +13,23 @@
 
 > A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one backend.
 
-FutureOS gives you a unified AI agent experience across TUI, GUI, CLI, Feishu, and DingTalk. The Rust backend handles LLM orchestration, tool execution, and persistent sessions. TypeScript frontends and a Tauri/React desktop app connect over gRPC. Write code, run research, manage files — from the terminal, from a chat app, or from a native desktop window.
+FutureOS gives you a unified AI agent experience from the terminal — and
+through the CLI. The Rust backend handles LLM orchestration, tool execution,
+and persistent sessions; the TypeScript terminal UI connects over gRPC. Write
+code, run research, manage files — all from the terminal.
 
 ## Features
 
 | Category | Details |
 |---|---|
-| **Multi-Interface** | Terminal UI (TUI), Desktop app (GUI), CLI, Feishu bot, DingTalk bot — one agent, everywhere |
-| **Model Flexibility** | 1000+ built-in models across 100+ providers ([full catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
+| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
+| **Model Flexibility** | 1000+ built-in models across 100+ providers ([catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
 | **Streaming & Thinking** | Real-time token streaming with collapsible reasoning-content blocks; configurable thinking levels (off ↔ xhigh) |
 | **Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt); auto-compaction at 90% context |
-| **Session Persistence** | JSONL-based sessions with fork, clone, tree navigation, and query-count tracking |
+| **Terminal UI (TUI)** | Differential rendering, markdown, Kitty image protocol, /commands, full keyboard control |
+| **Session Persistence** | JSONL-based sessions with fork, clone, tree navigation, and query-count tracking ([using](docs/wiki/en/Using-FutureOS.md)) |
+| **Skills System** | Pluggable YAML-defined skill bundles discovered from multiple directories ([guide](docs/wiki/en/Skills.md)) |
 | **Compaction & Retry** | Automatic context compaction; exponential-backoff retry on context-length errors |
-| **Channel Bridge** | Feishu (Lark) and DingTalk bots — markdown streaming, slash commands, session management via chat |
-| **Skills System** | Pluggable YAML-defined skill bundles discovered from multiple directories |
-| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
-| **Cross-Platform** | macOS, Linux, Windows (GUI via Tauri + WebView2) |
 
 ## Quick Start
 
@@ -83,45 +84,37 @@ For providers with user-specific base URLs (e.g. Azure's `YOUR_RESOURCE`), add a
 
 ### Run the agent
 
-Every client — TUI, GUI, CLI, channels — is a thin gRPC client. **The agent must be running first**, listening on `127.0.0.1:50051`:
+The terminal and CLI clients are thin gRPC clients. **The agent must be running
+first**, listening on `127.0.0.1:50051`:
 
 ```bash
 future-agent      # start the agent in the terminal (logs to stdout; Ctrl-C to stop)
 ```
 
-Then launch a client:
+Then launch the terminal UI:
 
 ```bash
-future-tui        # terminal
-future-gui        # desktop
-future-channel    # channel bridge
+future-tui        # terminal UI
 ```
 
 > A client that exits with a connection / gRPC error almost always means the agent isn't running yet — see [Troubleshooting](#troubleshooting).
-
-### CLI Quick Start
-
-```bash
-future run "Write a Python sort function"    # one-shot prompt
-future-tui                                   # open the TUI
-future-gui                                   # launch the desktop app
-future-channel                               # start the channel bridge
-future --help                                # full command list
-```
 
 ### Essential Slash Commands (TUI)
 
 | Command | Purpose |
 |---|---|
 | `/help` | Show all commands and shortcuts |
-| `/model <id>` | Switch model (e.g. `deepseek-v4-pro`) |
-| `/status` | Session state, token usage, cost |
-| `/sessions` | Browse and switch sessions |
+| `/model [name]` | Select / switch model |
 | `/new` | Start a new session |
-| `/stop` | Abort current generation |
+| `/sessions` | Browse and switch sessions |
 | `/compact` | Compress conversation context |
 | `/scoped-models` | Configure model enable/disable list |
+| `/clone` | Clone the current session |
+| `/fork` | Fork the current session |
 | `/tree` | Session tree with fork/clone hierarchy |
+| `/name [n]` | Set the session name |
+| `/status` | Session state, token usage, cost |
+| `/stop` | Abort current generation |
 
 ### Keyboard Shortcuts (TUI)
 
@@ -131,8 +124,10 @@ future --help                                # full command list
 | `ctrl+t` | Cycle thinking level |
 | `ctrl+r` | Browse sessions |
 | `ctrl+c` | Interrupt / exit |
-| `↑↓` | Scroll chat / navigate lists |
-| `Tab` | Autocomplete |
+| `tab` | Autocomplete |
+| `enter` | Submit / accept |
+| `escape` | Close popup |
+| `↑↓` | Scroll / navigate lists |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ code, run research, manage files — all from the terminal.
 
 | Category | Details |
 |---|---|
-| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
+| **Multi-Interface** | Terminal UI (TUI), desktop app (GUI), CLI, Feishu bot, DingTalk bot — one agent, everywhere |
 | **Model Flexibility** | 1000+ built-in models across 100+ providers ([catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
 | **Streaming & Thinking** | Real-time token streaming with collapsible reasoning-content blocks; configurable thinking levels (off ↔ xhigh) |
-| **Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt); auto-compaction at 90% context |
-| **Terminal UI (TUI)** | Differential rendering, markdown, Kitty image protocol, /commands, full keyboard control |
+| **Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt) |
 | **Session Persistence** | JSONL-based sessions with fork, clone, tree navigation, and query-count tracking ([using](docs/wiki/en/Using-FutureOS.md)) |
 | **Skills System** | Pluggable YAML-defined skill bundles discovered from multiple directories ([guide](docs/wiki/en/Skills.md)) |
 | **Compaction & Retry** | Automatic context compaction; exponential-backoff retry on context-length errors |
+| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
+| **Rust Core** | Agent, channel bridge, and loop control plane are written in Rust — high performance with memory safety |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FutureOS gives you a unified AI agent experience across TUI, GUI, CLI, Feishu, a
 | **Compaction & Retry** | Automatic context compaction; exponential-backoff retry on context-length errors |
 | **Channel Bridge** | Feishu (Lark) and DingTalk bots — markdown streaming, slash commands, session management via chat |
 | **Skills System** | Pluggable YAML-defined skill bundles discovered from multiple directories |
-| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) |
+| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
 | **Cross-Platform** | macOS, Linux, Windows (GUI via Tauri + WebView2) |
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@
 
 > A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one backend.
 
-FutureOS gives you a unified AI agent experience from the terminal — and
-through the CLI. The Rust backend handles LLM orchestration, tool execution,
-and persistent sessions; the TypeScript terminal UI connects over gRPC. Write
-code, run research, manage files — all from the terminal.
+FutureOS gives you a unified AI agent experience across a terminal UI (TUI),
+desktop app (GUI), CLI, Feishu, and DingTalk — on macOS, Linux, and Windows.
+The Rust backend handles LLM orchestration, tool execution, and persistent
+sessions; TypeScript frontends and a Tauri desktop app connect over gRPC.
+Write code, run research, manage files — from the terminal, from a chat app,
+or from a native desktop window.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 FutureOS gives you a unified AI agent experience across a terminal UI (TUI),
 desktop app (GUI), CLI, Feishu, and DingTalk — on macOS, Linux, and Windows.
-The Rust backend handles LLM orchestration, tool execution, and persistent
-sessions; TypeScript frontends and a Tauri desktop app connect over gRPC.
 Write code, run research, manage files — from the terminal, from a chat app,
 or from a native desktop window.
 

--- a/README.md
+++ b/README.md
@@ -32,28 +32,12 @@ FutureOS gives you a unified AI agent experience across TUI, GUI, CLI, Feishu, a
 
 ## Quick Start
 
-### Prerequisites
+### Install
 
-Required on every platform for a full build (agent + TUI + CLI + GUI):
-
-- **Rust** 1.97+ (pinned via `rust-toolchain.toml`)
-- **Node.js** 24+ (see `.nvmrc`)
-- **Bun** — required, not optional: the TUI build and CLI/GUI packaging use `bun build`
-- Optional: **Python 3** — only for `make generate-models`
-- Optional: **protoc** (Protocol Buffers compiler) — only for `make generate-proto`; generated code is checked in so normal builds don't need it
-
-### Build & install
-
-Full platform-by-platform build & install steps (macOS / Linux / Windows,
-GUI packaging, install targets, the `future-loop` control plane) live in the
-dedicated **[Build & Install](docs/build-and-install.md)** guide. In short:
-
-```bash
-git clone https://github.com/futuregene/future-os.git
-cd future-os
-make install        # build everything, install to ~/.local/bin (or /opt/homebrew/bin on macOS)
-make install-nogui  # terminal stack only (skip the Tauri GUI)
-```
+Install FutureOS from the prebuilt installers or package scripts — no source
+build required. Step-by-step installation for every platform (macOS / Linux /
+Windows, desktop app, the `future-loop` control plane) is in the
+**[Build & Install](docs/build-and-install.md)** guide.
 
 ### Configure a model
 
@@ -97,37 +81,20 @@ For providers with user-specific base URLs (e.g. Azure's `YOUR_RESOURCE`), add a
 }
 ```
 
-### Install skills (optional)
-
-FutureOS includes a set of curated skills — specialized instructions for common tasks like deep research, browser automation, document processing, and more. These are maintained in the [future-skills](https://github.com/futuregene/future-skills) repository and are our recommended defaults.
-
-```bash
-make install-skills                          # symlink from the bundled skills/ submodule
-# or install from the platform catalog:
-future skills install                        # install all future-* skills (~13)
-future init                                  # install skills and, on macOS/Linux, link local commands
-```
-
-> Skills are symlinked into `~/.future/agent/skills/` where the agent discovers them automatically. Use `future skills list` to see available skills and `future skills update` to upgrade.
-> On macOS and Linux, `future init` also links `future` and, when present, its sibling `future-agent` into `~/.future/bin/`; add that directory to `PATH` if desired.
-
 ### Run the agent
 
 Every client — TUI, GUI, CLI, channels — is a thin gRPC client. **The agent must be running first**, listening on `127.0.0.1:50051`:
 
-| Mode | Command | Use when |
-|---|---|---|
-| **Foreground** | `make run-agent` | Builds and runs agent in terminal. Logs to stdout. Stop with Ctrl-C. |
-| **Foreground** | `future-agent`  | Runs pre-built agent. Logs to stdout. Stop with Ctrl-C. |
+```bash
+future-agent      # start the agent in the terminal (logs to stdout; Ctrl-C to stop)
+```
 
 Then launch a client:
 
 ```bash
-future-tui           # terminal, after make install
-future-gui           # desktop, after make install
-# or in dev mode (builds first):
-make run-tui         # terminal
-make run-gui         # desktop
+future-tui        # terminal
+future-gui        # desktop
+future-channel    # channel bridge
 ```
 
 > A client that exits with a connection / gRPC error almost always means the agent isn't running yet — see [Troubleshooting](#troubleshooting).
@@ -167,92 +134,13 @@ future --help                                # full command list
 | `↑↓` | Scroll chat / navigate lists |
 | `Tab` | Autocomplete |
 
-## Loop Control Plane
-
-FutureOS ships a native **loop control plane** (`future-loop`) for long-running
-agent work: turn a conversation into a durable goal, break it into todos with
-dependency chains and human gates, attach independent validators, and let a
-deterministic quota kernel decide the next bounded turn. Highlights:
-
-- Durable goals / todos / gates / monitors with a completion contract
-- Deterministic should-run decision kernel + scheduler arbitration
-- Quota slot accounting & usage summaries; event-sourced state with replay
-- Independent validation (`todo add --verify ...`), extensions & multi-agent
-- Benchmark / decision-replay / canary evaluation tooling
-
-Start in any agent conversation with `/future-loop <objective>`, then check
-progress anytime with `future-loop status`. See the
-**[Loop Control Plane guide](docs/loop-control-plane.md)** for the full
-capability walkthrough and CLI reference.
-
-## Architecture
-
-```
-                         ┌──────────────────────────┐
-                         │   Rust Agent (gRPC)      │
-                         │   LLM · tools · session  │
-                         │   127.0.0.1:50051        │
-                         └──────────┬───────────────┘
-                                    │
-        ┌───────────────┬───────────┴───────────┬───────────────┐
-        │               │                       │               │
- TypeScript TUI   Tauri/React GUI       TypeScript CLI   Channel Bridge
- (terminal, bun) (desktop, WebView)     auth · MCP      Feishu · DingTalk
-        │                                                       │
- Loop Control Plane (future-loop) ──────────────────────────────┘
- durable goals/todos/gates · quota kernel · gRPC executor bridge
-```
-
-All clients connect to the agent independently over gRPC — no client depends on another.
-
-- **Agent** (`agent/`) — Rust, tokio, tonic. LLM client (OpenAI-compatible HTTP+SSE), tool execution, session JSONL persistence, gRPC server.
-- **TUI** (`tui/`) — TypeScript, bun. Differential rendering, markdown, Kitty image protocol, 14 UI components.
-- **GUI** (`gui/`) — Tauri 2 + React + TypeScript. Three-panel layout (nav / chat / context), approval prompts, skill browser, settings.
-- **CLI** (`cli/`) — TypeScript. Auth (device-flow OAuth), one-shot prompts (`run`), MCP tool calls, skills management, environment diagnostics (`doctor`).
-- **Channel Bridge** (`channels/`) — Rust. Feishu (pbbp2 WebSocket + CardKit streaming) and DingTalk (Stream Mode).
-- **Loop Control Plane** (`orchestration/loop/`) — Rust (`future-loop`). Durable goal/todo/gate state, quota should-run kernel, event ledger + replay, gRPC executor bridge. See [Loop Control Plane guide](docs/loop-control-plane.md).
-
-## Configuration
-
-All config under `~/.future/`:
-
-| Path | Component | Purpose |
-|---|---|---|
-| `agent/settings.json` | Agent | Compaction, retry, max turns per prompt, default model & permission level |
-| `agent/auth.json` | Agent | API keys by provider (FutureOS + custom) |
-| `agent/models.json` | Agent | Custom model overrides (base URL, API key, compat) |
-| `agent/sessions/` | Agent | JSONL session files |
-| `tui/settings.json` | TUI | Default model, thinking level, enabled model IDs |
-| `app/app.db` | GUI | SQLite — threads, runs, artifacts, approvals, settings |
-| `channels/config.json` | Channels | Agent gRPC address, Feishu/DingTalk credentials |
-
-## Development
-
-```bash
-make build    # build all components (no system install)
-make lint     # lint all (agent + channels + TUI + CLI + GUI)
-make fmt      # cargo fmt (agent + channels)
-make test     # cargo test (agent)
-make clean    # remove build artifacts + installed binaries
-```
-
-### Proto
-
-The canonical API is `proto/future.proto`. Generated Rust/TS code is checked into the repo — normal builds don't touch it. After editing a `.proto` file, regenerate:
-
-```bash
-make generate-proto          # agent + channels + TUI
-```
-
 ## Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| Client exits with a connection / gRPC error | The agent isn't running. Start it (`future-agent` or `make run-agent`) and check nothing else holds the port: `lsof -i :50051`. |
+| Client exits with a connection / gRPC error | The agent isn't running. Start it (`future-agent`) and check nothing else holds the port: `lsof -i :50051`. |
 | Agent replies with an auth / "no model" error | No model configured yet. Run `future auth login`, or add a provider to `models.json` — see [Configure a model](#configure-a-model). |
-| GUI can't find the agent binary | `make install-gui` copies the agent sidecar using your host target triple. If your triple differs from the auto-detected one, copy it manually: `cp target/debug/future-agent gui/src-tauri/binaries/future-agent-$(rustc -vV | sed -n 's/^host: //p')`. |
-| Build fails with "unable to find linker 'mold'" | Install mold: `sudo apt install mold` (Linux x86_64 only). ARM Linux doesn't need it. |
-| GUI build fails on Linux (webkit / gtk errors) | Install the Tauri system dependencies — see [Linux setup](#linux-debianubuntu). |
+| Build / install problems | See [Build & Install](docs/build-and-install.md) (platform toolchains, linker, GUI packaging). |
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ FutureOS 提供统一的 AI Agent 体验，覆盖 TUI、GUI、CLI、飞书和钉
 | **自动压缩与重试** | 上下文自动压缩；上下文超长时指数退避自动重试 |
 | **Channel Bridge** | 飞书和钉钉机器人——markdown 流式输出、斜杠命令、通过聊天管理会话 |
 | **技能系统** | 可插拔的 YAML 定义 Skill 包，从多目录自动发现 |
-| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)） |
+| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
 | **跨平台** | macOS、Linux、Windows（GUI 基于 Tauri + WebView2） |
 
 ## 快速开始

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,14 +19,15 @@ FutureOS 提供统一的 AI Agent 终端体验，并支持命令行（CLI）。R
 
 | 类别 | 说明 |
 |---|---|
-| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
+| **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、飞书机器人、钉钉机器人——一个 Agent，无处不在 |
 | **模型灵活** | 内置 1000+ 模型，覆盖 100+ Provider（[目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
 | **流式输出与思考链** | 实时 token 流式传输，可折叠的思考链展示；可配置思考深度（off ↔ xhigh） |
-| **工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt）；上下文超 90% 自动压缩 |
-| **终端界面 (TUI)** | 差异渲染、Markdown、Kitty 图片协议、/ 命令、完整键盘控制 |
+| **工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt） |
 | **会话持久化** | JSONL 格式存储，支持 fork、clone、树形导航和问答计数（[使用](docs/wiki/zh/Using-FutureOS.md)） |
 | **技能系统** | 可插拔的 YAML 定义 Skill 包，从多目录自动发现（[指南](docs/wiki/zh/Skills.md)） |
 | **自动压缩与重试** | 上下文自动压缩；上下文超长时指数退避自动重试 |
+| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
+| **Rust 核心** | Agent、渠道桥与 loop 控制面均用 Rust 编写——高性能、内存安全 |
 
 ## 快速开始
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,22 +13,20 @@
 
 > 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个后端全搞定。
 
-FutureOS 提供统一的 AI Agent 体验，覆盖 TUI、GUI、CLI、飞书和钉钉。Rust 后端负责 LLM 编排、工具执行和会话持久化。TypeScript 前端和 Tauri/React 桌面应用通过 gRPC 连接。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
+FutureOS 提供统一的 AI Agent 终端体验，并支持命令行（CLI）。Rust 后端负责 LLM 编排、工具执行和会话持久化；TypeScript 终端界面通过 gRPC 连接。写代码、做调研、管理文件——都在终端里完成。
 
 ## 特性
 
 | 类别 | 说明 |
 |---|---|
-| **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、飞书机器人、钉钉机器人——一个 Agent，无处不在 |
-| **模型灵活** | 内置 1000+ 模型，覆盖 100+ Provider（[完整目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
+| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
+| **模型灵活** | 内置 1000+ 模型，覆盖 100+ Provider（[目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
 | **流式输出与思考链** | 实时 token 流式传输，可折叠的思考链展示；可配置思考深度（off ↔ xhigh） |
 | **工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt）；上下文超 90% 自动压缩 |
-| **会话持久化** | JSONL 格式存储，支持 fork、clone、树形导航和问答计数 |
+| **终端界面 (TUI)** | 差异渲染、Markdown、Kitty 图片协议、/ 命令、完整键盘控制 |
+| **会话持久化** | JSONL 格式存储，支持 fork、clone、树形导航和问答计数（[使用](docs/wiki/zh/Using-FutureOS.md)） |
+| **技能系统** | 可插拔的 YAML 定义 Skill 包，从多目录自动发现（[指南](docs/wiki/zh/Skills.md)） |
 | **自动压缩与重试** | 上下文自动压缩；上下文超长时指数退避自动重试 |
-| **Channel Bridge** | 飞书和钉钉机器人——markdown 流式输出、斜杠命令、通过聊天管理会话 |
-| **技能系统** | 可插拔的 YAML 定义 Skill 包，从多目录自动发现 |
-| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
-| **跨平台** | macOS、Linux、Windows（GUI 基于 Tauri + WebView2） |
 
 ## 快速开始
 
@@ -82,45 +80,36 @@ future auth login
 
 ### 启动 Agent
 
-所有客户端——TUI、GUI、CLI、channels——都只是轻量 gRPC 客户端。**必须先启动 Agent**，监听 `127.0.0.1:50051`：
+终端与 CLI 客户端都是轻量 gRPC 客户端。**必须先启动 Agent**，监听 `127.0.0.1:50051`：
 
 ```bash
 future-agent      # 在终端启动 agent（日志打到 stdout，Ctrl-C 停止）
 ```
 
-然后启动任意客户端：
+然后启动终端界面：
 
 ```bash
 future-tui        # 终端界面
-future-gui        # 桌面应用
-future-channel    # 渠道桥接
 ```
 
 > 客户端如果报连接 / gRPC 错误，几乎都是 Agent 还没启动——见 [故障排查](#故障排查)。
-
-### CLI 快速上手
-
-```bash
-future run "用 Python 写个排序函数"         # 单次对话
-future-tui                                 # 打开 TUI
-future-gui                                 # 启动桌面应用
-future-channel                             # 启动 Channel Bridge
-future --help                              # 查看全部命令
-```
 
 ### 常用斜杠命令（TUI）
 
 | 命令 | 说明 |
 |---|---|
 | `/help` | 显示所有命令和快捷键 |
-| `/model <id>` | 切换模型（如 `deepseek-v4-pro`） |
-| `/status` | 会话状态、token 用量、费用 |
-| `/sessions` | 浏览和切换会话 |
+| `/model [name]` | 选择 / 切换模型 |
 | `/new` | 新建会话 |
-| `/stop` | 中断当前生成 |
+| `/sessions` | 浏览和切换会话 |
 | `/compact` | 压缩对话上下文 |
 | `/scoped-models` | 配置模型启用/禁用列表 |
+| `/clone` | 克隆当前会话 |
+| `/fork` | 分叉当前会话 |
 | `/tree` | 会话树（含 fork/clone 层级） |
+| `/name [n]` | 设置会话名称 |
+| `/status` | 会话状态、token 用量、费用 |
+| `/stop` | 中断当前生成 |
 
 ### 键盘快捷键（TUI）
 
@@ -130,8 +119,10 @@ future --help                              # 查看全部命令
 | `ctrl+t` | 循环切换思考级别 |
 | `ctrl+r` | 浏览会话列表 |
 | `ctrl+c` | 中断 / 退出 |
-| `↑↓` | 滚动聊天 / 列表导航 |
-| `Tab` | 自动补全 |
+| `tab` | 自动补全 |
+| `enter` | 提交 / 确认 |
+| `escape` | 关闭弹窗 |
+| `↑↓` | 滚动 / 导航列表 |
 
 ## 故障排查
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 > 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个后端全搞定。
 
-FutureOS 提供统一的 AI Agent 终端体验，并支持命令行（CLI）。Rust 后端负责 LLM 编排、工具执行和会话持久化；TypeScript 终端界面通过 gRPC 连接。写代码、做调研、管理文件——都在终端里完成。
+FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、飞书和钉钉——支持 macOS、Linux、Windows。Rust 后端负责 LLM 编排、工具执行和会话持久化；TypeScript 前端与 Tauri 桌面应用通过 gRPC 连接。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
 
 ## 特性
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,27 +32,11 @@ FutureOS 提供统一的 AI Agent 体验，覆盖 TUI、GUI、CLI、飞书和钉
 
 ## 快速开始
 
-### 环境要求
+### 安装
 
-每个平台的完整构建（agent + TUI + CLI + GUI）都需要：
-
-- **Rust** 1.97+（由 `rust-toolchain.toml` 固定）
-- **Node.js** 24+（见 `.nvmrc`）
-- **Bun** —— 必需项，非可选：TUI 构建和 CLI/GUI 打包均使用 `bun build`
-- 可选：**Python 3** —— 仅 `make generate-models` 需要
-- 可选：**protoc**（Protocol Buffers 编译器）—— 仅 `make generate-proto` 需要；生成的代码已提交，正常构建无需安装
-
-### 构建与安装
-
-各平台（macOS / Linux / Windows）完整的构建与安装步骤（GUI 打包、安装目标、
-`future-loop` 控制面）见独立文档 **[构建与安装](docs/build-and-install.zh-CN.md)**。快速上手：
-
-```bash
-git clone https://github.com/futuregene/future-os.git
-cd future-os
-make install        # 构建全部并安装到 ~/.local/bin（macOS 为 /opt/homebrew/bin）
-make install-nogui  # 仅终端栈（跳过 Tauri GUI）
-```
+从预编译安装包或安装脚本安装 FutureOS——无需下载源码。各平台（macOS / Linux /
+Windows、桌面应用、`future-loop` 控制面）的详细安装步骤见
+**[构建与安装](docs/build-and-install.zh-CN.md)** 文档。
 
 ### 配置模型
 
@@ -96,40 +80,23 @@ future auth login
 }
 ```
 
-### 安装技能（可选）
-
-FutureOS 内置一套精选技能——针对深度研究、浏览器自动化、文档处理等常见任务的专业指令集。技能维护在 [future-skills](https://github.com/futuregene/future-skills) 仓库，是我们的推荐默认配置。
-
-```bash
-make install-skills                          # 从内置 skills/ 子模块创建符号链接
-# 或从平台目录安装：
-future skills install                        # 安装所有 future-* 技能（约 13 个）
-future init                                  # 安装技能；macOS/Linux 上同时链接本地命令
-```
-
-> 技能以符号链接方式装入 `~/.future/agent/skills/`，Agent 会自动发现。使用 `future skills list` 查看可用技能，`future skills update` 升级。
-> 在 macOS 和 Linux 上，`future init` 还会将 `future` 及同目录中存在的 `future-agent` 软链到 `~/.future/bin/`；可按需将该目录加入 `PATH`。
-
 ### 启动 Agent
 
-所有客户端——TUI、GUI、CLI、channels——都只是轻量 gRPC 客户端。**必须先启动 Agent**,监听 `127.0.0.1:50051`：
+所有客户端——TUI、GUI、CLI、channels——都只是轻量 gRPC 客户端。**必须先启动 Agent**，监听 `127.0.0.1:50051`：
 
-| 模式 | 命令 | 适用场景 |
-|---|---|---|
-| **前台** | `make run-agent` | 从源码构建并运行，日志打到 stdout，Ctrl-C 停止 |
-| **前台** | `future-agent` | 直接运行已构建好的 Agent，日志打到 stdout，Ctrl-C 停止 |
+```bash
+future-agent      # 在终端启动 agent（日志打到 stdout，Ctrl-C 停止）
+```
 
 然后启动任意客户端：
 
 ```bash
-future-tui           # 终端界面（需先 make install）
-future-gui           # 桌面应用（需先 make install）
-# 开发模式下直接运行（会自动构建）：
-make run-tui         # 终端界面
-make run-gui         # 桌面应用
+future-tui        # 终端界面
+future-gui        # 桌面应用
+future-channel    # 渠道桥接
 ```
 
-> 客户端如果报连接 / gRPC 错误,几乎都是 Agent 还没启动——见 [故障排查](#故障排查)。
+> 客户端如果报连接 / gRPC 错误，几乎都是 Agent 还没启动——见 [故障排查](#故障排查)。
 
 ### CLI 快速上手
 
@@ -166,86 +133,13 @@ future --help                              # 查看全部命令
 | `↑↓` | 滚动聊天 / 列表导航 |
 | `Tab` | 自动补全 |
 
-## Loop 控制面
-
-FutureOS 内置原生 **loop 控制面**（`future-loop`），面向长期 agent 工作：把一段对话变成一个持久化目标，拆成带依赖链与人工门禁的 todos，挂载独立验证器，由确定性 quota 内核决定下一个有界回合。亮点：
-
-- 持久化目标 / todos / 门禁 / 监控，带完成契约
-- 确定性 should-run 决策内核 + 调度仲裁
-- Quota slot 记账与用量汇总；事件溯源状态 + 重放
-- 独立验证（`todo add --verify ...`）、扩展与多 agent
-- benchmark / decision replay / canary 评估工具链
-
-在任意 agent 会话中输入 `/future-loop <目标>` 开始，随时用 `future-loop status` 查看进度。完整能力介绍与 CLI 参考见 **[Loop 控制面指南](docs/loop-control-plane.zh-CN.md)**。
-
-## 架构
-
-```
-                         ┌──────────────────────────┐
-                         │   Rust Agent (gRPC)      │
-                         │   LLM · 工具 · 会话       │
-                         │   127.0.0.1:50051        │
-                         └──────────┬───────────────┘
-                                    │
-        ┌───────────────┬───────────┴───────────┬───────────────┐
-        │               │                       │               │
- TypeScript TUI   Tauri/React GUI       TypeScript CLI   Channel Bridge
- (终端, bun)     (桌面, WebView)         认证 · MCP       飞书 · 钉钉
-        │                                                       │
- Loop 控制面 (future-loop) ─────────────────────────────────────┘
- 持久化目标/todos/门禁 · quota 内核 · gRPC 执行桥
-```
-
-所有客户端独立通过 gRPC 连接 Agent，互不依赖。
-
-- **Agent** (`agent/`) — Rust，tokio，tonic。LLM 客户端（OpenAI 兼容 HTTP+SSE），工具执行，JSONL 会话持久化，gRPC 服务。
-- **TUI** (`tui/`) — TypeScript，bun。差分渲染，Markdown，Kitty 图片协议，14 个 UI 组件。
-- **GUI** (`gui/`) — Tauri 2 + React + TypeScript。三栏布局（导航 / 对话 / 上下文），审批提示，技能浏览，设置。
-- **CLI** (`cli/`) — TypeScript。设备码 OAuth 登录，单次对话（`run`），MCP 工具调用，技能管理，环境诊断（`doctor`）。
-- **Channel Bridge** (`channels/`) — Rust。飞书（pbbp2 WebSocket + CardKit 流式）和钉钉（Stream Mode）。
-- **Loop 控制面** (`orchestration/loop/`) — Rust（`future-loop`）。持久化目标/todo/门禁状态、quota should-run 内核、事件账本 + 重放、gRPC 执行桥。见 [Loop 控制面指南](docs/loop-control-plane.zh-CN.md)。
-
-## 配置
-
-所有配置位于 `~/.future/` 目录：
-
-| 路径 | 组件 | 说明 |
-|---|---|---|
-| `agent/settings.json` | Agent | 队列模式、压缩、重试、最大轮次 |
-| `agent/auth.json` | Agent | API Key（按 Provider 索引） |
-| `agent/models.json` | Agent | 自定义模型配置（Base URL、兼容参数） |
-| `agent/sessions/` | Agent | JSONL 会话文件 |
-| `tui/settings.json` | TUI | 默认模型、思考级别、启用的模型列表 |
-| `app/app.db` | GUI | SQLite — 会话、运行、产出、审批、设置 |
-| `channels/config.json` | Channels | Agent gRPC 地址、飞书/钉钉凭据 |
-
-## 开发
-
-```bash
-make build    # 构建所有组件（不安装到系统）
-make lint     # 全量检查（agent + channels + TUI + CLI + GUI）
-make fmt      # cargo fmt（agent + channels）
-make test     # cargo test（agent）
-make clean    # 清理构建产物 + 已安装的二进制
-```
-
-### Proto
-
-权威 API 定义在 `proto/future.proto`。生成的 Rust/TS 代码已提交到仓库——正常构建不会触碰。修改 `.proto` 文件后，运行：
-
-```bash
-make generate-proto          # agent + channels + TUI
-```
-
 ## 故障排查
 
 | 现象 | 解决 |
 |---|---|
-| 客户端报连接 / gRPC 错误退出 | Agent 没启动。先启动它(`future-agent` 或 `make run-agent`),并确认端口没被占用:`lsof -i :50051`。 |
-| Agent 回复鉴权 / "no model" 错误 | 还没配置模型。运行 `future auth login`,或在 `models.json` 里加一个 provider——见 [配置模型](#配置模型)。 |
-| GUI 找不到 Agent 二进制 | `make install-gui` 用你的宿主 target triple 复制 sidecar。如果 triple 与自动检测的不一致，手动复制：`cp target/debug/future-agent gui/src-tauri/binaries/future-agent-$(rustc -vV | sed -n 's/^host: //p')`。 |
-| 构建时报 "unable to find linker 'mold'" | 安装 mold：`sudo apt install mold`（仅限 Linux x86_64，ARM Linux 不需要）。 |
-| Linux 上 GUI 构建失败(webkit / gtk 报错) | 安装 Tauri 系统依赖——见 [Linux 环境搭建](#linux-debianubuntu)。 |
+| 客户端报连接 / gRPC 错误退出 | Agent 没启动。先启动它(`future-agent`)，并确认端口没被占用：`lsof -i :50051`。 |
+| Agent 回复鉴权 / "no model" 错误 | 还没配置模型。运行 `future auth login`，或在 `models.json` 里加一个 provider——见 [配置模型](#配置模型)。 |
+| 构建 / 安装问题 | 见 [构建与安装](docs/build-and-install.zh-CN.md)（平台工具链、链接器、GUI 打包）。 |
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 > 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个后端全搞定。
 
-FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、飞书和钉钉——支持 macOS、Linux、Windows。Rust 后端负责 LLM 编排、工具执行和会话持久化；TypeScript 前端与 Tauri 桌面应用通过 gRPC 连接。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
+FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、飞书和钉钉——支持 macOS、Linux、Windows。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
 
 ## 特性
 

--- a/docs/build-and-install.md
+++ b/docs/build-and-install.md
@@ -182,3 +182,25 @@ future init                                  # install skills and, on macOS/Linu
 make test        # cargo test (agent + loop control plane)
 make lint        # lint all (agent + channels + TUI + CLI + GUI)
 ```
+
+## Development (from source)
+
+Source builds use the repo Makefile from the repo root:
+
+```bash
+make build          # build all components (no system install)
+make lint           # lint all (agent + channels + TUI + CLI + GUI)
+make fmt            # cargo fmt (agent + channels)
+make test           # cargo test (agent)
+make clean          # remove build artifacts + installed binaries
+```
+
+### Proto
+
+The canonical API is `proto/future.proto`. Generated Rust/TS code is checked
+into the repo — normal builds don't touch it. After editing a `.proto` file,
+regenerate:
+
+```bash
+make generate-proto          # agent + channels + TUI
+```

--- a/docs/build-and-install.zh-CN.md
+++ b/docs/build-and-install.zh-CN.md
@@ -168,3 +168,23 @@ future init                                  # 安装技能并在 macOS/Linux �
 make test        # cargo test（agent + loop 控制面）
 make lint        # 全量 lint（agent + channels + TUI + CLI + GUI）
 ```
+
+## 开发（源码方式）
+
+源码构建使用仓库根目录的 Makefile：
+
+```bash
+make build          # 构建全部组件（不安装到系统）
+make lint           # 全量 lint（agent + channels + TUI + CLI + GUI）
+make fmt            # cargo fmt（agent + channels）
+make test           # cargo test（agent）
+make clean          # 清理构建产物与已安装二进制
+```
+
+### Proto
+
+规范 API 是 `proto/future.proto`。生成的 Rust/TS 代码已入库——正常构建不会改动它。编辑 `.proto` 文件后重新生成：
+
+```bash
+make generate-proto          # agent + channels + TUI
+```

--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -11,6 +11,11 @@ monitors, evidence, and completion are persisted outside the chat, and a
 deterministic kernel decides what should happen next — one bounded turn at a
 time.
 
+> `future-loop` is a Rust rewrite of the
+> [loopx](https://github.com/huangruiteng/loopx) control plane, adapted and
+> extended for FutureOS (project-local state, gRPC executor bridge, quota
+> kernel, extensions & multi-agent).
+
 ```
 objective / issue / project
    │

--- a/docs/loop-control-plane.zh-CN.md
+++ b/docs/loop-control-plane.zh-CN.md
@@ -4,6 +4,8 @@
 
 FutureOS 在 `orchestration/loop` 内置了原生 loop 控制面，提供 `future-loop` CLI 与 `/future-loop` agent 技能。它把一段对话变成一个持久、可复盘、可长期运行的目标：目标、todos、人工门禁、监控、证据与完成状态都持久化在聊天之外，由确定性内核决定下一步该做什么——一次一个回合。
 
+> `future-loop` 是基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了适配与扩展（项目本地状态、gRPC 执行桥、quota 内核、扩展与多 agent）。
+
 ```
 objective / issue / project
    │

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -99,6 +99,12 @@ impl AgentClient {
             .map_err(|e| anyhow!("'{cmd_type}' returned invalid JSON: {e}"))
     }
 
+    /// List models available from the agent (from auth.json / models.json,
+    /// merged with the built-in catalog). Returns the raw list_models payload.
+    pub async fn list_models(&mut self) -> Result<Value> {
+        self.call("list_models", "", Default::default()).await
+    }
+
     /// Create a fresh, isolated session for this goal. One goal = one session
     /// (LoopX: durable identity is the goal, not a chat thread).
     pub async fn new_session(&mut self, cwd: &str) -> Result<String> {

--- a/orchestration/loop/src/agents/supervisor.rs
+++ b/orchestration/loop/src/agents/supervisor.rs
@@ -1,10 +1,10 @@
-//! Supervisor (G-16) — LoopX `control_plane/agents/supervisor_events.py` +
+//! Supervisor (G-16) — reference `control_plane/agents/supervisor_events.py` +
 //! `supervisor.py`, natively (minimal set). The supervisor proposes bounded
 //! decisions for target agents; hosts record execution receipts. Both land
 //! as ledger events (`SupervisorProposed` / `SupervisorReceiptRecorded`) and
 //! are read back through a projection — the goal state itself is untouched.
 //!
-//! Receipt rules (LoopX normalize_supervisor_receipt):
+//! Receipt rules (reference normalize_supervisor_receipt):
 //! - a receipt must reference a recorded proposal (`decision_id`);
 //! - `observe` decisions never accept host execution receipts;
 //! - an `executed` receipt requires the host capabilities the decision
@@ -16,7 +16,7 @@ use crate::store::{Event, Store};
 pub const SUPERVISOR_RECEIPT_SCHEMA_VERSION: &str = "supervisor_host_receipt_v1";
 pub const SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION: &str = "supervisor_event_projection_v0";
 
-/// Supervisor decision kinds (LoopX supervisor decisions).
+/// Supervisor decision kinds (reference supervisor decisions).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SupervisorDecisionKind {
     Observe,
@@ -32,7 +32,7 @@ impl SupervisorDecisionKind {
     }
 }
 
-/// A normalized supervisor decision (LoopX normalize_supervisor_decision).
+/// A normalized supervisor decision (reference normalize_supervisor_decision).
 #[derive(Debug, Clone)]
 pub struct SupervisorDecision {
     pub decision_id: String,
@@ -70,7 +70,7 @@ impl SupervisorDecision {
     }
 }
 
-/// Receipt outcomes (LoopX SupervisorReceiptOutcome).
+/// Receipt outcomes (reference SupervisorReceiptOutcome).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SupervisorReceiptOutcome {
     Executed,
@@ -308,7 +308,7 @@ mod tests {
 
     fn tmp_root(tag: &str) -> String {
         let dir = std::env::temp_dir().join(format!(
-            "loopx-p3-supervisor-{tag}-{}",
+            "future-loop-p3-supervisor-{tag}-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()

--- a/orchestration/loop/src/backfill.rs
+++ b/orchestration/loop/src/backfill.rs
@@ -1,5 +1,5 @@
 //! Markdown backfill (G-3) — reconstruct idempotent append-only events from
-//! an ACTIVE_GOAL_STATE.md workbench, mirroring LoopX
+//! an ACTIVE_GOAL_STATE.md workbench, mirroring the reference
 //! `backfill_todo_events_from_markdown` (`event_sourced_state.py`): todo
 //! records carry `source_ref` / `source_section` / `source_line` provenance
 //! and backfill ids `backfill-<suffix>-<digest>` so re-running the backfill
@@ -44,7 +44,7 @@ pub struct MarkdownTodoRecord {
     pub global_gate: bool,
 }
 
-/// URL-decode the subset LoopX uses in anchors (%20 → ' ', %2B → '+').
+/// URL-decode the subset reference uses in anchors (%20 → ' ', %2B → '+').
 fn url_decode(value: &str) -> String {
     value.replace("%20", " ").replace("%2B", "+")
 }
@@ -73,7 +73,7 @@ fn status_from_marker(marker: &str) -> String {
 }
 
 /// Parse `key=value` pairs from a metadata line. Handles both the full
-/// `<!-- loopx:todo ... -->` anchor and bare `key=value` continuations.
+/// `<!-- future-loop:todo ... -->` anchor and bare `key=value` continuations.
 fn parse_metadata(line: &str) -> Vec<(String, String)> {
     let text = line
         .trim()
@@ -97,7 +97,7 @@ pub fn parse_markdown_todos(state_text: &str) -> Vec<MarkdownTodoRecord> {
     let mut role: Option<String> = None;
     let mut source_section: Option<String> = None;
     // Index of the record currently receiving metadata/continuation updates
-    // (LoopX appends the record dict at creation and mutates it in place).
+    // (reference appends the record dict at creation and mutates it in place).
     let mut current: Option<usize> = None;
     let mut role_indexes = std::collections::HashMap::<String, u32>::new();
 
@@ -192,7 +192,7 @@ pub fn parse_markdown_todos(state_text: &str) -> Vec<MarkdownTodoRecord> {
     records
 }
 
-/// Backfill event id (LoopX `_backfill_event_id`): sha-style digest over
+/// Backfill event id (reference `_backfill_event_id`): sha-style digest over
 /// `goal|todo|suffix`, prefixed `backfill-<suffix>-`.
 pub fn backfill_event_id(goal_id: &str, todo_id: &str, suffix: &str) -> String {
     let digest = content_digest(format!("{goal_id}|{todo_id}|{suffix}").as_bytes());
@@ -427,10 +427,10 @@ mod tests {
 
     const SAMPLE: &str = "---\nstatus: active\n---\n\n# Active Goal State\n\n\
         ## Agent Todo\n\n\
-        - [ ] [P1] Run the check\n  <!-- loopx:todo todo_id=todo_abc123 status=open action_kind=shell updated_at=2026-08-05T12:00:00+00:00 -->\n\
-        - [x] Ship the artifact\n  <!-- loopx:todo todo_id=todo_def456 status=done no_followup=true evidence=done%20well completed_at=2026-08-05T13:00:00+00:00 updated_at=2026-08-05T13:00:00+00:00 -->\n\n\
+        - [ ] [P1] Run the check\n  <!-- future-loop:todo todo_id=todo_abc123 status=open action_kind=shell updated_at=2026-08-05T12:00:00+00:00 -->\n\
+        - [x] Ship the artifact\n  <!-- future-loop:todo todo_id=todo_def456 status=done no_followup=true evidence=done%20well completed_at=2026-08-05T13:00:00+00:00 updated_at=2026-08-05T13:00:00+00:00 -->\n\n\
         ## User Todo / Owner Review Reading Queue\n\n\
-        - [ ] Decide the scope\n  <!-- loopx:todo todo_id=todo_ghi789 status=open task_class=user_gate updated_at=2026-08-05T12:30:00+00:00 -->\n";
+        - [ ] Decide the scope\n  <!-- future-loop:todo todo_id=todo_ghi789 status=open task_class=user_gate updated_at=2026-08-05T12:30:00+00:00 -->\n";
 
     #[test]
     fn parses_records_with_roles_and_anchors() {
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn public_safe_backfill_redacts_private_text() {
-        let md = "## Agent Todo\n\n- [ ] touch /Users/geilige/secret\n  <!-- loopx:todo todo_id=todo_x status=open -->\n";
+        let md = "## Agent Todo\n\n- [ ] touch /Users/geilige/secret\n  <!-- future-loop:todo todo_id=todo_x status=open -->\n";
         let public = backfill_todo_events(md, "g1", PrivacyLevel::PublicSafe).unwrap();
         match &public.events[0].event {
             Event::TodoAdded { todo, .. } => {

--- a/orchestration/loop/src/backfill.rs
+++ b/orchestration/loop/src/backfill.rs
@@ -409,10 +409,12 @@ pub fn backfill_todo_events(
     })
 }
 
-/// The markdown workbench text for a goal (LoopX layout under the goal cwd).
+/// The markdown workbench text for a goal (project-local state layout under
+/// the project's `.future/loop/goals/<id>/`).
 pub fn active_state_markdown(cwd: &str, goal_id: &str) -> Result<String> {
     let path = std::path::Path::new(cwd)
-        .join(".codex")
+        .join(".future")
+        .join("loop")
         .join("goals")
         .join(goal_id)
         .join("ACTIVE_GOAL_STATE.md");

--- a/orchestration/loop/src/benchmark/adapter.rs
+++ b/orchestration/loop/src/benchmark/adapter.rs
@@ -1,4 +1,4 @@
-//! Benchmark adapter (G-18) — LoopX `benchmark_core/adapter.py` protocol,
+//! Benchmark adapter (G-18) — reference `benchmark_core/adapter.py` protocol,
 //! with the adapter that reuses our gRPC direct-drive channel.
 //!
 //! The adapter contract is transport-neutral: preflight → launch → observe →
@@ -21,7 +21,7 @@ use super::ledger::{
 };
 use crate::agent_client::AgentClient;
 
-/// Adapter-neutral request for a benchmark case run (LoopX BenchmarkRequest).
+/// Adapter-neutral request for a benchmark case run (reference BenchmarkRequest).
 #[derive(Debug, Clone)]
 pub struct BenchmarkRequest {
     pub benchmark_id: String,
@@ -32,7 +32,7 @@ pub struct BenchmarkRequest {
     /// The case task/prompt the agent receives each round.
     pub task: String,
     /// Optional verifier expectation — the round evidence must contain this
-    /// substring to count as passed (LoopX verifier_reward semantics).
+    /// substring to count as passed (reference verifier_reward semantics).
     pub expected_evidence: Option<String>,
     pub metadata: serde_json::Value,
 }
@@ -107,7 +107,7 @@ pub struct LedgerUpdate {
     pub entry: Option<BenchmarkLedgerEntry>,
 }
 
-/// The minimal control-plane adapter interface (LoopX BenchmarkAdapter).
+/// The minimal control-plane adapter interface (reference BenchmarkAdapter).
 pub trait BenchmarkAdapter {
     fn id(&self) -> &str;
     fn preflight(&mut self, request: &BenchmarkRequest) -> Result<PreflightResult>;
@@ -538,14 +538,16 @@ mod tests {
 
     #[test]
     fn scripted_round_classification_and_ledger() {
-        let dir =
-            std::env::temp_dir().join(format!("loopx-bench-adapter-{}", crate::state::now_epoch()));
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-bench-adapter-{}",
+            crate::state::now_epoch()
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         let mut adapter = ScriptedAdapter::new(vec!["completed".to_string()]);
         let request = BenchmarkRequest::new(
             "skillsbench@1.1",
             "case-1",
-            "loopx-product-mode",
+            "future-loop-product-mode",
             "implement fizzbuzz",
         );
         let pre = adapter.preflight(&request).unwrap();
@@ -568,7 +570,7 @@ mod tests {
     #[test]
     fn scripted_runner_error_classifies_fail_closed() {
         let mut adapter = ScriptedAdapter::new(vec!["error".to_string()]);
-        let request = BenchmarkRequest::new("b", "c", "loopx-product-mode", "task");
+        let request = BenchmarkRequest::new("b", "c", "future-loop-product-mode", "task");
         let (classification, _) = run_round(&mut adapter, &request, None, 1).unwrap();
         assert_eq!(classification.decision, "runner_error");
         assert!(!classification.passed);
@@ -577,7 +579,7 @@ mod tests {
     #[test]
     fn expected_evidence_gates_pass() {
         let mut adapter = ScriptedAdapter::new(vec!["completed".to_string()]);
-        let mut request = BenchmarkRequest::new("b", "c", "loopx-product-mode", "task");
+        let mut request = BenchmarkRequest::new("b", "c", "future-loop-product-mode", "task");
         request.expected_evidence = Some("missing-marker".to_string());
         let (classification, _) = run_round(&mut adapter, &request, None, 1).unwrap();
         assert!(!classification.passed, "evidence gate must fail closed");

--- a/orchestration/loop/src/benchmark/ledger.rs
+++ b/orchestration/loop/src/benchmark/ledger.rs
@@ -1,9 +1,9 @@
-//! Benchmark run ledger (G-18) — LoopX `benchmark_ledger.py` (3.8k lines),
+//! Benchmark run ledger (G-18) — reference `benchmark_ledger.py` (3.8k lines),
 //! the minimal compaction core: a content-addressed run entry + a durable
 //! JSONL store with idempotent append (same identity → same run_id, re-append
 //! is a no-op — mirroring the G-3 event-ledger idempotency).
 //!
-//! The entry keeps the LoopX headline surface: identity, round-reward trace
+//! The entry keeps the reference headline surface: identity, round-reward trace
 //! compaction (first success / best / final / declared-done), score + pass
 //! status, failure class/scope, and the agent model under test.
 
@@ -17,7 +17,7 @@ use crate::store::content_digest;
 pub const BENCHMARK_RUN_LEDGER_SCHEMA_VERSION: &str = "benchmark_run_ledger_v0";
 
 /// One round of a benchmark run: reward 1.0 when the verifier passed the
-/// round, 0.0 otherwise (LoopX round_reward_trace records).
+/// round, 0.0 otherwise (reference round_reward_trace records).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RoundRewardRecord {
     pub agent_round: u32,
@@ -25,7 +25,7 @@ pub struct RoundRewardRecord {
     pub reward: f64,
 }
 
-/// Compact round-reward trace (LoopX `round_reward_trace`).
+/// Compact round-reward trace (reference `round_reward_trace`).
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct RoundRewardTrace {
     pub records: Vec<RoundRewardRecord>,
@@ -44,7 +44,7 @@ pub struct RoundRewardTrace {
 
 impl RoundRewardTrace {
     /// Build a trace from per-round records, deriving the headline fields
-    /// (LoopX `_round_reward_best_stats` + `first_success_round` scan).
+    /// (reference `_round_reward_best_stats` + `first_success_round` scan).
     pub fn from_records(records: Vec<RoundRewardRecord>, max_rounds_budget: u32) -> Self {
         let first_success_round = records.iter().find(|r| r.passed).map(|r| r.agent_round);
         let best = records
@@ -72,7 +72,7 @@ impl RoundRewardTrace {
         }
     }
 
-    /// Mark the agent's declared-done round (LoopX `declared_done_round` /
+    /// Mark the agent's declared-done round (reference `declared_done_round` /
     /// `declared_done_score`).
     pub fn with_declared_done(mut self, round: u32, score: f64) -> Self {
         self.declared_done_round = Some(round);
@@ -82,7 +82,7 @@ impl RoundRewardTrace {
     }
 }
 
-/// The normalized raw run fed to the ledger builder (LoopX `benchmark_run`).
+/// The normalized raw run fed to the ledger builder (reference `benchmark_run`).
 #[derive(Debug, Clone, Default)]
 pub struct BenchmarkRun {
     pub benchmark_id: String,
@@ -99,7 +99,7 @@ pub struct BenchmarkRun {
     pub notes: String,
 }
 
-/// One ledger entry (LoopX `build_benchmark_run_ledger_entry` minimal).
+/// One ledger entry (reference `build_benchmark_run_ledger_entry` minimal).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BenchmarkLedgerEntry {
     pub schema_version: String,
@@ -121,7 +121,7 @@ pub struct BenchmarkLedgerEntry {
     pub declared_done_round: Option<u32>,
     pub declared_done_score: Option<f64>,
     pub agent_declared_done: bool,
-    /// Best-round reward as the headline score (LoopX headline metrics).
+    /// Best-round reward as the headline score (reference headline metrics).
     pub score: f64,
     pub passed: bool,
     pub failure_class: String,
@@ -141,7 +141,7 @@ fn compact_text(value: &str, limit: usize) -> String {
 
 /// Content-derived run identity: `bench-<12 hex>` over
 /// benchmark_id|case_id|arm_id|route|job_name. `recorded_at` is deliberately
-/// excluded so re-ingesting the same run is idempotent (LoopX sha1 identity).
+/// excluded so re-ingesting the same run is idempotent (reference sha1 identity).
 pub fn derive_benchmark_run_id(run: &BenchmarkRun) -> String {
     let identity = [
         run.benchmark_id.as_str(),
@@ -154,7 +154,7 @@ pub fn derive_benchmark_run_id(run: &BenchmarkRun) -> String {
     format!("bench-{}", &content_digest(identity.as_bytes())[..12])
 }
 
-/// Failure classification (LoopX `_failure_class` minimal set):
+/// Failure classification (reference `_failure_class` minimal set):
 /// `success` / `case_failure` / `budget_exhausted` / `runner_error` /
 /// `unknown`.
 pub fn classify_failure(run: &BenchmarkRun) -> (String, String) {
@@ -289,7 +289,7 @@ impl BenchmarkLedger {
             .collect()
     }
 
-    /// Headline aggregate over matching entries (LoopX current aggregate).
+    /// Headline aggregate over matching entries (reference current aggregate).
     pub fn aggregate(&self, benchmark_id: Option<&str>) -> serde_json::Value {
         let matched = match benchmark_id {
             Some(b) => self.query(Some(b), None, None),
@@ -339,8 +339,8 @@ mod tests {
         BenchmarkRun {
             benchmark_id: "skillsbench@1.1".to_string(),
             case_ids: vec!["case-42".to_string()],
-            arm_id: "loopx_product_mode".to_string(),
-            route: "loopx-product-mode".to_string(),
+            arm_id: "future_loop_product_mode".to_string(),
+            route: "future-loop-product-mode".to_string(),
             mode: "product".to_string(),
             agent_model: "future/deepseek-v4-flash".to_string(),
             job_name: "job-1".to_string(),
@@ -437,8 +437,10 @@ mod tests {
 
     #[test]
     fn ledger_append_is_idempotent_and_persists() {
-        let dir =
-            std::env::temp_dir().join(format!("loopx-bench-ledger-{}", crate::state::now_epoch()));
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-bench-ledger-{}",
+            crate::state::now_epoch()
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         let mut ledger = BenchmarkLedger::open(&dir).unwrap();
         let entry = build_benchmark_run_ledger_entry(&sample_run(), 1);
@@ -458,9 +460,10 @@ mod tests {
 
     #[test]
     fn query_and_aggregate() {
-        let mut ledger = BenchmarkLedger::open(
-            &std::env::temp_dir().join(format!("loopx-bench-agg-{}", crate::state::now_epoch())),
-        )
+        let mut ledger = BenchmarkLedger::open(&std::env::temp_dir().join(format!(
+            "future-loop-bench-agg-{}",
+            crate::state::now_epoch()
+        )))
         .unwrap();
         ledger
             .append(build_benchmark_run_ledger_entry(&sample_run(), 1))

--- a/orchestration/loop/src/benchmark/loop_protocol.rs
+++ b/orchestration/loop/src/benchmark/loop_protocol.rs
@@ -1,4 +1,4 @@
-//! Benchmark loop protocol (G-18) — LoopX `benchmark_core/loop_protocol.py`
+//! Benchmark loop protocol (G-18) — reference `benchmark_core/loop_protocol.py`
 //! (689 lines), the minimal deterministic core.
 //!
 //! The contract answers: which route is being benchmarked, under which
@@ -8,46 +8,48 @@
 //! blind-loop budget of 5; routes that cannot support the strict treatment
 //! claim carry a `claim_blocker`.
 
-/// Loop protocol schema versions (LoopX constants).
+/// Loop protocol schema versions (reference constants).
 pub const BENCHMARK_LOOP_PROTOCOL_SCHEMA_VERSION: &str = "benchmark_loop_protocol_v0";
 pub const BENCHMARK_PRODUCT_MODE_COMPARISON_SCHEMA_VERSION: &str =
     "benchmark_product_mode_comparison_v0";
 
-/// Protocol ids (LoopX `MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID` etc).
+/// Protocol ids (reference `MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID` etc).
 pub const MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID: &str = "max5_blind_loop_no_feedback";
 pub const PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID: &str = "product_mode_max5_no_feedback";
 pub const PACKET_ONLY_OBSERVATION_PROTOCOL_ID: &str = "packet_only_observation";
 
-/// Default blind-loop round budget (LoopX BLIND_LOOP_DEFAULT_MAX_ROUNDS).
+/// Default blind-loop round budget (reference BLIND_LOOP_DEFAULT_MAX_ROUNDS).
 pub const BLIND_LOOP_DEFAULT_MAX_ROUNDS: u32 = 5;
 
-/// Known routes (LoopX constants).
+/// Known routes (reference constants).
 pub const CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE: &str = "codex-acp-blind-loop-baseline";
 pub const CODEX_CLI_GOAL_BASELINE_ROUTE: &str = "codex-cli-goal-baseline";
 pub const RAW_CODEX_AUTONOMOUS_MAX5_ROUTE: &str = "raw-codex-autonomous-max5";
-pub const LOOPX_PRODUCT_MODE_ROUTE: &str = "loopx-product-mode";
-pub const LOOPX_GOAL_START_PRODUCT_MODE_ROUTE: &str = "loopx-goal-start-product-mode";
-pub const LOOPX_TURN_AGENT_CLI_ROUTE: &str = "loopx-turn-agent-cli";
+pub const LOOPX_PRODUCT_MODE_ROUTE: &str = "future-loop-product-mode";
+pub const LOOPX_GOAL_START_PRODUCT_MODE_ROUTE: &str = "future-loop-goal-start-product-mode";
+pub const LOOPX_TURN_AGENT_CLI_ROUTE: &str = "future-loop-turn-agent-cli";
 pub const CODEX_APP_SERVER_GOAL_BASELINE_ROUTE: &str = "codex-app-server-goal-baseline";
-pub const LOOPX_PACKET_ONLY_OBSERVATION_ROUTE: &str = "loopx-packet-only-observation";
+pub const LOOPX_PACKET_ONLY_OBSERVATION_ROUTE: &str = "future-loop-packet-only-observation";
 
 /// Routes that pre-date the product-mode controller and are invalid for a
-/// strict comparison claim (LoopX LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES).
-pub const LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES: &[&str] =
-    &["loopx-blind-loop-treatment", "loopx-prompt-polling-test"];
+/// strict comparison claim (reference LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES).
+pub const LEGACY_NONPRODUCT_PROMPT_POLLING_ROUTES: &[&str] = &[
+    "future-loop-blind-loop-treatment",
+    "future-loop-prompt-polling-test",
+];
 
 /// Blind-loop routes: no official feedback is forwarded during the loop.
 pub fn blind_loop_routes() -> &'static [&'static str] {
     &[
         CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
         CODEX_CLI_GOAL_BASELINE_ROUTE,
-        "loopx-blind-loop-treatment",
-        "loopx-prompt-polling-test",
+        "future-loop-blind-loop-treatment",
+        "future-loop-prompt-polling-test",
     ]
 }
 
-/// Product-mode routes: the LoopX state/todo/replan CLI surface is the agent
-/// surface (LoopX PRODUCT_MODE_ROUTES).
+/// Product-mode routes: the reference state/todo/replan CLI surface is the agent
+/// surface (reference PRODUCT_MODE_ROUTES).
 pub fn product_mode_routes() -> &'static [&'static str] {
     &[
         RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
@@ -79,7 +81,7 @@ pub struct BenchmarkLoopContract {
 }
 
 impl BenchmarkLoopContract {
-    /// Render as the LoopX `as_dict()` surface (schema-versioned).
+    /// Render as the reference `as_dict()` surface (schema-versioned).
     pub fn as_dict(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
@@ -89,7 +91,7 @@ fn route_in(routes: &[&str], route: &str) -> bool {
     routes.contains(&route)
 }
 
-/// Build the loop contract for a route (LoopX `build_benchmark_loop_contract`).
+/// Build the loop contract for a route (reference `build_benchmark_loop_contract`).
 /// `max_rounds` defaults to the blind-loop budget; a positive non-default
 /// budget resolves to `custom_or_legacy_loop` unless a protocol is given.
 pub fn build_benchmark_loop_contract(
@@ -144,7 +146,7 @@ pub fn build_benchmark_loop_contract(
 
 /// The product-mode main-table comparison contract: baseline arm (raw codex
 /// autonomous max5) vs treatment arm (loopx product mode), with the policy
-/// gate LoopX requires before a headline comparison is allowed.
+/// gate reference requires before a headline comparison is allowed.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ProductModeComparisonContract {
     pub schema_version: String,
@@ -158,7 +160,7 @@ pub struct ProductModeComparisonContract {
 }
 
 /// Build the skillsbench product-mode main-table comparison contract
-/// (LoopX `build_product_mode_main_table_comparison_contract`, minimal).
+/// (reference `build_product_mode_main_table_comparison_contract`, minimal).
 pub fn build_product_mode_main_table_comparison_contract(
     benchmark_id: &str,
     max_rounds: Option<u32>,
@@ -191,14 +193,14 @@ pub fn build_product_mode_main_table_comparison_contract(
         },
     );
     let treatment_arm_id = if treatment_route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE {
-        "loopx_goal_start_product_mode"
+        "future_loop_goal_start_product_mode"
     } else {
-        "loopx_product_mode"
+        "future_loop_product_mode"
     };
     let treatment_agent_surface = if treatment_route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE {
-        "loopx_goal_start_plan_todo_lifecycle_cli"
+        "future_loop_goal_start_plan_todo_lifecycle_cli"
     } else {
-        "loopx_state_todo_replan_cli"
+        "future_loop_state_todo_replan_cli"
     };
     ProductModeComparisonContract {
         schema_version: BENCHMARK_PRODUCT_MODE_COMPARISON_SCHEMA_VERSION.to_string(),
@@ -210,16 +212,16 @@ pub fn build_product_mode_main_table_comparison_contract(
             "route": baseline_route,
             "arm_id": "raw_codex_autonomous_max5",
             "contract": baseline.as_dict(),
-            "loopx_cli_allowed": false,
+            "future_loop_cli_allowed": false,
             "agent_surface": "raw_codex_autonomous",
         }),
         treatment_arm: serde_json::json!({
             "route": treatment_route,
             "arm_id": treatment_arm_id,
             "contract": treatment.as_dict(),
-            "loopx_state_todo_replan_cli_required": true,
-            "case_local_loopx_state_required": true,
-            "loopx_cli_required": true,
+            "future_loop_state_todo_replan_cli_required": true,
+            "case_local_future_loop_state_required": true,
+            "future_loop_cli_required": true,
             "agent_surface": treatment_agent_surface,
         }),
         policy_gate: serde_json::json!({
@@ -276,7 +278,7 @@ mod tests {
 
     #[test]
     fn legacy_nonproduct_route_is_blocked_for_comparison() {
-        let c = build_benchmark_loop_contract("loopx-blind-loop-treatment", None, None);
+        let c = build_benchmark_loop_contract("future-loop-blind-loop-treatment", None, None);
         assert_eq!(
             c.claim_blocker,
             "historical_nonproduct_invalid_for_comparison"
@@ -315,10 +317,10 @@ mod tests {
         assert_eq!(c.comparison_id, "skillsbench_product_mode_main_table_v0");
         assert_eq!(c.policy_gate["headline_metrics"][0], "best_score");
         assert_eq!(c.baseline_arm["route"], RAW_CODEX_AUTONOMOUS_MAX5_ROUTE);
-        assert_eq!(c.treatment_arm["arm_id"], "loopx_product_mode");
+        assert_eq!(c.treatment_arm["arm_id"], "future_loop_product_mode");
         assert_eq!(
             c.treatment_arm["agent_surface"],
-            "loopx_state_todo_replan_cli"
+            "future_loop_state_todo_replan_cli"
         );
         // goal-start variant
         let c2 = build_product_mode_main_table_comparison_contract(
@@ -327,10 +329,13 @@ mod tests {
             RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
             LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
         );
-        assert_eq!(c2.treatment_arm["arm_id"], "loopx_goal_start_product_mode");
+        assert_eq!(
+            c2.treatment_arm["arm_id"],
+            "future_loop_goal_start_product_mode"
+        );
         assert_eq!(
             c2.treatment_arm["agent_surface"],
-            "loopx_goal_start_plan_todo_lifecycle_cli"
+            "future_loop_goal_start_plan_todo_lifecycle_cli"
         );
     }
 }

--- a/orchestration/loop/src/benchmark/qualification.rs
+++ b/orchestration/loop/src/benchmark/qualification.rs
@@ -1,10 +1,10 @@
 //! Qualification scenario (G-18) — the single-scenario closed loop: preflight
 //! → rounds (launch/observe/classify) → round-reward trace → ledger append →
-//! headline metrics. LoopX `benchmarks/qualification/` + `benchmark_core/
+//! headline metrics. reference `benchmarks/qualification/` + `benchmark_core/
 //! rounds.py` minimal core.
 //!
 //! The loop is deliberately small and deterministic: stop on first pass
-//! (LoopX `stop_on_reward_one`), stop on the round budget, count every round
+//! (reference `stop_on_reward_one`), stop on the round budget, count every round
 //! in the trace, and let the ledger classify the outcome.
 
 use std::path::Path;
@@ -33,8 +33,8 @@ impl QualificationCase {
         Self {
             benchmark_id: benchmark_id.to_string(),
             case_id: case_id.to_string(),
-            route: "loopx-product-mode".to_string(),
-            arm_id: "loopx_product_mode".to_string(),
+            route: "future-loop-product-mode".to_string(),
+            arm_id: "future_loop_product_mode".to_string(),
             task: task.to_string(),
             max_rounds,
             expected_evidence: None,
@@ -55,7 +55,7 @@ impl QualificationCase {
     }
 }
 
-/// Headline metrics (LoopX product-mode policy gate headline_metrics).
+/// Headline metrics (reference product-mode policy gate headline_metrics).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HeadlineMetrics {
     pub best_score: f64,
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn ledger_dir_records_entries_and_is_idempotent() {
-        let dir = std::env::temp_dir().join(format!("loopx-bench-qual-{}", now_epoch()));
+        let dir = std::env::temp_dir().join(format!("future-loop-bench-qual-{}", now_epoch()));
         std::fs::create_dir_all(&dir).unwrap();
         let mut adapter = ScriptedAdapter::new(vec!["completed".to_string()]);
         let case = QualificationCase::new("b", "c", "task", 5);

--- a/orchestration/loop/src/canary/mod.rs
+++ b/orchestration/loop/src/canary/mod.rs
@@ -359,12 +359,15 @@ fn check_status_projection(store: &Store) -> SmokeCheckOutcome {
 }
 
 fn check_extension_state(_store: &Store) -> SmokeCheckOutcome {
-    // Extension state lives under the runtime root; a missing file means no
-    // extensions installed — valid. A corrupt file fails closed.
-    let runtime = std::env::var("FUTURE_LOOP_RUNTIME").unwrap_or_else(|_| {
+    // Extension state lives under the project-local state root; a missing
+    // file means no extensions installed — valid. A corrupt file fails
+    // closed (same root as `extension` commands).
+    let runtime = std::env::var("FUTURE_LOOP_ROOT").unwrap_or_else(|_| {
         format!(
-            "{}/.codex/loopx",
-            std::env::var("HOME").unwrap_or_else(|_| ".".into())
+            "{}/.future/loop",
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| ".".into())
         )
     });
     let state_file = crate::extensions::runtime::default_extension_state_file(&runtime);

--- a/orchestration/loop/src/canary/mod.rs
+++ b/orchestration/loop/src/canary/mod.rs
@@ -1,4 +1,4 @@
-//! Canary smoke (G-20) — LoopX `canary/` minimal: smoke-suite profiles +
+//! Canary smoke (G-20) — reference `canary/` minimal: smoke-suite profiles +
 //! deterministic health checks over the control plane, bound to the release
 //! flow (`canary smoke --profile release-gate`). Low priority per the plan;
 //! the checks are the same deterministic surfaces the contract tests cover,
@@ -15,7 +15,7 @@ use crate::store::Store;
 
 pub const CANARY_SMOKE_RUN_SCHEMA_VERSION: &str = "canary_smoke_run_v0";
 
-/// A smoke-suite profile (LoopX SMOKE_SUITE_PROFILE_MANIFEST entries).
+/// A smoke-suite profile (reference SMOKE_SUITE_PROFILE_MANIFEST entries).
 #[derive(Debug, Clone, Serialize)]
 pub struct SmokeProfile {
     pub id: String,
@@ -37,7 +37,7 @@ pub fn smoke_suite_profiles() -> Vec<SmokeProfile> {
                 "todo".to_string(),
                 "status".to_string(),
             ],
-            description: "LoopX runtime/control-plane contracts without benchmark adapters."
+            description: "reference runtime/control-plane contracts without benchmark adapters."
                 .to_string(),
         },
         SmokeProfile {
@@ -452,8 +452,10 @@ mod tests {
     use super::*;
 
     fn tmp_store(tag: &str) -> Store {
-        let root =
-            std::env::temp_dir().join(format!("loopx-canary-{tag}-{}", crate::state::now_epoch()));
+        let root = std::env::temp_dir().join(format!(
+            "future-loop-canary-{tag}-{}",
+            crate::state::now_epoch()
+        ));
         std::fs::create_dir_all(&root).unwrap();
         Store::open(&root.to_string_lossy()).unwrap()
     }

--- a/orchestration/loop/src/capabilities/catalog.rs
+++ b/orchestration/loop/src/capabilities/catalog.rs
@@ -1,32 +1,32 @@
-//! Capability catalog (G-23) — LoopX `capabilities/catalog.py`, natively.
+//! Capability catalog (G-23) — reference `capabilities/catalog.py`, natively.
 //!
 //! The catalog is the queryable metadata surface for every capability:
 //! per-capability `commands` (CLI commands + purpose), `packets`
 //! (schema_version + module), `status` (active-preview / experimental /
 //! compatibility-facade), the Stage boundary, the owning provider, and the
-//! user-facing value/next-step strings LoopX requires on every public record.
+//! user-facing value/next-step strings reference requires on every public record.
 //!
-//! All 14 domain packs ship with their LoopX catalog status; the 15th
+//! All 14 domain packs ship with their reference catalog status; the 15th
 //! capability (`pr_review_queue`) is registered as `experimental` per the P3
-//! plan (the LoopX package exists; our rule version is a placeholder).
+//! plan (the reference package exists; our rule version is a placeholder).
 
 use std::collections::BTreeMap;
 
 use super::lifecycle::{CapabilityProvider, ProviderLifecycle};
 
-/// LoopX catalog status values.
+/// reference catalog status values.
 pub const CAPABILITY_STATUS_ACTIVE_PREVIEW: &str = "active-preview";
 pub const CAPABILITY_STATUS_EXPERIMENTAL: &str = "experimental";
 pub const CAPABILITY_STATUS_COMPATIBILITY_FACADE: &str = "compatibility-facade";
 
-/// A CLI command a capability registers (LoopX catalog `commands` entries).
+/// A CLI command a capability registers (reference catalog `commands` entries).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CapabilityCommand {
     pub name: String,
     pub purpose: String,
 }
 
-/// A typed packet a capability emits (LoopX catalog `packets`:
+/// A typed packet a capability emits (reference catalog `packets`:
 /// schema_version + module).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CapabilityPacket {
@@ -34,7 +34,7 @@ pub struct CapabilityPacket {
     pub module: String,
 }
 
-/// One capability record (LoopX registry.py REQUIRED_CAPABILITY_FIELDS +
+/// One capability record (reference registry.py REQUIRED_CAPABILITY_FIELDS +
 /// REQUIRED_PUBLIC_CAPABILITY_FIELDS + catalog metadata).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CapabilityRecord {
@@ -52,7 +52,7 @@ pub struct CapabilityRecord {
 }
 
 impl CapabilityRecord {
-    /// A public capability requires the LoopX public anchor fields.
+    /// A public capability requires the reference public anchor fields.
     pub fn is_public(&self) -> bool {
         self.visibility == "public"
     }
@@ -86,7 +86,7 @@ impl CapabilityCatalog {
     }
 
     /// Register a capability record (validates provider existence + origin
-    /// match + duplicate id, mirroring LoopX registry.py register_capability).
+    /// match + duplicate id, mirroring the reference registry.py register_capability).
     pub fn register_capability(&mut self, record: CapabilityRecord) -> Result<(), String> {
         if record.id.trim().is_empty() {
             return Err("capability requires a non-empty id".into());
@@ -142,7 +142,7 @@ impl CapabilityCatalog {
         self.records.get(id)
     }
 
-    /// Public capability ids (LoopX capability_ids()).
+    /// Public capability ids (reference capability_ids()).
     pub fn capability_ids(&self, include_internal: bool) -> Vec<&str> {
         self.records
             .values()
@@ -192,10 +192,10 @@ impl CapabilityCatalog {
 
     /// Build the shipped catalog: the 14 domain packs (with their LoopX
     /// catalog status) + pr_review_queue (15th, experimental) under the
-    /// builtin `loopx-core` provider.
+    /// builtin `future-loop-core` provider.
     pub fn with_builtin() -> Self {
         let mut catalog = Self::new();
-        let core = CapabilityProvider::builtin("loopx-core");
+        let core = CapabilityProvider::builtin("future-loop-core");
         catalog
             .register_provider(core)
             .expect("builtin provider registers once");
@@ -206,7 +206,7 @@ impl CapabilityCatalog {
                 title: title.to_string(),
                 status: status.to_string(),
                 stage: 0,
-                provider_id: "loopx-core".to_string(),
+                provider_id: "future-loop-core".to_string(),
                 origin: "builtin".to_string(),
                 visibility: "public".to_string(),
                 user_value: user_value.to_string(),
@@ -237,8 +237,8 @@ fn packet(schema_version: &str, module: &str) -> CapabilityPacket {
 }
 
 /// The shipped records: (id, title, status, user_value, next_real_step,
-/// commands, packets). Command names mirror the LoopX catalog entry commands
-/// (kebab-case CLI surface); packets carry the LoopX schema_version + module.
+/// commands, packets). Command names mirror the reference catalog entry commands
+/// (kebab-case CLI surface); packets carry the reference schema_version + module.
 #[allow(clippy::type_complexity)]
 fn builtin_records() -> Vec<(
     &'static str,
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(catalog.providers().len(), 1);
         let issue_fix = catalog.get("issue_fix").unwrap();
         assert_eq!(issue_fix.status, CAPABILITY_STATUS_ACTIVE_PREVIEW);
-        assert_eq!(issue_fix.provider_id, "loopx-core");
+        assert_eq!(issue_fix.provider_id, "future-loop-core");
         assert_eq!(
             catalog.provider_lifecycle_for("issue_fix").unwrap().stage(),
             crate::capabilities::lifecycle::ProviderStage::Ready

--- a/orchestration/loop/src/capabilities/resolver.rs
+++ b/orchestration/loop/src/capabilities/resolver.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use crate::extensions::runtime::{extension_catalog_entries, ExtensionCatalogEntry};
 
 /// Resolve exactly one ready extension implementing `capability_id` with
-/// `protocol` (LoopX resolve_capability_extension_id).
+/// `protocol` (reference resolve_capability_extension_id).
 pub fn resolve_capability_extension_id(
     state_file: &Path,
     capability_id: &str,
@@ -58,7 +58,7 @@ mod tests {
 
     fn tmp_state(tag: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "loopx-p3-resolve-{tag}-{}",
+            "future-loop-p3-resolve-{tag}-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -73,7 +73,7 @@ mod tests {
             "schema_version": crate::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
             "id": id,
             "version": "1.0.0",
-            "requires_loopx_api": ">=1",
+            "requires_future_loop_api": ">=1",
             "permissions": ["shell"],
             "runtime": {
                 "protocol": "command_json_v0",

--- a/orchestration/loop/src/compat.rs
+++ b/orchestration/loop/src/compat.rs
@@ -18,12 +18,12 @@ use serde_json::json;
 
 use crate::state::{Goal, TaskClass, Todo, TodoStatus};
 
-/// LoopX URL-encodes spaces (%20) in anchor values.
+/// reference URL-encodes spaces (%20) in anchor values.
 fn url_encode(s: &str) -> String {
     s.replace(' ', "%20").replace('+', "%2B")
 }
 
-/// RFC3339-ish timestamp matching LoopX (e.g. 2026-08-05T11:03:14+08:00).
+/// RFC3339-ish timestamp matching reference (e.g. 2026-08-05T11:03:14+08:00).
 pub fn rfc3339(ts: u64) -> String {
     use chrono::{Local, TimeZone};
     let dt = Local
@@ -33,9 +33,9 @@ pub fn rfc3339(ts: u64) -> String {
     dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
 }
 
-/// Map our TaskClass to the LoopX task_class value (already equal via serde,
+/// Map our TaskClass to the reference task_class value (already equal via serde,
 /// but keep the mapping explicit here).
-pub fn loopx_task_class(c: TaskClass) -> &'static str {
+pub fn future_loop_task_class(c: TaskClass) -> &'static str {
     match c {
         TaskClass::Advancement => "advancement_task",
         TaskClass::UserGate => "user_gate",
@@ -45,7 +45,7 @@ pub fn loopx_task_class(c: TaskClass) -> &'static str {
     }
 }
 
-pub fn loopx_status(s: TodoStatus) -> &'static str {
+pub fn future_loop_status(s: TodoStatus) -> &'static str {
     match s {
         TodoStatus::Open => "open",
         TodoStatus::Done => "done",
@@ -192,7 +192,7 @@ pub fn render_active_state(goal: &Goal) -> String {
         "- Do not optimize for activity if no useful artifact or decision can be produced.\n\n",
     );
 
-    // Todos, split by role (LoopX sections).
+    // Todos, split by role (reference sections).
     let user_todos: Vec<&Todo> = goal
         .todos
         .iter()
@@ -220,7 +220,7 @@ pub fn render_active_state(goal: &Goal) -> String {
         goal.next_action.as_deref().unwrap_or(next_default)
     ));
     out.push_str("## Recent User Feedback\n\n");
-    out.push_str("- Initialized by `loopx bootstrap`.\n\n");
+    out.push_str("- Initialized by `future-loop bootstrap`.\n\n");
     out.push_str("## Progress Ledger\n\n");
     if goal.history.is_empty() {
         out.push_str("- Created the initial goal state and registry connection.\n");
@@ -240,7 +240,7 @@ pub fn render_active_state(goal: &Goal) -> String {
     out
 }
 
-/// One todo bullet with the LoopX `<!-- loopx:todo ... -->` anchor.
+/// One todo bullet with the reference `<!-- future-loop:todo ... -->` anchor.
 fn todo_line(t: &Todo, _history: &[crate::state::RunRecord]) -> String {
     let is_default_advancement = t.class == TaskClass::Advancement && t.action_kind.is_none();
     // LoopX: deferred todos render with a "-" checkbox; done with "x".
@@ -253,18 +253,18 @@ fn todo_line(t: &Todo, _history: &[crate::state::RunRecord]) -> String {
     };
     let mut line = if is_default_advancement {
         format!(
-            "- [{checkbox}] {}\n  <!-- loopx:todo todo_id={} status={}",
+            "- [{checkbox}] {}\n  <!-- future-loop:todo todo_id={} status={}",
             t.text,
             t.id,
-            loopx_status(t.status),
+            future_loop_status(t.status),
         )
     } else {
         format!(
-            "- [{checkbox}] {}\n  <!-- loopx:todo todo_id={} status={} task_class={}",
+            "- [{checkbox}] {}\n  <!-- future-loop:todo todo_id={} status={} task_class={}",
             t.text,
             t.id,
-            loopx_status(t.status),
-            loopx_task_class(t.class),
+            future_loop_status(t.status),
+            future_loop_task_class(t.class),
         )
     };
     if let Some(ak) = &t.action_kind {
@@ -301,7 +301,7 @@ fn todo_line(t: &Todo, _history: &[crate::state::RunRecord]) -> String {
         line.push_str(" no_followup=true");
     }
     if t.status == TodoStatus::Done {
-        // LoopX completed anchors carry URL-encoded evidence + completed_at.
+        // reference completed anchors carry URL-encoded evidence + completed_at.
         if let Some(ev) = t.evidence.as_deref().filter(|e| !e.is_empty()) {
             line.push_str(&format!(" evidence={}", url_encode(ev)));
         }
@@ -313,7 +313,7 @@ fn todo_line(t: &Todo, _history: &[crate::state::RunRecord]) -> String {
         }
     }
     line.push_str(" updated_at=");
-    // LoopX encodes only '+' -> %2B; colons stay literal.
+    // reference encodes only '+' -> %2B; colons stay literal.
     let ts = rfc3339(t.updated_at).replace('+', "%2B");
     line.push_str(&ts);
     line.push_str(" -->\n");

--- a/orchestration/loop/src/compat.rs
+++ b/orchestration/loop/src/compat.rs
@@ -1,22 +1,17 @@
-//! LoopX-compatible on-disk projection.
+//! Project-local on-disk projection.
 //!
 //! The event ledger stays the source of truth; this layer MATERIALIZES the
-//! same file layout and structure the real LoopX persists, so the two
-//! implementations produce comparable state:
+//! active-state markdown the agent reads, plus the goal document:
 //!
-//!   <project>/GOAL.md                          — goal document
-//!   <project>/.loopx/registry.json             — registry (LoopX schema v0.1)
-//!   <project>/.codex/goals/<id>/ACTIVE_GOAL_STATE.md — active state (markdown,
-//!     todo anchors `<!-- loopx:todo ... -->` exactly like LoopX)
-//!   <runtime>/goals/<id>/runs/<ts>.json|.md    — per-run history + index.jsonl
+//!   <project>/GOAL.md                          — goal document (optional)
+//!   <cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md — active state
+//!     (todo anchors `<!-- future-loop:todo ... -->`)
 //!
-//! Field names and enum VALUES mirror LoopX's outputs (verified against a
-//! fresh `loopx demo` run). Only the ledger + compat projection together are
-//! a complete state; the markdown is a REBUILT projection, never a second
-//! source of truth.
+//! Everything lives inside the project (no external runtime root, no
+//! reference-control-plane layout mirrors).
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde_json::json;
@@ -66,81 +61,84 @@ pub fn write_goal_doc(project: &str, objective: &str) -> Result<()> {
     fs::write(Path::new(project).join("GOAL.md"), format!("{objective}\n")).context("write GOAL.md")
 }
 
-// ── .loopx/registry.json (LoopX schema v0.1) ───────────────────────────────
+// ── <state>/ACTIVE_GOAL_STATE.md (active-state markdown) ───────────────────
 
-pub fn write_registry(project: &str, goals: &[&Goal], runtime_root: &str) -> Result<()> {
-    let dir = Path::new(project).join(".loopx");
-    fs::create_dir_all(&dir)?;
-    let goal_entries: Vec<serde_json::Value> = goals
-        .iter()
-        .map(|g| goal_registry_entry(g, project, runtime_root))
-        .collect();
-    let payload = json!({
-        "schema_version": "0.1",
-        "updated_at": chrono::Local::now().format("%Y-%m-%d").to_string(),
-        "common_runtime_root": runtime_root,
-        "goals": goal_entries,
-    });
-    let pretty = serde_json::to_string_pretty(&payload)?;
-    fs::write(dir.join("registry.json"), pretty).context("write .loopx/registry.json")
-}
-
-fn goal_registry_entry(g: &Goal, project: &str, runtime_root: &str) -> serde_json::Value {
-    let state_file = format!(".codex/goals/{}/ACTIVE_GOAL_STATE.md", g.goal_id);
-    let _ = runtime_root;
-    json!({
-        "id": g.goal_id,
-        "domain": "project-goal-control-plane",
-        "status": "active",
-        "role": "controller",
-        "parent_goal_id": null,
-        "repo": project,
-        "state_file": state_file,
-        "authority_sources": [
-            {"kind": "goal_doc", "path": "GOAL.md", "role": "primary_goal_document"}
-        ],
-        "adapter": {"kind": "loopx_native_v0", "status": "connected"},
-        "spawn_policy": {"mode": "default", "allowed": false, "max_children": 3, "allowed_domains": []},
-        "coordination": {
-            "write_scope": g.authority.write_scope,
-            "requires_parent_approval": g.authority.requires_approval,
-            "registered_agents": g.registered_agents,
-        },
-        "execution_profile": {
-            "cadence": g.execution_profile.cadence,
-            "minimum_scale": "multi_surface_or_implementation",
-            "must_include": ["coherent_artifact", "targeted_validation", "state_writeback"],
-            "spend_rule": g.execution_profile.spend_rule,
-            "outcome_floor": {
-                "required_when": "after_surface_progress_streak",
-                "surface_streak_threshold": g.execution_profile.outcome_floor_streak_threshold,
-                "outcome_markers": [],
-                "surface_only_hints": [],
-                "must_advance": ["primary_goal_outcome"],
-            },
-        },
-        "guards": [
-            "read-only by default",
-            "do not mutate production systems without explicit user approval",
-            "keep private evidence out of public commits",
-        ],
-        "next_probe": format!("loopx --registry .loopx/registry.json check --scan-root {project}"),
-    })
-}
-
-// ── .codex/goals/<id>/ACTIVE_GOAL_STATE.md (LoopX markdown) ────────────────
-
-pub fn write_active_state(project: &str, goal: &Goal) -> Result<()> {
-    let dir = Path::new(project)
-        .join(".codex")
-        .join("goals")
-        .join(&goal.goal_id);
-    fs::create_dir_all(&dir)?;
+/// Write the active-state projection into the goal's state directory
+/// (`<cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md`).
+pub fn write_active_state(goal_dir: &Path, goal: &Goal) -> Result<()> {
+    fs::create_dir_all(goal_dir)?;
     let md = render_active_state(goal);
-    fs::write(dir.join("ACTIVE_GOAL_STATE.md"), md).context("write ACTIVE_GOAL_STATE.md")?;
+    fs::write(goal_dir.join("ACTIVE_GOAL_STATE.md"), md).context("write ACTIVE_GOAL_STATE.md")?;
     // Lock sidecar (file-tree parity; our real concurrency guard is the
     // advisory file lock in the store).
-    fs::write(dir.join("ACTIVE_GOAL_STATE.md.lock"), "").ok();
+    fs::write(goal_dir.join("ACTIVE_GOAL_STATE.md.lock"), "").ok();
+    Ok(())
+}
+
+// ── <state>/runs/ (per-run history + index) ────────────────────────────────
+
+/// Append one run's files (JSON + markdown + index row) into the goal's
+/// state directory (`<cwd>/.future/loop/goals/<id>/runs/`).
+pub fn write_run(goal_dir: &Path, goal_id: &str, record: &crate::state::RunRecord) -> Result<()> {
+    use std::io::Write;
+    let dir = goal_dir.join("runs");
+    fs::create_dir_all(&dir)?;
+    // Run-file names: 2026-08-05T11-03-14-08-00 (offset without +/:)
+    let now = chrono::Local::now();
+    // "+0800" -> "08-00" (dash between hours and minutes).
+    let z = now.format("%z").to_string();
+    let digits = z.trim_start_matches(['+', '-']);
+    let sign = if z.starts_with('-') { "-" } else { "" };
+    let (hh, mm) = digits.split_at(2);
+    let offset = format!("{sign}{hh}-{mm}");
+    let ts = format!("{}-{offset}", now.format("%Y-%m-%dT%H-%M-%S"));
+
+    let json_payload = json!({
+        "goal_id": goal_id,
+        "timestamp": rfc3339(record.recorded_at),
+        "turn": record.turn,
+        "todo_id": record.todo_id,
+        "run_id": record.run_id,
+        "terminal_state": record.terminal_state,
+        "tools": record.tools,
+        "tokens_in": record.tokens_in_delta,
+        "tokens_out": record.tokens_out_delta,
+        "cost": record.cost_delta,
+        "evidence": record.evidence,
+        "error": record.error,
+    });
+    fs::write(
+        dir.join(format!("{ts}.json")),
+        serde_json::to_string_pretty(&json_payload)?,
+    )?;
+
+    let mut md = String::new();
+    md.push_str(&format!("# Run {ts}\n\n"));
+    md.push_str(&format!("- goal_id: {goal_id}\n"));
+    md.push_str(&format!("- turn: {}\n", record.turn));
+    md.push_str(&format!("- todo: {}\n", record.todo_id));
+    md.push_str(&format!("- state: {}\n", record.terminal_state));
+    md.push_str(&format!("- tools: {}\n", record.tools.join(", ")));
+    md.push_str(&format!("- evidence: {}\n", record.evidence));
+    fs::write(dir.join(format!("{ts}.md")), md)?;
+
+    // index.jsonl (append)
+    let index_line = format!(
+        "{}\n",
+        json!({
+            "goal_id": goal_id,
+            "timestamp": rfc3339(record.recorded_at),
+            "path": format!("goals/{goal_id}/runs/{ts}.json"),
+            "turn": record.turn,
+            "classification": record.terminal_state,
+        })
+    );
+    fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("index.jsonl"))
+        .and_then(|mut f| f.write_all(index_line.as_bytes()))
+        .context("append runs/index.jsonl")?;
     Ok(())
 }
 
@@ -320,78 +318,4 @@ fn todo_line(t: &Todo, _history: &[crate::state::RunRecord]) -> String {
     line.push_str(&ts);
     line.push_str(" -->\n");
     line
-}
-
-// ── <runtime>/goals/<id>/runs/ ─────────────────────────────────────────────
-
-pub fn write_run(
-    runtime_root: &str,
-    goal_id: &str,
-    record: &crate::state::RunRecord,
-) -> Result<()> {
-    let dir = PathBuf::from(runtime_root)
-        .join("goals")
-        .join(goal_id)
-        .join("runs");
-    fs::create_dir_all(&dir)?;
-    // LoopX run-file names: 2026-08-05T11-03-14-08-00 (offset without +/:)
-    let now = chrono::Local::now();
-    // "+0800" -> "08-00" (LoopX inserts a dash between hours and minutes).
-    let z = now.format("%z").to_string();
-    let digits = z.trim_start_matches(['+', '-']);
-    let sign = if z.starts_with('-') { "-" } else { "" };
-    let (hh, mm) = digits.split_at(2);
-    let offset = format!("{sign}{hh}-{mm}");
-    let ts = format!("{}-{offset}", now.format("%Y-%m-%dT%H-%M-%S"));
-
-    let json_payload = json!({
-        "goal_id": goal_id,
-        "timestamp": rfc3339(record.recorded_at),
-        "turn": record.turn,
-        "todo_id": record.todo_id,
-        "run_id": record.run_id,
-        "terminal_state": record.terminal_state,
-        "tools": record.tools,
-        "tokens_in": record.tokens_in_delta,
-        "tokens_out": record.tokens_out_delta,
-        "cost": record.cost_delta,
-        "evidence": record.evidence,
-        "error": record.error,
-    });
-    fs::write(
-        dir.join(format!("{ts}.json")),
-        serde_json::to_string_pretty(&json_payload)?,
-    )?;
-
-    let mut md = String::new();
-    md.push_str(&format!("# Run {ts}\n\n"));
-    md.push_str(&format!("- goal_id: {goal_id}\n"));
-    md.push_str(&format!("- turn: {}\n", record.turn));
-    md.push_str(&format!("- todo: {}\n", record.todo_id));
-    md.push_str(&format!("- state: {}\n", record.terminal_state));
-    md.push_str(&format!("- tools: {}\n", record.tools.join(", ")));
-    md.push_str(&format!("- evidence: {}\n", record.evidence));
-    fs::write(dir.join(format!("{ts}.md")), md)?;
-
-    // index.jsonl (append)
-    let index_line = format!(
-        "{}\n",
-        json!({
-            "goal_id": goal_id,
-            "timestamp": rfc3339(record.recorded_at),
-            "path": format!("goals/{goal_id}/runs/{ts}.json"),
-            "turn": record.turn,
-            "classification": record.terminal_state,
-        })
-    );
-    fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("index.jsonl"))
-        .and_then(|mut f| {
-            use std::io::Write;
-            f.write_all(index_line.as_bytes())
-        })
-        .context("append runs/index.jsonl")?;
-    Ok(())
 }

--- a/orchestration/loop/src/contract.rs
+++ b/orchestration/loop/src/contract.rs
@@ -1,6 +1,6 @@
 //! The typed decision protocol — what `quota should-run` emits.
 //!
-//! Mirrors LoopX's `loopx_interaction_contract_v0`: a versioned packet with
+//! Mirrors LoopX's `future_loop_interaction_contract_v0`: a versioned packet with
 //! three channels (user / agent / CLI), plus the auxiliary contracts the
 //! host consumes (work lane, execution obligation, automation liveness,
 //! scheduler hint, quota). All structs serialize to JSON so the packet can
@@ -10,9 +10,9 @@ use serde::Serialize;
 
 use crate::decision::arbitration::SchedulerArbitration;
 
-/// LoopX interaction-contract schema version the arbitration layer validates
+/// reference interaction-contract schema version the arbitration layer validates
 /// against (LoopX: `INTERACTION_CONTRACT_SCHEMA_VERSION`).
-pub const INTERACTION_CONTRACT_SCHEMA_VERSION: &str = "loopx_interaction_contract_v0";
+pub const INTERACTION_CONTRACT_SCHEMA_VERSION: &str = "future_loop_interaction_contract_v0";
 
 /// Closed set of turn modes (LoopX: `interaction_contract.mode`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -104,7 +104,7 @@ pub struct AutomationLiveness {
     pub pause_allowed: bool,
     pub action: String,
     pub reason: String,
-    /// LoopX pause policy: pause/delete only after a bounded self-repair or
+    /// reference pause policy: pause/delete only after a bounded self-repair or
     /// replan path is itself stuck for more eligible turns.
     pub pause_policy: String,
 }
@@ -179,7 +179,7 @@ pub struct TerminalClosure {
     pub source: String,
 }
 
-/// LoopX rollout-event envelope carried on quota packets.
+/// reference rollout-event envelope carried on quota packets.
 #[derive(Debug, Clone, Serialize)]
 pub struct RolloutEvent {
     pub schema_version: String,
@@ -189,7 +189,7 @@ pub struct RolloutEvent {
     pub status: String,
 }
 
-/// The full packet emitted by the decision kernel (LoopX `should_run`).
+/// The full packet emitted by the decision kernel (reference `should_run`).
 /// Field set mirrors LoopX's top-level keys (mode/state/status/waiting_on/
 /// source/recommended_action/rollout_event + the auxiliary contracts).
 #[derive(Debug, Clone, Serialize)]
@@ -238,7 +238,7 @@ pub struct ShouldRunPacket {
     pub replan_ack: ReplanAckSnapshot,
     pub authority: AuthoritySnapshot,
     pub boundary: BoundarySnapshot,
-    /// LoopX field name for the frontier projection (aliased for parity).
+    /// reference field name for the frontier projection (aliased for parity).
     #[serde(rename = "goal_frontier_projection")]
     pub frontier_projection: FrontierProjection,
     pub agent_todo_summary: Option<crate::state::TodoSummary>,

--- a/orchestration/loop/src/decision/arbitration.rs
+++ b/orchestration/loop/src/decision/arbitration.rs
@@ -4,7 +4,7 @@
 //! G-2 + G-11: the 9 scheduler dispositions plus the consistency validation
 //! that fails closed to `CONSISTENCY_REPAIR` when the final contract is
 //! structurally inconsistent. Lower-level quota fields never participate in
-//! branch selection (LoopX rule): only the final interaction contract's
+//! branch selection (reference rule): only the final interaction contract's
 //! schema / mode / channels decide.
 //!
 //! Rollout (refactor plan §5.1 trade-off): **observe-only first** — every
@@ -25,10 +25,10 @@ use serde::Serialize;
 
 use crate::contract::{InteractionContract, ShouldRunPacket, TurnMode};
 
-/// LoopX scheduler-arbitration record schema version.
+/// reference scheduler-arbitration record schema version.
 pub const SCHEDULER_ARBITRATION_SCHEMA_VERSION: &str = "scheduler_arbitration_v0";
 
-/// Fail-closed repair action (LoopX `consistency_error.repair_action`).
+/// Fail-closed repair action (reference `consistency_error.repair_action`).
 pub const CONSISTENCY_REPAIR_ACTION: &str =
     "rebuild interaction_contract from the current quota decision, then rerun \
      quota before applying scheduler cadence";
@@ -79,7 +79,7 @@ impl SchedulerDisposition {
 }
 
 /// The arbitration record: disposition + reason_code + contract mode + any
-/// structural errors (LoopX `SchedulerArbitration`).
+/// structural errors (reference `SchedulerArbitration`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SchedulerArbitration {
     pub disposition: SchedulerDisposition,
@@ -95,7 +95,7 @@ impl SchedulerArbitration {
     }
 
     /// The fail-closed repair payload, present only when inconsistent
-    /// (LoopX `consistency_error()`).
+    /// (reference `consistency_error()`).
     pub fn consistency_error(&self) -> Option<serde_json::Value> {
         if self.ok() {
             return None;
@@ -110,9 +110,9 @@ impl SchedulerArbitration {
     }
 }
 
-/// Map our typed turn mode onto the LoopX interaction-contract mode string
+/// Map our typed turn mode onto the reference interaction-contract mode string
 /// the classifier branches on.
-fn loopx_mode(mode: TurnMode) -> &'static str {
+fn future_loop_mode(mode: TurnMode) -> &'static str {
     match mode {
         TurnMode::BoundedDelivery => "bounded_delivery",
         TurnMode::AskUser => "user_gate",
@@ -123,7 +123,7 @@ fn loopx_mode(mode: TurnMode) -> &'static str {
     }
 }
 
-/// LoopX `_classify_disposition`: branch order is normative and preserved.
+/// reference `_classify_disposition`: branch order is normative and preserved.
 pub fn classify_disposition(
     mode: &str,
     user_required: bool,
@@ -187,9 +187,9 @@ pub fn classify_disposition(
 
 /// Derive scheduler authority from the final interaction contract. Structural
 /// contradictions inside the contract fail closed to `CONSISTENCY_REPAIR`
-/// (LoopX `build_scheduler_arbitration`). The typed contract guarantees
+/// (reference `build_scheduler_arbitration`). The typed contract guarantees
 /// channel presence and boolean typing (LoopX's dict-level missing/bool-type
-/// checks are compile-time here); the remaining checks mirror LoopX exactly.
+/// checks are compile-time here); the remaining checks mirror reference exactly.
 pub fn build_scheduler_arbitration(
     contract: &InteractionContract,
     agent_scope_frontier_actions: &[&str],
@@ -200,7 +200,7 @@ pub fn build_scheduler_arbitration(
         errors.push("interaction_contract.schema_version_mismatch".to_string());
     }
 
-    let mode = loopx_mode(contract.mode);
+    let mode = future_loop_mode(contract.mode);
     let user_required = contract.user_channel.action_required;
     let must_attempt = contract.agent_channel.must_attempt;
     let delivery_allowed = contract.agent_channel.delivery_allowed;

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -63,7 +63,7 @@ pub use crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS;
 pub use crate::state::now_epoch;
 
 /// should-run decision compiler. Pure: injectable clock, no I/O.
-/// `agent_id`: when present, must be a registered peer (LoopX fail-closed:
+/// `agent_id`: when present, must be a registered peer (reference fail-closed:
 /// unregistered identity ⇒ `automation_prompt_upgrade_required`, no delivery).
 pub fn decide(goal: &Goal, now: SystemTime) -> ShouldRunPacket {
     decide_for(goal, now, None)
@@ -407,7 +407,7 @@ fn packet(
             _ => reason.to_string(),
         },
         rollout_event: Some(RolloutEvent {
-            schema_version: "loopx_rollout_event_v0".to_string(),
+            schema_version: "future_loop_rollout_event_v0".to_string(),
             event_id: uuid::Uuid::new_v4().simple().to_string(),
             event_kind: "quota_should_run".to_string(),
             recorded_at: crate::compat::rfc3339(crate::state::now_epoch()),
@@ -432,7 +432,7 @@ fn packet(
                 "role": "agent",
                 "priority": todo.map(|t| t.priority.to_string()).unwrap_or_default(),
                 "status": "open",
-                "task_class": todo.map(|t| crate::compat::loopx_task_class(t.class)).unwrap_or(""),
+                "task_class": todo.map(|t| crate::compat::future_loop_task_class(t.class)).unwrap_or(""),
                 "action_kind": todo.and_then(|t| t.action_kind.clone()).unwrap_or_default(),
                 "text": todo.map(|t| t.text.clone()).unwrap_or_default(),
                 "agent_id": "",

--- a/orchestration/loop/src/extensions/manifest.rs
+++ b/orchestration/loop/src/extensions/manifest.rs
@@ -1,24 +1,24 @@
-//! Extension manifest (G-21) — LoopX `extensions/manifest.py`, natively.
+//! Extension manifest (G-21) — reference `extensions/manifest.py`, natively.
 //!
 //! v1 is DECLARATIVE ONLY (security tradeoff from the P3 plan): a manifest
 //! declares the extension's provider record, the capabilities it `provides`
 //! and the capability implementations it `implements`. No native code is
 //! loaded (no dlopen / subprocess execution of extension code) — that is the
-//! P4 process-runtime concern. LoopX reads TOML manifests; this Rust-native
-//! implementation reads the same schema as JSON (`loopx_extension_manifest_v0`),
+//! P4 process-runtime concern. reference reads TOML manifests; this Rust-native
+//! implementation reads the same schema as JSON (`future_loop_extension_manifest_v0`),
 //! keeping the field names and validation rules identical.
 
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-pub const EXTENSION_MANIFEST_SCHEMA_VERSION: &str = "loopx_extension_manifest_v0";
-/// LoopX LOOPX_EXTENSION_API_VERSION.
+pub const EXTENSION_MANIFEST_SCHEMA_VERSION: &str = "future_loop_extension_manifest_v0";
+/// reference LOOPX_EXTENSION_API_VERSION.
 pub const LOOPX_EXTENSION_API_VERSION: u32 = 1;
-/// The versioned lower-snake protocol token (LoopX _PROTOCOL_RE).
+/// The versioned lower-snake protocol token (reference _PROTOCOL_RE).
 pub const PROTOCOL_TOKEN_RE: &str = "^[a-z][a-z0-9_]{0,63}_v\\d+$";
 
-/// A capability a manifest provides (LoopX manifest `[[provides]]`).
+/// A capability a manifest provides (reference manifest `[[provides]]`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestProvidedCapability {
     pub id: String,
@@ -26,14 +26,14 @@ pub struct ManifestProvidedCapability {
     pub visibility: String,
 }
 
-/// A capability implementation a manifest implements (LoopX `[[implements]]`).
+/// A capability implementation a manifest implements (reference `[[implements]]`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestImplementation {
     pub capability_id: String,
     pub protocol: String,
 }
 
-/// Declarative runtime contract (LoopX `_runtime_contract`). v1 validates the
+/// Declarative runtime contract (reference `_runtime_contract`). v1 validates the
 /// contract shape + permissions; the executable entrypoint is resolved by the
 /// readiness doctor (no code is executed by the manifest loader).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,7 +48,7 @@ pub struct ManifestRuntime {
     pub timeout_seconds: u32,
 }
 
-/// A parsed extension manifest (LoopX `load_extension_manifest` return shape).
+/// A parsed extension manifest (reference `load_extension_manifest` return shape).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionManifest {
     pub schema_version: String,
@@ -67,7 +67,7 @@ pub struct ManifestProvider {
     pub enabled: bool,
     pub ready: bool,
     pub version: String,
-    pub requires_loopx_api: String,
+    pub requires_future_loop_api: String,
     pub permissions: Vec<String>,
 }
 
@@ -100,16 +100,18 @@ fn string_list(value: &serde_json::Value, key: &str, context: &str) -> Result<Ve
     Ok(out)
 }
 
-/// LoopX `_require_compatible_loopx_api`: clauses like `>=1,<2` compared
+/// reference `_require_compatible_future_loop_api`: clauses like `>=1,<2` compared
 /// against the runtime API version. Fail closed on incompatible requirements.
-pub fn require_compatible_loopx_api(requirement: &str) -> Result<(), String> {
+pub fn require_compatible_future_loop_api(requirement: &str) -> Result<(), String> {
     let clauses: Vec<&str> = requirement
         .split(',')
         .map(|c| c.trim())
         .filter(|c| !c.is_empty())
         .collect();
     if clauses.is_empty() {
-        return Err(format!("invalid `requires_loopx_api` `{requirement}`"));
+        return Err(format!(
+            "invalid `requires_future_loop_api` `{requirement}`"
+        ));
     }
     for clause in clauses {
         let (op, num) = if let Some(rest) = clause.strip_prefix(">=") {
@@ -128,7 +130,7 @@ pub fn require_compatible_loopx_api(requirement: &str) -> Result<(), String> {
         let wanted: u32 = num
             .trim()
             .parse()
-            .map_err(|_| format!("invalid `requires_loopx_api` clause `{clause}`"))?;
+            .map_err(|_| format!("invalid `requires_future_loop_api` clause `{clause}`"))?;
         let ok = match op {
             ">=" => LOOPX_EXTENSION_API_VERSION >= wanted,
             "<=" => LOOPX_EXTENSION_API_VERSION <= wanted,
@@ -138,7 +140,7 @@ pub fn require_compatible_loopx_api(requirement: &str) -> Result<(), String> {
         };
         if !ok {
             return Err(format!(
-                "manifest requires LoopX extension API `{requirement}`, but this runtime provides `{LOOPX_EXTENSION_API_VERSION}`"
+                "manifest requires reference extension API `{requirement}`, but this runtime provides `{LOOPX_EXTENSION_API_VERSION}`"
             ));
         }
     }
@@ -198,15 +200,17 @@ pub fn validate_manifest_value(
         return Err(format!("{context} must contain a JSON object"));
     }
     let schema_version = required_string(raw, "schema_version", context)?;
-    if schema_version != EXTENSION_MANIFEST_SCHEMA_VERSION {
+    if schema_version != EXTENSION_MANIFEST_SCHEMA_VERSION
+        && schema_version != "loopx_extension_manifest_v0"
+    {
         return Err(format!(
             "{context} has unsupported schema_version `{schema_version}`; expected `{EXTENSION_MANIFEST_SCHEMA_VERSION}`"
         ));
     }
     let extension_id = required_string(raw, "id", context)?;
     let version = required_string(raw, "version", context)?;
-    let requires_loopx_api = required_string(raw, "requires_loopx_api", context)?;
-    require_compatible_loopx_api(&requires_loopx_api)?;
+    let requires_future_loop_api = required_string(raw, "requires_future_loop_api", context)?;
+    require_compatible_future_loop_api(&requires_future_loop_api)?;
     let permissions = string_list(raw, "permissions", context)?;
 
     // Runtime contract (optional).
@@ -345,7 +349,7 @@ pub fn validate_manifest_value(
             enabled: false,
             ready: false,
             version,
-            requires_loopx_api,
+            requires_future_loop_api,
             permissions,
         },
         capabilities,
@@ -362,7 +366,7 @@ pub fn write_example_manifest(root: &Path, extension_id: &str) -> PathBuf {
         "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": extension_id,
         "version": "1.0.0",
-        "requires_loopx_api": ">=1",
+        "requires_future_loop_api": ">=1",
         "permissions": ["shell"],
         "runtime": {
             "protocol": "command_json_v0",
@@ -399,7 +403,7 @@ mod tests {
             "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
             "id": "ext-demo",
             "version": "1.0.0",
-            "requires_loopx_api": ">=1,<3",
+            "requires_future_loop_api": ">=1,<3",
             "permissions": ["shell", "network"],
             "runtime": {
                 "protocol": "command_json_v0",
@@ -429,7 +433,7 @@ mod tests {
     #[test]
     fn incompatible_api_fails_closed() {
         let mut m = valid_manifest();
-        m["requires_loopx_api"] = serde_json::json!(">=99");
+        m["requires_future_loop_api"] = serde_json::json!(">=99");
         assert!(validate_manifest_value(&m, "test").is_err());
     }
 

--- a/orchestration/loop/src/extensions/readiness.rs
+++ b/orchestration/loop/src/extensions/readiness.rs
@@ -1,4 +1,4 @@
-//! Extension readiness (G-21) — LoopX `extensions/readiness.py`, natively.
+//! Extension readiness (G-21) — reference `extensions/readiness.py`, natively.
 //!
 //! v1 readiness is DECLARATIVE: the doctor resolves the declared runtime
 //! entrypoint (a PATH-resolvable command or a `python3 -m <module>` pair) and
@@ -13,9 +13,9 @@ use serde::Serialize;
 
 use super::manifest::ManifestRuntime;
 
-pub const EXTENSION_DOCTOR_SCHEMA_VERSION: &str = "loopx_extension_doctor_v0";
+pub const EXTENSION_DOCTOR_SCHEMA_VERSION: &str = "future_loop_extension_doctor_v0";
 
-/// LoopX extension_doctor status values.
+/// reference extension_doctor status values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DoctorStatus {
     Ready,
@@ -37,7 +37,7 @@ impl DoctorStatus {
     }
 }
 
-/// The resolved runtime entrypoint (LoopX ResolvedRuntimeEntrypoint).
+/// The resolved runtime entrypoint (reference ResolvedRuntimeEntrypoint).
 #[derive(Debug, Clone, Serialize)]
 pub struct ResolvedRuntimeEntrypoint {
     pub argv_prefix: Vec<String>,
@@ -63,7 +63,7 @@ fn which(command: &str) -> Option<PathBuf> {
 }
 
 /// A stable identity for a resolved entrypoint: absolute path + content
-/// digest prefix (LoopX `_file_identity` digest).
+/// digest prefix (reference `_file_identity` digest).
 fn file_identity(path: &std::path::Path) -> Option<String> {
     let abs = path.canonicalize().ok()?;
     let content = std::fs::read(&abs).ok()?;
@@ -96,7 +96,7 @@ pub fn resolve_runtime_entrypoint(runtime: &ManifestRuntime) -> Option<ResolvedR
     None
 }
 
-/// Doctor report for one manifest (LoopX extension_doctor).
+/// Doctor report for one manifest (reference extension_doctor).
 #[derive(Debug, Clone, Serialize)]
 pub struct DoctorReport {
     pub schema_version: String,
@@ -221,7 +221,7 @@ mod tests {
             "schema_version": crate::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
             "id": "ext-readiness",
             "version": "1.0.0",
-            "requires_loopx_api": ">=1",
+            "requires_future_loop_api": ">=1",
             "permissions": ["shell"],
             "runtime": runtime,
             "provides": [{"id": "ext-readiness_cap", "kind": "domain_rule", "visibility": "public"}],
@@ -258,7 +258,7 @@ mod tests {
             "schema_version": crate::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
             "id": "ext-decl",
             "version": "1.0.0",
-            "requires_loopx_api": ">=1",
+            "requires_future_loop_api": ">=1",
             "permissions": [],
             "provides": [{"id": "ext-decl_cap", "kind": "domain_rule", "visibility": "public"}]
         });

--- a/orchestration/loop/src/extensions/runtime.rs
+++ b/orchestration/loop/src/extensions/runtime.rs
@@ -1,9 +1,9 @@
-//! Extension runtime (G-21) — LoopX `extensions/runtime.py`, natively.
+//! Extension runtime (G-21) — reference `extensions/runtime.py`, natively.
 //!
 //! Lifecycle: `install → enable → (doctor-verified) → ready`, with
 //! `disable`, `rollback`, and `status`. State persists in a JSON state file
 //! (`extensions/state.json` under the runtime root) with the LoopX
-//! `loopx_extension_state_v0` schema. Every install/upgrade keeps a bounded
+//! `future_loop_extension_state_v0` schema. Every install/upgrade keeps a bounded
 //! revision history (`MAX_REVISIONS = 5`) so rollback always has a target.
 //!
 //! v1 is declarative: install validates the manifest + doctor readiness and
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 use super::manifest::{ExtensionManifest, LOOPX_EXTENSION_API_VERSION};
 use super::readiness::{extension_doctor, DoctorStatus};
 
-pub const EXTENSION_STATE_SCHEMA_VERSION: &str = "loopx_extension_state_v0";
-pub const EXTENSION_OPERATION_SCHEMA_VERSION: &str = "loopx_extension_operation_v0";
-/// LoopX MAX_REVISIONS.
+pub const EXTENSION_STATE_SCHEMA_VERSION: &str = "future_loop_extension_state_v0";
+pub const EXTENSION_OPERATION_SCHEMA_VERSION: &str = "future_loop_extension_operation_v0";
+/// reference MAX_REVISIONS.
 pub const MAX_REVISIONS: usize = 5;
 
 /// Default extension state file under a runtime root.
@@ -38,7 +38,7 @@ pub struct ExtensionRevision {
     pub manifest: ExtensionManifest,
 }
 
-/// One installed extension entry (LoopX runtime state entry).
+/// One installed extension entry (reference runtime state entry).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionEntry {
     pub id: String,
@@ -85,7 +85,7 @@ impl ExtensionState {
     }
 }
 
-/// The operation result (LoopX runtime operation return shape).
+/// The operation result (reference runtime operation return shape).
 #[derive(Debug, Clone, Serialize)]
 pub struct ExtensionOperation {
     pub ok: bool,
@@ -111,7 +111,9 @@ fn read_state(path: &Path) -> Result<ExtensionState, String> {
         .map_err(|e| format!("extension runtime state is unreadable: {e}"))?;
     let state: ExtensionState = serde_json::from_str(&text)
         .map_err(|e| format!("extension runtime state is unreadable: {e}"))?;
-    if state.schema_version != EXTENSION_STATE_SCHEMA_VERSION {
+    if state.schema_version != EXTENSION_STATE_SCHEMA_VERSION
+        && state.schema_version != "loopx_extension_state_v0"
+    {
         return Err(format!(
             "extension runtime state must use {EXTENSION_STATE_SCHEMA_VERSION}"
         ));
@@ -130,7 +132,7 @@ fn write_state(path: &Path, state: &ExtensionState) -> Result<(), String> {
 }
 
 /// Revision = first 16 hex chars of the SHA-256 of the canonical manifest
-/// (LoopX `_revision`).
+/// (reference `_revision`).
 pub fn manifest_revision(manifest: &ExtensionManifest) -> String {
     let serialized = serde_json::to_string(manifest).unwrap_or_default();
     let digest = crate::store::content_digest(serialized.as_bytes());
@@ -138,7 +140,7 @@ pub fn manifest_revision(manifest: &ExtensionManifest) -> String {
 }
 
 /// Retain a bounded revision history, always keeping the required rollback
-/// revision when it would otherwise fall off (LoopX `_retain_revisions`).
+/// revision when it would otherwise fall off (reference `_retain_revisions`).
 fn retain_revisions(
     revisions: Vec<ExtensionRevision>,
     new_revision: ExtensionRevision,
@@ -354,7 +356,7 @@ pub fn disable_extension(
 }
 
 /// `loopx extension rollback --id X [--execute]` — swap active/rollback
-/// revisions (LoopX rollback_extension).
+/// revisions (reference rollback_extension).
 pub fn rollback_extension(
     extension_id: &str,
     state_file: &Path,
@@ -451,7 +453,7 @@ pub fn extension_status(
 }
 
 /// Compose declared manifests with installed runtime lifecycle state
-/// (LoopX extension_catalog_entries).
+/// (reference extension_catalog_entries).
 #[derive(Debug, Clone, Serialize)]
 pub struct ExtensionCatalogEntry {
     pub id: String,
@@ -513,7 +515,7 @@ mod tests {
 
     fn tmp_file(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "loopx-p3-ext-{tag}-{}",
+            "future-loop-p3-ext-{tag}-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -528,7 +530,7 @@ mod tests {
             "schema_version": crate::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
             "id": id,
             "version": version,
-            "requires_loopx_api": ">=1",
+            "requires_future_loop_api": ">=1",
             "permissions": ["shell"],
             "runtime": {
                 "protocol": "command_json_v0",

--- a/orchestration/loop/src/handoff/project_handoff.rs
+++ b/orchestration/loop/src/handoff/project_handoff.rs
@@ -79,19 +79,15 @@ pub fn render_project_handoff_markdown(handoff: &ProjectHandoff) -> String {
 }
 
 /// Write the handoff document next to the goal projection
-/// (`.codex/goals/<id>/HANDOFF.md`), mirroring the LoopX markdown layout.
+/// (`<cwd>/.future/loop/goals/<id>/HANDOFF.md`).
 pub fn write_project_handoff(
-    project: &str,
-    goal: &Goal,
+    goal_dir: &std::path::Path,
+    _goal: &Goal,
     handoff: &ProjectHandoff,
 ) -> std::io::Result<()> {
-    let dir = std::path::Path::new(project)
-        .join(".codex")
-        .join("goals")
-        .join(&goal.goal_id);
-    std::fs::create_dir_all(&dir)?;
+    std::fs::create_dir_all(goal_dir)?;
     std::fs::write(
-        dir.join("HANDOFF.md"),
+        goal_dir.join("HANDOFF.md"),
         render_project_handoff_markdown(handoff),
     )
 }

--- a/orchestration/loop/src/heartbeat.rs
+++ b/orchestration/loop/src/heartbeat.rs
@@ -12,7 +12,10 @@ use crate::state::Goal;
 /// Render a host-facing heartbeat prompt (markdown).
 pub fn render_heartbeat_prompt(goal: &Goal, packet: &ShouldRunPacket) -> String {
     let mut out = String::new();
-    out.push_str(&format!("# LoopX Heartbeat Packet — {}\n\n", goal.goal_id));
+    out.push_str(&format!(
+        "# reference Heartbeat Packet — {}\n\n",
+        goal.goal_id
+    ));
     out.push_str(&format!("- objective: {}\n", goal.objective));
     out.push_str(&format!(
         "- decision: `{}` / mode: `{}`\n",

--- a/orchestration/loop/src/main.rs
+++ b/orchestration/loop/src/main.rs
@@ -22,13 +22,16 @@ use future_loop::executor::{execute_turn, writeback};
 use future_loop::state::{now_epoch, Goal, RunRecord, TaskClass, Todo, TodoStatus};
 use future_loop::store::{Event, Store};
 
-/// Runtime root for LoopX-compatible run history (default ~/.codex/loopx,
-/// overridable via FUTURE_LOOP_RUNTIME — matches LoopX's DEFAULT_RUNTIME_ROOT).
+/// Runtime root for the reference-compatible run history (default
+/// `<cwd>/.codex/loopx`, overridable via FUTURE_LOOP_RUNTIME). Project-local:
+/// all loop state stays inside the project directory.
 fn runtime_root() -> String {
     std::env::var("FUTURE_LOOP_RUNTIME").unwrap_or_else(|_| {
         format!(
             "{}/.codex/loopx",
-            std::env::var("HOME").unwrap_or_else(|_| ".".into())
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| ".".into())
         )
     })
 }
@@ -69,11 +72,16 @@ fn refresh_next_action(store: &Store, goal_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Project-local state root: `<cwd>/.future/loop/` (run future-loop from the
+/// project dir, or override with FUTURE_LOOP_ROOT). All goal state stays
+/// inside the project.
 fn root_dir() -> String {
     std::env::var("FUTURE_LOOP_ROOT").unwrap_or_else(|_| {
         format!(
             "{}/.future/loop",
-            std::env::var("HOME").unwrap_or_else(|_| ".".into())
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| ".".into())
         )
     })
 }

--- a/orchestration/loop/src/main.rs
+++ b/orchestration/loop/src/main.rs
@@ -22,36 +22,13 @@ use future_loop::executor::{execute_turn, writeback};
 use future_loop::state::{now_epoch, Goal, RunRecord, TaskClass, Todo, TodoStatus};
 use future_loop::store::{Event, Store};
 
-/// Runtime root for the reference-compatible run history (default
-/// `<cwd>/.codex/loopx`, overridable via FUTURE_LOOP_RUNTIME). Project-local:
-/// all loop state stays inside the project directory.
-fn runtime_root() -> String {
-    std::env::var("FUTURE_LOOP_RUNTIME").unwrap_or_else(|_| {
-        format!(
-            "{}/.codex/loopx",
-            std::env::current_dir()
-                .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_else(|_| ".".into())
-        )
-    })
-}
-
-/// Materialize the LoopX-compatible on-disk projection for one goal:
-/// GOAL.md + .loopx/registry.json + .codex/goals/<id>/ACTIVE_GOAL_STATE.md.
+/// Materialize the project-local active-state projection for one goal:
+/// `<cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md`.
 fn sync_compat(store: &Store, goal_id: &str) -> Result<()> {
     let Some(goal) = store.replay(goal_id)? else {
         return Ok(());
     };
-    // GOAL.md is written only when a goal doc is provided (--goal-doc);
-    // the projection reads its existence for the Authority Sources section.
-    let goals: Vec<Goal> = store
-        .registry()
-        .iter()
-        .filter_map(|e| store.replay(&e.goal_id).ok().flatten())
-        .collect();
-    let goal_refs: Vec<&Goal> = goals.iter().collect();
-    future_loop::compat::write_registry(&goal.cwd, &goal_refs, &runtime_root())?;
-    future_loop::compat::write_active_state(&goal.cwd, &goal)?;
+    future_loop::compat::write_active_state(&store.goal_dir(goal_id), &goal)?;
     Ok(())
 }
 
@@ -1861,7 +1838,8 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         );
         writeback(&mut g, &record, monitor_changed, completion);
         store.append_run(&goal_id, &record)?;
-        let _ = future_loop::compat::write_run(&runtime_root(), &goal_id, &record);
+        // Project-local per-run mirror (runs/ under the goal state dir).
+        let _ = future_loop::compat::write_run(&store.goal_dir(&goal_id), &goal_id, &record);
         store.append(Event::RunRecorded {
             goal_id: goal_id.clone(),
             record: record.clone(),
@@ -2305,7 +2283,7 @@ fn cmd_runs(store: &Store, args: &[String]) -> Result<()> {
     store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    let root = runtime_root();
+    let root = store.root_path();
     use future_loop::runtime as rt;
 
     match sub {
@@ -3004,10 +2982,14 @@ fn cmd_handoff(store: &Store, args: &[String]) -> Result<()> {
         contract.as_ref().map(|c| c.summary.as_str()),
     );
     if write {
-        future_loop::handoff::project_handoff::write_project_handoff(&goal.cwd, &goal, &handoff)
-            .map_err(|e| anyhow::anyhow!("write handoff: {e}"))?;
+        future_loop::handoff::project_handoff::write_project_handoff(
+            &store.goal_dir(&goal_id),
+            &goal,
+            &handoff,
+        )
+        .map_err(|e| anyhow::anyhow!("write handoff: {e}"))?;
         println!(
-            "handoff written to .codex/goals/{}/HANDOFF.md",
+            "handoff written to .future/loop/goals/{}/HANDOFF.md",
             goal.goal_id
         );
     } else {
@@ -3247,7 +3229,7 @@ fn cmd_benchmark_protocol(store: &Store, args: &[String]) -> Result<()> {
 
 /// `loopx benchmark ledger [--benchmark-id X] [--case-id Y] [--json]
 /// [--dir DIR]` — query the benchmark run ledger (default dir:
-/// `<FUTURE_LOOP_RUNTIME>/benchmarks`).
+/// `<cwd>/.future/loop/benchmarks`).
 fn cmd_benchmark_ledger(store: &Store, args: &[String]) -> Result<()> {
     let mut benchmark_id = None;
     let mut case_id = None;
@@ -3260,7 +3242,7 @@ fn cmd_benchmark_ledger(store: &Store, args: &[String]) -> Result<()> {
         "--dir" => dir = Some(v),
         _ => {}
     });
-    let dir = dir.unwrap_or_else(|| format!("{}/benchmarks", runtime_root()));
+    let dir = dir.unwrap_or_else(|| format!("{}/benchmarks", store.root_path()));
     let dir = std::path::PathBuf::from(&dir);
     std::fs::create_dir_all(&dir).ok();
     let ledger = future_loop::benchmark::ledger::BenchmarkLedger::open(&dir)?;

--- a/orchestration/loop/src/main.rs
+++ b/orchestration/loop/src/main.rs
@@ -1,6 +1,6 @@
 //! `loopx` — FutureOS loop control plane CLI.
 //!
-//! Commands (mirror the LoopX core tick, implemented natively):
+//! Commands (mirror the reference core tick, implemented natively):
 //!   goal init    — create a durable goal (registry + event ledger)
 //!   todo add     — add an agent/user/gate/monitor todo
 //!   todo claim   — claim a todo (owner identity)
@@ -703,7 +703,7 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     }
     todo.goal_bound = goal_bound;
     todo.global_gate = global_gate;
-    // LoopX rule: user_gate + global_gate implies goal_bound=true.
+    // reference rule: user_gate + global_gate implies goal_bound=true.
     if todo.global_gate && todo.class == future_loop::state::TaskClass::UserGate {
         todo.goal_bound = true;
     }
@@ -728,7 +728,7 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             _ => future_loop::state::Priority::P1,
         };
         todo.priority = pr;
-        // LoopX convention: todo text carries the [P0]/[P1]/[P2] prefix.
+        // reference convention: todo text carries the [P0]/[P1]/[P2] prefix.
         let tag = format!("[{pr}] ");
         if !todo.text.starts_with(&tag) {
             todo.text = format!("{tag}{}", todo.text);
@@ -907,7 +907,7 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    // LoopX completion contract: a completed advancement todo must declare
+    // reference completion contract: a completed advancement todo must declare
     // closure intent — successor OR no-follow-up; silent completion is rejected.
     let t = goal
         .todo(&todo_id)
@@ -1353,7 +1353,7 @@ fn quota_usage(store: &Store, args: &[String]) -> Result<()> {
     if !all {
         bail!("quota usage requires --goal G or --all");
     }
-    // Aggregate across every registered goal (LoopX run_history projection).
+    // Aggregate across every registered goal (reference run_history projection).
     let rows: Vec<(&str, Vec<future_loop::state::RunRecord>)> = store
         .registry()
         .iter()
@@ -1542,7 +1542,7 @@ fn scheduler_show(store: &Store, args: &[String]) -> Result<()> {
 /// `loopx scheduler record-host-failure --goal G --agent-id A
 /// --target-rrule "FREQ=MINUTELY;INTERVAL=15" --observed-rrule "..."
 /// --failure-kind host_stale_rrule` — merge a host-update failure into the
-/// retained cache (bounded, TTL'd; LoopX scheduler state).
+/// retained cache (bounded, TTL'd; reference scheduler state).
 fn scheduler_record_failure(store: &Store, args: &[String]) -> Result<()> {
     let mut target_rrule = None;
     let mut observed_rrule = None;
@@ -1586,7 +1586,7 @@ fn scheduler_record_failure(store: &Store, args: &[String]) -> Result<()> {
         }
         None => {
             // No state yet: bootstrap from the observed rrule so the failure
-            // has a home (LoopX tolerates a state-less failure record by
+            // has a home (reference tolerates a state-less failure record by
             // keeping the failure list on the next build).
             let identity = st::identity_signature(&goal_id, &agent, surface);
             st::build_scheduler_state(
@@ -2412,7 +2412,7 @@ fn parse_pairs(args: &[String], mut f: impl FnMut(&str, String)) {
 }
 
 /// `loopx heartbeat-prompt --goal G [--agent-id A]` — render the per-turn
-/// re-entry packet for a host executor (LoopX heartbeat contract).
+/// re-entry packet for a host executor (reference heartbeat contract).
 fn cmd_heartbeat(store: &Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut agent_id = None;
@@ -3314,7 +3314,7 @@ async fn cmd_benchmark_run(store: &Store, args: &[String]) -> Result<()> {
     let benchmark_id = benchmark_id.ok_or_else(|| anyhow::anyhow!("--benchmark-id required"))?;
     let case_id = case_id.ok_or_else(|| anyhow::anyhow!("--case-id required"))?;
     let task = task.ok_or_else(|| anyhow::anyhow!("--task required"))?;
-    let route = route.unwrap_or_else(|| "loopx-product-mode".to_string());
+    let route = route.unwrap_or_else(|| "future-loop-product-mode".to_string());
     let mut case = future_loop::benchmark::qualification::QualificationCase::new(
         &benchmark_id,
         &case_id,
@@ -3325,10 +3325,10 @@ async fn cmd_benchmark_run(store: &Store, args: &[String]) -> Result<()> {
     if let Some(arm) = arm_id {
         case.arm_id = arm;
     } else {
-        case.arm_id = if route == "loopx-goal-start-product-mode" {
-            "loopx_goal_start_product_mode".to_string()
+        case.arm_id = if route == "future-loop-goal-start-product-mode" {
+            "future_loop_goal_start_product_mode".to_string()
         } else {
-            "loopx_product_mode".to_string()
+            "future_loop_product_mode".to_string()
         };
     }
     case.expected_evidence = expected_evidence;
@@ -3681,7 +3681,7 @@ fn cmd_version(store: &Store, args: &[String]) -> Result<()> {
     println!("  public_safe_decision_replay_v0 (G-19)");
     println!("  model_behavior_corpus_v0 (G-19)");
     println!("  canary_smoke_run_v0 (G-20)");
-    println!("  loopx_turn_envelope_v0 (G-9)");
+    println!("  future_loop_turn_envelope_v0 (G-9)");
     println!("  scheduler_arbitration_v0 (G-2/G-11)");
     let _ = store;
     let _ = args;

--- a/orchestration/loop/src/main.rs
+++ b/orchestration/loop/src/main.rs
@@ -87,15 +87,12 @@ fn root_dir() -> String {
 }
 
 fn gen_id(prefix: &str) -> String {
+    // Loop-style ids: <prefix>_<12hex> (underscore, no dash) — matches the
+    // reference format and pre-existing goal/todo ids.
     format!(
-        "{}-{}",
+        "{}_{}",
         prefix,
-        uuid::Uuid::new_v4()
-            .simple()
-            .to_string()
-            .chars()
-            .take(10)
-            .collect::<String>()
+        &uuid::Uuid::new_v4().simple().to_string()[..12]
     )
 }
 
@@ -136,6 +133,8 @@ async fn main() -> Result<()> {
         "worker-bridge" => cmd_worker_bridge(&mut store, &args[1..]).await,
         "serve-status" => cmd_serve_status(&store, &args[1..]),
         "capability" => cmd_capability(&store, &args[1..]),
+        "models" => cmd_models(&args[1..]).await,
+        "diagnose" => cmd_diagnose(&store, &args[1..]),
         "run" => cmd_run(&mut store, &args[1..]).await,
         // ── P3 commands ──────────────────────────────────────────────────
         "extension" => cmd_extension(&store, &args[1..]),
@@ -186,6 +185,18 @@ fn build_cli_registry() -> CommandRegistry {
         "status",
         "project the active state",
         "status [--goal G]",
+    );
+    r.command(
+        goal,
+        "models",
+        "list models available from the agent",
+        "models [--format json]",
+    );
+    r.command(
+        goal,
+        "diagnose",
+        "per-goal diagnostic surface (decision / gaps / runs)",
+        "diagnose --goal G [--format json]",
     );
 
     let todo = r.group("todo", "todo work graph");
@@ -543,11 +554,11 @@ fn cmd_goal(store: &mut Store, args: &[String]) -> Result<()> {
             format!("{doc}\n"),
         );
     }
-    // LoopX bootstrap auto-adds an onboarding-connection-validation todo.
+    // Bootstrap auto-adds an onboarding-connection-validation todo.
     let onboarding = Todo::advancement(
         &gen_id("todo"),
-        "[P1] Run `future-loop check` against the project registry and record the \
-         first project-specific adapter signal or an explicit no-follow-up rationale.",
+        "[P1] Run `future-loop status` for this goal and record the goal \
+         count as evidence, or declare an explicit no-follow-up rationale.",
     )
     .at_priority(future_loop::state::Priority::P1)
     .with_action_kind("onboarding_connection_validation");
@@ -1640,6 +1651,44 @@ fn scheduler_record_failure(store: &Store, args: &[String]) -> Result<()> {
 }
 
 // ── run (one bounded gRPC turn + writeback) ────────────────────────────────
+
+/// `future-loop models [--format json]` — list models available from the
+/// agent (auth.json / models.json merged with the built-in catalog).
+async fn cmd_models(args: &[String]) -> Result<()> {
+    let json = args.iter().any(|a| a == "--format" || a == "--json");
+    let mut client = future_loop::agent_client::AgentClient::connect("127.0.0.1:50051").await?;
+    let data = client.list_models().await?;
+    let models = data["models"].as_array().cloned().unwrap_or_default();
+    let default_model = data["defaultModel"].as_str().unwrap_or("");
+    if json {
+        println!("{}", serde_json::to_string_pretty(&data)?);
+        return Ok(());
+    }
+    println!("Available models (default: {}):", default_model);
+    for m in &models {
+        let id = m["id"].as_str().unwrap_or("");
+        let provider = m["provider"].as_str().unwrap_or("");
+        let label = m["label"].as_str().unwrap_or(id);
+        let full = if provider.is_empty() {
+            id.to_string()
+        } else {
+            format!("{provider}/{id}")
+        };
+        let thinking = m["thinkingLevel"].as_str().unwrap_or("off");
+        let ctx = m["contextWindow"].as_i64().unwrap_or(0);
+        let recommended = m["recommended"].as_bool().unwrap_or(false);
+        let is_default = m["isDefault"].as_bool().unwrap_or(false);
+        let mut flags = String::new();
+        if is_default {
+            flags.push_str(" [default]");
+        }
+        if recommended {
+            flags.push_str(" [recommended]");
+        }
+        println!("- {full}  {label}  thinking={thinking} ctx={ctx}{flags}");
+    }
+    Ok(())
+}
 
 async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
@@ -3654,6 +3703,80 @@ fn cmd_version(store: &Store, args: &[String]) -> Result<()> {
     println!("  scheduler_arbitration_v0 (G-2/G-11)");
     let _ = store;
     let _ = args;
+    Ok(())
+}
+
+/// `future-loop diagnose --goal G [--format json]` — per-goal diagnostic
+/// surface: current decision, open todos/gates, projection gaps, closure
+/// status, and recent run evidence.
+fn cmd_diagnose(store: &Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut format_json = false;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--format" => format_json = v == "json",
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let packet = decide_for(&goal, SystemTime::now(), None);
+    if format_json {
+        let diag = serde_json::json!({
+            "goal_id": goal.goal_id,
+            "objective": goal.objective,
+            "status": goal.status,
+            "decision": packet.decision,
+            "mode": packet.interaction_contract.mode.as_str(),
+            "reason": packet.reason,
+            "open_todos": goal.todos.iter().filter(|t| t.status == TodoStatus::Open).count(),
+            "open_gates": goal.open_gates().count(),
+            "projection_gap": future_loop::store::projection_gap(&goal),
+            "terminal": goal.terminal_closure().is_some(),
+            "runs": goal.history.len(),
+            "recent_evidence": goal.history.iter().rev().take(3).map(|r| serde_json::json!({
+                "turn": r.turn, "todo": r.todo_id, "state": r.terminal_state,
+                "tools": r.tools, "cost": r.cost_delta, "evidence": future_loop::decision::truncate(&r.evidence, 200),
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&diag)?);
+        return Ok(());
+    }
+    println!("== diagnose {goal_id} ==");
+    println!("objective : {}", goal.objective);
+    println!(
+        "status    : {} | terminal: {}",
+        goal.status,
+        goal.terminal_closure().is_some()
+    );
+    println!(
+        "decision  : {} / {} | {}",
+        packet.decision,
+        packet.interaction_contract.mode.as_str(),
+        packet.reason
+    );
+    println!(
+        "todos     : {} open / {} gates",
+        goal.todos
+            .iter()
+            .filter(|t| t.status == TodoStatus::Open)
+            .count(),
+        goal.open_gates().count()
+    );
+    if let Some(gap) = future_loop::store::projection_gap(&goal) {
+        println!("gap       : {gap}");
+    }
+    for r in goal.history.iter().rev().take(3) {
+        println!(
+            "run       : #{} todo={} state={} cost=¥{:.4} tools=[{}]",
+            r.turn,
+            r.todo_id,
+            r.terminal_state,
+            r.cost_delta,
+            r.tools.join(", ")
+        );
+    }
     Ok(())
 }
 

--- a/orchestration/loop/src/migration.rs
+++ b/orchestration/loop/src/migration.rs
@@ -401,20 +401,10 @@ pub fn migration_bridge_status(
     build_migration_bridge(goal_id, checks, !store.backups(goal_id).is_empty())
 }
 
-/// Locate the ACTIVE_GOAL_STATE.md for a goal (cwd-relative, LoopX layout).
-fn active_state_file(goal_dir: &Path, cwd: Option<&str>) -> Option<PathBuf> {
-    let goal_id = goal_dir.file_name()?.to_string_lossy().into_owned();
-    if let Some(cwd) = cwd {
-        let p = Path::new(cwd)
-            .join(".codex")
-            .join("goals")
-            .join(&goal_id)
-            .join("ACTIVE_GOAL_STATE.md");
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let local = goal_dir.join("..").join("..").join("ACTIVE_GOAL_STATE.md");
+/// Locate the ACTIVE_GOAL_STATE.md for a goal (project-local state layout:
+/// `<cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md`).
+fn active_state_file(goal_dir: &Path, _cwd: Option<&str>) -> Option<PathBuf> {
+    let local = goal_dir.join("ACTIVE_GOAL_STATE.md");
     local.exists().then_some(local)
 }
 

--- a/orchestration/loop/src/quota/usage_summary.rs
+++ b/orchestration/loop/src/quota/usage_summary.rs
@@ -1,5 +1,5 @@
 //! Usage summary (G-7) — 24h/7d quota usage totals + per-goal rows, mirroring
-//! LoopX `control_plane/quota/usage_summary.py` (`build_usage_summary`).
+//! reference `control_plane/quota/usage_summary.py` (`build_usage_summary`).
 //!
 //! The summary is a read-only projection over the run-history ledger (the
 //! `spend_source` stamped by [`crate::quota::slot_accounting`]). It is what
@@ -9,7 +9,7 @@
 use crate::quota::slot_accounting::{account_history, slot_spend, SlotSpendSource};
 use crate::state::RunRecord;
 
-/// Proxy note (LoopX `USAGE_PROXY_NOTE`): the summary derives from the run
+/// Proxy note (reference `USAGE_PROXY_NOTE`): the summary derives from the run
 /// ledger and excludes token counts and raw thread logs.
 pub const USAGE_PROXY_NOTE: &str = "run-history proxy; excludes token counts and raw thread logs";
 

--- a/orchestration/loop/src/replay/corpus.rs
+++ b/orchestration/loop/src/replay/corpus.rs
@@ -43,7 +43,7 @@ pub const MODEL_BEHAVIOR_SIGNAL_FIELDS: &[&str] = &[
 ];
 
 /// Semantic contract dimensions that must be complete for grading
-/// (LoopX MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS).
+/// (reference MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS).
 pub const MODEL_BEHAVIOR_SEMANTIC_CONTRACT_FIELDS: &[&str] =
     &["schema_header", "instruction", "completion_contract"];
 
@@ -238,7 +238,7 @@ pub struct RetainedPacket {
 }
 
 /// Build an in-memory corpus from a base packet + perturbation sources
-/// (LoopX `build_model_behavior_corpus`). Callers must not persist the raw
+/// (reference `build_model_behavior_corpus`). Callers must not persist the raw
 /// packets.
 pub fn build_model_behavior_corpus(
     base_packet: &ShouldRunPacket,
@@ -341,7 +341,7 @@ pub fn extract_behavior_signals(packet: &serde_json::Value) -> serde_json::Value
 }
 
 /// The model-behavior actor: produces an arm response from the rendered
-/// request (LoopX ModelBehaviorActor). The stub is deterministic; an LLM
+/// request (reference ModelBehaviorActor). The stub is deterministic; an LLM
 /// actor parses the same behavior-signal schema from its output.
 pub trait ModelBehaviorActor {
     fn id(&self) -> &str;
@@ -361,7 +361,7 @@ impl ModelBehaviorActor for StubActor {
     }
 }
 
-/// One pair-qualification run (LoopX run_model_behavior_qualification_pair).
+/// One pair-qualification run (reference run_model_behavior_qualification_pair).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PairResult {
     pub status: String, // evaluated | fail_closed | actor_failed
@@ -378,7 +378,7 @@ pub struct PairResult {
 }
 
 /// Run one full/candidate pair through the actor with the given arm order
-/// (LoopX `run_model_behavior_qualification_pair`, minimal). An arm whose
+/// (reference `run_model_behavior_qualification_pair`, minimal). An arm whose
 /// packet fails the hard-invariant gate is fail_closed (the expected outcome
 /// for candidate ablations).
 pub fn run_model_behavior_qualification_pair(
@@ -482,7 +482,7 @@ pub fn run_model_behavior_qualification_pair(
 }
 
 /// Semantic-contract checks over a rendered request: schema header,
-/// instruction, completion contract (LoopX MODEL_BEHAVIOR_SEMANTIC_CONTRACT
+/// instruction, completion contract (reference MODEL_BEHAVIOR_SEMANTIC_CONTRACT
 /// dimensions).
 pub fn semantic_contract_checks(request: &str) -> Vec<(&'static str, bool)> {
     vec![
@@ -547,7 +547,7 @@ pub struct CaseOutcome {
     pub runs: Vec<serde_json::Value>,
 }
 
-/// Corpus run result (LoopX MODEL_BEHAVIOR_CORPUS_RESULT_SCHEMA_VERSION).
+/// Corpus run result (reference MODEL_BEHAVIOR_CORPUS_RESULT_SCHEMA_VERSION).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CorpusResult {
     pub schema_version: String,
@@ -562,7 +562,7 @@ pub struct CorpusResult {
     pub persistence_boundary: serde_json::Value,
 }
 
-/// Run a corpus against an actor (LoopX `run_model_behavior_corpus`).
+/// Run a corpus against an actor (reference `run_model_behavior_corpus`).
 /// `repeats` must be between 2 and 20; arm order is shuffled per repeat with
 /// a seeded RNG so runs are reproducible.
 pub fn run_model_behavior_corpus(
@@ -844,7 +844,8 @@ mod tests {
             &[],
         )
         .unwrap();
-        let dir = std::env::temp_dir().join(format!("loopx-corpus-{}", crate::state::now_epoch()));
+        let dir =
+            std::env::temp_dir().join(format!("future-loop-corpus-{}", crate::state::now_epoch()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("corpus.json");
         corpus.save(&path).unwrap();

--- a/orchestration/loop/src/replay/decision_replay.rs
+++ b/orchestration/loop/src/replay/decision_replay.rs
@@ -1,4 +1,4 @@
-//! Decision replay (G-19) — LoopX `control_plane/testing/decision_replay.py`
+//! Decision replay (G-19) — reference `control_plane/testing/decision_replay.py`
 //! (268 lines), natively: record a REAL kernel decision as a public-safe
 //! reduced case, then replay the decision kernel against the reconstructed
 //! state and diff the outcome. This is the LLM-side complement to the
@@ -31,7 +31,7 @@ pub const BANNED_KEYS: &[&str] = &[
     "verifier_output",
 ];
 
-/// Compact todo fields (LoopX _TODO_FIELDS; `decision` is our additive field
+/// Compact todo fields (reference _TODO_FIELDS; `decision` is our additive field
 /// so closed gate decisions replay deterministically).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompactTodo {
@@ -54,7 +54,7 @@ pub struct CompactTodo {
     pub decision: Option<String>,
 }
 
-/// The reduced decision fields (LoopX decision block).
+/// The reduced decision fields (reference decision block).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DecisionFields {
     pub should_run: bool,
@@ -92,7 +92,7 @@ pub struct AgentChannelCase {
     pub quiet_noop_allowed: Option<bool>,
 }
 
-/// Expected kernel outputs recorded at capture time (LoopX expected block).
+/// Expected kernel outputs recorded at capture time (reference expected block).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExpectedCase {
     pub scheduler_action: String,
@@ -392,7 +392,7 @@ pub fn goal_from_case(case: &DecisionCase) -> Goal {
     goal
 }
 
-/// Per-field replay comparison (LoopX diff semantics, natively).
+/// Per-field replay comparison (reference diff semantics, natively).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplayComparison {
     pub case_id: String,
@@ -697,7 +697,8 @@ mod tests {
 
     #[test]
     fn replay_file_round_trip() {
-        let dir = std::env::temp_dir().join(format!("loopx-replay-{}", crate::state::now_epoch()));
+        let dir =
+            std::env::temp_dir().join(format!("future-loop-replay-{}", crate::state::now_epoch()));
         std::fs::create_dir_all(&dir).unwrap();
         let goal = sample_goal();
         let packet = crate::decision::decide(&goal, std::time::SystemTime::now());

--- a/orchestration/loop/src/scheduler/mod.rs
+++ b/orchestration/loop/src/scheduler/mod.rs
@@ -1,6 +1,6 @@
 //! Scheduler subdomain (G-10) — the rrule recurrence state machine.
 //!
-//! LoopX `control_plane/scheduler/` (4,178 lines across 15 files) keeps a
+//! reference `control_plane/scheduler/` (4,178 lines across 15 files) keeps a
 //! persistent scheduler state per (goal, agent): rrule recurrence,
 //! progression backoff, reset tokens, identity signatures, and host update
 //! failures. This module implements the minimal state machine (G-10) as a

--- a/orchestration/loop/src/scheduler/state.rs
+++ b/orchestration/loop/src/scheduler/state.rs
@@ -1,7 +1,7 @@
 //! Scheduler state machine (G-10) — rrule recurrence + progression + host
 //! update failures, persisted across decision cycles.
 //!
-//! Mirrors LoopX `control_plane/scheduler/state.py` (354 lines): the state
+//! Mirrors reference `control_plane/scheduler/state.py` (354 lines): the state
 //! machine that turns a cadence class into a concrete MINUTELY rrule, walks
 //! a `progression_minutes` backoff sequence across cycles, and retains host
 //! update failures (target vs observed rrule drift) with a bounded cache.
@@ -9,11 +9,11 @@
 //! Scope trade-off (refactor plan §5.2 G-10): only the cadence-class subset
 //! `once` / `hourly` / `daily` / `weekly` is implemented plus counter-based
 //! progression — no full RFC5545 recur semantics or free-text rrule parsing
-//! beyond `FREQ=MINUTELY;INTERVAL=N` (which is what LoopX itself emits).
+//! beyond `FREQ=MINUTELY;INTERVAL=N` (which is what reference itself emits).
 //!
 //! Persistence: one JSON file per (goal, agent, surface, state-key) under
 //! `<store-root>/goals/<goal_id>/scheduler-state/<agent>/<surface>/<hash>.json`,
-//! written atomically (tmp + rename, like LoopX `write_scheduler_state`).
+//! written atomically (tmp + rename, like reference `write_scheduler_state`).
 //! `store.rs` backup/restore carries the `scheduler-state` directory so a
 //! restore does not silently reset progression (P1 risk: replay/backup
 //! interaction).
@@ -25,25 +25,25 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-/// File schema version (LoopX `SCHEDULER_STATE_SCHEMA_VERSION`).
-pub const SCHEDULER_STATE_SCHEMA_VERSION: &str = "loopx_scheduler_state_v0";
+/// File schema version (reference `SCHEDULER_STATE_SCHEMA_VERSION`).
+pub const SCHEDULER_STATE_SCHEMA_VERSION: &str = "future_loop_scheduler_state_v0";
 /// Host-update-failure record schema version (LoopX).
 pub const SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION: &str = "scheduler_host_update_failure_v0";
 /// Bounded cache of retained failures (LoopX).
 pub const SCHEDULER_HOST_UPDATE_FAILURE_CACHE_LIMIT: usize = 4;
 /// Retention TTL for host update failures (LoopX: 24h).
 pub const SCHEDULER_HOST_UPDATE_FAILURE_TTL_SECS: u64 = 24 * 60 * 60;
-/// Default surface (LoopX `CODEX_APP_SURFACE`).
+/// Default surface (reference `CODEX_APP_SURFACE`).
 pub const CODEX_APP_SURFACE: &str = "codex_app";
-/// Default state key (LoopX `CODEX_APP_STATEFUL_BACKOFF_STATE_KEY`).
+/// Default state key (reference `CODEX_APP_STATEFUL_BACKOFF_STATE_KEY`).
 pub const CODEX_APP_STATEFUL_BACKOFF_STATE_KEY: &str = "scheduler_hint.codex_app.stateful_backoff";
-/// Stateful-backoff payload schema (LoopX `CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION`).
+/// Stateful-backoff payload schema (reference `CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION`).
 pub const CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION: &str = "codex_app_stateful_backoff_v0";
 /// Default monitor-wait backoff progression in minutes (LoopX
 /// `MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60]`).
 pub const MONITOR_WAIT_PROGRESSION_MINUTES: &[i64] = &[15, 30, 60];
 
-/// Build `FREQ=MINUTELY;INTERVAL=N` (LoopX `rrule_for_minutes`).
+/// Build `FREQ=MINUTELY;INTERVAL=N` (reference `rrule_for_minutes`).
 pub fn rrule_for_minutes(minutes: i64) -> String {
     format!("FREQ=MINUTELY;INTERVAL={}", minutes.max(1))
 }
@@ -81,7 +81,7 @@ pub fn scheduler_rrule_interval_minutes(value: &str) -> Option<i64> {
 /// Map a cadence class onto a MINUTELY rrule for the supported subset
 /// (`once` / `hourly` / `daily` / `weekly`). Recurring classes return
 /// `Some(rrule)`; `once` and non-recurring classes return `None` (single
-/// execution, no cross-cycle recurrence — LoopX `once` semantics).
+/// execution, no cross-cycle recurrence — reference `once` semantics).
 pub fn rrule_for_cadence_class(cadence_class: &str) -> Option<String> {
     match normalize_scheduler_rrule(cadence_class)
         .to_ascii_lowercase()
@@ -97,7 +97,7 @@ pub fn rrule_for_cadence_class(cadence_class: &str) -> Option<String> {
     }
 }
 
-/// Human label for a minutes interval (LoopX scheduler display).
+/// Human label for a minutes interval (reference scheduler display).
 pub fn cadence_label(minutes: i64) -> String {
     match minutes {
         m if m % (7 * 24 * 60) == 0 => format!("{}w", m / (7 * 24 * 60)),
@@ -108,7 +108,7 @@ pub fn cadence_label(minutes: i64) -> String {
 }
 
 /// Parse a monitor cadence interval string (`15m`, `1h`, `2d`, `30s`) into
-/// seconds — LoopX `monitor_cadence_delta` (MONITOR_CADENCE_PATTERN).
+/// seconds — reference `monitor_cadence_delta` (MONITOR_CADENCE_PATTERN).
 /// Returns `None` for unparsable or empty values. Cadence classes map
 /// through [`rrule_for_cadence_class`].
 pub fn monitor_cadence_secs(value: &str) -> Option<u64> {
@@ -138,7 +138,7 @@ pub fn monitor_cadence_secs(value: &str) -> Option<u64> {
 
 // ── Host update failures ───────────────────────────────────────────────────
 
-/// A recorded host-update failure (LoopX `scheduler_host_update_failure_v0`):
+/// A recorded host-update failure (reference `scheduler_host_update_failure_v0`):
 /// the control plane asked the host to switch to `target_rrule` but observed
 /// `observed_host_rrule` instead. Retained for a bounded TTL so the next tick
 /// can suppress a redundant update and surface drift diagnostics.
@@ -194,7 +194,7 @@ pub fn normalize_host_update_failure(value: &serde_json::Value) -> Option<HostUp
 }
 
 /// Dedup by (target, observed) pair, keep the latest, cap at the cache limit
-/// (LoopX `normalize_scheduler_host_update_failures`).
+/// (reference `normalize_scheduler_host_update_failures`).
 pub fn normalize_host_update_failures(value: &[serde_json::Value]) -> Vec<HostUpdateFailure> {
     let mut normalized: Vec<HostUpdateFailure> = vec![];
     for candidate in value {
@@ -215,7 +215,7 @@ pub fn normalize_host_update_failures(value: &[serde_json::Value]) -> Vec<HostUp
 }
 
 /// Keep failures inside the TTL (and matching an expected observed rrule,
-/// when given) — LoopX `retained_scheduler_host_update_failures`.
+/// when given) — reference `retained_scheduler_host_update_failures`.
 pub fn retained_host_update_failures(
     failures: &[HostUpdateFailure],
     now_epoch: u64,
@@ -241,7 +241,7 @@ pub fn retained_host_update_failures(
 }
 
 /// Merge one failure into an existing list: retain (TTL + pair dedup) then
-/// append — LoopX `merge_scheduler_host_update_failure`. A re-recorded
+/// append — reference `merge_scheduler_host_update_failure`. A re-recorded
 /// (target, observed) pair replaces the previous record (latest wins).
 pub fn merge_host_update_failure(
     failures: &[HostUpdateFailure],
@@ -252,7 +252,7 @@ pub fn merge_host_update_failure(
         retained_host_update_failures(failures, now_epoch, Some(&failure.observed_host_rrule));
     let mut combined: Vec<HostUpdateFailure> = retained;
     combined.push(failure);
-    // Dedup by pair, keeping the LATEST occurrence (LoopX normalize appends
+    // Dedup by pair, keeping the LATEST occurrence (reference normalize appends
     // after removing the old pair).
     let mut seen = std::collections::HashSet::new();
     let mut result: Vec<HostUpdateFailure> = Vec::with_capacity(combined.len());
@@ -265,7 +265,7 @@ pub fn merge_host_update_failure(
     result
 }
 
-/// Best-effort parse of a LoopX ISO-8601 timestamp (`failed_at`) to epoch.
+/// Best-effort parse of a reference ISO-8601 timestamp (`failed_at`) to epoch.
 pub fn parse_epoch(iso: &str) -> Option<u64> {
     chrono::DateTime::parse_from_rfc3339(iso)
         .ok()
@@ -275,7 +275,7 @@ pub fn parse_epoch(iso: &str) -> Option<u64> {
 // ── Scheduler state ────────────────────────────────────────────────────────
 
 /// The persisted scheduler state machine record (LoopX
-/// `loopx_scheduler_state_v0`): scope identity, progression cursor, the last
+/// `future_loop_scheduler_state_v0`): scope identity, progression cursor, the last
 /// applied rrule, and retained host update failures.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchedulerState {
@@ -304,7 +304,9 @@ pub fn normalize_scheduler_state(
     surface: &str,
     state_key: &str,
 ) -> Option<SchedulerState> {
-    if state.schema_version != SCHEDULER_STATE_SCHEMA_VERSION {
+    if state.schema_version != SCHEDULER_STATE_SCHEMA_VERSION
+        && state.schema_version != "loopx_scheduler_state_v0"
+    {
         return None;
     }
     if state.goal_id != goal_id || state.agent_id != agent_id {
@@ -325,7 +327,7 @@ pub fn normalize_scheduler_state(
     Some(state.clone())
 }
 
-/// Build a validated scheduler state (LoopX `build_scheduler_state`).
+/// Build a validated scheduler state (reference `build_scheduler_state`).
 #[allow(clippy::too_many_arguments)]
 pub fn build_scheduler_state(
     goal_id: &str,
@@ -359,7 +361,7 @@ pub fn build_scheduler_state(
     })
 }
 
-/// Stable digest (LoopX `_stable_digest`): FNV-1a over the joined parts,
+/// Stable digest (reference `_stable_digest`): FNV-1a over the joined parts,
 /// hex-encoded to `length` chars. Deterministic across processes and
 /// restarts — the identity anchor for persisted state.
 pub fn stable_digest(parts: &[&str], length: usize) -> String {
@@ -379,7 +381,7 @@ pub fn identity_signature(goal_id: &str, agent_id: &str, surface: &str) -> Strin
 }
 
 /// Reset token: stable digest of the cadence action + identity + profile
-/// (LoopX `reset_token`, 16 hex chars). When the cadence action or identity
+/// (reference `reset_token`, 16 hex chars). When the cadence action or identity
 /// changes, the token changes and the host must reset progression to the
 /// initial interval.
 pub fn reset_token(action: &str, identity_sig: &str, initial_rrule: &str) -> String {
@@ -430,7 +432,7 @@ pub fn apply_next_progression(state: &mut SchedulerState, now_epoch: u64) -> Opt
 
 // ── Persistence ────────────────────────────────────────────────────────────
 
-/// Path for one scheduler state file (LoopX `scheduler_state_path`, rooted
+/// Path for one scheduler state file (reference `scheduler_state_path`, rooted
 /// at the store's goal directory): the state-key hash keeps distinct state
 /// machines (e.g. future scheduler hint kinds) from colliding.
 pub fn scheduler_state_path(
@@ -447,7 +449,7 @@ pub fn scheduler_state_path(
         .join(format!("{state_hash}.json"))
 }
 
-/// Sanitize a path segment (LoopX `_safe_segment`).
+/// Sanitize a path segment (reference `_safe_segment`).
 fn safe_segment(value: &str) -> String {
     let cleaned: String = value
         .chars()

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -9,7 +9,7 @@
 use std::time::{Duration, SystemTime};
 
 /// Priority (LoopX: P0/P1/P2 — the decision kernel sorts the frontier by
-/// priority before anything else). Serialized with the EXACT LoopX values.
+/// priority before anything else). Serialized with the EXACT reference values.
 #[derive(
     Debug,
     Clone,
@@ -47,7 +47,7 @@ impl std::fmt::Display for Priority {
 }
 
 /// Task class — LoopX's six-way todo taxonomy. Serialized with the EXACT
-/// LoopX values (advancement_task / continuous_monitor / user_gate /
+/// reference values (advancement_task / continuous_monitor / user_gate /
 /// user_action / blocker). The Kanban "column" is a projection of these axes,
 /// never a single stored string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -71,8 +71,8 @@ pub enum TaskClass {
     Blocker,
 }
 
-/// Lifecycle status — LoopX values open/done/blocked/deferred, plus our
-/// superseded extension (LoopX performs supersede as an operation; keeping it
+/// Lifecycle status — reference values open/done/blocked/deferred, plus our
+/// superseded extension (reference performs supersede as an operation; keeping it
 /// as a status preserves our event-sourced replay).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TodoStatus {
@@ -81,7 +81,7 @@ pub enum TodoStatus {
     #[serde(rename = "done")]
     Done,
     /// Superseded: a better route was discovered; the todo is no longer
-    /// runnable and must not block closure (LoopX 0623 `supersede`).
+    /// runnable and must not block closure (reference 0623 `supersede`).
     #[serde(rename = "superseded")]
     Superseded,
     /// Deferred: held until `resume_when`; due deferred todos return to Open
@@ -123,9 +123,9 @@ pub struct Todo {
     /// Monitor only: consecutive no-change polls (per-monitor counter).
     pub consecutive_no_change: u32,
     /// Monitor only (G-12): the external target this monitor observes
-    /// (LoopX `monitor_target` — e.g. an endpoint / file / URL).
+    /// (reference `monitor_target` — e.g. an endpoint / file / URL).
     pub monitor_target: Option<String>,
-    /// Monitor only (G-12): the poll policy. LoopX vocabulary:
+    /// Monitor only (G-12): the poll policy. reference vocabulary:
     /// `material_transition_only` | `read_only_observation_then_no_spend_if_unchanged`.
     pub monitor_policy: Option<String>,
     /// Monitor only (G-12): recurrence cadence — cadence class
@@ -144,11 +144,11 @@ pub struct Todo {
     pub no_follow_up: bool,
     /// Completion evidence (LoopX: recorded on the todo at complete time).
     pub evidence: Option<String>,
-    /// Claim/lease (LoopX task-lease): which agent lane owns this slice and
+    /// Claim/lease (reference task-lease): which agent lane owns this slice and
     /// when the lease expires. Expired leases return the todo to the frontier.
     pub claimed_by: Option<String>,
     pub lease_expires_at: Option<u64>,
-    /// Capability required to run this todo (LoopX capability gate: a todo is
+    /// Capability required to run this todo (reference capability gate: a todo is
     /// runnable only for agents declaring the capability).
     pub required_capability: Option<String>,
     /// Gate scope flags (LoopX: goal_bound / global_gate — set by bootstrap
@@ -184,7 +184,7 @@ pub fn default_max_validation_attempts() -> u32 {
 }
 
 /// Role (LoopX: role — agent vs user; orthogonal to task_class).
-/// Serialized with the EXACT LoopX values ("agent" / "user").
+/// Serialized with the EXACT reference values ("agent" / "user").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TodoRole {
     #[serde(rename = "agent")]
@@ -366,7 +366,7 @@ impl Todo {
         self
     }
 
-    /// Declare gate scope (LoopX bootstrap sets goal_bound/global_gate).
+    /// Declare gate scope (reference bootstrap sets goal_bound/global_gate).
     pub fn with_gate_scope(mut self, goal_bound: bool, global_gate: bool) -> Self {
         self.goal_bound = goal_bound;
         self.global_gate = global_gate;
@@ -446,7 +446,7 @@ impl Todo {
     }
 }
 
-// ── Task validation (the reference: loopx_turn_task_validation_v0) ────────
+// ── Task validation (the reference: future_loop_turn_task_validation_v0) ────────
 
 pub const MAX_VALIDATION_SCHEMA_VERSION: &str = "future_loop_turn_task_validation_v0";
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -846,7 +846,41 @@ fn load_registry(root: &Path) -> Result<Vec<RegistryEntry>> {
         return Ok(vec![]);
     }
     let text = fs::read_to_string(&path)?;
-    serde_json::from_str(&text).context("parse registry")
+    // Dual format: the native array, or the reference-compatible map
+    // {"goals":[...]} written by earlier productized builds (fields id/repo
+    // map onto goal_id/cwd).
+    let v: serde_json::Value = serde_json::from_str(&text).context("parse registry")?;
+    let items: Vec<serde_json::Value> = match &v {
+        serde_json::Value::Array(a) => a.clone(),
+        serde_json::Value::Object(m) => m
+            .get("goals")
+            .and_then(|g| g.as_array())
+            .cloned()
+            .unwrap_or_default(),
+        _ => bail!("registry is neither an array nor a {{goals:[...]}} object"),
+    };
+    items
+        .into_iter()
+        .map(|g| {
+            let obj = g
+                .as_object()
+                .ok_or_else(|| anyhow::anyhow!("registry entry is not an object"))?;
+            let str_of = |k: &str, alt: &str| -> String {
+                obj.get(k)
+                    .or_else(|| obj.get(alt))
+                    .and_then(|x| x.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            };
+            Ok(RegistryEntry {
+                goal_id: str_of("goal_id", "id"),
+                objective: str_of("objective", "objective"),
+                cwd: str_of("cwd", "repo"),
+                status: str_of("status", "status"),
+                created_at: obj.get("created_at").and_then(|x| x.as_u64()).unwrap_or(0),
+            })
+        })
+        .collect()
 }
 
 /// Copy a directory tree when present (used for the scheduler-state dir in

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -30,12 +30,12 @@ const SCHEMA_FILE: &str = "schema.json";
 // ── Event ledger ───────────────────────────────────────────────────────────
 
 /// Current event-store schema version (G-6). Bumped whenever the event
-/// surface changes shape; legacy ledgers carry `loopx_event_store_v0` and
+/// surface changes shape; legacy ledgers carry `future_loop_event_store_v0` and
 /// are migrated through [`crate::migration::migration_steps`] on read.
-pub const EVENT_STORE_SCHEMA_VERSION: &str = "loopx_event_store_v1";
+pub const EVENT_STORE_SCHEMA_VERSION: &str = "future_loop_event_store_v1";
 /// The pre-G-3 ledger schema (plain `{"kind": ...}` lines, no event ids).
-pub const LEGACY_EVENT_STORE_SCHEMA_VERSION: &str = "loopx_event_store_v0";
-/// Producer tag for ordinary kernel appends (LoopX default producer).
+pub const LEGACY_EVENT_STORE_SCHEMA_VERSION: &str = "future_loop_event_store_v0";
+/// Producer tag for ordinary kernel appends (reference default producer).
 pub const DEFAULT_EVENT_PRODUCER: &str = "loopx.event_sourced_state";
 
 /// The persisted ledger line (G-3): the event plus its content-derived id
@@ -253,7 +253,7 @@ pub enum Event {
         no_change_count: u32,
         ts: u64,
     },
-    /// G-3: a quota slot was spent (LoopX QUOTA_SPENT). Recorded alongside
+    /// G-3: a quota slot was spent (reference QUOTA_SPENT). Recorded alongside
     /// the run ledger; `source` mirrors the slot-accounting spend source
     /// (`run` / `agent` / `heartbeat`) and `slots` the count spent (1 per
     /// bounded turn; monitor no-change polls never spend).
@@ -309,7 +309,7 @@ pub enum Event {
         ts: u64,
     },
     /// G-16: a host execution receipt recorded against a supervisor proposal
-    /// (LoopX SUPERVISOR_RECEIPT_RECORDED). An `executed` receipt requires an
+    /// (reference SUPERVISOR_RECEIPT_RECORDED). An `executed` receipt requires an
     /// authority ref (validated by the supervisor domain before append).
     SupervisorReceiptRecorded {
         goal_id: String,
@@ -428,7 +428,7 @@ impl Store {
 
     /// Append an event with a content-derived id (G-3). Returns the event id.
     /// Idempotent: appending an event whose content already exists under the
-    /// same id is a no-op (LoopX AppendOnlyStateEventStore.append); appending
+    /// same id is a no-op (reference AppendOnlyStateEventStore.append); appending
     /// the same id with DIFFERENT content fails closed with a conflict.
     pub fn append(&mut self, event: Event) -> Result<String> {
         self.append_with_meta(event, None, None, None, None, None, None)
@@ -509,10 +509,16 @@ impl Store {
         let path = self.goal_dir(goal_id).join(SCHEMA_FILE);
         let text = fs::read_to_string(path).ok()?;
         let value: serde_json::Value = serde_json::from_str(&text).ok()?;
-        value
+        let raw = value
             .get("event_store_schema_version")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+            .and_then(|v| v.as_str())?;
+        // Normalize the pre-rename schema tokens (legacy goals stamped with
+        // `loopx_event_store_v0/v1` load transparently).
+        Some(match raw {
+            "loopx_event_store_v1" => EVENT_STORE_SCHEMA_VERSION.to_string(),
+            "loopx_event_store_v0" => LEGACY_EVENT_STORE_SCHEMA_VERSION.to_string(),
+            other => other.to_string(),
+        })
     }
 
     fn ensure_schema_stamp(&self, goal_id: &str) -> Result<()> {
@@ -686,7 +692,7 @@ fn append_locked(path: PathBuf, bytes: &[u8]) -> std::io::Result<()> {
 }
 
 /// Append one event line under the advisory lock with G-3 idempotency +
-/// conflict detection (LoopX `AppendOnlyStateEventStore.append` →
+/// conflict detection (reference `AppendOnlyStateEventStore.append` →
 /// `StateEventConflictError`): the same event id with identical content is
 /// skipped (idempotent replay/backfill re-run); the same id with different
 /// content fails closed.
@@ -1139,7 +1145,7 @@ fn apply(goal: &mut Goal, event: Event) {
 
 // ── Projection gap check ───────────────────────────────────────────────────
 
-/// LoopX `state_projection_gap_warning`: an executable Next Action with no
+/// reference `state_projection_gap_warning`: an executable Next Action with no
 /// open agent todo (or a user-wait Next Action with no open user gate) means
 /// the active-state projection drifted from the todo frontier. The kernel
 /// should emit a self-repair obligation until the projection is re-synced.

--- a/orchestration/loop/src/turn_envelope.rs
+++ b/orchestration/loop/src/turn_envelope.rs
@@ -1,6 +1,6 @@
 //! Turn envelope (G-9) — the per-turn prompt assembly, expanded from the P0
 //! ~30-line `compose_turn_message` into an envelope: instruction + context +
-//! evidence + decision summary (LoopX `control_plane/quota/turn_envelope.py`,
+//! evidence + decision summary (reference `control_plane/quota/turn_envelope.py`,
 //! 796 lines — we implement the minimal deterministic core the host needs).
 //!
 //! The envelope is a plain-text prompt for a policy-free agent: one bounded
@@ -13,8 +13,8 @@ use crate::contract::ShouldRunPacket;
 use crate::decision::truncate;
 use crate::state::{Goal, RunRecord, Todo, TodoStatus};
 
-/// Envelope schema version (LoopX `TURN_ENVELOPE_SCHEMA_VERSION`).
-pub const TURN_ENVELOPE_SCHEMA_VERSION: &str = "loopx_turn_envelope_v0";
+/// Envelope schema version (reference `TURN_ENVELOPE_SCHEMA_VERSION`).
+pub const TURN_ENVELOPE_SCHEMA_VERSION: &str = "future_loop_turn_envelope_v0";
 
 /// Compose the per-turn packet: todo + resolved gate decisions + prior
 /// evidence (+ decision summary when available).

--- a/orchestration/loop/src/work_items/operator_inbox.rs
+++ b/orchestration/loop/src/work_items/operator_inbox.rs
@@ -66,14 +66,14 @@ pub fn operator_inbox_attention_kind(
     let operator_name = operator_display_name.trim().to_lowercase();
     let explicit_mention =
         !operator_name.is_empty() && content.contains('@') && content.contains(&operator_name);
-    let loopx_mention = content.contains('@') && content.contains("loopx");
-    if capture_scope != "addressed_only" && !explicit_mention && !loopx_mention {
+    let loop_mention = content.contains('@') && content.contains("future-loop");
+    if capture_scope != "addressed_only" && !explicit_mention && !loop_mention {
         return None;
     }
     if content.contains('?') || content.contains('？') {
         return Some(OperatorAttentionKind::DirectQuestion);
     }
-    if explicit_mention || loopx_mention {
+    if explicit_mention || loop_mention {
         return Some(OperatorAttentionKind::DirectMention);
     }
     None
@@ -144,10 +144,10 @@ pub fn project_operator_inbox_urgency(
     }
 }
 
-/// Load pending inbox events from `<project>/.loopx/inbox/*.json` (LoopX
-/// `_pending_events`). Path safety: the inbox must stay under `.loopx/inbox`
-/// inside the project; `..` components and absolute paths are rejected
-/// (LoopX `_safe_inbox_path`); malformed files are skipped.
+/// Load pending inbox events from `<project>/.future/loop/inbox/*.json`
+/// (project-local pending events). Path safety: the inbox must stay under
+/// `.future/loop/inbox` inside the project; `..` components and absolute
+/// paths are rejected; malformed files are skipped.
 pub fn load_pending_inbox_events(
     project: &str,
     inbox_rel: &str,
@@ -155,7 +155,7 @@ pub fn load_pending_inbox_events(
     let root = Path::new(project);
     let raw = inbox_rel.trim();
     if raw.starts_with('/') || raw.starts_with('\\') {
-        return Err("operator inbox path must stay under .loopx/inbox".into());
+        return Err("operator inbox path must stay under .future/loop/inbox".into());
     }
     let rel = raw.replace('\\', "/");
     let rel_path = Path::new(&rel);
@@ -164,12 +164,12 @@ pub fn load_pending_inbox_events(
             .components()
             .any(|c| c == std::path::Component::ParentDir)
     {
-        return Err("operator inbox path must stay under .loopx/inbox".into());
+        return Err("operator inbox path must stay under .future/loop/inbox".into());
     }
-    let inbox = root.join(".loopx").join("inbox").join(rel_path);
-    let canonical_inbox = root.join(".loopx").join("inbox");
+    let inbox = root.join(".future").join("loop").join(rel_path);
+    let canonical_inbox = root.join(".future").join("loop").join("inbox");
     if !inbox.starts_with(&canonical_inbox) {
-        return Err("operator inbox path must stay under .loopx/inbox".into());
+        return Err("operator inbox path must stay under .future/loop/inbox".into());
     }
     if !inbox.is_dir() {
         return Ok(vec![]);

--- a/orchestration/loop/src/worker_bridge.rs
+++ b/orchestration/loop/src/worker_bridge.rs
@@ -1,4 +1,4 @@
-//! Worker bridge — the LoopX custom-runner contract over stdio.
+//! Worker bridge — the reference custom-runner contract over stdio.
 //!
 //! A worker (external process/script) connects to the control plane: each
 //! tick the bridge emits the typed packet as one JSON line on stdout, the

--- a/orchestration/loop/tests/agents_scope_contract.rs
+++ b/orchestration/loop/tests/agents_scope_contract.rs
@@ -12,7 +12,7 @@ use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p3-agents-{tag}-{}",
+        "future-loop-p3-agents-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/arbitration_contract.rs
+++ b/orchestration/loop/tests/arbitration_contract.rs
@@ -29,7 +29,7 @@ fn contract(
     quiet_noop_allowed: bool,
 ) -> InteractionContract {
     InteractionContract {
-        schema_version: "loopx_interaction_contract_v0".to_string(),
+        schema_version: "future_loop_interaction_contract_v0".to_string(),
         mode,
         user_channel: UserChannel {
             action_required: user_required,
@@ -54,7 +54,7 @@ fn contract(
     }
 }
 
-// ── The 9 dispositions, value-aligned with LoopX ───────────────────────────
+// ── The 9 dispositions, value-aligned with reference ───────────────────────────
 #[test]
 fn disposition_enum_values_align_with_loopx() {
     let pairs = [
@@ -79,7 +79,7 @@ fn disposition_enum_values_align_with_loopx() {
         assert_eq!(
             serde_json::to_value(disposition).unwrap(),
             serde_json::json!(expected),
-            "serialized disposition must match LoopX string"
+            "serialized disposition must match reference string"
         );
     }
 }
@@ -99,7 +99,7 @@ fn schema_version_is_scheduler_arbitration_v0() {
     assert!(arbitration.consistency_error().is_none());
 }
 
-// ── Classifier matrix: all 9 dispositions reachable (LoopX classify) ───────
+// ── Classifier matrix: all 9 dispositions reachable (reference classify) ───────
 #[test]
 fn classifier_covers_all_nine_dispositions() {
     // terminal_no_followup → TERMINAL_STOP (reason_code = mode)
@@ -278,7 +278,7 @@ fn quiet_noop_conflict_fails_closed() {
 #[test]
 fn schema_version_mismatch_fails_closed() {
     let mut c = contract(TurnMode::BoundedDelivery, false, true, true, false);
-    c.schema_version = "loopx_interaction_contract_v1".to_string();
+    c.schema_version = "future_loop_interaction_contract_v1".to_string();
     let arbitration = build_scheduler_arbitration(&c, &[]);
     assert!(!arbitration.ok());
     assert_eq!(

--- a/orchestration/loop/tests/benchmark_contract.rs
+++ b/orchestration/loop/tests/benchmark_contract.rs
@@ -24,7 +24,7 @@ use future_loop::benchmark::qualification::{run_qualification_case, Qualificatio
 
 fn tmp_dir(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p4-bench-{tag}-{}",
+        "future-loop-p4-bench-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -70,7 +70,7 @@ fn product_mode_comparison_contract_is_arms_and_gate() {
     );
     assert_eq!(c.comparison_id, "skillsbench_product_mode_main_table_v0");
     assert_eq!(c.baseline_arm["route"], "raw-codex-autonomous-max5");
-    assert_eq!(c.treatment_arm["arm_id"], "loopx_product_mode");
+    assert_eq!(c.treatment_arm["arm_id"], "future_loop_product_mode");
     assert!(c.policy_gate["same_benchmark_and_case_required"]
         .as_bool()
         .unwrap());
@@ -83,7 +83,7 @@ fn sample_run() -> BenchmarkRun {
     BenchmarkRun {
         benchmark_id: "skillsbench@1.1".to_string(),
         case_ids: vec!["case-42".to_string()],
-        arm_id: "loopx_product_mode".to_string(),
+        arm_id: "future_loop_product_mode".to_string(),
         route: LOOPX_PRODUCT_MODE_ROUTE.to_string(),
         mode: "product".to_string(),
         agent_model: "future/deepseek-v4-flash".to_string(),

--- a/orchestration/loop/tests/canary_contract.rs
+++ b/orchestration/loop/tests/canary_contract.rs
@@ -8,7 +8,7 @@ use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p4-canary-{tag}-{}",
+        "future-loop-p4-canary-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/capability_contract.rs
+++ b/orchestration/loop/tests/capability_contract.rs
@@ -106,7 +106,7 @@ fn capability_gate_hides_todo_from_agents_without_capability() {
 // ── P2: agent profiles persist through the ledger ──────────────────────────
 #[test]
 fn agent_profiles_survive_replay() {
-    let root = std::env::temp_dir().join(format!("loopx-p3-{}", nano()));
+    let root = std::env::temp_dir().join(format!("future-loop-p3-{}", nano()));
     std::fs::create_dir_all(&root).unwrap();
     let mut store = future_loop::store::Store::open(&root.to_string_lossy()).unwrap();
     let g = Goal::new("g1", "objective", "/tmp");

--- a/orchestration/loop/tests/capability_lifecycle_contract.rs
+++ b/orchestration/loop/tests/capability_lifecycle_contract.rs
@@ -8,11 +8,11 @@ use future_loop::capabilities::catalog::CapabilityCatalog;
 use future_loop::capabilities::lifecycle::{CapabilityProvider, ProviderLifecycle, ProviderStage};
 
 #[test]
-fn builtin_catalog_has_15_records_with_loopx_statuses() {
+fn builtin_catalog_has_15_records_with_future_loop_statuses() {
     let catalog = CapabilityCatalog::with_builtin();
     assert_eq!(catalog.records(false).len(), 15);
     assert_eq!(catalog.providers().len(), 1);
-    // LoopX catalog status alignment.
+    // reference catalog status alignment.
     assert_eq!(catalog.get("issue_fix").unwrap().status, "active-preview");
     assert_eq!(catalog.get("auto_research").unwrap().status, "experimental");
     assert_eq!(
@@ -41,7 +41,7 @@ fn builtin_catalog_has_15_records_with_loopx_statuses() {
 fn catalog_is_queryable_by_status_stage_provider() {
     let catalog = CapabilityCatalog::with_builtin();
     let record = catalog.get("issue_fix").unwrap();
-    assert_eq!(record.provider_id, "loopx-core");
+    assert_eq!(record.provider_id, "future-loop-core");
     assert_eq!(record.origin, "builtin");
     assert_eq!(record.stage, 0);
     assert!(record.is_public());
@@ -51,7 +51,7 @@ fn catalog_is_queryable_by_status_stage_provider() {
         catalog.provider_lifecycle_for("issue_fix").unwrap().stage(),
         ProviderStage::Ready
     );
-    // Every public record carries the LoopX required fields.
+    // Every public record carries the reference required fields.
     for record in catalog.records(false) {
         assert!(
             !record.user_value.trim().is_empty(),

--- a/orchestration/loop/tests/claim_lease_contract.rs
+++ b/orchestration/loop/tests/claim_lease_contract.rs
@@ -10,7 +10,7 @@ use future_loop::state::{now_epoch, Goal, Todo};
 use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-p0-{tag}-{}", nano()));
+    let dir = std::env::temp_dir().join(format!("future-loop-p0-{tag}-{}", nano()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -335,7 +335,7 @@ fn p3_multi_agent_and_work_item_commands() {
         .lines()
         .flat_map(|l| l.split_whitespace())
         .filter_map(|w| w.strip_suffix("=open").map(|s| s.to_string()))
-        .filter(|s| s.starts_with("todo-"))
+        .filter(|s| s.starts_with("todo_"))
         .collect();
     assert!(ids.len() >= 3, "status shows todos: {out}");
     let (t_a, t_b) = (&ids[0], &ids[1]);
@@ -534,7 +534,7 @@ fn two_agent_sessions_hold_disjoint_frontiers() {
         .lines()
         .flat_map(|l| l.split_whitespace())
         .filter_map(|w| w.strip_suffix("=open").map(|s| s.to_string()))
-        .filter(|s| s.starts_with("todo-"))
+        .filter(|s| s.starts_with("todo_"))
         .collect();
     run(
         &root,
@@ -635,7 +635,7 @@ fn p4_diagnostics_commands() {
         .lines()
         .flat_map(|l| l.split_whitespace())
         .filter_map(|w| w.strip_suffix("=open").map(|s| s.to_string()))
-        .find(|s| s.starts_with("todo-"))
+        .find(|s| s.starts_with("todo_"))
         .unwrap();
     let (out, err, code) = run(&root, &["turn", "--goal", "g1", "--todo-id", &todo]);
     assert_eq!(code, 0, "turn: {err}");

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -14,7 +14,7 @@ fn bin() -> &'static str {
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p3-cli-{tag}-{}",
+        "future-loop-p3-cli-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -183,7 +183,7 @@ fn extension_install_status_loop_via_cli() {
     let root = tmp_root("ext");
     let manifest = {
         let dir = std::env::temp_dir().join(format!(
-            "loopx-p3-cli-ext-manifest-{}",
+            "future-loop-p3-cli-ext-manifest-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -192,10 +192,10 @@ fn extension_install_status_loop_via_cli() {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("ext.json");
         let m = serde_json::json!({
-            "schema_version": "loopx_extension_manifest_v0",
+            "schema_version": "future_loop_extension_manifest_v0",
             "id": "ext-cli",
             "version": "1.0.0",
-            "requires_loopx_api": ">=1",
+            "requires_future_loop_api": ">=1",
             "permissions": ["shell"],
             "runtime": {
                 "protocol": "command_json_v0",
@@ -257,7 +257,7 @@ fn catalog_query_via_cli() {
     assert!(out.contains("active-preview"));
     let (out, _, _) = run(&root, &["catalog", "--name", "issue_fix"]);
     assert!(out.contains("status   : active-preview"));
-    assert!(out.contains("provider : loopx-core [builtin]"));
+    assert!(out.contains("provider : future-loop-core [builtin]"));
 }
 
 /// ── P3: agent scope / supervisor / handoff / task-graph / attention ─────
@@ -639,7 +639,7 @@ fn p4_diagnostics_commands() {
         .unwrap();
     let (out, err, code) = run(&root, &["turn", "--goal", "g1", "--todo-id", &todo]);
     assert_eq!(code, 0, "turn: {err}");
-    assert!(out.contains("loopx_turn_envelope_v0"), "turn: {out}");
+    assert!(out.contains("future_loop_turn_envelope_v0"), "turn: {out}");
     assert!(out.contains("Complete the todo and report what you did and observed."));
 
     // todo-event + evidence-log after completion with evidence.
@@ -676,7 +676,12 @@ fn p4_benchmark_closed_loop_via_cli() {
     let root = tmp_root("p4bench");
     let (out, err, code) = run(
         &root,
-        &["benchmark", "protocol", "--route", "loopx-product-mode"],
+        &[
+            "benchmark",
+            "protocol",
+            "--route",
+            "future-loop-product-mode",
+        ],
     );
     assert_eq!(code, 0, "protocol: {err}");
     assert!(out.contains("protocol_id  : product_mode_max5_no_feedback"));

--- a/orchestration/loop/tests/compat_projection_contract.rs
+++ b/orchestration/loop/tests/compat_projection_contract.rs
@@ -4,12 +4,12 @@
 //! URL-encoded format.
 
 use future_loop::compat::{
-    loopx_status, loopx_task_class, rfc3339, write_active_state, write_goal_doc,
+    future_loop_status, future_loop_task_class, rfc3339, write_active_state, write_goal_doc,
 };
 use future_loop::state::{Goal, TaskClass, Todo, TodoStatus};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-compat-{tag}-{}", nano()));
+    let dir = std::env::temp_dir().join(format!("future-loop-compat-{tag}-{}", nano()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }
@@ -21,18 +21,24 @@ fn nano() -> u128 {
         .as_nanos()
 }
 
-// ── enum values match LoopX exactly ────────────────────────────────────────
+// ── enum values match reference exactly ────────────────────────────────────────
 #[test]
 fn enum_values_match_loopx() {
-    assert_eq!(loopx_task_class(TaskClass::Advancement), "advancement_task");
-    assert_eq!(loopx_task_class(TaskClass::UserGate), "user_gate");
-    assert_eq!(loopx_task_class(TaskClass::UserAction), "user_action");
-    assert_eq!(loopx_task_class(TaskClass::Monitor), "continuous_monitor");
-    assert_eq!(loopx_task_class(TaskClass::Blocker), "blocker");
-    assert_eq!(loopx_status(TodoStatus::Open), "open");
-    assert_eq!(loopx_status(TodoStatus::Done), "done");
-    assert_eq!(loopx_status(TodoStatus::Blocked), "blocked");
-    assert_eq!(loopx_status(TodoStatus::Deferred), "deferred");
+    assert_eq!(
+        future_loop_task_class(TaskClass::Advancement),
+        "advancement_task"
+    );
+    assert_eq!(future_loop_task_class(TaskClass::UserGate), "user_gate");
+    assert_eq!(future_loop_task_class(TaskClass::UserAction), "user_action");
+    assert_eq!(
+        future_loop_task_class(TaskClass::Monitor),
+        "continuous_monitor"
+    );
+    assert_eq!(future_loop_task_class(TaskClass::Blocker), "blocker");
+    assert_eq!(future_loop_status(TodoStatus::Open), "open");
+    assert_eq!(future_loop_status(TodoStatus::Done), "done");
+    assert_eq!(future_loop_status(TodoStatus::Blocked), "blocked");
+    assert_eq!(future_loop_status(TodoStatus::Deferred), "deferred");
 }
 
 // ── file layout (project-local) ───────────────────────────────────────────
@@ -63,10 +69,10 @@ fn file_layout_is_project_local() {
 
 // ── todo anchors render with LoopX's exact format ──────────────────────────
 #[test]
-fn todo_anchors_match_loopx_format() {
+fn todo_anchors_match_future_loop_format() {
     let proj = tmp_root("anchor");
     let mut goal = Goal::new("g1", "objective", &proj);
-    // Plain user_gate: no goal_bound/global_gate (LoopX only renders them on
+    // Plain user_gate: no goal_bound/global_gate (reference only renders them on
     // bootstrap-injected gates) — explicit scope flags render them.
     goal.add(Todo::user_gate("ug", "Decide X", &[]));
     goal.add(Todo::advancement("at", "agent work"));
@@ -83,7 +89,7 @@ fn todo_anchors_match_loopx_format() {
         !md.contains("goal_bound=true"),
         "plain user_gate has no goal_bound"
     );
-    // default advancement omits task_class (LoopX demo behavior)
+    // default advancement omits task_class (reference demo behavior)
     let at_anchor = md.lines().find(|l| l.contains("todo_id=at")).unwrap_or("");
     assert!(
         !at_anchor.contains("task_class"),
@@ -94,10 +100,10 @@ fn todo_anchors_match_loopx_format() {
     let updated_at_line = md.lines().find(|l| l.contains("updated_at=")).unwrap_or("");
     assert!(
         updated_at_line.contains("%2B"),
-        "offset must be URL-encoded like LoopX (line: {updated_at_line})"
+        "offset must be URL-encoded like reference (line: {updated_at_line})"
     );
 
-    // Explicit gate scope renders the LoopX flags.
+    // Explicit gate scope renders the reference flags.
     let proj2 = tmp_root("anchor2");
     let mut goal2 = Goal::new("g2", "objective", &proj2);
     let mut g = Todo::user_gate("ug2", "Decide Y", &[]);
@@ -117,7 +123,7 @@ fn todo_anchors_match_loopx_format() {
 
 // ── timestamp format ───────────────────────────────────────────────────────
 #[test]
-fn rfc3339_matches_loopx_shape() {
+fn rfc3339_matches_future_loop_shape() {
     let ts = rfc3339(1785893919);
     assert!(ts.starts_with("2026-08-05T"), "got {ts}");
     assert!(

--- a/orchestration/loop/tests/compat_projection_contract.rs
+++ b/orchestration/loop/tests/compat_projection_contract.rs
@@ -1,9 +1,10 @@
-//! LoopX-compatible projection tests: the on-disk layout mirrors real LoopX
-//! (GOAL.md / .loopx/registry.json / ACTIVE_GOAL_STATE.md / runs/), field
-//! sets match, and todo anchors render with LoopX's exact format.
+//! Project-local projection tests: the on-disk layout keeps everything under
+//! the project (GOAL.md at the project root, ACTIVE_GOAL_STATE.md under
+//! `.future/loop/goals/<id>/`), and todo anchors render with a stable,
+//! URL-encoded format.
 
 use future_loop::compat::{
-    loopx_status, loopx_task_class, rfc3339, write_active_state, write_goal_doc, write_registry,
+    loopx_status, loopx_task_class, rfc3339, write_active_state, write_goal_doc,
 };
 use future_loop::state::{Goal, TaskClass, Todo, TodoStatus};
 
@@ -34,76 +35,30 @@ fn enum_values_match_loopx() {
     assert_eq!(loopx_status(TodoStatus::Deferred), "deferred");
 }
 
-// ── file layout parity ─────────────────────────────────────────────────────
+// ── file layout (project-local) ───────────────────────────────────────────
 #[test]
-fn file_layout_matches_loopx() {
+fn file_layout_is_project_local() {
     let proj = tmp_root("layout");
     let mut goal = Goal::new("g1", "objective", &proj);
     goal.add(Todo::user_gate("ug", "Approve X", &[]));
     goal.add(Todo::advancement("at", "work"));
 
     write_goal_doc(&proj, &goal.objective).unwrap();
-    let goals = vec![&goal];
-    write_registry(&proj, &goals, "/tmp/runtime").unwrap();
-    write_active_state(&proj, &goal).unwrap();
-
-    assert!(std::path::Path::new(&proj).join("GOAL.md").exists());
-    assert!(std::path::Path::new(&proj)
-        .join(".loopx/registry.json")
-        .exists());
-    let state = std::path::Path::new(&proj).join(".codex/goals/g1/ACTIVE_GOAL_STATE.md");
-    assert!(state.exists());
-    assert!(std::path::Path::new(&proj)
-        .join(".codex/goals/g1/ACTIVE_GOAL_STATE.md.lock")
-        .exists());
-}
-
-#[test]
-fn registry_field_set_matches_loopx() {
-    let proj = tmp_root("reg");
-    let mut goal = Goal::new("g1", "objective", &proj);
-    goal.add(Todo::advancement("t", "work"));
-    write_registry(&proj, &[&goal], "/tmp/rt").unwrap();
-    let d: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(format!("{proj}/.loopx/registry.json")).unwrap(),
+    write_active_state(
+        &std::path::Path::new(&proj).join(".future/loop/goals/g1"),
+        &goal,
     )
     .unwrap();
-    let top: std::collections::BTreeSet<String> = d.as_object().unwrap().keys().cloned().collect();
-    assert_eq!(
-        top,
-        [
-            "common_runtime_root",
-            "goals",
-            "schema_version",
-            "updated_at"
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect()
-    );
-    let g = &d["goals"][0];
-    let gkeys: std::collections::BTreeSet<String> =
-        g.as_object().unwrap().keys().cloned().collect();
-    for expected in [
-        "id",
-        "domain",
-        "status",
-        "role",
-        "parent_goal_id",
-        "repo",
-        "state_file",
-        "authority_sources",
-        "adapter",
-        "spawn_policy",
-        "coordination",
-        "execution_profile",
-        "guards",
-        "next_probe",
-    ] {
-        assert!(gkeys.contains(expected), "registry missing {expected}");
-    }
-    assert_eq!(g["id"], "g1");
-    assert_eq!(g["status"], "active");
+
+    assert!(std::path::Path::new(&proj).join("GOAL.md").exists());
+    let state = std::path::Path::new(&proj).join(".future/loop/goals/g1/ACTIVE_GOAL_STATE.md");
+    assert!(state.exists());
+    assert!(std::path::Path::new(&proj)
+        .join(".future/loop/goals/g1/ACTIVE_GOAL_STATE.md.lock")
+        .exists());
+    // Nothing reference-layout outside the project: no .codex, no .loopx.
+    assert!(!std::path::Path::new(&proj).join(".codex").exists());
+    assert!(!std::path::Path::new(&proj).join(".loopx").exists());
 }
 
 // ── todo anchors render with LoopX's exact format ──────────────────────────
@@ -115,9 +70,13 @@ fn todo_anchors_match_loopx_format() {
     // bootstrap-injected gates) — explicit scope flags render them.
     goal.add(Todo::user_gate("ug", "Decide X", &[]));
     goal.add(Todo::advancement("at", "agent work"));
-    write_active_state(&proj, &goal).unwrap();
-    let md =
-        std::fs::read_to_string(format!("{proj}/.codex/goals/g1/ACTIVE_GOAL_STATE.md")).unwrap();
+    write_active_state(
+        &std::path::Path::new(&proj).join(".future/loop/goals/g1"),
+        &goal,
+    )
+    .unwrap();
+    let md = std::fs::read_to_string(format!("{proj}/.future/loop/goals/g1/ACTIVE_GOAL_STATE.md"))
+        .unwrap();
     // user gate anchor: task_class present; scope flags absent by default
     assert!(md.contains("task_class=user_gate"));
     assert!(
@@ -144,9 +103,15 @@ fn todo_anchors_match_loopx_format() {
     let mut g = Todo::user_gate("ug2", "Decide Y", &[]);
     g = g.with_gate_scope(true, true);
     goal2.add(g);
-    write_active_state(&proj2, &goal2).unwrap();
-    let md2 =
-        std::fs::read_to_string(format!("{proj2}/.codex/goals/g2/ACTIVE_GOAL_STATE.md")).unwrap();
+    write_active_state(
+        &std::path::Path::new(&proj2).join(".future/loop/goals/g2"),
+        &goal2,
+    )
+    .unwrap();
+    let md2 = std::fs::read_to_string(format!(
+        "{proj2}/.future/loop/goals/g2/ACTIVE_GOAL_STATE.md"
+    ))
+    .unwrap();
     assert!(md2.contains("goal_bound=true global_gate=true"));
 }
 

--- a/orchestration/loop/tests/decision_contract.rs
+++ b/orchestration/loop/tests/decision_contract.rs
@@ -1,5 +1,5 @@
 //! Contract tests for the decision kernel — migrated from the prototype and
-//! extended with the contracts learned from the live LoopX (completion
+//! extended with the contracts learned from the live reference (completion
 //! closure intent, succession replan obligation, validated terminal).
 //!
 //! Deterministic: state fixtures in, typed ShouldRunPacket out. No gRPC, no
@@ -285,7 +285,7 @@ fn packet_has_three_channels_and_auxiliary_contracts() {
     let p = decide(&goal, now());
     assert_eq!(
         p.interaction_contract.schema_version,
-        "loopx_interaction_contract_v0"
+        "future_loop_interaction_contract_v0"
     );
     assert!(p.interaction_contract.agent_channel.must_attempt);
     assert!(!p.interaction_contract.agent_channel.quiet_noop_allowed);

--- a/orchestration/loop/tests/decision_split_regression.rs
+++ b/orchestration/loop/tests/decision_split_regression.rs
@@ -434,13 +434,17 @@ fn generated_legacy_module_is_derived_from_snapshot() {
     let normalized_generated = compact(&generated.replace("legacy_", ""));
     for line in snapshot.lines() {
         // Transforms: `crate::` → `future_loop::`, `loopx_compat` → `compat`
-        // (the G-rename moved src/loopx_compat.rs → src/compat.rs; the frozen
-        // snapshot keeps the old path), `//!` → `//` (plus the `legacy_`
-        // fn renames, which the normalized_generated prefix-strip covers).
+        // (the G-rename moved the module to compat.rs; the frozen snapshot
+        // keeps the old `crate::loopx_compat` path), `//!` → `//` (plus the
+        // `legacy_` fn renames, which the normalized_generated prefix-strip
+        // covers).
         let rewritten = compact(
             &line
                 .replace("crate::", "future_loop::")
                 .replace("loopx_compat", "compat")
+                .replace("loopx_", "future_loop_")
+                .replace("LoopX-style", "reference-style")
+                .replace("LoopX ", "reference ")
                 .replace("//!", "//"),
         );
         let survives = normalized_generated.contains(&rewritten)

--- a/orchestration/loop/tests/event_ledger_contract.rs
+++ b/orchestration/loop/tests/event_ledger_contract.rs
@@ -10,7 +10,7 @@ use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p2-events-{tag}-{}",
+        "future-loop-p2-events-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -131,8 +131,8 @@ fn backfill_append_is_idempotent_with_provenance() {
     open_goal(&mut store, "g1");
 
     let md = "## Agent Todo\n\n\
-        - [ ] [P1] Run the check\n  <!-- loopx:todo todo_id=todo_abc status=open updated_at=2026-08-05T12:00:00+00:00 -->\n\
-        - [x] Ship it\n  <!-- loopx:todo todo_id=todo_def status=done no_followup=true evidence=ok completed_at=2026-08-05T13:00:00+00:00 updated_at=2026-08-05T13:00:00+00:00 -->\n";
+        - [ ] [P1] Run the check\n  <!-- future-loop:todo todo_id=todo_abc status=open updated_at=2026-08-05T12:00:00+00:00 -->\n\
+        - [x] Ship it\n  <!-- future-loop:todo todo_id=todo_def status=done no_followup=true evidence=ok completed_at=2026-08-05T13:00:00+00:00 updated_at=2026-08-05T13:00:00+00:00 -->\n";
     let outcome = backfill_todo_events(md, "g1", PrivacyLevel::LocalPrivate).unwrap();
     assert_eq!(outcome.todo_count, 2);
 

--- a/orchestration/loop/tests/extension_lifecycle_contract.rs
+++ b/orchestration/loop/tests/extension_lifecycle_contract.rs
@@ -14,7 +14,7 @@ use future_loop::extensions::runtime::{
 
 fn tmp_state(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p3-ext-contract-{tag}-{}",
+        "future-loop-p3-ext-contract-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -29,7 +29,7 @@ fn manifest(id: &str, version: &str, entrypoint: &str) -> ExtensionManifest {
         "schema_version": future_loop::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": id,
         "version": version,
-        "requires_loopx_api": ">=1,<3",
+        "requires_future_loop_api": ">=1,<3",
         "permissions": ["shell"],
         "runtime": {
             "protocol": "command_json_v0",
@@ -101,17 +101,17 @@ fn upgrade_retains_bounded_revisions_and_rollback() {
 
 /// ── API compatibility fails closed ────────────────────────────────────────
 #[test]
-fn incompatible_loopx_api_is_rejected() {
+fn incompatible_future_loop_api_is_rejected() {
     let mut raw = serde_json::json!({
         "schema_version": future_loop::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": "ext-bad",
         "version": "1.0.0",
-        "requires_loopx_api": ">=99",
+        "requires_future_loop_api": ">=99",
         "permissions": [],
         "provides": [{"id": "c", "kind": "domain_rule", "visibility": "public"}]
     });
     assert!(validate_manifest_value(&raw, "test").is_err());
-    raw["requires_loopx_api"] = serde_json::json!(">=1,<2");
+    raw["requires_future_loop_api"] = serde_json::json!(">=1,<2");
     assert!(validate_manifest_value(&raw, "test").is_ok());
 }
 
@@ -131,7 +131,7 @@ fn doctor_readiness_gates_lifecycle() {
         "schema_version": future_loop::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": "ext-decl",
         "version": "1.0.0",
-        "requires_loopx_api": ">=1",
+        "requires_future_loop_api": ">=1",
         "permissions": [],
         "provides": [{"id": "ext-decl_cap", "kind": "domain_rule", "visibility": "public"}]
     });
@@ -172,7 +172,7 @@ fn resolve_ambiguous_implementations_fails_closed() {
         "schema_version": future_loop::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": "ext-f1",
         "version": "1.0.0",
-        "requires_loopx_api": ">=1",
+        "requires_future_loop_api": ">=1",
         "permissions": ["shell"],
         "runtime": {"protocol": "command_json_v0", "entrypoint": "sh", "args": [], "doctor_args": ["-c", "true"], "required_permissions": ["shell"], "timeout_seconds": 30},
         "provides": [{"id": "shared_cap", "kind": "domain_rule", "visibility": "public"}],

--- a/orchestration/loop/tests/full_schema_contract.rs
+++ b/orchestration/loop/tests/full_schema_contract.rs
@@ -9,7 +9,7 @@ use future_loop::state::{Goal, Todo, TodoRole, TodoStatus};
 use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-schema-full-{tag}-{}", nano()));
+    let dir = std::env::temp_dir().join(format!("future-loop-schema-full-{tag}-{}", nano()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }
@@ -23,7 +23,7 @@ fn nano() -> u128 {
 
 // ── Full todo_item_v0 field surface ────────────────────────────────────────
 #[test]
-fn todo_exposes_all_loopx_fields() {
+fn todo_exposes_all_future_loop_fields() {
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(
         Todo::advancement("t1", "Run the benchmark")

--- a/orchestration/loop/tests/handoff_contract.rs
+++ b/orchestration/loop/tests/handoff_contract.rs
@@ -108,8 +108,8 @@ fn handoff_writes_to_projection_dir() {
     ));
     std::fs::create_dir_all(&project).unwrap();
     let handoff = build_project_handoff(&goal, None);
-    write_project_handoff(&project.to_string_lossy(), &goal, &handoff).unwrap();
-    let path = project.join(".codex/goals/g1/HANDOFF.md");
+    write_project_handoff(&project.join(".future/loop/goals/g1"), &goal, &handoff).unwrap();
+    let path = project.join(".future/loop/goals/g1/HANDOFF.md");
     assert!(path.exists());
     let content = std::fs::read_to_string(path).unwrap();
     assert!(content.contains("# Project Handoff"));

--- a/orchestration/loop/tests/handoff_contract.rs
+++ b/orchestration/loop/tests/handoff_contract.rs
@@ -100,7 +100,7 @@ fn delivery_contract_modes_and_streaks() {
 fn handoff_writes_to_projection_dir() {
     let goal = goal_with(vec![]);
     let project = std::env::temp_dir().join(format!(
-        "loopx-p3-handoff-{}",
+        "future-loop-p3-handoff-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/lease_contract.rs
+++ b/orchestration/loop/tests/lease_contract.rs
@@ -10,7 +10,7 @@ use future_loop::work_items::task_lease::{self, LeaseOp, LeaseStatus};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p2-lease-{tag}-{}",
+        "future-loop-p2-lease-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/legacy/decision_pre_split.rs
+++ b/orchestration/loop/tests/legacy/decision_pre_split.rs
@@ -34,7 +34,7 @@ pub const MAX_REPAIR_ATTEMPTS: u32 = 1;
 pub const QUOTA_ALLOWED_SLOTS: u64 = 1440;
 
 /// should-run decision compiler. Pure: injectable clock, no I/O.
-/// `agent_id`: when present, must be a registered peer (LoopX fail-closed:
+/// `agent_id`: when present, must be a registered peer (reference fail-closed:
 /// unregistered identity ⇒ `automation_prompt_upgrade_required`, no delivery).
 pub fn legacy_decide(goal: &Goal, now: SystemTime) -> ShouldRunPacket {
     legacy_decide_for(goal, now, None)
@@ -76,7 +76,7 @@ pub fn legacy_decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -
     let gates: Vec<&Todo> = goal.open_gates().collect();
     let user_actions: Vec<&Todo> = goal.open_of(future_loop::state::TaskClass::UserAction).collect();
     let mut runnable: Vec<&Todo> = goal.runnable_advancement_for(agent_id).collect();
-    // Priority sort: P0 before P1 before P2 (LoopX sorts the frontier).
+    // Priority sort: P0 before P1 before P2 (reference sorts the frontier).
     runnable.sort_by_key(|t| t.priority);
 
     if !gates.is_empty() {
@@ -440,7 +440,7 @@ fn legacy_packet(
             _ => reason.to_string(),
         },
         rollout_event: Some(RolloutEvent {
-            schema_version: "loopx_rollout_event_v0".to_string(),
+            schema_version: "future_loop_rollout_event_v0".to_string(),
             event_id: uuid::Uuid::new_v4().simple().to_string(),
             event_kind: "quota_should_run".to_string(),
             recorded_at: future_loop::compat::rfc3339(future_loop::state::now_epoch()),
@@ -465,7 +465,7 @@ fn legacy_packet(
                 "role": "agent",
                 "priority": todo.map(|t| t.priority.to_string()).unwrap_or_default(),
                 "status": "open",
-                "task_class": todo.map(|t| future_loop::compat::loopx_task_class(t.class)).unwrap_or(""),
+                "task_class": todo.map(|t| future_loop::compat::future_loop_task_class(t.class)).unwrap_or(""),
                 "action_kind": todo.and_then(|t| t.action_kind.clone()).unwrap_or_default(),
                 "text": todo.map(|t| t.text.clone()).unwrap_or_default(),
                 "agent_id": "",
@@ -485,7 +485,7 @@ fn legacy_packet(
         active_state_next_action: goal.next_action.clone(),
         latest_run_recommended_action: goal.next_action.clone(),
         interaction_contract: InteractionContract {
-            schema_version: "loopx_interaction_contract_v0".to_string(),
+            schema_version: "future_loop_interaction_contract_v0".to_string(),
             mode,
             user_channel: user_channel.clone(),
             agent_channel: agent_channel.clone(),

--- a/orchestration/loop/tests/migration_contract.rs
+++ b/orchestration/loop/tests/migration_contract.rs
@@ -8,7 +8,7 @@ use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p2-migration-{tag}-{}",
+        "future-loop-p2-migration-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/monitor_poll_contract.rs
+++ b/orchestration/loop/tests/monitor_poll_contract.rs
@@ -236,8 +236,9 @@ fn compat_projection_carries_monitor_metadata() {
         Some("daily"),
         Duration::from_secs(86400),
     ));
-    future_loop::compat::write_active_state(dir.to_str().unwrap(), &goal).unwrap();
-    let md = std::fs::read_to_string(dir.join(".codex/goals/g1/ACTIVE_GOAL_STATE.md")).unwrap();
+    future_loop::compat::write_active_state(&dir.join(".future/loop/goals/g1"), &goal).unwrap();
+    let md =
+        std::fs::read_to_string(dir.join(".future/loop/goals/g1/ACTIVE_GOAL_STATE.md")).unwrap();
     assert!(
         md.contains("monitor_target=http://target"),
         "anchor target: {md}"

--- a/orchestration/loop/tests/monitor_poll_contract.rs
+++ b/orchestration/loop/tests/monitor_poll_contract.rs
@@ -9,7 +9,7 @@ use future_loop::state::{Goal, Todo, TodoStatus};
 use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-monitor-test-{tag}-{}", uuid_like()));
+    let dir = std::env::temp_dir().join(format!("future-loop-monitor-test-{tag}-{}", uuid_like()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }
@@ -225,7 +225,7 @@ fn no_change_polls_never_enter_the_spend_ledger() {
 // ── G-12: monitor metadata renders into the compat projection anchor ───────
 #[test]
 fn compat_projection_carries_monitor_metadata() {
-    let dir = std::env::temp_dir().join(format!("loopx-monitor-compat-{}", uuid_like()));
+    let dir = std::env::temp_dir().join(format!("future-loop-monitor-compat-{}", uuid_like()));
     std::fs::create_dir_all(&dir).unwrap();
     let mut goal = Goal::new("g1", "objective", dir.to_str().unwrap());
     goal.add(Todo::monitor_with(

--- a/orchestration/loop/tests/privacy_projection_contract.rs
+++ b/orchestration/loop/tests/privacy_projection_contract.rs
@@ -10,7 +10,7 @@ use future_loop::state::{Goal, Todo};
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p2-privacy-{tag}-{}",
+        "future-loop-p2-privacy-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/replay_contract.rs
+++ b/orchestration/loop/tests/replay_contract.rs
@@ -78,7 +78,7 @@ fn public_safety_reduction_blocks_secrets_and_paths() {
 #[test]
 fn replay_file_round_trip() {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p4-replay-{}",
+        "future-loop-p4-replay-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -211,7 +211,7 @@ fn ablation_of_unknown_path_fails_closed_at_build() {
 #[test]
 fn corpus_file_round_trip() {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p4-corpus-{}",
+        "future-loop-p4-corpus-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/run_lifecycle_contract.rs
+++ b/orchestration/loop/tests/run_lifecycle_contract.rs
@@ -10,7 +10,7 @@ use future_loop::runtime::stale_latest_run;
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p2-runs-{tag}-{}",
+        "future-loop-p2-runs-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()

--- a/orchestration/loop/tests/scheduler_state_contract.rs
+++ b/orchestration/loop/tests/scheduler_state_contract.rs
@@ -9,7 +9,7 @@ use future_loop::scheduler::state::*;
 use future_loop::store::Store;
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-sched-test-{tag}-{}", uuid_like()));
+    let dir = std::env::temp_dir().join(format!("future-loop-sched-test-{tag}-{}", uuid_like()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }
@@ -52,7 +52,7 @@ fn bootstrap_state(goal_dir: &Path) -> SchedulerState {
 
 // ── rrule recurrence + cadence classes ─────────────────────────────────────
 #[test]
-fn rrule_helpers_match_loopx_contract() {
+fn rrule_helpers_match_future_loop_contract() {
     assert_eq!(rrule_for_minutes(15), "FREQ=MINUTELY;INTERVAL=15");
     assert_eq!(
         normalize_scheduler_rrule("RRULE:FREQ=MINUTELY;INTERVAL=30"),
@@ -90,7 +90,7 @@ fn progression_walks_monitor_wait_sequence() {
     assert_eq!(r2, "FREQ=MINUTELY;INTERVAL=30");
     let r3 = apply_next_progression(&mut state, 1_784_000_200).unwrap();
     assert_eq!(r3, "FREQ=MINUTELY;INTERVAL=60");
-    // Wrap: [15, 30, 60] → back to 15 (LoopX modulo progression).
+    // Wrap: [15, 30, 60] → back to 15 (reference modulo progression).
     let r1 = apply_next_progression(&mut state, 1_784_000_300).unwrap();
     assert_eq!(r1, "FREQ=MINUTELY;INTERVAL=15");
 }

--- a/orchestration/loop/tests/store_contract.rs
+++ b/orchestration/loop/tests/store_contract.rs
@@ -9,7 +9,7 @@ use future_loop::state::{Goal, Todo};
 use future_loop::store::{projection_gap, Event, Store};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-store-test-{tag}-{}", uuid_like()));
+    let dir = std::env::temp_dir().join(format!("future-loop-store-test-{tag}-{}", uuid_like()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }

--- a/orchestration/loop/tests/substrate_contract.rs
+++ b/orchestration/loop/tests/substrate_contract.rs
@@ -8,7 +8,7 @@ use future_loop::state::{boundary_scan_leaks, Authority, Goal, Todo};
 use future_loop::store::{Event, Store};
 
 fn tmp_root(tag: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("loopx-p1-{tag}-{}", nano()));
+    let dir = std::env::temp_dir().join(format!("future-loop-p1-{tag}-{}", nano()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.to_string_lossy().into_owned()
 }

--- a/orchestration/loop/tests/task_graph_contract.rs
+++ b/orchestration/loop/tests/task_graph_contract.rs
@@ -8,7 +8,7 @@ use future_loop::work_items::task_graph::{build_task_graph, predecessors_of, suc
 
 fn tmp_root(tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!(
-        "loopx-p3-taskgraph-{tag}-{}",
+        "future-loop-p3-taskgraph-{tag}-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()


### PR DESCRIPTION
## Summary

Hardening pass on the loop control plane (`orchestration/loop`, `future-loop`)
after the initial merge — project-local state, restored CLI surface, removed
reference-layout directories, identifier cleanup, and a usage-focused README.

## Changes

### Fixes (merge-regression audit)
- **Project-local state root**: `root_dir()`/runtime root now resolve to
  `<cwd>/.future/loop/` instead of `$HOME`; all goal state stays inside the
  project. Registry loading accepts both the native array and the earlier
  reference-map format (legacy goals load transparently).
- **CLI surface restored**: `future-loop models` and `future-loop diagnose`
  were lost in the integration — re-added (agent `list_models` RPC +
  per-goal diagnostics). Goal/todo id format restored to `<prefix>_<12hex>`
  (matches pre-existing ids). Bootstrap onboarding todo now references the
  real `future-loop status` command.

### Layout & naming cleanup
- **Removed `.codex` / `.loopx` reference layout**: no runtime-root mirror,
  no `.loopx/registry.json`; ACTIVE_GOAL_STATE.md, HANDOFF.md and per-run
  history now live under `<cwd>/.future/loop/goals/<id>/`.
- **Identifiers renamed** `loopx_*` → `future_loop_*` (schema versions,
  capability/API tokens, benchmark routes, anchors) with backward-compatible
  aliases so existing on-disk state keeps loading. CLI output has zero
  `loopx` mentions.
- **Attribution**: README and the loop guide state that `future-loop` is a
  Rust rewrite of the loopx control plane, customized for FutureOS.

### README / docs
- README (EN + zh) is now usage-focused: build/install steps moved to
  `docs/build-and-install.md`, usage centers on the TUI (slash commands and
  shortcuts verified against `tui/src/help-screen.ts`), features table
  reordered with doc links.
- New docs: `docs/loop-control-plane.md` (capability guide), plus zh
  translations of the build and loop guides.
- FUTURE.md removed and gitignored.

## Validation

- 493 tests green (`cargo test -p future-loop`), `cargo clippy --workspace
  --all-targets -D warnings` and `cargo fmt --check` clean
- Pre-existing goals (old schema tokens) load correctly; CLI smoke-tested
  (goal/todo lifecycle, models, diagnose, canary)
