### PR TITLE
fix(tui): stop file-path autocomplete from hijacking slash-command args

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -4253,6 +4253,131 @@ mod tests {
         assert_eq!(normalize_path("/tmp/foo"), "/tmp/foo");
     }
 
+    // ─── /cwd end-to-end (in-process mock agent) ──────────────────────
+
+    use future_rpc::proto::future_agent_server::{FutureAgent, FutureAgentServer};
+    use future_rpc::proto::{RpcCommand, RpcResponse, StreamEvent, StreamRequest};
+    use futures_util::StreamExt;
+    use std::net::TcpListener;
+    use std::pin::Pin;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+    use tonic::transport::Server;
+
+    /// Minimal mock agent: answers unary commands, and on `set_cwd` echoes a
+    /// `cwd_changed` event carrying the stored (trailing-slash-trimmed) cwd —
+    /// the same behavior as the real agent (agent/src/rpc/commands.rs).
+    #[derive(Clone)]
+    struct CwdMockAgent {
+        subs: Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<StreamEvent>>>>,
+    }
+
+    #[tonic::async_trait]
+    impl FutureAgent for CwdMockAgent {
+        async fn execute_command(
+            &self,
+            request: tonic::Request<RpcCommand>,
+        ) -> Result<tonic::Response<RpcResponse>, tonic::Status> {
+            let cmd = request.into_inner();
+            if cmd.r#type == "set_cwd" {
+                let cwd = cmd.cwd.trim().trim_end_matches(['/', '\\']).to_string();
+                let event = StreamEvent {
+                    r#type: "cwd_changed".into(),
+                    data: serde_json::json!({ "cwd": cwd }).to_string(),
+                    ..Default::default()
+                };
+                for sub in self.subs.lock().unwrap().iter() {
+                    let _ = sub.send(event.clone());
+                }
+            }
+            Ok(tonic::Response::new(RpcResponse {
+                id: cmd.id,
+                r#type: "response".into(),
+                command: cmd.r#type.clone(),
+                success: true,
+                data: "{}".into(),
+                error: String::new(),
+                error_code: String::new(),
+                error_data: String::new(),
+                payload: None,
+            }))
+        }
+
+        type StreamEventsStream =
+            Pin<Box<dyn tokio_stream::Stream<Item = Result<StreamEvent, tonic::Status>> + Send>>;
+
+        async fn stream_events(
+            &self,
+            _request: tonic::Request<StreamRequest>,
+        ) -> Result<tonic::Response<Self::StreamEventsStream>, tonic::Status> {
+            let (tx, rx) = mpsc::unbounded_channel::<StreamEvent>();
+            self.subs.lock().unwrap().push(tx);
+            Ok(tonic::Response::new(Box::pin(
+                UnboundedReceiverStream::new(rx).map(Ok),
+            )))
+        }
+    }
+
+    async fn spawn_cwd_mock_agent() -> (tokio::task::JoinHandle<()>, String) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener); // tonic binds the same port below
+        let agent = CwdMockAgent {
+            subs: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let handle = tokio::spawn(async move {
+            let _ = Server::builder()
+                .add_service(FutureAgentServer::new(agent))
+                .serve(addr)
+                .await;
+        });
+        // Give the server a moment to start listening.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        (handle, format!("127.0.0.1:{}", addr.port()))
+    }
+
+    /// `app.state.cwd` is exactly what the footer renders (`data.cwd`). A
+    /// relative cwd like `a/b` with `/cwd ../` must land on a clean `a` —
+    /// not `a/b/../` and not `a/ ../`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cwd_dotdot_from_relative_cwd_renders_clean_parent() {
+        let (_server, addr) = spawn_cwd_mock_agent().await;
+        let (op_tx, mut op_rx) = mpsc::unbounded_channel();
+        let (client, mut events, _conn) = GrpcClient::new(&addr);
+        let mut app = App::new(
+            FakeTerminal {
+                writes: Rc::new(RefCell::new(Vec::new())),
+                cols: 80,
+                rows: 24,
+            },
+            Arc::new(client),
+            op_tx,
+            &CliOptions::default(),
+            std::env::temp_dir().join("tui-cwd-test-settings.json"),
+        );
+        app.state.cwd = "a/b".into();
+
+        app.handle_submit("/cwd ../");
+
+        // Apply the CwdSet UiCmd when it arrives.
+        let deadline = tokio::time::timeout(Duration::from_secs(5), op_rx.recv()).await;
+        if let Ok(Some(cmd)) = deadline {
+            app.handle_cmd(cmd);
+        }
+
+        // The agent's `cwd_changed` echo (best-effort — the stream may not be
+        // subscribed yet, but the real agent always emits it after set_cwd).
+        if let Ok(Some(ev)) = tokio::time::timeout(Duration::from_millis(500), events.recv()).await
+        {
+            app.handle_agent_event(&ev);
+        }
+
+        assert_eq!(
+            app.state.cwd, "a",
+            "footer cwd must be a clean parent `a`, got {:?}",
+            app.state.cwd
+        );
+    }
+
     // ─── Welcome screen ─────────────────────────────────────────────────
 
     #[tokio::test]

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -490,7 +490,16 @@ fn split_ws_js(s: &str) -> Vec<&str> {
             in_run = false;
         }
     }
-    out.push(&s[start..]);
+    if in_run {
+        // Trailing whitespace: JS `split(/\s+/)` yields a trailing EMPTY
+        // element ("cwd ../ " → ["cwd", "../", ""]). Pushing `&s[start..]`
+        // here would re-emit the last token with the trailing space
+        // attached (["cwd", "../", "../ "]), which turned `/cwd ../ ` into
+        // arg "../ ../ " and corrupted the resolved cwd.
+        out.push("");
+    } else {
+        out.push(&s[start..]);
+    }
     out
 }
 
@@ -2466,7 +2475,11 @@ impl<T: TerminalIo> App<T> {
                         self.request_render(false);
                         return;
                     }
-                    let mut resolved = arg.clone();
+                    // Trim the arg: `/cwd ../ ` (trailing space) would join to
+                    // `a/b/../ ` and normalize to `a/ ` (the stray space
+                    // becomes a path component). The agent trims its side;
+                    // the TUI must too, or the footer shows the dirty path.
+                    let mut resolved = arg.trim().to_string();
                     let homedir = dirs::home_dir().unwrap_or_default();
                     if resolved == "~" {
                         resolved = homedir.display().to_string();
@@ -4337,7 +4350,9 @@ mod tests {
 
     /// `app.state.cwd` is exactly what the footer renders (`data.cwd`). A
     /// relative cwd like `a/b` with `/cwd ../` must land on a clean `a` —
-    /// not `a/b/../` and not `a/ ../`.
+    /// not `a/b/../` and not `a/ ../`. The trailing-space variant (`/cwd
+    /// ../ `) must behave identically (the arg is trimmed, so the stray
+    /// space never becomes a path component).
     #[tokio::test(flavor = "multi_thread")]
     async fn cwd_dotdot_from_relative_cwd_renders_clean_parent() {
         let (_server, addr) = spawn_cwd_mock_agent().await;
@@ -4354,28 +4369,32 @@ mod tests {
             &CliOptions::default(),
             std::env::temp_dir().join("tui-cwd-test-settings.json"),
         );
-        app.state.cwd = "a/b".into();
 
-        app.handle_submit("/cwd ../");
+        for input in ["/cwd ../", "/cwd ../ "] {
+            app.state.cwd = "a/b".into();
 
-        // Apply the CwdSet UiCmd when it arrives.
-        let deadline = tokio::time::timeout(Duration::from_secs(5), op_rx.recv()).await;
-        if let Ok(Some(cmd)) = deadline {
-            app.handle_cmd(cmd);
+            app.handle_submit(input);
+
+            // Apply the CwdSet UiCmd when it arrives.
+            let deadline = tokio::time::timeout(Duration::from_secs(5), op_rx.recv()).await;
+            if let Ok(Some(cmd)) = deadline {
+                app.handle_cmd(cmd);
+            }
+
+            // The agent's `cwd_changed` echo (best-effort — the stream may
+            // not be subscribed yet, but the real agent always emits it).
+            if let Ok(Some(ev)) =
+                tokio::time::timeout(Duration::from_millis(500), events.recv()).await
+            {
+                app.handle_agent_event(&ev);
+            }
+
+            assert_eq!(
+                app.state.cwd, "a",
+                "input {input:?}: footer cwd must be a clean parent `a`, got {:?}",
+                app.state.cwd
+            );
         }
-
-        // The agent's `cwd_changed` echo (best-effort — the stream may not be
-        // subscribed yet, but the real agent always emits it after set_cwd).
-        if let Ok(Some(ev)) = tokio::time::timeout(Duration::from_millis(500), events.recv()).await
-        {
-            app.handle_agent_event(&ev);
-        }
-
-        assert_eq!(
-            app.state.cwd, "a",
-            "footer cwd must be a clean parent `a`, got {:?}",
-            app.state.cwd
-        );
     }
 
     // ─── Welcome screen ─────────────────────────────────────────────────
@@ -4412,6 +4431,12 @@ mod tests {
         assert_eq!(split_ws_js("a  b"), vec!["a", "b"]);
         assert_eq!(split_ws_js(""), vec![""]);
         assert_eq!(split_ws_js("status"), vec!["status"]);
+        // Trailing whitespace yields a trailing EMPTY element, exactly like
+        // JS `split(/\s+/)` — NOT a re-emission of the last token with the
+        // space attached (the pre-fix bug that corrupted `/cwd ../ `).
+        assert_eq!(split_ws_js("cwd ../ "), vec!["cwd", "../", ""]);
+        assert_eq!(split_ws_js("cwd "), vec!["cwd", ""]);
+        assert_eq!(split_ws_js(" "), vec!["", ""]);
     }
 
     /// `/status` lines must match the TS template verbatim — in particular

--- a/tui/src/components/autocomplete.rs
+++ b/tui/src/components/autocomplete.rs
@@ -324,6 +324,14 @@ impl AutocompleteProvider for FilePathProvider {
     }
 
     fn r#match(&self, text: &str, cursor_pos: usize) -> Option<AutocompleteContext> {
+        // Slash commands are literal command lines — don't hijack their
+        // arguments with file-path completions. Without this, `/cwd ../`
+        // opens a parent-directory popup and Enter selects the highlighted
+        // entry instead of submitting the command, so the cwd lands on a
+        // wrong path (`a/ ../`-style artifacts) instead of the clean parent.
+        if text.starts_with('/') {
+            return None;
+        }
         // Detect file path patterns: starts with . or contains / at cursor
         let prefix = &text[..cursor_pos.min(text.len())];
         // Look for the last path-like token
@@ -1106,6 +1114,19 @@ mod tests {
     fn file_path_match_none_without_slash_or_dot() {
         let provider = FilePathProvider::new(Some("/tmp".into()));
         assert!(provider.r#match("hello world", 11).is_none());
+    }
+
+    #[test]
+    fn file_path_match_refuses_slash_command_context() {
+        let provider = FilePathProvider::new(Some("/tmp".into()));
+        // `/cwd ../` is a slash command — path completion must NOT hijack
+        // its argument (the popup would consume Enter and corrupt the cwd).
+        assert!(provider.r#match("/cwd ../", 8).is_none());
+        assert!(provider.r#match("/cwd /usr/lo", 13).is_none());
+        // Plain messages still complete paths (slashes at position 0 are
+        // reserved for slash commands).
+        assert!(provider.r#match("ls /usr/lo", 10).is_some());
+        assert!(provider.r#match("cat .git", 8).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Typing `/cwd ../` opened the file-path autocomplete popup (`FilePathProvider` suggested parent-directory entries like `../Downloads/`, `../ASR/`, ...). Pressing **Enter while the popup is open selects the highlighted entry instead of submitting the command** (faithful TS-port behavior). The input became `/cwd ../<entry>/`, a second Enter submitted that, and the cwd landed on a wrong path — reported as `a/ ../`-style artifacts instead of the clean parent `a/`.

`/cwd ../ ` (trailing space) was broken too: the ported `split_ws_js` re-emitted the last token with the trailing space attached (`"cwd ../ "` → `["cwd", "../", "../ "]`) instead of JS `split(/\s+/)`'s trailing empty element, so the arg became `"../ ../ "` and the cwd landed on `a/ ..`.

## Fix

- `FilePathProvider::r#match` returns `None` when the input starts with `/` (slash-command context). Slash commands are literal command lines — their arguments must not be hijacked by file-path completion. `/cwd ../` now submits on a single Enter and resolves to the clean parent.
- `split_ws_js` now emits a trailing empty element for trailing whitespace (byte-identical to JS `split(/\s+/)`).
- The `/cwd` handler trims the arg (the agent already trims its side).

Plain-message path completion (`ls /usr/lo`, `cat .git`) is unchanged. Deliberate tradeoff: no tab/path completion inside slash-command args (e.g. `/cwd /Us<Tab>` won't complete).

## Tests

- `file_path_match_refuses_slash_command_context` — provider-level regression test.
- `cwd_dotdot_from_relative_cwd_renders_clean_parent` — app-level end-to-end `/cwd ../` from relative cwd `a/b` → `a`, covering both `/cwd ../` and `/cwd ../ `, against an in-process mock agent that echoes `cwd_changed` like the real agent.
- `split_ws_matches_js_regex_semantics` extended with trailing-space cases.
- TUI unit tests 415/415; workspace tests 2147/0; clippy `-D warnings` clean; fmt clean.
- Golden harnesses: render parity 97/97, tmux screen consistency 11/11.
- Verified against the real binary in tmux: no popup for `/cwd ../` (nor `/cwd ../ `), one Enter → `Working directory: /`.

## Test plan for reviewers

```
cargo test -p future-tui
make test-tui-diff   # render parity
make test-tui-tmux   # screen consistency
```