### PR TITLE
feat(loop): agent list + enforce --agent-id on run (parallel-safety)

### DIFF
--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -15,9 +15,19 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, warn};
 
-const DEFAULT_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_TIMEOUT_SECS: u64 = 1800;
 const STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
 const STREAM_TOOL_CALL_IDLE_TIMEOUT_SECS: u64 = 15;
+
+/// HTTP request timeout for a single LLM call. Defaults to 30 min (1800 s);
+/// override with the FUTURE_LLM_TIMEOUT_SECS env var without rebuilding.
+fn llm_timeout_secs() -> u64 {
+    std::env::var("FUTURE_LLM_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v >= 60)
+        .unwrap_or(DEFAULT_TIMEOUT_SECS)
+}
 
 /// Why the LLM SSE read loop exited before seeing a genuine terminal signal
 /// (`[DONE]` or `finish_reason`). Distinguishes abort/disconnect (expected —
@@ -63,7 +73,7 @@ impl Client {
         max_tokens: Option<i32>,
     ) -> Self {
         let http = HttpClient::builder()
-            .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .timeout(std::time::Duration::from_secs(llm_timeout_secs()))
             .build()
             .unwrap_or_else(|_| HttpClient::new());
 

--- a/orchestration/loop/skill/future-loop/SKILL.md
+++ b/orchestration/loop/skill/future-loop/SKILL.md
@@ -239,6 +239,92 @@ report-generation todo. When executing it, copy files with `cp` (not mv)
 from `<cwd>/.future/loop/goals/<id>/` to `<cwd>/`, so the user can find
 results directly in the project root without digging into `.future/loop/`.
 
+### 6.0 Agent identity & parallel safety — `--agent-id` MANDATORY (enforced)
+
+Every `future loop run` MUST carry an `--agent-id` — **enforced by the CLI**
+(2026-08): `run` without it fails fast with a hint pointing at `agent list`;
+pass `--anonymous` only for a legacy uncoordinated one-shot run (prints a
+warning). This is the control plane's ONLY automatic mutual-exclusion
+mechanism:
+
+- **No separate registration step needed — `run` auto-registers on first
+  use:** the first `run --agent-id <name>` appends `AgentRegistered`
+  automatically (replay is idempotent).
+  `future loop agent onboard --goal <goal-id> --agent-id <name>
+  [--capabilities c1,c2]` is still available to declare capabilities;
+  `agent register` remains for plain registration.
+- **Use a unique name per parallel worker** (e.g. `<host>-<task>` /
+  `<user>-<workerN>`); never reuse one id for two concurrent runs — a run
+  sees its OWN leased todos as runnable, so two runs sharing one id both
+  pick the same todo and double-execute.
+- **Run with the id:**
+  ```bash
+  future loop run --goal <goal-id> --agent-id <unique-name> \
+    --model <confirmed-model> --thinking-level <confirmed-thinking> --max-turns 1
+  ```
+- **Why it matters (verified in code, 2026-08):** a run WITH `--agent-id`
+  claims a lease on the selected todo BEFORE executing
+  (`Event::TodoClaimed`; default 4h — `--lease-secs N` to override), and the
+  frontier filter hides todos leased by other agents (`claimed_by_other`) —
+  so parallel runs grab DIFFERENT todos and never double-execute. An
+  `--anonymous` run claims nothing and hides nothing — two agentless runs
+  deterministically pick the SAME next todo and race.
+- **Conflict-avoidance checklist before launching any run:**
+  1. `future loop agent list --goal <goal-id>` — who is registered and
+     currently running (reuse existing ids; don't re-register).
+  2. `ps aux | grep "future loop run"` — confirm no other run is active, or
+     that you WANT parallel workers (each with a distinct id).
+  3. `future loop status --goal <goal-id>` — confirm the expected next todo.
+  4. `future loop quota should-run --goal <goal-id> --agent-id <me>` —
+     preview which todo this agent would get.
+  5. `future loop lease status --goal <goal-id> --todo-id <T> --agent-id <me>`
+     — inspect a lease before claiming/repairing.
+- `lease claim` and `quota should-run --agent-id` REQUIRE the agent to be
+  registered first (error: `agent \`X\` is not registered for goal …`);
+  `run --agent-id` auto-registers instead of failing.
+- NOTE: `run`'s help text DOES list `--agent-id` — the flag is enforced,
+  not optional.
+
+### 6.1 Multi-agent parallel runs (scale-out on one goal)
+
+The loop supports N concurrent runs on the SAME goal — each `run --agent-id`
+is an independent process sharing the goal ledger (event appends are
+advisory-file-locked, so interleaving is safe). To avoid the decide→claim
+TOCTOU race (two fresh runs can both pick the same FREE todo in the same
+second; last claim wins in the ledger), ASSIGN todos deterministically
+BEFORE launching:
+
+1. **Register one agent per worker:**
+   ```bash
+   future loop agent register --goal <goal-id> --agent-id worker-1
+   # … worker-2, worker-3, …
+   ```
+2. **Pre-claim one open todo per agent (deterministic assignment):**
+   ```bash
+   future loop todo claim --goal <goal-id> --todo-id <T1> --agent-id worker-1 --lease-secs 14400
+   future loop todo claim --goal <goal-id> --todo-id <T2> --agent-id worker-2 --lease-secs 14400
+   ```
+   A worker still sees its OWN leased todo as runnable (`claimed_by_other`
+   excludes only OTHER agents) → each run picks exactly its assigned todo.
+3. **Launch one run per worker (background, distinct ids):**
+   ```bash
+   nohup future loop run --goal <goal-id> --agent-id worker-1 \
+     --model <M> --thinking-level <L> --max-turns 1 > logs/worker-1.log 2>&1 &
+   nohup future loop run --goal <goal-id> --agent-id worker-2 … &
+   ```
+4. **Verify no double-execution:** `future loop lease status --goal G --todo-id <T1> --agent-id worker-1`.
+
+- **Lease duration:** `todo claim` / `lease claim` default 3600s; `run`
+  defaults to 4h (14400s) and accepts `--lease-secs N`. An expired lease frees
+  the todo for other workers but does NOT abort a running turn.
+- **Keep working after a turn:** each run process executes `--max-turns 1`;
+  re-launch the same command (same agent-id) to continue — the worker keeps
+  its claim on its assigned todo and resumes.
+- **Resource rule:** worker count must fit the machine (heavy compute tasks
+  contend); agree the count with the user BEFORE launching (default 3).
+- **Priority caveat:** pre-claim overrides pure-priority ordering — assign
+  the highest-value open todos to workers first (e.g. P0/P1 before P2).
+
 ### 6. Run the agent — one turn at a time
 
 Use the confirmed model and thinking level from step 2. **Always use
@@ -247,8 +333,8 @@ user wait with no visibility; a turn-by-turn loop lets them see each step's
 progress, cost, and any issues as they happen:
 
 ```bash
-future loop run --goal <goal-id> --model <confirmed-model> \
-  --thinking-level <confirmed-thinking> --max-turns 1
+future loop run --goal <goal-id> --agent-id <unique-name> \
+  --model <confirmed-model> --thinking-level <confirmed-thinking> --max-turns 1
 ```
 
 > **Session lifecycle (no manual cleanup needed):** each `run` creates a
@@ -268,18 +354,9 @@ future loop run --goal <goal-id> --model <confirmed-model> \
 > usually NOT enough. Run **blocking** with an explicit longer timeout on the
 > shell call (e.g. `timeout: 1800`), and poll `future loop status` between
 > turns. Avoid backgrounding the run (nohup/&): it hides progress, risks
-> overlapping turns, and the kernel expects one run at a time. If a blocking
+> overlapping turns, and the kernel expects one run at a time (parallel runs
+> are supported ONLY with distinct `--agent-id`, §6.0). If a blocking
 > run is interrupted, check `status` before re-running to see what completed.
-
-> **Agent ids — register once, reuse, never duplicate**: before registering
-> a new identity run `future loop agent list --goal <goal-id>` — it shows
-> every registered agent plus live execution status (`running` = holds a
-> live lease on a todo right now, with the lease time remaining; `idle` =
-> free to take work). Register/onboard ONLY ids that are missing: each
-> concurrent `run --agent-id` needs its own unique id, and re-registering an
-> existing id merely appends a redundant ledger event (replay is idempotent).
-> `agent list` also reveals who is mid-execution, so a fresh worker can pick
-> a different todo instead of racing the same one.
 
 After each `run`, before starting the next step:
 1. Report what was done (which todo, cost, new status).
@@ -334,7 +411,7 @@ acceptance gaps, succession obligation), it injects a `PLAN_REVIEW` user gate.
 3. resolve the gate and re-run:
    ```bash
    future loop gate resolve --goal G --todo-id <gate> --decision "agent replan: <summary>" --note "..."
-   future loop run --goal G ...
+   future loop run --goal G --agent-id <unique-name> ...   # ALWAYS --agent-id (§6.0)
    ```
 
 **Escalate to the user ONLY when absolutely necessary** — never guess a
@@ -430,9 +507,10 @@ future loop todo complete --goal G --todo-id T [--no-follow-up | --successor T2]
 future loop todo supersede --goal G --todo-id T --reason "..."
 future loop gate resolve --goal G --todo-id T --decision "..." [--note "..."]
 future loop quota should-run --goal G [--agent-id A]
-future loop agent list --goal G      # registered agents + live execution status
 future loop heartbeat-prompt --goal G          # re-entry packet for the next turn
-future loop run --goal G [--model M] [--thinking-level L] [--max-turns N]
+future loop agent register --goal G --agent-id A    # optional — run auto-registers; onboard declares capabilities
+future loop agent list --goal G      # registered agents + live execution status (check before registering)
+future loop run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N]   # --agent-id MANDATORY (enforced §6.0); --anonymous = legacy uncoordinated
 future loop backup --goal G [--list | --restore DIR]
 future loop serve-status [--port 8791]         # browser dashboard
 
@@ -441,7 +519,7 @@ future loop serve-status [--port 8791]         # browser dashboard
 > automatic per `run`; for manual cleanup of leftover sessions use the
 > top-level `future session list` / `future session delete <id>`.
 
-### Full command surface (52 commands, 12 groups — `future loop registry`)
+### Full command surface (53 commands, 12 groups — `future loop registry`)
 
 Beyond the workflow commands above, the control plane ships a wider surface
 (verified 2026-08, v0.0.1574). Use `future loop --help` / `future loop
@@ -454,11 +532,13 @@ registry` for the authoritative list; the notable extras:
   agent to be `agent register`ed for the goal).
 - **gates & replan**: `gate resolve`; `replan ack` / `replan obligations`
   (kernel-injected plan-review checkpoints).
-- **agents**: `agent register|onboard` (onboard declares capabilities);
-  `agent list` (registered agents + live execution status — check this
-  BEFORE registering so parallel workers reuse existing ids instead of
-  re-registering the same one); `scope` (identity-scoped frontier);
-  `lane` (lane recommendation); `supervisor propose|receipt|events`.
+- **agents**: `agent list` (registered agents + live execution status —
+  check this BEFORE registering so parallel workers reuse existing ids);
+  `agent register` (auto-registered by `run --agent-id` on first use; still a
+  prerequisite for `lease claim` / `quota should-run --agent-id`),
+  `agent onboard` (declares capabilities); `scope` (identity-scoped
+  frontier); `lane` (lane recommendation);
+  `supervisor propose|receipt|events`.
 - **quota/scheduler**: `quota should-run|usage|spend`;
   `scheduler tick|show|record-host-failure`.
 - **ops**: `diagnose` (per-goal decision surface, supports `--format json`);

--- a/orchestration/loop/skill/future-loop/SKILL.md
+++ b/orchestration/loop/skill/future-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.1
+version: 1.0.3
 name: future-loop
 description: FutureOS loop control plane — manage long-running goals, todo lists, human gates, monitors, and validated completion via the loop control plane. Use when the user wants a long-lived/multi-step/cross-session task tracked as a goal, asks to "keep working on X", "track this issue", "run this overnight", needs progress/status of ongoing agent work, or starts a message with "/future-loop" (treat everything after the prefix as the goal).
 allowed-tools: Bash(future-loop:*)
@@ -271,6 +271,16 @@ future loop run --goal <goal-id> --model <confirmed-model> \
 > overlapping turns, and the kernel expects one run at a time. If a blocking
 > run is interrupted, check `status` before re-running to see what completed.
 
+> **Agent ids — register once, reuse, never duplicate**: before registering
+> a new identity run `future loop agent list --goal <goal-id>` — it shows
+> every registered agent plus live execution status (`running` = holds a
+> live lease on a todo right now, with the lease time remaining; `idle` =
+> free to take work). Register/onboard ONLY ids that are missing: each
+> concurrent `run --agent-id` needs its own unique id, and re-registering an
+> existing id merely appends a redundant ledger event (replay is idempotent).
+> `agent list` also reveals who is mid-execution, so a fresh worker can pick
+> a different todo instead of racing the same one.
+
 After each `run`, before starting the next step:
 1. Report what was done (which todo, cost, new status).
 2. **Reflect & improve — run a deliberate reflection pass (not just a status
@@ -420,6 +430,7 @@ future loop todo complete --goal G --todo-id T [--no-follow-up | --successor T2]
 future loop todo supersede --goal G --todo-id T --reason "..."
 future loop gate resolve --goal G --todo-id T --decision "..." [--note "..."]
 future loop quota should-run --goal G [--agent-id A]
+future loop agent list --goal G      # registered agents + live execution status
 future loop heartbeat-prompt --goal G          # re-entry packet for the next turn
 future loop run --goal G [--model M] [--thinking-level L] [--max-turns N]
 future loop backup --goal G [--list | --restore DIR]
@@ -444,8 +455,10 @@ registry` for the authoritative list; the notable extras:
 - **gates & replan**: `gate resolve`; `replan ack` / `replan obligations`
   (kernel-injected plan-review checkpoints).
 - **agents**: `agent register|onboard` (onboard declares capabilities);
-  `scope` (identity-scoped frontier); `lane` (lane recommendation);
-  `supervisor propose|receipt|events`.
+  `agent list` (registered agents + live execution status — check this
+  BEFORE registering so parallel workers reuse existing ids instead of
+  re-registering the same one); `scope` (identity-scoped frontier);
+  `lane` (lane recommendation); `supervisor propose|receipt|events`.
 - **quota/scheduler**: `quota should-run|usage|spend`;
   `scheduler tick|show|record-host-failure`.
 - **ops**: `diagnose` (per-goal decision surface, supports `--format json`);

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -13,6 +13,7 @@
 //! State lives under `--root` (default `~/.future/loop/`), one goal per
 //! directory, event-sourced: `loop status` replays the ledger each time.
 
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 use crate::cli::registry::CommandRegistry;
@@ -232,6 +233,12 @@ fn build_cli_registry() -> CommandRegistry {
         "agent",
         "register/onboard agents",
         "agent onboard --goal G --agent-id A [--capabilities c1,c2]",
+    );
+    r.command(
+        agent,
+        "list",
+        "registered agents + live execution status (leases)",
+        "agent list --goal G",
     );
     r.command(
         agent,
@@ -878,6 +885,9 @@ fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
     if args.first().map(|s| s.as_str()) == Some("onboard") {
         return cmd_agent_onboard(store, &args[1..]);
     }
+    if args.first().map(|s| s.as_str()) == Some("list") {
+        return cmd_agent_list(store, &args[1..]);
+    }
     let mut goal_id = None;
     let mut agent_id = None;
     parse_pairs(args, |k, v| match k {
@@ -909,7 +919,9 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
         "--agent-id" => agent_id = Some(v),
-        "--capability" => capabilities = v.split(',').map(|s| s.trim().to_string()).collect(),
+        "--capability" | "--capabilities" => {
+            capabilities = v.split(',').map(|s| s.trim().to_string()).collect()
+        }
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -925,6 +937,107 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
     })?;
     println!("agent `{agent_id}` onboarded (capabilities={capabilities:?}) ✔");
     Ok(())
+}
+
+/// `future loop agent list --goal G` — registered agents + their current
+/// execution status. Status is derived from the live task-lease ledger:
+/// `running` = the agent holds a live lease on a todo right now (shown with
+/// the lease's remaining time); `idle` = registered but holding no lease.
+/// Also shows declared capabilities and the agent's most recent activity.
+/// Intended as the pre-flight check before `agent register`/`onboard`, so
+/// parallel workers reuse existing ids instead of re-registering the same
+/// one (each concurrent run needs its own unique id).
+fn cmd_agent_list(store: &Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    parse_pairs(args, |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v);
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+
+    // Event-derived metadata: most recent activity timestamp per agent
+    // (registration, onboarding, or any lease transition).
+    let now = now_epoch();
+    let mut last_active: HashMap<String, u64> = HashMap::new();
+    for ev in store.events(&goal_id).unwrap_or_default() {
+        let (agent, ts) = match &ev.event {
+            Event::AgentRegistered { agent_id, ts, .. }
+            | Event::AgentOnboarded { agent_id, ts, .. }
+            | Event::TodoClaimed { agent_id, ts, .. }
+            | Event::TodoRenewed { agent_id, ts, .. }
+            | Event::TodoReleased { agent_id, ts, .. } => (agent_id.as_str(), *ts),
+            _ => continue,
+        };
+        last_active
+            .entry(agent.to_string())
+            .and_modify(|t| *t = (*t).max(ts))
+            .or_insert(ts);
+    }
+
+    if goal.registered_agents.is_empty() {
+        println!("no agents registered for {goal_id}");
+        return Ok(());
+    }
+    println!(
+        "agents registered for {goal_id} ({}):",
+        goal.registered_agents.len()
+    );
+    println!(
+        "  {:<12} {:<8} {:<32} {:<14} {:<12}",
+        "agent_id", "status", "work-on", "capabilities", "last-active"
+    );
+    for aid in &goal.registered_agents {
+        let mut work: Vec<String> = Vec::new();
+        for t in goal.todos.iter() {
+            if t.claimed_by.as_deref() == Some(aid.as_str())
+                && t.lease_expires_at.map(|e| e > now).unwrap_or(false)
+            {
+                let left = t.lease_expires_at.unwrap().saturating_sub(now);
+                work.push(format!("{} (lease {} left)", t.id, human_dur(left)));
+            }
+        }
+        let status = if work.is_empty() { "idle" } else { "running" };
+        let work_label = if work.is_empty() {
+            "-".to_string()
+        } else {
+            work.join("; ")
+        };
+        let caps = goal
+            .agent_profiles
+            .iter()
+            .find(|p| p.id == *aid)
+            .map(|p| p.capabilities.join(","))
+            .unwrap_or_else(|| "-".to_string());
+        let last = last_active
+            .get(aid)
+            .map(|ts| format!("{} ago", human_dur(now.saturating_sub(*ts))))
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "  {:<12} {:<8} {:<32} {:<14} {:<12}",
+            aid, status, work_label, caps, last
+        );
+    }
+    println!(
+        "hint: agent ids are goal-scoped; check this list before `agent register`/`onboard` \
+         to avoid duplicate ids (each parallel worker needs its own unique id)"
+    );
+    Ok(())
+}
+
+/// Compact human duration ("59s" / "4m12s" / "3h59m") for lease/activity
+/// display in `agent list`.
+fn human_dur(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    }
 }
 
 fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -396,8 +396,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         ops,
         "run",
-        "drive one bounded gRPC turn",
-        "run --goal G [--model M] [--thinking-level L] [--max-turns N]",
+        "drive one bounded gRPC turn (requires --agent-id; auto-registers)",
+        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N]",
     );
 
     let work_items = r.group("work-items", "attention / operator inbox (G-15)");
@@ -1808,21 +1808,76 @@ async fn cmd_models(args: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// Default task-lease length for a `run` turn (4h — long LLM/compute turns
+/// routinely exceed the old 1h lease, which would let another worker steal
+/// the todo mid-turn once the lease expired).
+const DEFAULT_RUN_LEASE_SECS: u64 = 4 * 3600;
+
+/// Resolve run identity (G-27): `run` REQUIRES `--agent-id` so the lease
+/// mechanism actually engages — an anonymous run claims nothing and hides
+/// nothing, so two agentless runs deterministically race on the same todo.
+/// An id that is not yet registered is auto-registered on first use (replay
+/// is idempotent, so `run` never needs a separate `agent register` step).
+/// `--anonymous` opts back into the legacy uncoordinated one-shot path.
+/// Returns the resolved agent id (None for `--anonymous`).
+pub fn ensure_run_identity(
+    store: &mut Store,
+    goal_id: &str,
+    agent_id: Option<&str>,
+    anonymous: bool,
+) -> Result<Option<String>> {
+    match (agent_id, anonymous) {
+        (Some(aid), _) => {
+            let goal = store
+                .replay(goal_id)?
+                .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+            if !goal.is_registered_agent(Some(aid)) {
+                store.append(Event::AgentRegistered {
+                    goal_id: goal_id.to_string(),
+                    agent_id: aid.to_string(),
+                    ts: now_epoch(),
+                })?;
+                println!("agent `{aid}` auto-registered for {goal_id} ✔");
+            }
+            Ok(Some(aid.to_string()))
+        }
+        (None, true) => {
+            println!(
+                "⚠ anonymous run: no lease coordination — parallel runs may race on the same todo"
+            );
+            Ok(None)
+        }
+        (None, false) => bail!(
+            "run requires --agent-id <name> (or --anonymous for an uncoordinated one-shot run); \
+             check existing ids with `{} agent list --goal {goal_id}`",
+            prog()
+        ),
+    }
+}
+
 async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut model = None;
     let mut thinking = None;
     let mut max_turns = 6u32;
     let mut agent_id = None;
+    let mut anonymous = false;
+    let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
         "--model" => model = Some(v),
         "--thinking-level" => thinking = Some(v),
         "--max-turns" => max_turns = v.parse().unwrap_or(6),
         "--agent-id" => agent_id = Some(v),
+        "--lease-secs" => lease_secs = v.parse().unwrap_or(DEFAULT_RUN_LEASE_SECS),
+        "--anonymous" => anonymous = true,
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+
+    // Identity gate BEFORE any gRPC/session work — fail fast with a hint
+    // (and stays unit-testable without an agent server).
+    let agent_id = ensure_run_identity(store, &goal_id, agent_id.as_deref(), anonymous)?;
 
     let mut client = crate::agent_client::AgentClient::connect("127.0.0.1:50051").await?;
     let goal0 = store
@@ -1847,6 +1902,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         &goal_id,
         &session_id,
         max_turns,
+        lease_secs,
         agent_id.as_deref(),
     )
     .await;
@@ -1865,6 +1921,7 @@ async fn run_turns(
     goal_id: &str,
     session_id: &str,
     max_turns: u32,
+    lease_secs: u64,
     agent_id: Option<&str>,
 ) -> Result<()> {
     let mut turn = 0u32;
@@ -1933,7 +1990,7 @@ async fn run_turns(
                         goal_id: goal_id.to_string(),
                         todo_id: todo_id.clone(),
                         agent_id: aid.to_string(),
-                        lease_expires_at: now + 3600,
+                        lease_expires_at: now + lease_secs,
                         ts: now,
                     })?;
                 }
@@ -2573,7 +2630,7 @@ fn parse_pairs(args: &[String], mut f: impl FnMut(&str, String)) {
         let k = args[i].as_str();
         if k.starts_with("--") {
             // boolean flags (no value) are followed by another flag or end.
-            if matches!(k, "--no-follow-up" | "--help" | "-h") {
+            if matches!(k, "--no-follow-up" | "--anonymous" | "--help" | "-h") {
                 f(k, "true".to_string());
                 i += 1;
             } else if i + 1 < args.len() && !args[i + 1].starts_with("--") {

--- a/orchestration/loop/tests/agents_list_contract.rs
+++ b/orchestration/loop/tests/agents_list_contract.rs
@@ -1,0 +1,187 @@
+//! `agent list` contract: registered agents + live execution status.
+//! Pre-flight check so parallel workers reuse existing ids instead of
+//! re-registering. Deterministic — no gRPC/LLM.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_future-loop")
+}
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-agent-list-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn run(root: &str, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(args)
+        .output()
+        .expect("future-loop binary runs");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn init_goal(root: &str, id: &str) {
+    let (_out, err, code) = run(
+        root,
+        &[
+            "goal",
+            "init",
+            "--objective",
+            "agents contract",
+            "--goal-id",
+            id,
+            "--cwd",
+            "/tmp",
+        ],
+    );
+    assert_eq!(code, 0, "goal init failed: {err}");
+}
+
+/// Todo ids from status output (todo-<hex>=open tokens).
+fn todo_ids(root: &str, goal: &str) -> Vec<String> {
+    let (out, _, _) = run(root, &["status", "--goal", goal]);
+    out.lines()
+        .flat_map(|l| l.split_whitespace())
+        .filter_map(|w| w.strip_suffix("=open").map(|s| s.to_string()))
+        .filter(|s| s.starts_with("todo_"))
+        .collect()
+}
+
+/// Empty goal: no agents registered.
+#[test]
+fn agent_list_empty_goal() {
+    let root = tmp_root("empty");
+    init_goal(&root, "g1");
+    let (out, err, code) = run(&root, &["agent", "list", "--goal", "g1"]);
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("no agents registered"), "{out}");
+}
+
+/// Registered agents are listed; unregistered ids are not.
+#[test]
+fn agent_list_shows_registered_ids_only() {
+    let root = tmp_root("ids");
+    init_goal(&root, "g1");
+    let (_o, err, code) = run(
+        &root,
+        &["agent", "register", "--goal", "g1", "--agent-id", "alice"],
+    );
+    assert_eq!(code, 0, "{err}");
+    let (_o, err, code) = run(
+        &root,
+        &[
+            "agent",
+            "onboard",
+            "--goal",
+            "g1",
+            "--agent-id",
+            "bob",
+            "--capabilities",
+            "lammps,abacus",
+        ],
+    );
+    assert_eq!(code, 0, "{err}");
+
+    let (out, _, code) = run(&root, &["agent", "list", "--goal", "g1"]);
+    assert_eq!(code, 0);
+    assert!(out.contains("alice"), "{out}");
+    assert!(out.contains("bob"), "{out}");
+    assert!(out.contains("lammps,abacus"), "capabilities shown: {out}");
+    // Both registered but holding no lease → idle, nothing running.
+    assert!(out.contains("idle"), "idle status shown: {out}");
+    assert!(!out.contains("running"), "no live leases yet: {out}");
+    assert!(
+        !out.contains("carol"),
+        "unregistered id must not appear: {out}"
+    );
+}
+
+/// A live lease flips the agent's status to running with the todo + lease
+/// remaining; releasing it flips back to idle.
+#[test]
+fn agent_list_reflects_live_leases() {
+    let root = tmp_root("leases");
+    init_goal(&root, "g1");
+    run(
+        &root,
+        &["agent", "onboard", "--goal", "g1", "--agent-id", "alice"],
+    );
+    let (_o, err, code) = run(
+        &root,
+        &[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--role",
+            "agent",
+            "--class",
+            "advancement",
+            "--text",
+            "do work",
+        ],
+    );
+    assert_eq!(code, 0, "{err}");
+    let ids = todo_ids(&root, "g1");
+    assert!(!ids.is_empty(), "todo added");
+    let t = &ids[0];
+
+    let (_o, err, code) = run(
+        &root,
+        &[
+            "todo",
+            "claim",
+            "--goal",
+            "g1",
+            "--todo-id",
+            t,
+            "--agent-id",
+            "alice",
+        ],
+    );
+    assert_eq!(code, 0, "claim failed: {err}");
+
+    let (out, _, code) = run(&root, &["agent", "list", "--goal", "g1"]);
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("running"),
+        "alice holds a live lease → running: {out}"
+    );
+    assert!(out.contains(t), "claimed todo shown: {out}");
+    assert!(out.contains("lease"), "lease remaining shown: {out}");
+
+    // Release the lease → back to idle.
+    let (_o, err, code) = run(
+        &root,
+        &[
+            "lease",
+            "release",
+            "--goal",
+            "g1",
+            "--todo-id",
+            t,
+            "--agent-id",
+            "alice",
+        ],
+    );
+    assert_eq!(code, 0, "release failed: {err}");
+    let (out, _, _) = run(&root, &["agent", "list", "--goal", "g1"]);
+    assert!(out.contains("idle"), "after release: {out}");
+    assert!(
+        !out.contains("running"),
+        "no live lease after release: {out}"
+    );
+}

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -54,6 +54,7 @@ fn help_lists_all_pre_existing_commands_in_groups() {
         "gate resolve --goal G",
         "── agent ──",
         "agent onboard --goal G",
+        "agent list --goal G",
         "── capability ──",
         "capability list|propose|commands",
         "── extension ──",

--- a/orchestration/loop/tests/run_identity_contract.rs
+++ b/orchestration/loop/tests/run_identity_contract.rs
@@ -1,0 +1,158 @@
+//! `run` identity gate contract (G-27): `run` REQUIRES `--agent-id` (so the
+//! lease mechanism engages), auto-registers unregistered ids, and keeps an
+//! explicit `--anonymous` escape hatch for uncoordinated one-shot runs.
+//! Deterministic — no gRPC/LLM: the identity gate runs before any agent
+//! connection, so the failure path and the auto-register side effect are
+//! testable without a server.
+
+use std::process::Command;
+
+use future_loop::console::ensure_run_identity;
+use future_loop::store::Store;
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-run-identity-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn store_with_goal(root: &str, goal_id: &str) -> Store {
+    let mut store = Store::open(root).expect("store opens");
+    let goal = future_loop::state::Goal::new(goal_id, "identity gate", "/tmp");
+    store.register(&goal).expect("goal registered");
+    // `replay` needs the event ledger file too (goal init appends GoalStarted).
+    store
+        .append(future_loop::store::Event::GoalStarted {
+            goal_id: goal_id.to_string(),
+            ts: future_loop::state::now_epoch(),
+        })
+        .expect("goal started event");
+    store
+}
+
+// ── Unit: ensure_run_identity (the whole gate, no gRPC) ───────────────────
+
+#[test]
+fn run_without_agent_id_fails_closed_with_hint() {
+    let root = tmp_root("gate");
+    let mut store = store_with_goal(&root, "g1");
+    let err = ensure_run_identity(&mut store, "g1", None, false).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("--agent-id"),
+        "error must demand --agent-id: {msg}"
+    );
+    assert!(
+        msg.contains("agent list"),
+        "error must point at `agent list`: {msg}"
+    );
+}
+
+#[test]
+fn anonymous_escapes_the_gate() {
+    let root = tmp_root("anon");
+    let mut store = store_with_goal(&root, "g1");
+    let id = ensure_run_identity(&mut store, "g1", None, true).expect("anonymous allowed");
+    assert_eq!(id, None, "anonymous run resolves to no identity");
+}
+
+#[test]
+fn unregistered_id_is_auto_registered_once() {
+    let root = tmp_root("auto");
+    let mut store = store_with_goal(&root, "g1");
+    let id = ensure_run_identity(&mut store, "g1", Some("worker-1"), false)
+        .expect("auto-register resolves");
+    assert_eq!(id.as_deref(), Some("worker-1"));
+
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert!(
+        goal.is_registered_agent(Some("worker-1")),
+        "auto-register must persist the id"
+    );
+
+    // Second call: already registered → no duplicate event appended.
+    let events_before = store.events("g1").unwrap().len();
+    let _ = ensure_run_identity(&mut store, "g1", Some("worker-1"), false).unwrap();
+    let events_after = store.events("g1").unwrap().len();
+    assert_eq!(
+        events_before, events_after,
+        "re-registering the same id must not append another event"
+    );
+}
+
+#[test]
+fn existing_registered_id_passes_through() {
+    let root = tmp_root("existing");
+    let mut store = store_with_goal(&root, "g1");
+    // Register alice via the real event path first.
+    store
+        .append(future_loop::store::Event::AgentRegistered {
+            goal_id: "g1".to_string(),
+            agent_id: "alice".to_string(),
+            ts: future_loop::state::now_epoch(),
+        })
+        .unwrap();
+    let id = ensure_run_identity(&mut store, "g1", Some("alice"), false).unwrap();
+    assert_eq!(id.as_deref(), Some("alice"));
+    let events = store.events("g1").unwrap();
+    assert_eq!(
+        events.len(),
+        2,
+        "goal_started + registration only — no extra event for an already-registered id"
+    );
+}
+
+// ── Binary: fail-fast before any gRPC connection ──────────────────────────
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_future-loop")
+}
+
+fn run(root: &str, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(args)
+        .output()
+        .expect("future-loop binary runs");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn cli_run_without_agent_id_errors_before_connecting() {
+    let root = tmp_root("cli");
+    let (_out, err, code) = run(
+        &root,
+        &[
+            "goal",
+            "init",
+            "--objective",
+            "gate",
+            "--goal-id",
+            "g1",
+            "--cwd",
+            "/tmp",
+        ],
+    );
+    assert_eq!(code, 0, "{err}");
+    let (out, err, code) = run(&root, &["run", "--goal", "g1", "--max-turns", "1"]);
+    assert_ne!(code, 0, "run without --agent-id must fail");
+    let all = format!("{out}\n{err}");
+    assert!(
+        all.contains("--agent-id"),
+        "error must demand --agent-id: {all}"
+    );
+    assert!(
+        all.contains("agent list"),
+        "error must point at `agent list`: {all}"
+    );
+}


### PR DESCRIPTION
## Summary
Parallel-safety hardening for `future loop run` + an agent-registry inspection command.

### Commit 1 — `agent list` (0ff24a86)
New `future loop agent list --goal G`: lists every registered agent with live
execution status — `running` (holds a live lease on a todo, with lease time
remaining) vs `idle` — plus declared capabilities and last activity. Pre-flight
check before registering/launching so parallel workers reuse existing ids
instead of re-registering the same one. 3 new contract tests.

### Commit 2 — enforce `--agent-id` on run (8bea289b)
- `run` now REQUIRES `--agent-id` and fails fast (before any gRPC/session work)
  with a hint pointing at `agent list`; `--anonymous` opts back into the legacy
  uncoordinated one-shot path with a warning.
- `ensure_run_identity()` auto-registers an unregistered id on first use
  (check-then-register, replay idempotent → no duplicate events); registered
  ids pass through untouched.
- `run` claims the task lease with `--lease-secs` (default 4h instead of the
  hardcoded 1h — long LLM/compute turns >1h could get the todo stolen
  mid-turn once the lease expired).
- `agent onboard` accepts both `--capability` and `--capabilities` (docs used
  the plural, code only parsed the singular).
- 5 new `run_identity_contract` tests (fail-closed hint, anonymous escape,
  auto-register once, existing-id passthrough, CLI fail-fast before connect).

### Also included
- `agent/src/llm/mod.rs`: LLM call timeout 600→1800s + `FUTURE_LLM_TIMEOUT_SECS`
  env override (long-turn support).
- Skill v1.0.3: parallel-safety sections (6.0/6.1), `agent list`, enforced
  `--agent-id`, 4h lease / `--lease-secs` docs.

## Validation
- 512 loop contract tests + full workspace suite (851) green
- clippy `--workspace --all-targets -D warnings` clean, fmt clean
- desktop `--lib` tests green (no desktop files changed; TS checks run in CI
  with deps installed — worktree has no node_modules)
