### PR TITLE
fix(loop): enforce gate blocking on complete; real resume-when deadlines

### DIFF
--- a/orchestration/loop/skill/future-loop/SKILL.md
+++ b/orchestration/loop/skill/future-loop/SKILL.md
@@ -42,6 +42,16 @@ For one-shot conversations, just answer normally — no goal needed.
 - The agent must be running for `future loop run` — start it with
   `future agent` (gRPC 127.0.0.1:50051). Probe it with `future models`
   — a plain curl to the gRPC port reports nothing useful.
+- **Verify the CLI binary is not stale before relying on recent loop
+  features.** The installed `future` binary can be older than the loop
+  source (observed 2026-08: session auto-cleanup, `todo update --blocks`,
+  and gate enforcement silently absent from an out-of-date binary — the
+  commands still "work" but skip the new behavior with no warning). Quick
+  freshness probe: `strings $(command -v future) | grep -c "session cleanup failed"`
+  — `1` = fresh (session auto-clean present), `0` = stale → rebuild with
+  `cargo build -p future-cli` (or reinstall) before relying on loop features.
+  If you see `⚠ session cleanup failed` lines or stray per-run sessions in
+  `future session list`, treat it as the same stale-binary symptom.
 
 ## State layout (project-local, all under `<cwd>`)
 
@@ -190,7 +200,12 @@ future loop todo add --goal <goal-id> --role user --class user_gate \
   --blocks <todo-id-of-the-action>
 ```
 Describing approval in the objective text is NOT enough — a gate todo is
-what actually blocks the action.
+what actually blocks the action. Semantics (verified): the `--blocks` value
+is a declarative link; what actually freezes work is the gate being OPEN —
+the run loop returns `AskUser` for the whole goal until the gate is resolved
+(any open gate freezes everything, not just the linked todo), and since the
+2026-08 hardening pass `todo complete` also rejects completing non-gate
+todos while a gate is pending.
 
 **Conditional iteration (validate until it passes).** When a todo must
 iterate until a condition is met (e.g. optimize until tests pass), attach an
@@ -359,13 +374,32 @@ future loop todo complete --goal <goal-id> --todo-id <stale-id> --no-follow-up \
   (todos done + closure intent + no acceptance gaps). Check `closure_proof`.
 - **Never silently complete agent work**: `todo complete` requires
   `--no-follow-up` or `--successor`; the CLI rejects silent completion.
+- **Gates freeze ALL work until resolved — enforced at the CLI too.**
+  The run loop returns `AskUser` while any user gate is open (it does NOT
+  gate by reverse `--blocks` wiring — any open gate freezes everything), and
+  `todo complete` now rejects completing a non-gate todo while a gate is
+  pending. To complete gated work: `gate resolve` the gate first, then
+  complete the todo. Gates themselves are completed via `gate resolve`, never
+  `todo complete`.
 - **Never guess a gate decision — but not every gate is the user's.**
   Gates created by the kernel as `PLAN_REVIEW` replan checkpoints are the
   agent's to resolve (review plan → adjust todos via CLI → resolve gate).
   Gates that pose a genuine human decision (approvals, scope/goal changes,
   risky/irreversible actions) MUST be surfaced to the user IN the
   conversation — stop and wait, never guess.
-- **Monitors**: not-due monitors must NOT be polled; `run` handles cadence.
+- **Monitors**: not-due monitors must NOT be polled; `run` handles cadence
+  (a run with only not-due monitors returns `wait / wait_monitor`). A
+  monitor's due time is driven by its cadence (`--cadence 15m|1h|2d` or a
+  class) or `--defer-secs N`; numeric `todo update --resume-when N` also
+  defers N seconds from now (real deadline), while a non-numeric value is a
+  text-only hint with NO deadline (the todo stays deferred forever — don't
+  use text hints when you need the todo to become due again).
+- **`--verify` semantics**: exit 0 → todo completes validated; exit non-zero
+  → validation fails, the kernel marks repair-required and retries up to
+  `--max-validation-attempts` (default 3), then replans. NOTE: the agent
+  itself can still `todo complete --no-follow-up` a failing validator via the
+  CLI (agent autonomy) — the validator only gates the kernel's automatic
+  completion path.
 - **Evidence honesty**: report real outputs (paths, test results); the
   control plane readbacks key results itself.
 - **Deliverables to CWD**: agent turns write artifacts into the loop state
@@ -391,8 +425,44 @@ future loop run --goal G [--model M] [--thinking-level L] [--max-turns N]
 future loop backup --goal G [--list | --restore DIR]
 future loop serve-status [--port 8791]         # browser dashboard
 
-> Model listing lives on the top-level CLI (`future models [--json]`) — the
-> loop does not need its own copy. Session cleanup is automatic per `run`;
-> for manual cleanup of leftover sessions use the top-level
-> `future session list` / `future session delete <id>`.
+> Model listing is available BOTH on the top-level CLI (`future models
+> [--json]`) AND as `future loop models` (same catalog). Session cleanup is
+> automatic per `run`; for manual cleanup of leftover sessions use the
+> top-level `future session list` / `future session delete <id>`.
+
+### Full command surface (52 commands, 12 groups — `future loop registry`)
+
+Beyond the workflow commands above, the control plane ships a wider surface
+(verified 2026-08, v0.0.1574). Use `future loop --help` / `future loop
+registry` for the authoritative list; the notable extras:
+
+- **todo graph**: `todo update` (text/priority/blocks/evidence/note —
+  `--blocks a,b` replaces, `--blocks ""` clears, absent leaves untouched);
+  `task-graph` (dependency DAG — **fails closed** on unknown block refs);
+  `lease claim|renew|release|expire|status` (task leases — claim requires the
+  agent to be `agent register`ed for the goal).
+- **gates & replan**: `gate resolve`; `replan ack` / `replan obligations`
+  (kernel-injected plan-review checkpoints).
+- **agents**: `agent register|onboard` (onboard declares capabilities);
+  `scope` (identity-scoped frontier); `lane` (lane recommendation);
+  `supervisor propose|receipt|events`.
+- **quota/scheduler**: `quota should-run|usage|spend`;
+  `scheduler tick|show|record-host-failure`.
+- **ops**: `diagnose` (per-goal decision surface, supports `--format json`);
+  `doctor` (ledger integrity + canary self-check); `runs
+  history|compact|retention|stale`; `backup --list|--restore`;
+  `evidence-log`; `todo-event`; `turn` (per-todo turn envelope);
+  `privacy` (privacy-graded projection); `store verify|migrate|bridge`;
+  `authority`; `profile`; `version`.
+- **work-items & handoff**: `attention` (attention queue); `inbox` (operator
+  inbox urgency); `handoff --write` (handoff doc + delivery contract).
+- **extensions**: `extension install|upgrade|enable|disable|rollback`;
+  `capability list|propose|commands|catalog`; `agent-turn-recall`,
+  `change-quality`, `content-ops`, `explore`, `integration-branch`,
+  `issue-fix`, `periodic-report`, `reward-memory`, `semantic-preference`,
+  `value-connectors` (each takes `--input` for one private turn context).
+- **benchmark/replay/canary**: `benchmark protocol|run|ledger`;
+  `replay record|run` (+ `replay corpus build|run`); `canary smoke
+  [--profile core-control-plane|extension-runtime|release-gate]` (release
+  gate default) — run `canary smoke` after touching loop code.
 ```

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -740,9 +740,17 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     }
     if let Some(rw) = resume_when_cond {
         todo.resume_when_text = Some(rw.clone());
-        todo.resume_when =
-            Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600));
         todo.status = crate::state::TodoStatus::Deferred;
+        // Numeric `--resume-when N` defers N seconds from now (real deadline,
+        // same semantics as --defer-secs); non-numeric keeps legacy +3600s
+        // placeholder (text hint only).
+        if let Ok(secs) = rw.trim().parse::<u64>() {
+            todo.resume_when =
+                Some(std::time::SystemTime::now() + std::time::Duration::from_secs(secs));
+        } else {
+            todo.resume_when =
+                Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600));
+        }
     }
     if let Some(n) = note {
         todo.note = Some(n);
@@ -948,6 +956,22 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
             "agent todo completion must declare --no-follow-up or --successor \
              (completion policy, successor, and no-follow-up contracts are enforced)"
         );
+    }
+    // Gate enforcement at the CLI too — aligned with the run loop's semantics:
+    // any OPEN user gate freezes gated work (decision step 1 → AskUser) until
+    // it is resolved. Completing a non-gate todo while a gate is open would
+    // bypass that contract; the run loop already refuses to schedule it, this
+    // closes the manual `todo complete` bypass. Resolving the gate itself is
+    // the gate's own path (`gate resolve`) — gates are never completed here.
+    if t.class != TaskClass::UserGate && t.class != TaskClass::Blocker {
+        let open_gates: Vec<String> = goal.open_gates().map(|g| g.id.clone()).collect();
+        if !open_gates.is_empty() {
+            bail!(
+                "todo {todo_id} cannot be completed while open gate(s) [{}] are pending — \
+                 resolve them first (`future loop gate resolve --goal {goal_id} --todo-id <gate> --decision \"...\"`)",
+                open_gates.join(", ")
+            );
+        }
     }
     let successors = successor.clone().into_iter().collect::<Vec<_>>();
     store.append(Event::TodoCompleted {
@@ -4345,6 +4369,17 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
              (completion policy, successor, and no-follow-up contracts are enforced)"
         );
     }
+    // `--resume-when N` with a numeric N means "defer N seconds from now"
+    // (same semantics as `--defer-secs`), so a deferred/monitor todo actually
+    // becomes due. A non-numeric value keeps the legacy text-only behavior
+    // (resume_when_text hint, no real deadline).
+    let resume_when_parsed = resume_when.as_deref().map(|rw| {
+        if let Ok(secs) = rw.trim().parse::<u64>() {
+            format!("defer:{secs}")
+        } else {
+            rw.to_string()
+        }
+    });
     store.append(Event::TodoUpdated {
         goal_id: goal_id.clone(),
         todo_id: todo_id.clone(),
@@ -4353,7 +4388,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
         evidence: evidence.clone(),
         note: note.clone(),
         priority: priority.clone(),
-        resume_when: resume_when.clone(),
+        resume_when: resume_when_parsed,
         blocks: blocks.clone(),
         ts: crate::state::now_epoch(),
     })?;

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -982,6 +982,19 @@ fn apply(goal: &mut Goal, event: Event) {
                 if let Some(rw) = resume_when {
                     t.resume_when_text = Some(rw.clone());
                     t.status = crate::state::TodoStatus::Deferred;
+                    // `defer:N` (written by `todo update --resume-when N` with a
+                    // numeric N) sets a REAL deadline: resume_when = now + N
+                    // seconds, so the deferred/monitor todo becomes due again.
+                    // Any other value is a text-only hint (no deadline) and
+                    // keeps the legacy behavior.
+                    if let Some(secs) = rw
+                        .strip_prefix("defer:")
+                        .and_then(|s| s.parse::<u64>().ok())
+                    {
+                        t.resume_when = Some(
+                            std::time::SystemTime::now() + std::time::Duration::from_secs(secs),
+                        );
+                    }
                 }
                 if let Some(st) = status.as_deref() {
                     match st {

--- a/orchestration/loop/tests/loop_hardening_contract.rs
+++ b/orchestration/loop/tests/loop_hardening_contract.rs
@@ -1,0 +1,362 @@
+//! Contract tests for the 2026-08 loop hardening pass:
+//!   1. `todo update --resume-when N` (numeric) sets a REAL deadline
+//!      (`defer:N` → resume_when = now + N secs), so deferred/monitor todos
+//!      become due again instead of being stuck forever (previously the raw
+//!      string was stored and never parsed to SystemTime).
+//!   2. `todo complete` refuses to complete a todo blocked by an OPEN
+//!      user gate / blocker — the manual CLI bypass of gate enforcement
+//!      (which the run loop already applies at schedule time).
+//!
+//! These exercise the real CLI entry (`console::run`) against an isolated
+//! `FUTURE_LOOP_ROOT`, so they cover the parse → event → projection path.
+
+use future_loop::console;
+use future_loop::state::TodoStatus;
+use future_loop::store::Store;
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; tests run in parallel, so
+    // serialize all CLI tests behind one mutex (each still gets its own
+    // isolated root dir).
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = std::env::temp_dir().join(format!("future-loop-hardening-{tag}-{}", uuid_like()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let root = dir.join(".future/loop");
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", root.to_str().unwrap());
+    f(root.to_str().unwrap());
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    format!(
+        "{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+/// Find a todo id in a goal by text prefix.
+fn todo_id_by_text(root: &str, goal: &str, text_prefix: &str) -> String {
+    let store = Store::open(root).unwrap();
+    let g = store.replay(goal).unwrap().unwrap();
+    g.todos
+        .iter()
+        .find(|t| t.text.contains(text_prefix))
+        .map(|t| t.id.clone())
+        .unwrap_or_else(|| panic!("no todo with text containing {text_prefix:?}"))
+}
+
+/// End-to-end: goal init → todo add → todo update --resume-when 30 →
+/// status projection shows a REAL SystemTime deadline (~30s out).
+#[test]
+fn cli_resume_when_numeric_sets_real_deadline() {
+    with_root("cli-defer", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "defer test",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--text",
+            "deferred work",
+            "--priority",
+            "P1",
+        ])
+        .unwrap();
+        let todo_id = todo_id_by_text(root, "g1", "deferred work");
+        cli(&[
+            "todo",
+            "update",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--resume-when",
+            "30",
+        ])
+        .unwrap();
+
+        let store = Store::open(root).unwrap();
+        let g = store.replay("g1").unwrap().unwrap();
+        let t = g.todo(&todo_id).unwrap();
+        assert_eq!(t.status, TodoStatus::Deferred);
+        assert_eq!(t.resume_when_text.as_deref(), Some("defer:30"));
+        let rw = t
+            .resume_when
+            .expect("numeric resume-when must set SystemTime");
+        let remaining = rw
+            .duration_since(std::time::SystemTime::now())
+            .unwrap_or_default();
+        assert!(
+            remaining.as_secs() <= 30 && remaining.as_secs() >= 25,
+            "deadline should be ~30s in the future, got {remaining:?}"
+        );
+    });
+}
+
+/// End-to-end: non-numeric `--resume-when` stays a text-only hint (Deferred
+/// status, NO SystemTime deadline).
+#[test]
+fn cli_resume_when_text_keeps_no_deadline() {
+    with_root("cli-text", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "text test",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--text",
+            "hint work",
+            "--priority",
+            "P1",
+        ])
+        .unwrap();
+        let todo_id = todo_id_by_text(root, "g1", "hint work");
+        cli(&[
+            "todo",
+            "update",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--resume-when",
+            "when-ci-passes",
+        ])
+        .unwrap();
+
+        let store = Store::open(root).unwrap();
+        let g = store.replay("g1").unwrap().unwrap();
+        let t = g.todo(&todo_id).unwrap();
+        assert_eq!(t.status, TodoStatus::Deferred);
+        assert_eq!(t.resume_when_text.as_deref(), Some("when-ci-passes"));
+        assert!(
+            t.resume_when.is_none(),
+            "text-only resume-when: no deadline"
+        );
+    });
+}
+
+/// `todo complete` on a todo blocked by an OPEN user gate must be REJECTED
+/// by the CLI (bail with a helpful message), even with --no-follow-up.
+#[test]
+fn cli_complete_blocked_by_open_gate_rejected() {
+    with_root("cli-gate", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "gate test",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--text",
+            "gated work",
+            "--priority",
+            "P0",
+        ])
+        .unwrap();
+        let t1_id = todo_id_by_text(root, "g1", "gated work");
+        // gate g2 blocks t1
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--role",
+            "user",
+            "--class",
+            "user_gate",
+            "--gate-question",
+            "Approve the gated work?",
+            "--text",
+            "Approve the gated work?",
+            "--blocks",
+            &t1_id,
+        ])
+        .unwrap();
+        let g2_id = todo_id_by_text(root, "g1", "Approve the gated work?");
+
+        // t1 blocks on g2; completing t1 while g2 is open must fail.
+        let err = cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &t1_id,
+            "--no-follow-up",
+        ])
+        .expect_err("completing a gate-blocked todo must be rejected");
+        assert!(
+            err.contains(&g2_id) && err.contains("open gate"),
+            "error should name the open gate: {err}"
+        );
+
+        // state unchanged: t1 still open, g2 still open.
+        let store = Store::open(root).unwrap();
+        let g = store.replay("g1").unwrap().unwrap();
+        assert_eq!(g.todo(&t1_id).unwrap().status, TodoStatus::Open);
+        assert_eq!(g.todo(&g2_id).unwrap().status, TodoStatus::Open);
+    });
+}
+
+/// After resolving the gate, the previously blocked todo completes cleanly.
+#[test]
+fn cli_complete_after_gate_resolved() {
+    with_root("cli-gate-resolved", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "gate2",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--text",
+            "gated work",
+            "--priority",
+            "P0",
+        ])
+        .unwrap();
+        let t1_id = todo_id_by_text(root, "g1", "gated work");
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--role",
+            "user",
+            "--class",
+            "user_gate",
+            "--gate-question",
+            "Approve?",
+            "--text",
+            "Approve?",
+            "--blocks",
+            &t1_id,
+        ])
+        .unwrap();
+        let g2_id = todo_id_by_text(root, "g1", "Approve?");
+
+        cli(&[
+            "gate",
+            "resolve",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &g2_id,
+            "--decision",
+            "approved",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &t1_id,
+            "--no-follow-up",
+            "--evidence",
+            "after approval",
+        ])
+        .unwrap();
+
+        let store = Store::open(root).unwrap();
+        let g = store.replay("g1").unwrap().unwrap();
+        assert_eq!(g.todo(&t1_id).unwrap().status, TodoStatus::Done);
+        assert_eq!(g.todo(&g2_id).unwrap().status, TodoStatus::Done);
+    });
+}
+
+/// Resolving the gate itself is never blocked (a gate is not blocked by
+/// anything), and completing a NON-gate-blocked todo still works.
+#[test]
+fn cli_complete_unblocked_todo_ok() {
+    with_root("cli-free", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "free",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--text",
+            "free work",
+            "--priority",
+            "P1",
+        ])
+        .unwrap();
+        let t1_id = todo_id_by_text(root, "g1", "free work");
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &t1_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        let g = store.replay("g1").unwrap().unwrap();
+        assert_eq!(g.todo(&t1_id).unwrap().status, TodoStatus::Done);
+    });
+}


### PR DESCRIPTION
## Summary

Two hardening fixes found during the 2026-08 comprehensive `future-loop` test pass (52 commands / 12 groups, 6 real agent runs), plus skill doc updates. Also folds in the CI/test changes from #121 (already on main).

### 1. `todo complete` now enforces gate blocking
Previously the CLI silently allowed completing a non-gate todo while a user gate was open — bypassing gate enforcement that the run loop already applies at schedule time (decision step 1 → `AskUser`: **any** open gate freezes gated work; it is NOT reverse `--blocks` wiring).

```text
$ future loop todo complete --goal g1 --todo-id T --no-follow-up
Error: todo T cannot be completed while open gate(s) [G] are pending — resolve them first
  (`future loop gate resolve --goal g1 --todo-id <gate> --decision "..."`)
```

### 2. Numeric `--resume-when N` now sets a real deadline
`todo update --resume-when N` (and `todo add --resume-when N`) with a numeric N previously stored the raw string and never parsed it to `SystemTime` — deferred/monitor todos stayed deferred **forever**. Now:
- numeric N → ledger records `defer:N` → projection sets `resume_when = now + N secs` (real deadline; todo becomes due again)
- non-numeric value keeps the legacy text-only hint (no deadline)

## Tests
- New `orchestration/loop/tests/loop_hardening_contract.rs`: 5 CLI-level contract tests (numeric/text resume-when, gate rejection, gate-resolve-then-complete, unblocked complete) — exercise the real `console::run` entry against an isolated `FUTURE_LOOP_ROOT`
- `cargo test --workspace`: all pass (852+ unit + integration)
- `cargo clippy --workspace --all-targets`: clean with `-D warnings`
- `cargo fmt --check`: clean

## Docs
`orchestration/loop/skill/future-loop/SKILL.md` updated:
- **Prerequisites**: stale-binary freshness probe (`strings $(command -v future) | grep -c "session cleanup failed"`) — an out-of-date binary silently lacks session auto-clean, `--blocks` rewiring, and gate enforcement
- Corrected: `future loop models` exists (old doc said model listing was top-level CLI only)
- Command reference expanded to the full 52-command / 12-group surface (`future loop registry`)
- Key semantics: gate freeze semantics (any open gate freezes everything), `--verify` agent-autonomy note (a failing validator only gates the kernel's auto-completion; the agent can still complete via CLI), numeric `--resume-when` semantics

## Not fixed (documented, non-core)
- `replay record → run` can MISMATCH: case stores a minimal todo snapshot (status/class only), so replay lacks run-history/outcome-streak context and decisions can drift (e.g. terminal→replan). Design tradeoff, not a core-feature bug.

## Verification
- E2E: gate open → complete rejected → `gate resolve` → complete succeeds
- E2E: `--resume-when 2` → todo deferred with real deadline → becomes runnable after 2s and is picked by the scheduler