### PR TITLE
feat(loop): enforce todo blocks, mid-turn steering, turn budget, atomic claims

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -72,6 +72,12 @@ pub struct Loop {
     /// Cached model registry — avoids re-deserialising the 906-model catalog
     /// on auto-compaction checks and image-support queries inside the hot loop.
     pub model_registry: Option<Arc<parking_lot::RwLock<crate::models::Registry>>>,
+    /// Mid-turn steering notes: orchestrators/injected operator messages that
+    /// must reach a RUNNING turn. The run loop drains this cell at every step
+    /// and appends pending notes to the system prompt of the next LLM call.
+    /// Shared between the shared Loop and its `independent_copy` snapshot (like
+    /// the compaction cells) so notes written mid-run are seen by the snapshot.
+    pub steering_notes: Arc<Mutex<Vec<String>>>,
 }
 
 impl Loop {
@@ -97,6 +103,7 @@ impl Loop {
             compaction_occurred: Arc::new(AtomicBool::new(false)),
             stream_incomplete: Arc::new(AtomicBool::new(false)),
             model_registry: None,
+            steering_notes: Arc::new(Mutex::new(vec![])),
         }
     }
 
@@ -134,6 +141,9 @@ impl Loop {
         copy.verbose = self.verbose;
         copy.parallel_tools = self.parallel_tools;
         copy.model_registry = self.model_registry.clone();
+        // Share the steering cell with the snapshot so notes pushed while the
+        // snapshot runs are delivered at its next step boundary.
+        copy.steering_notes = self.steering_notes.clone();
         copy
     }
 

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -149,13 +149,18 @@ impl Loop {
             // time-to-first-byte takes effect immediately instead of blocking
             // on the request to return (especially noticeable on Windows where
             // flaky connections make this phase slow).
+            // Drain any mid-turn steering notes and fold them into this step's
+            // system prompt (the frozen snapshot semantics for model/tools/
+            // config are unchanged — steering is an additive operator channel).
+            let step_system_prompt =
+                fold_steering_into_prompt(&ctx.system_prompt, &mut self.steering_notes.lock());
             let stream_result = match self
                 .await_or_interrupt(
                     self.provider.stream_chat(
                         ctx.model.clone(),
                         llm_messages,
                         tool_defs.clone(),
-                        ctx.system_prompt.clone(),
+                        step_system_prompt,
                     ),
                     interrupt_rx.as_mut(),
                 )
@@ -973,9 +978,49 @@ fn is_retryable_size_error(err_msg: &str) -> bool {
     err_msg.starts_with("[CTX_LIMIT]")
 }
 
+/// Drain pending mid-turn steering notes and fold them into the system prompt
+/// for the next LLM call. Notes are consumed exactly once; an empty queue
+/// returns the base prompt unchanged.
+fn fold_steering_into_prompt(
+    base: &str,
+    notes: &mut parking_lot::MutexGuard<'_, Vec<String>>,
+) -> String {
+    if notes.is_empty() {
+        return base.to_string();
+    }
+    let drained = std::mem::take(&mut **notes);
+    format!(
+        "{}\n\n── steering update (injected mid-turn by the orchestrator) ──\n{}",
+        base,
+        drained.join("\n\n")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn steering_fold_returns_base_when_empty() {
+        let cell = std::sync::Arc::new(parking_lot::Mutex::new(vec![]));
+        let mut guard = cell.lock();
+        assert_eq!(
+            fold_steering_into_prompt("base prompt", &mut guard),
+            "base prompt"
+        );
+    }
+
+    #[test]
+    fn steering_fold_drains_once_and_appends() {
+        let cell = std::sync::Arc::new(parking_lot::Mutex::new(vec!["do X instead".to_string()]));
+        let mut guard = cell.lock();
+        let out = fold_steering_into_prompt("base", &mut guard);
+        assert!(out.contains("base"));
+        assert!(out.contains("do X instead"));
+        assert!(guard.is_empty(), "notes drained exactly once");
+        let out2 = fold_steering_into_prompt("base", &mut guard);
+        assert_eq!(out2, "base", "second call sees an empty queue");
+    }
 
     #[test]
     fn size_error_matches_context_limit_prefix() {

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -621,6 +621,10 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             session.write().append_system_prompt(&cmd.system_prompt);
             RpcResponse::ok(id, "append_system_prompt", serde_json::json!({}))
         }
+        "steer" => {
+            session.write().steer(&cmd.system_prompt);
+            RpcResponse::ok(id, "steer", serde_json::json!({}))
+        }
         "set_ephemeral" => {
             wlock!(session, id).set_ephemeral(cmd.ephemeral);
             RpcResponse::ok(

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -672,6 +672,16 @@ impl ServerSession {
         self.agent_loop.try_write().unwrap().system_prompt = new_prompt;
     }
 
+    /// Mid-turn steering: queue a note that the RUNNING turn drains at its
+    /// next step boundary (via the shared steering cell that links the shared
+    /// Loop and its run snapshot). Unlike `append_system_prompt` — which only
+    /// takes effect on the next run — this reaches the in-flight turn.
+    pub fn steer(&mut self, note: &str) {
+        if let Ok(loop_) = self.agent_loop.try_read() {
+            loop_.steering_notes.lock().push(note.to_string());
+        }
+    }
+
     pub fn set_ephemeral(&mut self, ephemeral: bool) {
         self.ephemeral = ephemeral;
     }

--- a/orchestration/loop/skill/future-loop/SKILL.md
+++ b/orchestration/loop/skill/future-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.3
+version: 2.0.0
 name: future-loop
 description: FutureOS loop control plane — manage long-running goals, todo lists, human gates, monitors, and validated completion via the loop control plane. Use when the user wants a long-lived/multi-step/cross-session task tracked as a goal, asks to "keep working on X", "track this issue", "run this overnight", needs progress/status of ongoing agent work, or starts a message with "/future-loop" (treat everything after the prefix as the goal).
 allowed-tools: Bash(future-loop:*)
@@ -29,29 +29,19 @@ For one-shot conversations, just answer normally — no goal needed.
 
 ## Prerequisites
 
-- The loop control plane runs through the unified CLI: **`future loop
-  <cmd>`**. Before anything else, look for an existing install on the
-  system (`command -v future`; also check common locations like
-  `~/.local/bin/future`, `~/bin/future`, Homebrew cask/brew links). If
-  `future loop` is NOT available, do NOT rebuild from source — point the
-  user to the official install instructions at
-  <https://github.com/futuregene/future-os> (README install section) and
-  wait for them to install. (This skill installs to
-  `~/.future/agent/skills/future-loop/`.) State lives in the PROJECT:
+- Everything runs through the unified CLI: **`future loop <cmd>`**. Look for an
+  existing install (`command -v future`; also `~/.local/bin/future`, `~/bin/future`,
+  Homebrew links). If missing, point the user to
+  <https://github.com/futuregene/future-os> (README install section) — do NOT
+  rebuild from source on the user's behalf. State lives in the PROJECT:
   `<cwd>/.future/loop/` (run from the project dir, or pass --cwd).
-- The agent must be running for `future loop run` — start it with
-  `future agent` (gRPC 127.0.0.1:50051). Probe it with `future models`
-  — a plain curl to the gRPC port reports nothing useful.
-- **Verify the CLI binary is not stale before relying on recent loop
-  features.** The installed `future` binary can be older than the loop
-  source (observed 2026-08: session auto-cleanup, `todo update --blocks`,
-  and gate enforcement silently absent from an out-of-date binary — the
-  commands still "work" but skip the new behavior with no warning). Quick
-  freshness probe: `strings $(command -v future) | grep -c "session cleanup failed"`
-  — `1` = fresh (session auto-clean present), `0` = stale → rebuild with
-  `cargo build -p future-cli` (or reinstall) before relying on loop features.
-  If you see `⚠ session cleanup failed` lines or stray per-run sessions in
-  `future session list`, treat it as the same stale-binary symptom.
+- `future loop run` needs the agent server: `future agent` (gRPC
+  127.0.0.1:50051). Probe with `future models`.
+- **Check binary freshness before relying on newer features** — an old binary
+  runs the commands but silently skips new behavior. Probe:
+  `strings $(command -v future) | grep -c "max-turn-secs"` — `≥1` = current
+  (blocks enforcement, mid-turn steering, turn budget, atomic claims,
+  `status --format json`); `0` = stale → rebuild with `cargo build -p future-cli`.
 
 ## State layout (project-local, all under `<cwd>`)
 
@@ -59,11 +49,11 @@ For one-shot conversations, just answer normally — no goal needed.
 <cwd>/.future/loop/registry.json                        — registry (source of truth)
 <cwd>/.future/loop/goals/<id>/events.jsonl              — per-goal event ledger
 <cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md      — reference-compatible projection
-<cwd>/.future/loop/runs/                                — run history
+<cwd>/.future/loop/runs/                                — run history + <run_id>.live.jsonl
 ```
 
 Runtime state is NEVER written outside the project. Add `.future/loop/` to the
-project `.gitignore` (runtime state, never commit).
+project `.gitignore`.
 
 ## Workflow
 
@@ -76,486 +66,296 @@ If the user's objective already exists, continue it — never silently create a 
 
 ### 2. Confirm the plan with the user BEFORE creating anything
 
-Before `goal init`, present a concrete plan and get the user's confirmation:
+Present a concrete plan and get confirmation:
 
-1. **Steps** — the todos you will execute, in order (e.g. collect data →
-   analyze → write report → copy deliverables). Keep it short and concrete.
+1. **Steps** — the todos you will execute, in order. Short and concrete.
 2. **Model + thinking level** — default to the CURRENT session's model and
-   thinking level (read them from your own environment: `Current model:` /
-   `Thinking level:`), and propose those as the default. Keep the user's
-   adjustment cost low:
-   - if the user wants a different model, run `future models` to list
-     alternatives (`--json` for machine-readable output); prefer a
-     model flagged `[recommended]`, else `[default]`;
-   - thinking level: `high` for reasoning/analysis-heavy goals, `off`/`low`
-     for mechanical or fast-turn work — `future models` shows each
-     model's suggested level;
-   - if the agent is not running, `future models` will fail — fall
-     back to the current session's model + `high` and tell the user the model
-     list was unavailable.
-3. Ask for confirmation, e.g.:
-   ```
-   Plan confirmation (goal: <objective text>)
-   Steps: 1) <...>  2) <...>  3) <...>
-   Model: <current session model, e.g. future/deepseek-v4-flash> (default = current session; can switch)
-   thinking: <current session thinking level, e.g. high> (default = current session; adjustable)
-   Confirm start? (model/thinking or steps adjustable)
-   ```
+   thinking level (read your own environment). If the user wants a different
+   model, `future models [--json]` lists options (prefer `[recommended]` /
+   `[default]`); `high` thinking for reasoning-heavy goals, `off`/`low` for
+   mechanical work. If the agent server is down and `future models` fails, fall
+   back to the current session's model + `high` and say so.
+3. Ask: `Plan confirmation (goal: …) Steps: 1)… 2)… 3)… Model: … Thinking: … Confirm?`
 
-Do NOT create the goal or todos until the user confirms (or adjusts).
+Skip this confirmation only when the user's opening message already contains the
+full objective AND explicit operating constraints (model, concurrency, deadline) —
+that mandate IS the confirmation; start immediately.
 
 ### 3. Create a goal (or reuse)
 
 ```bash
 future loop goal init --objective "..." --cwd <project-dir> [--goal-id <id>]
 ```
-When the user names a directory (e.g. "in /tmp/foo"), pass it as `--cwd`;
-when they name a repo, use its root. If the directory does not exist,
-create it first (`mkdir -p`).
+Use the user-named directory/repo root as `--cwd`; `mkdir -p` it if missing.
+`goal init` auto-creates an onboarding todo — complete it with `--no-follow-up`
+during setup; it is not real work.
 
-### 4. Break the work into todos (optional but recommended)
+### 4. Break the work into todos
 
 ```bash
 future loop todo add --goal <goal-id> --text "..." --priority P0
 ```
 
-**Dependency chains.** When a todo logically depends on the output of another
-todo, encode that with `--blocks`. Without `--blocks`, the run loop sees all
-open todos as independently runnable and may reorder or skip them. Example:
+**Dependency chains.** When "X must finish before Y can start", add `--blocks X`
+to Y. A blocked todo stays out of the runnable frontier until every predecessor
+reaches Done or Superseded (an unknown predecessor id does not wedge the
+frontier; `task-graph` flags it as an error instead). Without `--blocks`, open
+todos are independently runnable in priority order.
 
 ```bash
-# Report generation depends on first fetching data:
-future loop todo add --goal <goal-id> --text "Generate the change-analysis summary report" --priority P0 \
-  --blocks <data-todo-id-1>,<data-todo-id-2>
-# Copy-to-CWD must happen after the report exists:
-future loop todo add --goal <goal-id> --text "Copy the final deliverables to the project root (cwd)" --priority P0 \
-  --blocks <report-todo-id>
+future loop todo add --goal G --text "Generate the report" --priority P0 --blocks <data-todo-1>,<data-todo-2>
+future loop todo add --goal G --text "Copy deliverables to project root" --priority P0 --blocks <report-todo>
 ```
 
-Rule of thumb: if "X must finish before Y can start", add `--blocks X` to Y.
+**Todo-creation pitfalls.**
 
-**Todo-creation pitfalls (field-tested 2026-08, cli-rust-port + tui-rust-port goals).**
+1. **Capture todo ids from the `todo add` output** (`todo todo_xxx added ✔`) —
+   the only reliable source. There is no `todo list`; look ids up via
+   `future loop status --goal G [--format json]` or the event ledger
+   (`kind:"todo_added"` events carry the full todo). Field-name gotcha: in the
+   ledger the dependency field is `blocked_by_gate` (NOT `blocks`) and the
+   validator is `validator` (NOT `verify`).
+2. **Verify the wiring after creation** — `future loop status --goal G`; repair
+   with `todo update --blocks a,b` (replaces; `--blocks ""` clears; absent leaves
+   untouched).
+3. **Chain the FINAL validation todo too** — priority alone does not order
+   execution; the acceptance todo MUST `--blocks` all implementation todos or it
+   can run while they are still stubs.
+4. **`goal delete` requires `--force` and is irreversible** — recreate via
+   `goal init` afterwards.
+5. **Keep cleanup/deletion words out of test-goal objectives** — the run agent
+   may execute `goal delete --force` itself if the objective mentions them.
+   Delete test goals yourself.
+6. **CLI strictness**: unknown flags and unknown todo-ids are rejected; most
+   subcommands ignore `--help` (`todo update --help` prints usage). Exact flags:
+   `orchestration/loop/src/console.rs` `parse_pairs` call sites.
 
-1. **Capture todo ids from the `todo add` output itself.** The command prints
-   the new id (`todo todo_xxx added ✔`) — that is the only reliable source.
-   There is NO `future loop todo list` subcommand, and `future loop status`
-   has NO `--format json` flag (only `future models` does) — piping
-   `--blocks $(future loop status --format json …)` fails SILENTLY (the
-   substitution yields an empty string, `--blocks` is accepted with no value,
-   and the dependency is quietly dropped). To look ids up afterwards, parse
-   `future loop status --goal G` (`todos:` line lists `id=status`), or read
-   the event ledger `<cwd>/.future/loop/goals/<id>/events.jsonl`
-   (`kind: "todo_added"` events carry the full `todo` object). **Field-name
-   gotcha:** in the ledger the dependency is `blocked_by_gate` (NOT `blocks`)
-   and the validator is `validator` (NOT `verify`) — inspecting a todo with
-   guessed field names will falsely report flags as dropped; print the whole
-   object (or the goal's `schema.json`) before concluding.
-2. **Verify the wiring after creation.** Run `future loop status --goal G` and
-   confirm each dependent todo's `blocks` is set. An empty `--blocks` never
-   errors — only a status check catches it. **Repair in place with
-   `todo update --blocks`** (supported since the 2026-08 loop update):
-   `future loop todo update --goal G --todo-id T --blocks a,b` REPLACES the
-   blocking set, and `--blocks ""` clears it; an update without `--blocks`
-   leaves the set untouched. Older loop builds silently ignored `--blocks`
-   — for those, the only repair was to
-   recreate the goal: `future loop goal delete --goal G --force` (delete is
-   IRREVERSIBLE and refuses without `--force`) → `goal init` → re-add all
-   todos in dependency order, capturing each id from the add output.
-3. **Chain the FINAL validation todo too.** The run loop schedules any open,
-   unblocked todo — priority alone does NOT order execution. The last
-   acceptance/validation todo MUST `--blocks` all implementation todos;
-   otherwise it can be picked while they are still stubs (observed: the
-   differential-test todo ran mid-port and had to be re-planned via
-   `complete --successor` back to the implementation todos).
-4. **`goal init` auto-creates an onboarding todo.** A fresh goal starts with
-   one extra open todo ("Run `future loop status` … record the goal count as
-   evidence"). Complete it with `--no-follow-up` during setup (or at the end,
-   with the goal count as `--evidence`); don't mistake it for a real work
-   item — it does not block the chain but stays open until completed.
-5. **`goal delete` requires `--force` and is irreversible.** A mis-created
-   goal cannot be repaired in place — `future loop goal delete --goal G`
-   refuses with "irreversible — pass --force". Passing `--force` removes the
-   registry entry + state, so recreate via `goal init` afterwards.
-6. **`registry.json` holds only goal summaries** (objective/cwd/status); todo
-   ids and their `blocks`/priority live in the event ledger
-   `<cwd>/.future/loop/goals/<id>/events.jsonl` — the reliable place to
-   re-derive ids after a botched creation.
-7. **Subcommand `--help` is NOT supported.** `future loop todo update --help`
-   silently ignores the flag (and "updates" even a nonexistent `--todo-id`).
-   Check the exact flags in `orchestration/loop/src/main.rs`
-   (`todo_add`/`todo_update` `parse_pairs`) or in this skill instead.
-8. **The agent treats the objective as an instruction list — keep
-   cleanup/deletion words OUT of test goals.** The run-loop agent may execute
-   `future loop goal delete --force` itself if the objective mentions
-   "cleanup/delete" (observed 2026-08: a smoke-test goal whose objective ended
-   with "清理" got self-deleted by the agent mid-run). Since 2026-08 the loop
-   no longer panics on this (`goal X not found (deleted while running?)` is a
-   clean error), but the goal state is gone either way — delete test goals
-   yourself, don't ask the agent to.
+**User gates.** When the user asks for approval before a specific action, create
+a real gate — describing it in the objective is NOT enough:
 
-If the user asks for approval before a specific action, create a real gate:
 ```bash
-future loop todo add --goal <goal-id> --role user --class user_gate \
-  --gate-question "<the exact question>" --text "<the exact question>" \
-  --blocks <todo-id-of-the-action>
+future loop todo add --goal G --role user --class user_gate \
+  --gate-question "<exact question>" --text "<exact question>" --blocks <action-todo>
 ```
-Describing approval in the objective text is NOT enough — a gate todo is
-what actually blocks the action. Semantics (verified): the `--blocks` value
-is a declarative link; what actually freezes work is the gate being OPEN —
-the run loop returns `AskUser` for the whole goal until the gate is resolved
-(any open gate freezes everything, not just the linked todo), and since the
-2026-08 hardening pass `todo complete` also rejects completing non-gate
-todos while a gate is pending.
+Any OPEN gate freezes all work: `run` returns `AskUser`, and `todo complete`
+rejects non-gate completions until it is resolved. Gates are completed via
+`gate resolve`, never `todo complete`.
 
-**Conditional iteration (validate until it passes).** When a todo must
-iterate until a condition is met (e.g. optimize until tests pass), attach an
-independent validator — the kernel runs it in the goal's cwd after each turn
-and only completes the todo when it exits 0:
+**Conditional iteration.** Attach an independent validator; the kernel runs it in
+the goal cwd after each turn and only completes the todo on exit 0:
 
 ```bash
-future loop todo add --goal <goal-id> --text "Optimize until tests pass" --priority P0 \
+future loop todo add --goal G --text "Optimize until tests pass" --priority P0 \
   --verify "cargo test" --max-validation-attempts 5
 ```
+Non-zero → repair retry up to the attempts budget, then a replan gate. The agent
+can still force-complete via `todo complete --no-follow-up` (agent autonomy).
 
-- `--verify "<command>"`: exit 0 → todo completes (validated); non-zero →
-  todo stays open and the loop iterates (repair), bounded by
-  `--max-validation-attempts` (default 3);
-- after the budget is exhausted the kernel replans and surfaces to the user
-  (final judgment stays human);
-- a todo without `--verify` keeps the old behavior (agent self-judged).
+### 5. End with a deliverable-copy todo
 
-### 5. Add a deliverable-copy todo as the final step
-
-Every goal that produces files (reports, CSVs, docs, etc.) MUST end with
-a final P0 todo that copies the deliverables from the loop state directory
-to the CWD:
+Every goal that produces files MUST end with a final P0 todo that copies
+deliverables from the loop state directory to the project root (`cp`, not `mv`),
+blocked behind the producing todos:
 
 ```bash
-future loop todo add --goal <goal-id> --text "Copy the final deliverables to the project root (cwd)" --priority P0
+future loop todo add --goal G --text "Copy the final deliverables to the project root (cwd)" --priority P0 --blocks <producer-todos>
 ```
 
-This todo should be the last in the chain — add it as the successor of the
-report-generation todo. When executing it, copy files with `cp` (not mv)
-from `<cwd>/.future/loop/goals/<id>/` to `<cwd>/`, so the user can find
-results directly in the project root without digging into `.future/loop/`.
+### 6.0 Agent identity — `--agent-id` MANDATORY on every run
 
-### 6.0 Agent identity & parallel safety — `--agent-id` MANDATORY (enforced)
+`run` without `--agent-id` fails fast; `--anonymous` is the legacy
+uncoordinated one-shot. The agent-id is the ONLY mutual-exclusion mechanism:
 
-Every `future loop run` MUST carry an `--agent-id` — **enforced by the CLI**
-(2026-08): `run` without it fails fast with a hint pointing at `agent list`;
-pass `--anonymous` only for a legacy uncoordinated one-shot run (prints a
-warning). This is the control plane's ONLY automatic mutual-exclusion
-mechanism:
+- `run --agent-id <name>` auto-registers on first use; `agent onboard` declares
+  capabilities; `agent list` shows who is registered/running.
+- **Unique name per parallel worker** (e.g. `<host>-<task>`). A run sees its OWN
+  leased todos as runnable, so two runs sharing one id double-execute.
+- With `--agent-id`, `run` claims a lease (default 4h; `--lease-secs N`) BEFORE
+  executing and hides other agents' leased todos (`claimed_by_other`) — parallel
+  runs grab DIFFERENT todos. Claims are atomic (check+append under one lock; a
+  lost race re-decides and takes the next runnable todo).
+- Conflict-avoidance checklist before launching: `agent list` → `ps aux | grep
+  "future loop run"` → `status --goal G` → `quota should-run --goal G --agent-id
+  <me>` → `lease status --goal G --todo-id T --agent-id <me>`.
 
-- **No separate registration step needed — `run` auto-registers on first
-  use:** the first `run --agent-id <name>` appends `AgentRegistered`
-  automatically (replay is idempotent).
-  `future loop agent onboard --goal <goal-id> --agent-id <name>
-  [--capabilities c1,c2]` is still available to declare capabilities;
-  `agent register` remains for plain registration.
-- **Use a unique name per parallel worker** (e.g. `<host>-<task>` /
-  `<user>-<workerN>`); never reuse one id for two concurrent runs — a run
-  sees its OWN leased todos as runnable, so two runs sharing one id both
-  pick the same todo and double-execute.
-- **Run with the id:**
-  ```bash
-  future loop run --goal <goal-id> --agent-id <unique-name> \
-    --model <confirmed-model> --thinking-level <confirmed-thinking> --max-turns 1
-  ```
-- **Why it matters (verified in code, 2026-08):** a run WITH `--agent-id`
-  claims a lease on the selected todo BEFORE executing
-  (`Event::TodoClaimed`; default 4h — `--lease-secs N` to override), and the
-  frontier filter hides todos leased by other agents (`claimed_by_other`) —
-  so parallel runs grab DIFFERENT todos and never double-execute. An
-  `--anonymous` run claims nothing and hides nothing — two agentless runs
-  deterministically pick the SAME next todo and race.
-- **Conflict-avoidance checklist before launching any run:**
-  1. `future loop agent list --goal <goal-id>` — who is registered and
-     currently running (reuse existing ids; don't re-register).
-  2. `ps aux | grep "future loop run"` — confirm no other run is active, or
-     that you WANT parallel workers (each with a distinct id).
-  3. `future loop status --goal <goal-id>` — confirm the expected next todo.
-  4. `future loop quota should-run --goal <goal-id> --agent-id <me>` —
-     preview which todo this agent would get.
-  5. `future loop lease status --goal <goal-id> --todo-id <T> --agent-id <me>`
-     — inspect a lease before claiming/repairing.
-- `lease claim` and `quota should-run --agent-id` REQUIRE the agent to be
-  registered first (error: `agent \`X\` is not registered for goal …`);
-  `run --agent-id` auto-registers instead of failing.
-- NOTE: `run`'s help text DOES list `--agent-id` — the flag is enforced,
-  not optional.
+### 6.1 Multi-agent parallel runs
 
-### 6.1 Multi-agent parallel runs (scale-out on one goal)
-
-The loop supports N concurrent runs on the SAME goal — each `run --agent-id`
-is an independent process sharing the goal ledger (event appends are
-advisory-file-locked, so interleaving is safe). To avoid the decide→claim
-TOCTOU race (two fresh runs can both pick the same FREE todo in the same
-second; last claim wins in the ledger), ASSIGN todos deterministically
+N concurrent runs on the SAME goal share the ledger safely. On current binaries
+the claim race is closed; for extra determinism (or old binaries), assign todos
 BEFORE launching:
 
-1. **Register one agent per worker:**
-   ```bash
-   future loop agent register --goal <goal-id> --agent-id worker-1
-   # … worker-2, worker-3, …
-   ```
-2. **Pre-claim one open todo per agent (deterministic assignment):**
-   ```bash
-   future loop todo claim --goal <goal-id> --todo-id <T1> --agent-id worker-1 --lease-secs 14400
-   future loop todo claim --goal <goal-id> --todo-id <T2> --agent-id worker-2 --lease-secs 14400
-   ```
-   A worker still sees its OWN leased todo as runnable (`claimed_by_other`
-   excludes only OTHER agents) → each run picks exactly its assigned todo.
-3. **Launch one run per worker (background, distinct ids):**
-   ```bash
-   nohup future loop run --goal <goal-id> --agent-id worker-1 \
-     --model <M> --thinking-level <L> --max-turns 1 > logs/worker-1.log 2>&1 &
-   nohup future loop run --goal <goal-id> --agent-id worker-2 … &
-   ```
-4. **Verify no double-execution:** `future loop lease status --goal G --todo-id <T1> --agent-id worker-1`.
+```bash
+future loop agent register --goal G --agent-id worker-1     # … worker-2, worker-3
+future loop todo claim --goal G --todo-id <T1> --agent-id worker-1 --lease-secs 14400
+nohup future loop run --goal G --agent-id worker-1 --model <M> --thinking-level <L> \
+  --max-turns 1 > logs/worker-1.log 2>&1 &
+```
 
-- **Lease duration:** `todo claim` / `lease claim` default 3600s; `run`
-  defaults to 4h (14400s) and accepts `--lease-secs N`. An expired lease frees
-  the todo for other workers but does NOT abort a running turn.
-- **Keep working after a turn:** each run process executes `--max-turns 1`;
-  re-launch the same command (same agent-id) to continue — the worker keeps
-  its claim on its assigned todo and resumes.
-- **Resource rule:** worker count must fit the machine (heavy compute tasks
-  contend); agree the count with the user BEFORE launching (default 3).
-- **Priority caveat:** pre-claim overrides pure-priority ordering — assign
-  the highest-value open todos to workers first (e.g. P0/P1 before P2).
+- Lease expiry frees the todo for others but does NOT abort a running turn.
+  Release a parked claim with `future loop lease release` so the queue's most
+  valuable todo is never walled off by a stale lease.
+- Relaunch the same command (same agent-id) to continue after each turn — the
+  worker keeps its claim and resumes.
+- Worker count must fit the machine; agree it with the user (default 3).
+- Pre-claim overrides pure-priority ordering: assign highest-value todos first.
+
+### 6.2 Orchestration patterns for parallel workers
+
+1. **Orchestrator-only dangerous actions.** Anything consuming a LIMITED
+   external resource (submission quotas, paid calls, irrecoverable deletes)
+   must not be callable by workers — a worker's *failed* attempt may still
+   consume the resource. Convention: workers finalize artifacts and write a
+   signal file (e.g. `logs/NEEDS_ACTION` with the payload); only the
+   orchestrator executes the capped action. State it explicitly in todo text.
+2. **Shared project memory as broadcast channel.** Instruct workers (in todo
+   text) to re-read the project memory file at turn start; use it for
+   cross-worker discoveries and infra locations. The turn envelope carries only
+   todo text + last evidence.
+3. **Steer by updating todo text, anytime.** `todo update --text` on a running
+   todo is delivered mid-turn (see §6 mechanics).
+4. **Watch artifacts, not just loop status.** Long compute runs via nohup +
+   checkpoint files; the orchestrator tracks output mtimes. Killing a worker's
+   run process and relaunching with the same `--agent-id` is always safe —
+   context replays from the ledger.
+5. **Wrap-up belongs to the orchestrator.** A final/validation todo left
+   unchained can be picked early and close the goal prematurely — `--blocks` it
+   behind everything, or do the wrap-up outside the loop.
 
 ### 6. Run the agent — one turn at a time
 
-Use the confirmed model and thinking level from step 2. **Always use
-`--max-turns 1`** and loop manually — running all turns in one shot makes the
-user wait with no visibility; a turn-by-turn loop lets them see each step's
-progress, cost, and any issues as they happen:
+**Always `--max-turns 1`** and loop manually for visibility:
 
 ```bash
-future loop run --goal <goal-id> --agent-id <unique-name> \
-  --model <confirmed-model> --thinking-level <confirmed-thinking> --max-turns 1
+future loop run --goal G --agent-id <unique-name> --model <M> --thinking-level <L> --max-turns 1
 ```
 
-> **Session lifecycle (no manual cleanup needed):** each `run` creates a
-> fresh scratch agent session, executes the bounded turn loop, then **deletes
-> the session automatically on every exit path** (terminal, gate, monitor
-> wait, max-turns, or error) — context is replayed into each run via the
-> turn envelope from the goal events.jsonl, so nothing durable lives in the
-> agent session. `~/.future/agent/sessions/` should therefore NOT accumulate
-> per-run files. If you ever see a stray `⚠ session cleanup failed` line, or
-> want to tidy leftover sessions from other tools, clean them manually with
-> the top-level CLI: `future session list` to find ids, then
-> `future session delete <id>` (same agent `delete_session` RPC the loop
-> uses).
+Run mechanics:
+- **`--max-turn-secs N`** — per-turn wall-clock budget; timeout stops the run
+  gracefully (session cleaned up, context replays on relaunch).
+- **Mid-turn steering** — `todo update --text` on the todo a worker is executing
+  is injected into the running session (~10s poll; delivered at the agent's next
+  step boundary).
+- **Session id in the envelope** — the turn message starts with `session: <id>`
+  so in-turn tooling can find the real session file deterministically.
+- **Live run logs** — streamed events tee to `.future/loop/runs/<run_id>.live.jsonl`.
+- **`status --format json`** — machine-readable goal + todos projection.
 
-> **Long turns vs. shell timeouts**: a single `run --max-turns 1` turn often
-> takes several minutes — the ~120s default timeout of typical shell tools is
-> usually NOT enough. Run **blocking** with an explicit longer timeout on the
-> shell call (e.g. `timeout: 1800`), and poll `future loop status` between
-> turns. Avoid backgrounding the run (nohup/&): it hides progress, risks
-> overlapping turns, and the kernel expects one run at a time (parallel runs
-> are supported ONLY with distinct `--agent-id`, §6.0). If a blocking
-> run is interrupted, check `status` before re-running to see what completed.
+**Launch pattern — nohup + poll (foreground blocking dies with shell timeouts):**
 
-After each `run`, before starting the next step:
-1. Report what was done (which todo, cost, new status).
-2. **Reflect & improve — run a deliberate reflection pass (not just a status
-   check)**: before deciding what's next, step back and ask:
-   - **What did this turn reveal?** New facts, surprises, or assumptions that
-     turned out wrong (write them down — they are plan inputs, not noise).
-   - **Is the objective still right?** Does the goal text match what the work
-     has shown? Are the acceptance criteria still valid and testable?
-   - **Is the todo decomposition still optimal?** Too coarse → split into
-     smaller todos; too fine → merge; wrong order → reorder with `--blocks`;
-     missing a step → `todo add`; obsolete step → `todo supersede --reason`.
-   - **Is there a better path?** Would a different approach, tool, or
-     ordering reach the objective faster or with higher quality? Don't keep
-     a plan just because it was approved — the plan serves the objective.
-   - **New risks / dependencies?** Anything that now needs a human gate
-     (`--role user --class user_gate`), a monitor (`--class monitor`), or a
-     validation hook (`--verify`) to keep the goal on track?
-   - **Periodic deep re-plan** (every ~3–5 turns or at milestones): re-read
-     the objective and the full todo list, and rewrite the remaining plan as
-     if you were planning it fresh with everything you now know.
-   Apply the answers via the CLI immediately — you are allowed to adjust the
-   plan yourself, no user confirmation for routine replans:
-   - `todo add` — new steps discovered by the completed step;
-   - `todo supersede --reason "..."` — steps that are now obsolete;
-   - `todo update` — fix a step's text/priority/blocks (`--blocks a,b` replaces
-  the blocking set, `--blocks ""` clears it);
-   - `todo archive` — tidy completed work.
-3. **Check whether the plan still holds** — `future loop status --goal <goal-id>`:
-   does the remaining todo list still make sense given what this step revealed?
-4. Stop and ask the user ONLY when absolutely necessary (see step 7):
-   risky/irreversible changes, decisions only the user can make, or you
-   cannot determine the right adjustment.
-5. If the exit code is non-zero, it means `--max-turns 1` was hit — check
-   `future loop status --goal <goal-id>` and run again ONLY if open todos
-   remain.
-6. If validated closure is reached (terminal), stop.
+```bash
+nohup future loop run --goal G --agent-id <me> --max-turns 1 > logs/worker-<me>.log 2>&1 &
+tail -f .future/loop/runs/<run_id>.live.jsonl
+```
 
-`run` stops when: validated closure (terminal), a human gate needs the user,
-a blocker waits (unresolved `--blocks`), or max-turns is reached.
+**Session lifecycle:** each `run` creates a fresh scratch session and deletes it
+on every exit path — nothing durable lives in `~/.future/agent/sessions/`. A
+stray `⚠ session cleanup failed` line or accumulated sessions = stale binary
+(see Prerequisites) or leftover from other tools; clean with `future session
+list` / `future session delete <id>`.
 
-### 7. Handle replan gates — resolve them yourself; escalate only when necessary
+`run` stops when: validated closure (terminal), a human gate opens, a blocker
+waits (unresolved `--blocks`), or max-turns/max-turn-secs is reached.
 
-**Replan gates (plan needs adjustment).** When the kernel decides the plan
-cannot continue as-is (validation/repair budget exhausted, outcome floor,
-acceptance gaps, succession obligation), it injects a `PLAN_REVIEW` user gate.
-**Handle it yourself first** — the agent owns routine replans:
+**After each turn:**
+1. Report what was done (todo, cost, new status).
+2. **Reflect & improve** — what did the turn reveal? Is the objective still
+   right? Is the decomposition still optimal (split/merge/reorder)? New risks
+   needing a gate/monitor/`--verify`? Every ~3–5 turns, deep-replan the
+   remainder as if planning fresh. Apply routine adjustments yourself:
+   `todo add` / `todo supersede --reason` / `todo update` / `todo archive`.
+3. Check the plan still holds: `future loop status --goal G`.
+4. Stop and ask the user ONLY when absolutely necessary (risky/irreversible
+   changes, user-only decisions, or you cannot determine the adjustment).
+5. Non-zero exit = max-turns hit; rerun only if open todos remain.
 
-1. review the plan: `future loop status --goal G` (and `future loop diagnose --goal G`);
-2. adjust the todo list with the CLI: `todo add` / `todo update` /
-   `todo supersede --reason "..."` / `todo archive`;
-3. resolve the gate and re-run:
-   ```bash
-   future loop gate resolve --goal G --todo-id <gate> --decision "agent replan: <summary>" --note "..."
-   future loop run --goal G --agent-id <unique-name> ...   # ALWAYS --agent-id (§6.0)
-   ```
+### 7. Handle replan gates — resolve routine ones yourself
 
-**Escalate to the user ONLY when absolutely necessary** — never guess a
-human decision:
-- the adjustment is risky or hard to reverse (deleting real work, changing
-  the goal/acceptance, production actions, approvals);
-- a decision is required that only the user can make;
-- you tried but cannot determine the right adjustment.
+**PLAN_REVIEW gates** (kernel-injected when validation budget is exhausted,
+outcome floor hit, or acceptance gaps remain) are the agent's to resolve:
+review (`status` / `diagnose --goal G`) → adjust todos via CLI → resolve and
+resume:
 
-Then stop and report the gate IN THIS CONVERSATION, quoting the exact
-question and the gate todo id, and wait — do not resolve it yourself. After
-the user decides, resolve with their decision and resume `future loop run`.
+```bash
+future loop gate resolve --goal G --todo-id <gate> --decision "agent replan: <summary>" --note "..."
+future loop run --goal G --agent-id <unique-name> ...
+```
 
-After each `run`, if the output contains `USER GATE` / `ask_user`:
-1. if it is a `PLAN_REVIEW` gate and the adjustment is routine → self-resolve
-   (steps 1–3 above);
-2. otherwise (a genuine user decision) → stop, report the exact question and
-   gate id to the user IN THIS CONVERSATION, and wait;
-3. after the user decides:
-   ```bash
-   future loop gate resolve --goal <goal-id> --todo-id <gate-id> --decision "<user's decision>" --note "..."
-   ```
-4. resume with `future loop run` again.
+**Genuine user gates** (approvals, scope changes, risky/irreversible actions):
+STOP, quote the exact question and gate id IN THIS CONVERSATION, and wait.
+Never guess. After the user decides, `gate resolve` with their decision and
+resume.
 
 ### 8. Report progress
 
-After each turn, always run status and report the result to the user:
+After each turn: `future loop status --goal G` (+ `quota should-run`). Report
+todo state, next action, gates, cost. Close stale open todos the agent did
+inline:
 
 ```bash
-future loop status --goal <goal-id>
-future loop quota should-run --goal <goal-id> [--agent-id <id>]
-```
-Report: current todo state, next action, any gates, cost if available.
-
-Also check for stale open todos — if the agent did the work inline (e.g.
-fetched issues data while generating the report without marking the issues
-todo done), close them manually:
-
-```bash
-future loop todo complete --goal <goal-id> --todo-id <stale-id> --no-follow-up \
-  --evidence "data already collected and included in report"
+future loop todo complete --goal G --todo-id <stale-id> --no-follow-up --evidence "..."
 ```
 
 ## Key semantics (do not misuse)
 
-- **Terminal ≠ all todos checked.** Completion is validated closure
-  (todos done + closure intent + no acceptance gaps). Check `closure_proof`.
+- **Terminal ≠ all todos checked.** Completion is validated closure (todos done
+  + closure intent + no acceptance gaps). Check `closure_proof`.
 - **Never silently complete agent work**: `todo complete` requires
-  `--no-follow-up` or `--successor`; the CLI rejects silent completion.
-- **Gates freeze ALL work until resolved — enforced at the CLI too.**
-  The run loop returns `AskUser` while any user gate is open (it does NOT
-  gate by reverse `--blocks` wiring — any open gate freezes everything), and
-  `todo complete` now rejects completing a non-gate todo while a gate is
-  pending. To complete gated work: `gate resolve` the gate first, then
-  complete the todo. Gates themselves are completed via `gate resolve`, never
-  `todo complete`.
-- **Never guess a gate decision — but not every gate is the user's.**
-  Gates created by the kernel as `PLAN_REVIEW` replan checkpoints are the
-  agent's to resolve (review plan → adjust todos via CLI → resolve gate).
-  Gates that pose a genuine human decision (approvals, scope/goal changes,
-  risky/irreversible actions) MUST be surfaced to the user IN the
-  conversation — stop and wait, never guess.
-- **Monitors**: not-due monitors must NOT be polled; `run` handles cadence
-  (a run with only not-due monitors returns `wait / wait_monitor`). A
-  monitor's due time is driven by its cadence (`--cadence 15m|1h|2d` or a
-  class) or `--defer-secs N`; numeric `todo update --resume-when N` also
-  defers N seconds from now (real deadline), while a non-numeric value is a
-  text-only hint with NO deadline (the todo stays deferred forever — don't
-  use text hints when you need the todo to become due again).
-- **`--verify` semantics**: exit 0 → todo completes validated; exit non-zero
-  → validation fails, the kernel marks repair-required and retries up to
-  `--max-validation-attempts` (default 3), then replans. NOTE: the agent
-  itself can still `todo complete --no-follow-up` a failing validator via the
-  CLI (agent autonomy) — the validator only gates the kernel's automatic
-  completion path.
-- **Evidence honesty**: report real outputs (paths, test results); the
-  control plane readbacks key results itself.
-- **Deliverables to CWD**: agent turns write artifacts into the loop state
-  directory. The final todo in every goal MUST copy user-facing deliverables
-  to the CWD so the user finds them immediately at the project root.
+  `--no-follow-up` or `--successor`.
+- **Gates freeze ALL work** while any user gate is open (not just linked todos);
+  gates complete via `gate resolve`, never `todo complete`.
+- **Not every gate is the user's**: `PLAN_REVIEW` checkpoints are agent-resolved;
+  genuine human decisions are surfaced and awaited.
+- **Monitors**: not-due monitors must NOT be polled (run returns `wait`). Due
+  time comes from `--cadence`/`--defer-secs N`; `todo update --resume-when N`
+  (numeric) defers N seconds for real, a text value is only a hint with NO
+  deadline.
+- **Evidence honesty**: report real outputs (paths, test results) — the control
+  plane readbacks key results.
+- **Deliverables to CWD**: the final todo copies user-facing artifacts to the
+  project root.
 
 ## Command reference
 
-All commands below use the unified `future loop` form.
-
 ```bash
-future loop status [--goal G]
+future loop status [--goal G] [--format json]
 future loop goal init --objective "..." --cwd DIR [--goal-id G] [--goal-doc "..."]
-future loop todo add --goal G --text "..." [--priority P0|P1|P2] [--role user --class user_gate --gate-question "..." --blocks T]
-future loop todo update --goal G --todo-id T [--text "..."] [--priority ...] [--blocks T]   # fix wiring after add
+future loop todo add --goal G --text "..." [--priority P0|P1|P2] [--blocks T] [--verify "cmd"] [--role user --class user_gate --gate-question "..."]
+future loop todo update --goal G --todo-id T [--text "..."] [--priority ...] [--blocks T]
 future loop todo claim --goal G --todo-id T --agent-id A [--lease-secs N]
 future loop todo complete --goal G --todo-id T [--no-follow-up | --successor T2] [--evidence "..."]
 future loop todo supersede --goal G --todo-id T --reason "..."
 future loop gate resolve --goal G --todo-id T --decision "..." [--note "..."]
 future loop quota should-run --goal G [--agent-id A]
-future loop heartbeat-prompt --goal G          # re-entry packet for the next turn
-future loop agent register --goal G --agent-id A    # optional — run auto-registers; onboard declares capabilities
-future loop agent list --goal G      # registered agents + live execution status (check before registering)
-future loop run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N]   # --agent-id MANDATORY (enforced §6.0); --anonymous = legacy uncoordinated
+future loop agent register --goal G --agent-id A        # run auto-registers; onboard declares capabilities
+future loop agent list --goal G
+future loop lease claim|renew|release|expire|status
+future loop run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-turn-secs N] [--lease-secs N]
 future loop backup --goal G [--list | --restore DIR]
-future loop serve-status [--port 8791]         # browser dashboard
+future loop serve-status [--port 8791]                  # browser dashboard
+future loop models                                      # same catalog as `future models`
+```
 
-> Model listing is available BOTH on the top-level CLI (`future models
-> [--json]`) AND as `future loop models` (same catalog). Session cleanup is
-> automatic per `run`; for manual cleanup of leftover sessions use the
-> top-level `future session list` / `future session delete <id>`.
+### Full command surface (`future loop registry`)
 
-### Full command surface (53 commands, 12 groups — `future loop registry`)
+Notable extras beyond the workflow commands:
 
-Beyond the workflow commands above, the control plane ships a wider surface
-(verified 2026-08, v0.0.1574). Use `future loop --help` / `future loop
-registry` for the authoritative list; the notable extras:
-
-- **todo graph**: `todo update` (text/priority/blocks/evidence/note —
-  `--blocks a,b` replaces, `--blocks ""` clears, absent leaves untouched);
-  `task-graph` (dependency DAG — **fails closed** on unknown block refs);
-  `lease claim|renew|release|expire|status` (task leases — claim requires the
-  agent to be `agent register`ed for the goal).
-- **gates & replan**: `gate resolve`; `replan ack` / `replan obligations`
-  (kernel-injected plan-review checkpoints).
-- **agents**: `agent list` (registered agents + live execution status —
-  check this BEFORE registering so parallel workers reuse existing ids);
-  `agent register` (auto-registered by `run --agent-id` on first use; still a
-  prerequisite for `lease claim` / `quota should-run --agent-id`),
-  `agent onboard` (declares capabilities); `scope` (identity-scoped
-  frontier); `lane` (lane recommendation);
-  `supervisor propose|receipt|events`.
-- **quota/scheduler**: `quota should-run|usage|spend`;
-  `scheduler tick|show|record-host-failure`.
-- **ops**: `diagnose` (per-goal decision surface, supports `--format json`);
-  `doctor` (ledger integrity + canary self-check); `runs
-  history|compact|retention|stale`; `backup --list|--restore`;
-  `evidence-log`; `todo-event`; `turn` (per-todo turn envelope);
-  `privacy` (privacy-graded projection); `store verify|migrate|bridge`;
-  `authority`; `profile`; `version`.
-- **work-items & handoff**: `attention` (attention queue); `inbox` (operator
-  inbox urgency); `handoff --write` (handoff doc + delivery contract).
+- **todo graph**: `task-graph` (dependency DAG, fails closed on unknown refs);
+  `lease claim|renew|release|expire|status`.
+- **gates & replan**: `gate resolve`; `replan ack|obligations`.
+- **agents**: `agent list|register|onboard`; `scope`; `lane`; `supervisor
+  propose|receipt|events`.
+- **quota/scheduler**: `quota should-run|usage|spend`; `scheduler
+  tick|show|record-host-failure`.
+- **ops**: `diagnose [--format json]`; `doctor`; `runs
+  history|compact|retention|stale`; `backup`; `evidence-log`; `todo-event`;
+  `turn`; `privacy`; `store verify|migrate|bridge`; `authority`; `profile`;
+  `version`.
+- **work-items & handoff**: `attention`; `inbox`; `handoff --write`.
 - **extensions**: `extension install|upgrade|enable|disable|rollback`;
   `capability list|propose|commands|catalog`; `agent-turn-recall`,
   `change-quality`, `content-ops`, `explore`, `integration-branch`,
   `issue-fix`, `periodic-report`, `reward-memory`, `semantic-preference`,
-  `value-connectors` (each takes `--input` for one private turn context).
-- **benchmark/replay/canary**: `benchmark protocol|run|ledger`;
-  `replay record|run` (+ `replay corpus build|run`); `canary smoke
-  [--profile core-control-plane|extension-runtime|release-gate]` (release
-  gate default) — run `canary smoke` after touching loop code.
-```
+  `value-connectors` (each takes `--input`).
+- **benchmark/replay/canary**: `benchmark protocol|run|ledger`; `replay
+  record|run`; `canary smoke [--profile core-control-plane|extension-runtime|release-gate]`
+  — run `canary smoke` after touching loop code.

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -136,6 +136,21 @@ impl AgentClient {
         Ok(())
     }
 
+    /// Queue a mid-turn steering note (drained by the running turn at its next
+    /// LLM step, unlike append_system_prompt which applies from the next run).
+    pub async fn steer(&mut self, session_id: &str, text: &str) -> Result<()> {
+        self.call(
+            "steer",
+            session_id,
+            RpcCommand {
+                system_prompt: text.to_string(),
+                ..Default::default()
+            },
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Select the model for this session (e.g. "future/deepseek-v4-flash").
     pub async fn set_model(&mut self, session_id: &str, model: &str) -> Result<()> {
         self.call(
@@ -229,7 +244,15 @@ impl AgentClient {
     /// Subscribe to one canonical run from its beginning (atomic attach closes
     /// the prompt-ack -> subscribe loss window) and collect events until
     /// `agent_end` (or the stream closes / errors).
-    pub async fn run_turn(&mut self, session_id: &str, run_id: &str) -> Result<RunSummary> {
+    /// `live_log`: when set, every streamed event is teed to this JSONL file
+    /// so operators can watch a long turn live (`loop status` shows one line
+    /// otherwise).
+    pub async fn run_turn(
+        &mut self,
+        session_id: &str,
+        run_id: &str,
+        live_log: Option<&std::path::Path>,
+    ) -> Result<RunSummary> {
         let request = tonic::Request::new(StreamRequest {
             session_id: session_id.to_string(),
             run_id: run_id.to_string(),
@@ -265,6 +288,26 @@ impl AgentClient {
             let Some(data) = parse_data(&ev) else {
                 continue;
             };
+            if let Some(path) = live_log {
+                let mut line = serde_json::json!({
+                    "type": ev.r#type.as_str(),
+                    "idx": ev.idx,
+                    "wall_ts": crate::state::now_epoch(),
+                });
+                if ev.r#type == "tool_start" {
+                    if let Some(n) = data.get("tool_name").and_then(|v| v.as_str()) {
+                        line["tool"] = serde_json::Value::String(n.to_string());
+                    }
+                }
+                if let Ok(mut f) = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                {
+                    use std::io::Write;
+                    let _ = writeln!(f, "{}", line);
+                }
+            }
             match ev.r#type.as_str() {
                 "tool_start" => {
                     if let Some(name) = data.get("tool_name").and_then(|v| v.as_str()) {

--- a/orchestration/loop/src/benchmark/adapter.rs
+++ b/orchestration/loop/src/benchmark/adapter.rs
@@ -237,7 +237,7 @@ impl BenchmarkAdapter for GrpcLoopxAdapter {
 
     fn observe(&mut self, handle: &RunHandle) -> Result<Observation> {
         let before = Self::block_on(self.client.session_totals(&self.session_id))?;
-        let summary = Self::block_on(self.client.run_turn(&self.session_id, &handle.run_id))?;
+        let summary = Self::block_on(self.client.run_turn(&self.session_id, &handle.run_id, None))?;
         let after = Self::block_on(self.client.session_totals(&self.session_id))?;
         Ok(Observation {
             terminal_state: summary.terminal_state,

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1325,11 +1325,17 @@ fn cmd_profile(store: &mut Store, args: &[String]) -> Result<()> {
 
 fn cmd_status(store: &Store, args: &[String]) -> Result<()> {
     let mut goal_filter = None;
+    let mut format = String::new();
     parse_pairs(args, |k, v| {
         if k == "--goal" {
             goal_filter = Some(v)
+        } else if k == "--format" {
+            format = v;
         }
     });
+    if format == "json" {
+        return print_status_json(store, goal_filter);
+    }
     if let Some(g) = goal_filter {
         let goal = store
             .replay(&g)?
@@ -1347,6 +1353,37 @@ fn cmd_status(store: &Store, args: &[String]) -> Result<()> {
             println!();
         }
     }
+    Ok(())
+}
+
+/// `loop status --format json` — machine-readable projection (goal, todos
+/// with priority/class/status/blocks, terminal flag). Added because piping
+/// the human-readable status used to silently yield nothing scriptable.
+fn print_status_json(store: &Store, goal_filter: Option<String>) -> Result<()> {
+    let mut out = vec![];
+    let ids: Vec<String> = match &goal_filter {
+        Some(g) => vec![g.clone()],
+        None => store.registry().iter().map(|e| e.goal_id.clone()).collect(),
+    };
+    for gid in ids {
+        let goal = store
+            .replay(&gid)?
+            .ok_or_else(|| anyhow::anyhow!("goal {gid} not found"))?;
+        out.push(serde_json::json!({
+            "goal_id": goal.goal_id,
+            "objective": goal.objective,
+            "status": goal.status,
+            "todos": goal.todos.iter().map(|t| serde_json::json!({
+                "id": t.id,
+                "text": t.text,
+                "class": format!("{:?}", t.class),
+                "status": status_label(t),
+                "priority": format!("{:?}", t.priority),
+                "blocks": t.blocked_by_gate.clone().unwrap_or_default(),
+            })).collect::<Vec<_>>(),
+        }));
+    }
+    println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
 }
 
@@ -1860,6 +1897,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut model = None;
     let mut thinking = None;
     let mut max_turns = 6u32;
+    let mut max_turn_secs = 0u64;
     let mut agent_id = None;
     let mut anonymous = false;
     let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
@@ -1868,6 +1906,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         "--model" => model = Some(v),
         "--thinking-level" => thinking = Some(v),
         "--max-turns" => max_turns = v.parse().unwrap_or(6),
+        "--max-turn-secs" => max_turn_secs = v.parse().unwrap_or(0),
         "--agent-id" => agent_id = Some(v),
         "--lease-secs" => lease_secs = v.parse().unwrap_or(DEFAULT_RUN_LEASE_SECS),
         "--anonymous" => anonymous = true,
@@ -1904,6 +1943,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         max_turns,
         lease_secs,
         agent_id.as_deref(),
+        max_turn_secs,
     )
     .await;
     if let Err(e) = client.delete_session(&session_id).await {
@@ -1912,9 +1952,72 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     result
 }
 
+/// Mid-turn steering watcher: tail the goal ledger; when the orchestrator
+/// updates the CURRENT todo's text mid-turn (`todo update --text`), inject the
+/// new instructions into the running session via the `steer` RPC (drained by
+/// the agent at its next step boundary). Runs as a background task for the
+/// duration of one turn; never completes on its own (all error paths retry).
+async fn steer_todo_updates(events_path: std::path::PathBuf, todo_id: String, session_id: String) {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut offset = std::fs::metadata(&events_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let mut client: Option<crate::agent_client::AgentClient> = None;
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        let Ok(meta) = std::fs::metadata(&events_path) else {
+            continue;
+        };
+        if meta.len() <= offset {
+            continue;
+        }
+        let mut buf = String::new();
+        {
+            let Ok(mut f) = std::fs::File::open(&events_path) else {
+                continue;
+            };
+            if f.seek(SeekFrom::Start(offset)).is_err() {
+                continue;
+            }
+            if f.read_to_string(&mut buf).is_err() {
+                continue;
+            }
+            offset = meta.len();
+        }
+        for line in buf.lines() {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            if v.get("kind").and_then(|k| k.as_str()) != Some("todo_updated") {
+                continue;
+            }
+            if v.get("todo_id").and_then(|t| t.as_str()) != Some(todo_id.as_str()) {
+                continue;
+            }
+            let Some(new_text) = v.get("text").and_then(|t| t.as_str()) else {
+                continue;
+            };
+            if client.is_none() {
+                client = crate::agent_client::AgentClient::connect("127.0.0.1:50051")
+                    .await
+                    .ok();
+            }
+            if let Some(c) = client.as_mut() {
+                let msg = format!(
+                    "ORCHESTRATOR STEERING (todo {todo_id} updated mid-turn — new instructions below; adjust your current work accordingly):\n{new_text}"
+                );
+                if c.steer(&session_id, &msg).await.is_err() {
+                    client = None; // reconnect on the next event
+                }
+            }
+        }
+    }
+}
+
 /// One `run` = one bounded turn loop against a fresh agent session. `cmd_run`
 /// owns the session lifecycle (create before, delete after); this function
 /// only executes turns and writes back their ledger effects.
+#[allow(clippy::too_many_arguments)]
 async fn run_turns(
     client: &mut crate::agent_client::AgentClient,
     store: &mut Store,
@@ -1923,6 +2026,7 @@ async fn run_turns(
     max_turns: u32,
     lease_secs: u64,
     agent_id: Option<&str>,
+    max_turn_secs: u64,
 ) -> Result<()> {
     let mut turn = 0u32;
     loop {
@@ -1970,37 +2074,70 @@ async fn run_turns(
         }
 
         // bounded_delivery / monitor_poll: execute one turn.
-        let Some(todo_id) = packet
-            .interaction_contract
-            .agent_channel
-            .selected_todo
-            .clone()
-        else {
-            println!("   no selected todo; stopping");
-            break;
-        };
-        // Claim with a lease BEFORE executing (parallel `run --agent-id`
-        // workers compete for different todos; leased todos are hidden from
-        // other agents' frontiers until the lease expires or work completes).
-        if let Some(aid) = &agent_id {
-            let now = crate::state::now_epoch();
-            if let Some(t) = goal.todo(&todo_id) {
-                if !t.claimed_by_other(Some(aid), now) {
-                    store.append(Event::TodoClaimed {
-                        goal_id: goal_id.to_string(),
-                        todo_id: todo_id.clone(),
-                        agent_id: aid.to_string(),
-                        lease_expires_at: now + lease_secs,
-                        ts: now,
+        // Claim with a lease BEFORE executing — atomically (check+append under
+        // one lock) so two concurrent `run --agent-id` workers can never both
+        // win the same todo; on contention, re-decide against the fresh
+        // ledger and pick the next runnable todo (up to 3 re-decides).
+        let mut packet = packet;
+        let mut todo_id_opt = None;
+        for _ in 0..3 {
+            let Some(tid) = packet
+                .interaction_contract
+                .agent_channel
+                .selected_todo
+                .clone()
+            else {
+                break;
+            };
+            match &agent_id {
+                Some(aid) => {
+                    if store.try_claim_todo(goal_id, &tid, aid, lease_secs)? {
+                        todo_id_opt = Some(tid);
+                        break;
+                    }
+                    println!("   ⚔ claim race lost on {tid} — re-deciding");
+                    let fresh = store.replay(goal_id)?.ok_or_else(|| {
+                        anyhow::anyhow!("goal {goal_id} not found (deleted while running?)")
                     })?;
+                    packet = decide_for(&fresh, SystemTime::now(), agent_id);
+                    if packet.interaction_contract.mode
+                        != crate::contract::TurnMode::BoundedDelivery
+                        && packet.interaction_contract.mode
+                            != crate::contract::TurnMode::MonitorPoll
+                    {
+                        todo_id_opt = None;
+                        break;
+                    }
+                }
+                None => {
+                    todo_id_opt = Some(tid);
+                    break;
                 }
             }
         }
+        let Some(todo_id) = todo_id_opt else {
+            println!("   no selected todo; stopping");
+            break;
+        };
+        let goal = store
+            .replay(goal_id)?
+            .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
         let todo = goal.todo(&todo_id).unwrap().clone();
         let boundary = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
-        let record = execute_turn(
+        let runs_dir = std::path::PathBuf::from(store.root_path()).join("runs");
+        let _ = std::fs::create_dir_all(&runs_dir);
+        // Mid-turn steering: watch the ledger for orchestrator `todo update`s
+        // targeting THIS todo and inject them into the running session (the
+        // turn envelope is only composed at turn start, so without this the
+        // agent never sees updates until the next turn). Aborted after the turn.
+        let steer_handle = tokio::spawn(steer_todo_updates(
+            store.goal_dir(goal_id).join("events.jsonl"),
+            todo_id.clone(),
+            session_id.to_string(),
+        ));
+        let turn_future = execute_turn(
             client,
             session_id,
             &boundary,
@@ -2011,14 +2148,38 @@ async fn run_turns(
             // G-9: embed the decision summary (mode/reason/arbitration) in
             // the turn envelope.
             Some(&packet),
-        )
-        .await?;
+            Some(runs_dir),
+        );
+        let record = if max_turn_secs > 0 {
+            // Wall-clock budget per turn: a long turn that never sees new
+            // instructions is an observability hole; bound it so orchestrators
+            // can relaunch on a safe cadence (context replays from the ledger).
+            match tokio::time::timeout(std::time::Duration::from_secs(max_turn_secs), turn_future)
+                .await
+            {
+                Ok(r) => r?,
+                Err(_) => {
+                    steer_handle.abort();
+                    println!(
+                        "   ⏱ turn exceeded --max-turn-secs ({max_turn_secs}s) — stopping run gracefully; relaunch to continue"
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            turn_future.await?
+        };
+        steer_handle.abort();
         println!(
             "   run={} state={} tools=[{}] cost=¥{:.4}",
             record.run_id,
             record.terminal_state,
             record.tools.join(", "),
             record.cost_delta
+        );
+        println!(
+            "   live log: .future/loop/runs/{}.live.jsonl",
+            record.run_id
         );
         if let Some(v) = &record.validation {
             println!(
@@ -4503,6 +4664,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     let mut priority = None;
     let mut resume_when = None;
     let mut blocks: Option<Vec<String>> = None;
+    let mut unknown_flags: Vec<String> = vec![];
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
         "--todo-id" => todo_id = Some(v),
@@ -4526,13 +4688,23 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
                     .collect()
             });
         }
-        _ => {}
+        "--help" | "-h" => {
+            eprintln!("usage: todo update --goal G --todo-id T [--text T] [--status S] [--evidence E] [--note N] [--priority P0|P1|P2] [--resume-when N|TEXT] [--blocks a,b]");
+            std::process::exit(0);
+        }
+        other => unknown_flags.push(other.to_string()),
     });
+    if !unknown_flags.is_empty() {
+        anyhow::bail!("todo update: unknown flag(s): {}", unknown_flags.join(", "));
+    }
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let todo_id = todo_id.ok_or_else(|| anyhow::anyhow!("--todo-id required"))?;
-    store
+    let goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    if goal.todo(&todo_id).is_none() {
+        anyhow::bail!("todo {todo_id} not found in goal {goal_id}");
+    }
     if status.as_deref() == Some("done") {
         bail!(
             "todo update --status done is not allowed — use `todo complete --no-follow-up|--successor` \

--- a/orchestration/loop/src/decision/frontier.rs
+++ b/orchestration/loop/src/decision/frontier.rs
@@ -87,4 +87,71 @@ mod tests {
         assert_eq!(fp.monitors_open, 1);
         assert_eq!(fp.monitors_due, 1);
     }
+
+    #[test]
+    fn todo_blocks_todo_excluded_until_predecessor_done() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "first"));
+        g.add(Todo::advancement("T2", "second").blocking(&["T1"]));
+        // T2 blocked while T1 open (todo→todo dependency enforced).
+        let ids: Vec<&str> = sorted_runnable(&g, None)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["T1"], "T2 must wait for T1");
+        // Completing T1 unblocks T2.
+        g.todo_mut("T1").unwrap().complete(true, vec![]);
+        let ids: Vec<&str> = sorted_runnable(&g, None)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["T2"]);
+    }
+
+    #[test]
+    fn superseded_predecessor_does_not_block() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "obsolete route"));
+        g.add(Todo::advancement("T2", "second").blocking(&["T1"]));
+        g.todo_mut("T1").unwrap().status = crate::state::TodoStatus::Superseded;
+        let ids: Vec<&str> = sorted_runnable(&g, None)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["T2"],
+            "superseded predecessor must not wedge the goal"
+        );
+    }
+
+    #[test]
+    fn unknown_predecessor_does_not_block_frontier() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T2", "second").blocking(&["T-missing"]));
+        let ids: Vec<&str> = sorted_runnable(&g, None)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["T2"],
+            "unknown ids are flagged by task-graph, not wedged"
+        );
+    }
+
+    #[test]
+    fn gate_predecessor_blocks_until_resolved() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::user_gate("G1", "approve?", &[]));
+        g.add(Todo::advancement("T2", "gated work").blocking(&["G1"]));
+        assert!(sorted_runnable(&g, None).is_empty(), "open gate blocks T2");
+        g.todo_mut("G1").unwrap().decision = Some("approved".to_string());
+        g.todo_mut("G1").unwrap().status = crate::state::TodoStatus::Done;
+        let ids: Vec<&str> = sorted_runnable(&g, None)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["T2"], "resolved gate releases T2");
+    }
 }

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -77,6 +77,7 @@ pub async fn execute_turn(
     prev: Option<&RunRecord>,
     boundary_injected: bool,
     decision_summary: Option<&crate::contract::ShouldRunPacket>,
+    runs_dir: Option<std::path::PathBuf>,
 ) -> Result<RunRecord> {
     if !boundary_injected {
         client
@@ -87,6 +88,10 @@ pub async fn execute_turn(
         Some(packet) => compose_turn_envelope(goal, todo, Some(packet), prev),
         None => compose_turn_message(goal, todo, prev),
     };
+    // Surface the backing agent session id so in-turn tooling (e.g. trace
+    // converters) can locate the real session deterministically instead of
+    // guessing by file mtime.
+    let message = format!("session: {session_id}\n{message}");
     // Idempotency key owned by the orchestrator — retry must not double-execute.
     let client_request_id = format!("turn-{}-{}", turn, todo.id);
 
@@ -94,7 +99,10 @@ pub async fn execute_turn(
     let run_id = client
         .prompt(session_id, &message, &client_request_id)
         .await?;
-    let summary: RunSummary = client.run_turn(session_id, &run_id).await?;
+    let live_path = runs_dir.map(|d| d.join(format!("{run_id}.live.jsonl")));
+    let summary: RunSummary = client
+        .run_turn(session_id, &run_id, live_path.as_deref())
+        .await?;
     let after = client.session_totals(session_id).await?;
     let terminal_state = summary.terminal_state.clone();
 

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -811,6 +811,38 @@ impl Goal {
         self.runnable_advancement_for(None)
     }
 
+    /// Whether `t` is held out of the frontier by an unresolved predecessor.
+    ///
+    /// `blocked_by_gate` carries predecessor ids (comma-joined). An id blocks
+    /// `t` when it names:
+    /// - an OPEN gate/blocker (existing behavior: gates freeze linked work
+    ///   until resolved), or
+    /// - a plain todo that has not reached Done/Superseded (todo→todo
+    ///   dependency — `--blocks` on `todo add`/`todo update`). Previously
+    ///   these ids were only ever compared against the open-gate set, so
+    ///   todo→todo blocks silently never took effect; they are now enforced.
+    ///
+    /// Unknown predecessor ids do NOT block here (liveness); the
+    /// `task-graph` projection fails closed on them instead.
+    pub fn is_blocked(&self, t: &Todo) -> bool {
+        let Some(ids) = t.blocked_by_gate.as_deref() else {
+            return false;
+        };
+        ids.split(',').any(|gid| {
+            let gid = gid.trim();
+            if gid.is_empty() {
+                return false;
+            }
+            match self.todo(gid) {
+                Some(pred) => match pred.class {
+                    TaskClass::UserGate | TaskClass::Blocker => pred.status == TodoStatus::Open,
+                    _ => !matches!(pred.status, TodoStatus::Done | TodoStatus::Superseded),
+                },
+                None => false,
+            }
+        })
+    }
+
     /// Identity-scoped frontier (LoopX: registered peers see their own slice;
     /// unclaimed work wakes every eligible peer; a live lease held by another
     /// agent hides the todo from this frontier). Also applies the capability
@@ -823,19 +855,12 @@ impl Goal {
         let now_sys = SystemTime::now();
         let now = now_epoch();
         let caps = agent_id.map(|a| self.agent_capabilities(a));
-        let open_gate_ids: Vec<&str> = self
-            .open_blocking_sources()
-            .map(|g| g.id.as_str())
-            .collect();
         self.todos.iter().filter(move |t| {
             // Open OR due-deferred (returns to the frontier) advancement.
             (t.class == TaskClass::Advancement
                 && (t.status == TodoStatus::Open || t.is_due_deferred(now_sys)))
                 && !t.claimed_by_other(agent_id, now)
-                && t.blocked_by_gate
-                    .as_deref()
-                    .map(|ids| ids.split(',').all(|gid| !open_gate_ids.contains(&gid)))
-                    .unwrap_or(true)
+                && !self.is_blocked(t)
                 && t.required_capability
                     .as_deref()
                     .map(|cap| {

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -487,6 +487,88 @@ impl Store {
             .collect())
     }
 
+    /// Atomically claim `todo_id` for `agent_id`: lease-state check and the
+    /// claim append happen under the SAME exclusive file lock, closing the
+    /// decide→claim TOCTOU race between concurrent `run --agent-id` processes
+    /// (previously both could pass the free-lease check and the last claim
+    /// won in the ledger → the same todo got executed twice).
+    /// Returns Ok(true) when the claim was appended, Ok(false) when another
+    /// agent holds a live lease.
+    pub fn try_claim_todo(
+        &self,
+        goal_id: &str,
+        todo_id: &str,
+        agent_id: &str,
+        lease_secs: u64,
+    ) -> Result<bool> {
+        use std::io::Write;
+        let now = crate::state::now_epoch();
+        let dir = self.ensure_goal_dir(goal_id)?;
+        let path = dir.join(EVENTS_FILE);
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .append(true)
+            .open(&path)?;
+        file.lock_exclusive()?;
+        let result = (|| -> Result<bool> {
+            let existing = fs::read_to_string(&path).unwrap_or_default();
+            // Reconstruct the current lease for this todo from the ledger
+            // (StoredEvent flattens the Event payload to top level).
+            let mut lease: Option<(String, u64)> = None;
+            for line in existing.lines().filter(|l| !l.trim().is_empty()) {
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                    continue;
+                };
+                if v.get("todo_id").and_then(|t| t.as_str()) != Some(todo_id) {
+                    continue;
+                }
+                match v.get("kind").and_then(|k| k.as_str()).unwrap_or("") {
+                    "todo_claimed" => {
+                        let agent = v
+                            .get("agent_id")
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let exp = v
+                            .get("lease_expires_at")
+                            .and_then(|e| e.as_u64())
+                            .unwrap_or(0);
+                        lease = Some((agent, exp));
+                    }
+                    "todo_released" => lease = None,
+                    _ => {}
+                }
+            }
+            if let Some((holder, exp)) = &lease {
+                if *exp > now && holder != agent_id {
+                    return Ok(false);
+                }
+            }
+            let event = Event::TodoClaimed {
+                goal_id: goal_id.to_string(),
+                todo_id: todo_id.to_string(),
+                agent_id: agent_id.to_string(),
+                lease_expires_at: now + lease_secs,
+                ts: now,
+            };
+            let stored = StoredEvent {
+                event_id: derive_event_id(&event),
+                producer: None,
+                source_ref: None,
+                source_section: None,
+                source_line: None,
+                privacy: None,
+                event,
+            };
+            let line = format!("{}\n", serde_json::to_string(&stored)?);
+            file.write_all(line.as_bytes())?;
+            Ok(true)
+        })();
+        let _ = file.unlock();
+        result
+    }
+
     /// The parsed ledger (G-3/G-6 read path): legacy lines are migrated
     /// in-memory to the current schema and get a content-derived id.
     pub fn events(&self, goal_id: &str) -> Result<Vec<StoredEvent>> {

--- a/orchestration/loop/tests/claim_lease_contract.rs
+++ b/orchestration/loop/tests/claim_lease_contract.rs
@@ -175,3 +175,58 @@ fn claim_requires_registration() {
     assert!(!g.is_registered_agent(Some("alice")));
     assert!(g.is_registered_agent(None));
 }
+
+// ── Contract: try_claim_todo is atomic (check+append under one lock) ───────
+// Regression: concurrent `run --agent-id` processes both passed the old
+// check-then-append path and the last claim won → double execution.
+fn store_with_todo(tag: &str) -> (String, Store) {
+    let root = tmp_root(tag);
+    let mut store = Store::open(&root).unwrap();
+    let g = Goal::new("g1", "objective", &root);
+    store.register(&g).unwrap();
+    let ts = g.created_at;
+    store
+        .append(Event::GoalStarted {
+            goal_id: "g1".into(),
+            ts,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::advancement("t1", "work"),
+            ts,
+        })
+        .unwrap();
+    (root, store)
+}
+
+#[test]
+fn atomic_claim_conflict_is_reported() {
+    let (_root, store) = store_with_todo("atomic-conflict");
+    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    // A different agent loses atomically (no overwrite in the ledger).
+    assert!(!store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    // The holder reclaiming (renewal) succeeds.
+    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+}
+
+#[test]
+fn atomic_claim_after_expiry_or_release() {
+    let (_root, mut store) = store_with_todo("atomic-expiry");
+    // Lease of 0s is immediately expired → another agent may claim.
+    assert!(store.try_claim_todo("g1", "t1", "alice", 0).unwrap());
+    assert!(store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    // A third agent cannot claim while bob's lease is live.
+    assert!(!store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+    // An explicit release frees the todo immediately.
+    store
+        .append(Event::TodoReleased {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "bob".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    assert!(store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+}


### PR DESCRIPTION
# Loop control-plane hardening (field-driven)

Context: running **3 parallel workers on a 24h scored benchmark** through `future loop` exposed several behavioral bugs and operability gaps. This PR fixes the bugs and adds the missing mechanics. All changes are covered by tests; full workspace suite green (2168 passed / 0 failed).

## Behavior fixes

- **`--blocks` (todo→todo) is now actually enforced.** Root cause: `todo add --blocks` was stored into `Todo.blocked_by_gate`, but the frontier only ever compared that field against *open gates* — todo→todo dependencies silently never took effect and execution order fell back to priority-only. Fix: `Goal::is_blocked` (state.rs) — a predecessor blocks until Done/Superseded; open gates/blockers keep their existing semantics; unknown predecessor ids do not wedge the frontier (`task-graph` still fails closed on them).
- **decide→claim TOCTOU closed.** Two concurrent `run --agent-id` processes could both pass the free-lease check and both claim the same todo (last write won → double execution). Fix: `Store::try_claim_todo` — lease-state check + claim append under one exclusive ledger lock; a lost race re-decides against the fresh ledger and takes the next runnable todo.
- **CLI input validation.** `todo update` now rejects unknown flags and errors on unknown todo-ids (previously it silently "updated" nothing, and `--help` was silently swallowed). `status` gains `--format json` (goal + todos incl. priority/class/status/blocks).

## New mechanics

- **Mid-turn steering.** `todo update --text` on the todo a worker is *currently executing* is now injected into the running session: a per-turn watcher tails the goal ledger and calls a new `steer` RPC, which queues the note on a steering cell shared between the shared `Loop` and its run snapshot (same pattern as the compaction cells); the run loop drains it into the system prompt of the next LLM call. The frozen run-snapshot semantics for model/tools/config are unchanged — steering is an additive operator channel. No more kill+relaunch to steer a worker.
- **`run --max-turn-secs N`** — per-turn wall-clock budget; timeout stops the run gracefully (session cleaned up, context replays on relaunch).
- **Session id in the turn envelope** (`session: <id>` line) so in-turn tooling (e.g. trace converters) can locate the real session file deterministically instead of guessing by mtime.
- **Live run logs** — every streamed run event is teed to `.future/loop/runs/<run_id>.live.jsonl`; long turns are finally observable.

## Skill

`orchestration/loop/skill/future-loop/SKILL.md` rewritten to v2.0.0: documents the new mechanics, corrects the stale blocks/pitfall guidance, and adds a concise parallel-orchestration patterns section (orchestrator-only capped actions, shared memory broadcast, lease hygiene, wrap-up discipline).

## Tests

8 new: frontier blocks ×4 (`todo_blocks_todo_excluded_until_predecessor_done`, `superseded_predecessor_does_not_block`, `unknown_predecessor_does_not_block_frontier`, `gate_predecessor_blocks_until_resolved`), steering fold ×2, atomic claim ×2 (conflict / expiry+release). Workspace: **2168 passed, 0 failed**.

## Deliberately deferred

- Lease auto-shrink on turn end (conflicts with the relaunch-to-continue pattern).
- A ledger-native external-budget primitive (rate-limit/quota accounting) — deserves its own design pass.
