### PR TITLE
ci: fold cli/tui tests into rust-tests, golden diff → manual, fix 4 Dependabot alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
       rust_workspace: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.rust_workspace == 'true' || steps.filter.outputs.ci == 'true' }}
       gui_tauri: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.gui_tauri == 'true' || steps.filter.outputs.ci == 'true' }}
       gui_frontend: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.gui_frontend == 'true' || steps.filter.outputs.ci == 'true' }}
-      cli: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.cli == 'true' || steps.filter.outputs.ci == 'true' }}
-      tui: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.tui == 'true' || steps.filter.outputs.ci == 'true' }}
       mobile: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ci == 'true' }}
     steps:
       - id: force
@@ -75,12 +73,6 @@ jobs:
             gui_frontend:
               - 'gui/**'
               - '!gui/src-tauri/**'
-            cli:
-              - 'cli/**'
-              - 'future-rpc/**'
-            tui:
-              - 'tui/**'
-              - 'future-rpc/**'
             mobile:
               - 'mobile/**'
               - '!mobile/android/**'
@@ -180,6 +172,12 @@ jobs:
   # This deliberately duplicates setup from `rust-quality`: separate jobs do
   # not share a live target directory, but running lint and tests in parallel
   # reduces PR wall-clock time.
+  #
+  # `cargo test --workspace` covers every workspace crate including tui/cli
+  # (their former dedicated jobs were folded in here — see #120). The cli/tui
+  # golden-diff harnesses are NOT part of CI: they were the TS→Rust migration
+  # acceptance gate and now only run manually (make test-cli-diff / test-tui-diff)
+  # before a release.
   rust-tests:
     name: Rust tests (Linux)
     needs: changes
@@ -328,96 +326,6 @@ jobs:
       - name: cargo check (GUI Tauri backend)
         if: needs.changes.outputs.gui_tauri == 'true'
         run: cargo check --manifest-path gui/src-tauri/Cargo.toml
-
-  # ─── CLI: Rust tests + golden diff harness ──────────────────────────────
-  # The CLI is a Rust workspace member (bin `future`); fmt + clippy are covered
-  # by the `rust-quality` job (full-workspace `--all`/`--workspace --all-targets`).
-  # This job runs only the CLI's own tests + the golden harness. The golden
-  # harness (cli/tests/golden-diff.sh) checks byte-identical output against the
-  # committed goldens recorded from the retired TypeScript CLI. It needs
-  # python3 (mock platform server) and skips the live-agent group when no
-  # future-agent binary is present.
-  # NOTE: the "typecheck" in the job name is a TS-era leftover, pinned by the
-  # "Protect Main" ruleset's required status checks ("CLI typecheck + test") —
-  # renaming it would un-mergeable the PRs.
-  cli:
-    name: CLI typecheck + test
-    needs: changes
-    if: needs.changes.outputs.cli == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-
-      # mold + binutils because .cargo/config.toml pins -fuse-ld=mold (build
-      # scripts and test binaries link too); libssl-dev for rustls-less
-      # transitive deps that still build openssl-sys.
-      - name: Install Linux deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            binutils \
-            mold \
-            pkg-config \
-            libssl-dev
-
-      - name: cargo test (cli)
-        run: cargo test -p future-cli
-
-      - name: Golden diff harness
-        run: bash cli/tests/golden-diff.sh
-
-  # ─── TUI: Rust tests + golden harness ────────────────────────────────────
-  # The TUI is a Rust workspace member (bin `future-tui`); fmt + clippy are
-  # covered by the `rust-quality` job (full-workspace). The TypeScript
-  # implementation was retired (2026-08, same as the CLI) and its render +
-  # screen outputs are committed as goldens (tui/tests/golden/). The golden
-  # harness (tui/tests/golden-diff.sh) byte-compares the Rust renderer
-  # against the recorded TS outputs headlessly.
-  # NOTE: the "typecheck" in the job name is a TS-era leftover, pinned by the
-  # "Protect Main" ruleset's required status checks ("TUI typecheck + test") —
-  # renaming it would un-mergeable the PRs.
-  tui:
-    name: TUI typecheck + test
-    needs: changes
-    if: needs.changes.outputs.tui == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-
-      # mold + binutils because .cargo/config.toml pins -fuse-ld=mold (build
-      # scripts and test binaries link too); libssl-dev for rustls-less
-      # transitive deps that still build openssl-sys.
-      - name: Install Linux deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y             build-essential             binutils             mold             pkg-config             libssl-dev
-
-      - name: cargo test (tui)
-        run: cargo test -p future-tui
-
-      - name: Golden render harness
-        run: bash tui/tests/golden-diff.sh
 
   # ─── GUI: typecheck + eslint + stylelint + vitest ─────────────────────────
   # Frontend only. The Tauri *backend* Rust is covered by rust-build (compile,

--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,13 @@ build-mobile-ios:
 	cd mobile && npm run ios
 
 # ─── Test ───────────────────────────────────────────────────────────────────
+#
+# test-tui-diff / test-tui-tmux / test-cli-diff are migration-acceptance tools
+# (TS→Rust port), NOT part of `make test`: they only run manually before a
+# release. The unit tests below (test-agent/channels/cli/tui/...) are the CI
+# regression gate.
 
-test: test-agent test-channels test-cli test-tui test-tui-diff test-tui-tmux test-gui test-gui-rust test-mobile
+test: test-agent test-channels test-cli test-tui test-gui test-gui-rust test-mobile
 
 test-agent:
 	cd agent && cargo test
@@ -423,10 +428,10 @@ help:
 	@echo "  check-mobile       Typecheck, lint, format-check, and test mobile"
 	@echo "  test               Run all tests (Rust crates + cli/tui/gui/mobile)"
 	@echo "  test-tui           Run the Rust TUI unit tests (cargo test -p future-tui)"
-	@echo "  test-tui-diff      Rust render parity vs golden (tui/tests/golden-diff.sh)"
-	@echo "  test-tui-tmux      tmux screen consistency vs golden (tui/tests/tmux-diff.sh)"
+	@echo "  test-tui-diff      [manual] migration gate: TUI render vs golden (tui/tests/golden-diff.sh)"
+	@echo "  test-tui-tmux      [manual] migration gate: tmux screen vs golden (tui/tests/tmux-diff.sh)"
 	@echo "  test-cli           Run the Rust CLI unit tests (cargo test -p future-cli)"
-	@echo "  test-cli-diff      Golden regression: CLI output vs recorded goldens (cli/tests/golden-diff.sh)"
+	@echo "  test-cli-diff      [manual] migration gate: CLI output vs goldens (cli/tests/golden-diff.sh)"
 	@echo "  lint               Lint all (agent + channels + TUI + CLI + GUI + mobile)"
 	@echo "  fmt                Format Rust and mobile code"
 	@echo "  run-agent          Run agent directly (debug build)"

--- a/cli/tests/golden-diff.sh
+++ b/cli/tests/golden-diff.sh
@@ -6,6 +6,12 @@
 # retired; the TS implementation no longer exists — this harness compares the
 # Rust CLI against the committed snapshots only).
 #
+# STATUS: migration-acceptance tool, NOT a CI gate. The TS→Rust port is
+# complete (2026-08) and the goldens are no longer regenerated, so this is
+# intentionally run only manually before a release (`make test-cli-diff`) to
+# confirm the CLI's output has not drifted. Behavior changes no longer need
+# --record — the unit tests (cargo test -p future-cli) are the regression gate.
+#
 # Modes:
 #   (default)  build the Rust CLI, run every corpus case under a controlled
 #              environment (fake $HOME, fixed version, mock platform server,

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -12,7 +12,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "i18next": "^26.3.4",
         "lucide-react": "^1.22.0",
-        "pdfjs-dist": "^6.1.200",
+        "pdfjs-dist": "^6.2.108",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -5416,9 +5416,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7181,9 +7181,9 @@
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.1.200",
-      "resolved": "https://registry.npmmirror.com/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
-      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "version": "6.2.108",
+      "resolved": "https://registry.npmmirror.com/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"

--- a/gui/package.json
+++ b/gui/package.json
@@ -21,7 +21,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "i18next": "^26.3.4",
     "lucide-react": "^1.22.0",
-    "pdfjs-dist": "^6.1.200",
+    "pdfjs-dist": "^6.2.108",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -56,5 +56,8 @@
   "allowScripts": {
     "esbuild@0.25.12": true,
     "fsevents@2.3.3": true
+  },
+  "overrides": {
+    "js-yaml": "^4.3.1"
   }
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1400,9 +1400,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2156,9 +2156,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -10312,9 +10312,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -52,7 +52,9 @@
     "check": "npm run typecheck && npm run lint && npm run format:check && npm test"
   },
   "overrides": {
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "js-yaml@3": "^3.15.1",
+    "js-yaml@4": "^4.3.1"
   },
   "private": true
 }

--- a/tui/tests/golden-diff.sh
+++ b/tui/tests/golden-diff.sh
@@ -2,6 +2,11 @@
 #
 # Golden render harness: Rust TUI vs recorded TypeScript outputs.
 #
+# STATUS: migration-acceptance tool, NOT a CI gate. The TS→Rust port is
+# complete (2026-08) and the golden is no longer regenerated, so this is
+# intentionally run only manually before a release (`make test-tui-diff`) to
+# confirm the TUI's render has not drifted.
+#
 # The TypeScript TUI was retired (2026-08, same as the CLI): its render
 # outputs were recorded per corpus case into
 # `tui/tests/golden/parity-ts.golden` BEFORE the TS sources were deleted, so


### PR DESCRIPTION
## Summary

**CI simplification** (after removing the "CLI/TUI typecheck + test" required checks from the Protect Main ruleset):
- Deleted the `cli` and `tui` jobs — their `cargo test -p future-cli/tui` was already covered by `cargo test --workspace` in the `rust-tests` job. Removed the now-unused `cli`/`tui` path filters and job outputs.
- Golden-diff harnesses are no longer a CI gate: they were the TS→Rust migration acceptance check (byte-comparing the Rust output against snapshots recorded from the retired TS CLI). The TS implementation is gone and the goldens are never regenerated, so they only run manually before a release now (`make test-cli-diff` / `test-tui-diff`).
- `make test` no longer includes the diff targets; help text marks them `[manual]`; both golden scripts annotated as migration tools.

**Dependabot — 4 high alerts fixed:**
| alert | path | package | before → after |
|---|---|---|---|
| #23 | gui runtime | pdfjs-dist | 6.1.200 → **6.2.108** (CVE: JS exec on malicious PDF) |
| #22 | gui dev | js-yaml (stylelint→cosmiconfig) | 4.3.0 → **4.3.1** (override) |
| #24 | mobile runtime | js-yaml (istanbul chain) | 3.15.0 → **3.15.1** (override) |
| #25 | mobile dev | js-yaml (eslint/expo chain) | 4.3.0 → **4.3.1** (override) |

Locks regenerated for gui + mobile.

## Test plan
- [x] `cargo fmt --check` + `cargo test --workspace` (852 passed)
- [x] gui: `tsc --noEmit`, `eslint`, `vitest` (251 passed) with pdfjs-dist 6.2.108
- [x] mobile: `typecheck` passes with js-yaml 3.15.1 + 4.3.1
- [x] workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)