### PR TITLE
fix(tui): merge duplicate tool_start events into a single tool bubble

### DIFF
--- a/tui/src/__tests__/chat-streaming.test.ts
+++ b/tui/src/__tests__/chat-streaming.test.ts
@@ -165,4 +165,34 @@ describe("ChatArea streaming render", () => {
     (chat as any).rerender();
     expect(chat.renderAll(W)).toEqual(eagerLines(full, false));
   });
+
+  test("duplicate tool_start for the same id merges into a single bubble", () => {
+    const chat = new ChatArea(W);
+    chat.render(W);
+    // The agent emits tool_start twice per call: the provider stream first
+    // (toolcall_start — args still empty → would render as a bare "shell"
+    // line), then execution with the finalized arguments. Both must collapse
+    // into one line showing the command.
+    chat.addToolStart("call_1", "shell", "");
+    chat.addToolStart("call_1", "shell", '{"command":"cd /tmp"}');
+    const msgs = (chat as any).messages as ChatMessage[];
+    expect(msgs.filter((m) => m.role === "tool")).toHaveLength(1);
+    const lines = chat.renderAll(W).filter((line) => line.trim());
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("$");
+    expect(lines[0]).toContain("cd /tmp");
+  });
+
+  test("distinct tool ids still render separate bubbles", () => {
+    const chat = new ChatArea(W);
+    chat.render(W);
+    chat.addToolStart("call_1", "shell", '{"command":"cd /tmp"}');
+    chat.addToolStart("call_2", "read", '{"path":"/etc/hosts"}');
+    const msgs = (chat as any).messages as ChatMessage[];
+    expect(msgs.filter((m) => m.role === "tool")).toHaveLength(2);
+    const lines = chat.renderAll(W).filter((line) => line.trim());
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("$");
+    expect(lines[1]).toContain("read");
+  });
 });

--- a/tui/src/components/chat-area.ts
+++ b/tui/src/components/chat-area.ts
@@ -238,6 +238,20 @@ export class ChatArea implements Component {
   // ─── Tool call management ───────────────────────────────────────
 
   addToolStart(toolId: string, toolName: string, toolArgs?: string): void {
+    // The agent emits tool_start twice for the same call: once from the
+    // provider stream (toolcall_start — arguments may still be empty, which
+    // rendered as a bare tool-name line) and once when execution actually
+    // begins with the finalized arguments. Update the existing bubble instead
+    // of appending a second one, so a tool call renders as a single line.
+    const existingIdx = toolId ? this.findToolIndex(toolId) : -1;
+    if (existingIdx >= 0) {
+      const existing = this.messages[existingIdx];
+      if (toolName) existing.name = toolName;
+      if (toolArgs) (existing as { toolArgs?: string }).toolArgs = toolArgs;
+      this.rerenderMessage(existingIdx);
+      if (this.autoScroll) this.scrollToBottom();
+      return;
+    }
     const msg: ChatMessage = {
       id: crypto.randomUUID(),
       role: "tool",


### PR DESCRIPTION
## Summary

Fix: tool calls in the TUI rendered as **two lines** (e.g. `shell` then `$ cd ...`) — the first line is now gone.

## Root cause

The agent emits `tool_start` **twice** for the same call id:

1. **Provider stream** — `toolcall_start` is canonicalized to `tool_start`; at that point the tool arguments are still empty (Anthropic-style streams send the block header first), so the TUI rendered a bare tool-name line (`shell`).
2. **Execution loop** (`agent/src/agent/mod.rs`) — a second `tool_start` with the finalized arguments, rendering `$ cd ...`.

`ChatArea.addToolStart` appended a new message per event (no dedup), so every tool call showed two bubbles/lines.

## Fix

`addToolStart` now looks up the existing tool message by `tool_id` and **updates it in place** (finalized name/args) instead of appending — one line per tool call. This matches the GUI's `agentActivity` reducer, which already merges by tool id.

## Tests

- duplicate `tool_start` for the same id merges into a single bubble (`$ cd /tmp`)
- distinct tool ids still render separate bubbles

`tsc --noEmit` clean, `bun test` 167 pass / 0 fail.
