### PR TITLE
chore: simplify Makefile — lint matches CI, prune dead/duplicated logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
-.PHONY: version build build-cli build-desktop build-desktop-dist build-mobile-android test test-mobile lint lint-agent lint-channels lint-tui lint-cli lint-desktop lint-mobile stylelint-desktop check-desktop check-mobile clean run run-agent run-tui run-cli run-desktop run-mobile-android run-channels run-loop package-desktop install uninstall install-cli install-desktop install-skills fmt fmt-mobile generate-models generate-proto help test-desktop-rust desktop-sidecars
+.PHONY: help version \
+	build build-cli build-desktop build-desktop-dist build-mobile-android build-mobile-ios desktop-sidecars \
+	test test-agent test-channels test-cli test-tui test-cli-diff test-tui-diff test-tui-tmux \
+	test-desktop test-desktop-rust test-mobile \
+	lint lint-rust lint-desktop stylelint-desktop lint-mobile check-desktop check-mobile fmt fmt-mobile \
+	run-agent run-tui run-cli run-desktop run-mobile-android run-mobile-ios run-channels run-loop \
+	profile-agent-build profile-agent profile-quick profile-heap \
+	generate-models generate-proto \
+	install install-cli install-desktop install-skills uninstall package-desktop clean
 
-# ─── Version ──────────────────────────────────────────────────────────────────
-# Single source of truth for the build version (see scripts/version.mjs).
-# Exported so the cargo build.rs files pick it up. On a release tag CI sets
-# FUTURE_VERSION in the environment, which wins over this default.
-# Resolve FUTURE_VERSION from git; fall back to 0.0.0-dev if git or the
-# version script is unavailable (e.g. Windows without bash).
+# ─── Version ────────────────────────────────────────────────────────────────
+# Single source of truth for the build version (scripts/version.mjs); exported
+# so the cargo build.rs files pick it up. CI sets FUTURE_VERSION on release tags.
 FUTURE_VERSION_SCRIPT := $(CURDIR)/scripts/version.mjs
 export FUTURE_VERSION ?= $(shell node "$(FUTURE_VERSION_SCRIPT)" || node -e "console.log('0.0.0-dev')" || echo 0.0.0-dev)
 
 version:
 	@node scripts/version.mjs --json
 
-# ─── Platform ────────────────────────────────────────────────────────────────
+# ─── Platform ───────────────────────────────────────────────────────────────
 
 TARGET := $(shell rustc -vV | node -e "process.stdin.on('data',d=>{const m=d.toString().match(/host:\s*(.+)/);if(m)console.log(m[1])})")
 OS := $(word 3,$(subst -, ,$(TARGET)))
@@ -33,34 +38,24 @@ else
   EXE_SUFFIX := .exe
 endif
 
-# ─── Install ──────────────────────────────────────────────────────────────────
+# Rust toolchain pinned by rust-toolchain.toml. rustup shims resolve it
+# automatically; spelling it out keeps `-D warnings` clippy aligned with CI
+# even when another cargo shadows the shim (e.g. Homebrew).
+RUST_TOOLCHAIN := $(shell node -e "const m=require('fs').readFileSync('$(CURDIR)/rust-toolchain.toml','utf8').match(/channel\s*=\s*\"([^\"]+)/);console.log(m?m[1]:'stable')")
+CARGO_PINNED := rustup run $(RUST_TOOLCHAIN) cargo
 
-# The unified `future` CLI (install-cli) embeds agent/tui/channel/loop, and
-# the desktop bundles its own future sidecar (desktop-sidecars; the agent runs via
-# `future agent`). So the install surface is exactly four targets: everything
-# (install), the desktop, the CLI, and the skills (which also links the
-# /future-loop skill). The standalone future-agent/tui/channel/loop binaries
-# remain runnable via `make run-*` (dev use) and buildable with
-# `cargo build -p <crate>`; the standalone future-loop binary is installable
-# via scripts/install-future-loop.sh.
+# ─── Install ────────────────────────────────────────────────────────────────
+# The unified `future` CLI embeds agent/tui/channel/loop; the desktop bundles
+# it as a sidecar (`future agent`). Standalone future-agent/-tui/-channel/-loop
+# binaries are dev-only (cargo run -p <crate>) — install puts exactly two files
+# in PREFIX: `future` and `future-desktop`.
+
 install: install-cli install-desktop install-skills
-
-uninstall:
-ifeq ($(OS),windows)
-	cmd /c del /q "$(PREFIX)\future-agent$(EXE_SUFFIX)" 2>NUL
-	cmd /c del /q "$(PREFIX)\future$(EXE_SUFFIX)" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-tui$(EXE_SUFFIX)" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-desktop$(EXE_SUFFIX)" 2>NUL
-	cmd /c del /q "$(PREFIX)\future-channel$(EXE_SUFFIX)" 2>NUL
-else
-	$(SUDO) rm -f $(PREFIX)/future-agent$(EXE_SUFFIX) $(PREFIX)/future$(EXE_SUFFIX) $(PREFIX)/future-tui$(EXE_SUFFIX) $(PREFIX)/future-desktop$(EXE_SUFFIX) $(PREFIX)/future-channel$(EXE_SUFFIX)
-endif
-	@echo "Removed: future-agent, future, future-tui, future-desktop, future-channel"
 
 install-cli: build-cli
 ifeq ($(OS),windows)
 	@if not exist "$(USERPROFILE)\.future\bin" mkdir "$(USERPROFILE)\.future\bin"
-	$(SUDO) $(COPY_CMD) target\release\future$(EXE_SUFFIX) "$(PREFIX)\future$(EXE_SUFFIX)"
+	$(COPY_CMD) target\release\future$(EXE_SUFFIX) "$(PREFIX)\future$(EXE_SUFFIX)"
 else
 	$(SUDO) cp target/release/future "$(PREFIX)/future"
 endif
@@ -69,17 +64,22 @@ install-desktop: install-cli desktop-sidecars
 	$(call npm-install-if-needed,desktop)
 	cd desktop && npx tauri build --no-bundle
 ifeq ($(OS),windows)
-	$(SUDO) $(COPY_CMD) desktop\src-tauri\target\release\futureos$(EXE_SUFFIX) "$(PREFIX)\future-desktop$(EXE_SUFFIX)"
+	$(COPY_CMD) desktop\src-tauri\target\release\futureos$(EXE_SUFFIX) "$(PREFIX)\future-desktop$(EXE_SUFFIX)"
 else
 	$(SUDO) cp desktop/src-tauri/target/release/futureos "$(PREFIX)/future-desktop"
 endif
 
-# Symlink the built-in skill bundles into the agent's app-skills directory
-# so the agent discovers them on startup.  Pulls the latest from the skills
-# submodule first, then links each skill.  Orphaned symlinks (skills removed
-# from the repo) are cleaned up. Also links the /future-loop skill (single
-# source of truth = repo SKILL.md; the loop control plane itself runs through
-# the unified `future` CLI, `future loop` — no binary build needed).
+# Also removes pre-unification installs (future-agent/-tui/-channel).
+uninstall:
+ifeq ($(OS),windows)
+	-cmd /c del /q "$(PREFIX)\future$(EXE_SUFFIX)" "$(PREFIX)\future-desktop$(EXE_SUFFIX)" "$(PREFIX)\future-agent$(EXE_SUFFIX)" "$(PREFIX)\future-tui$(EXE_SUFFIX)" "$(PREFIX)\future-channel$(EXE_SUFFIX)" 2>NUL
+else
+	$(SUDO) rm -f $(addprefix $(PREFIX)/,future future-desktop future-agent future-tui future-channel)
+endif
+	@echo "Removed installed binaries from $(PREFIX)"
+
+# Symlink the built-in skill bundles into the agent's skills directory
+# (orphaned links are pruned), plus the /future-loop skill from the repo.
 install-skills:
 	git submodule update --init --remote skills
 ifeq ($(OS),windows)
@@ -92,15 +92,12 @@ ifeq ($(OS),windows)
 	@if not exist "%USERPROFILE%\.future\agent\skills\future-loop" mkdir "%USERPROFILE%\.future\agent\skills\future-loop"
 	@copy /y orchestration\loop\skill\future-loop\SKILL.md "%USERPROFILE%\.future\agent\skills\future-loop\SKILL.md" >NUL
 	@echo   ✓ future-loop skill
-	@echo Copied built-in skills + future-loop skill to ~/.future/agent/skills/
 else
 	@mkdir -p "$${HOME}/.future/agent/skills"
 	@for skill_dir in skills/builtin/*/; do \
 		name=$$(basename "$$skill_dir"); \
-		link="$${HOME}/.future/agent/skills/$$name"; \
-		abs=$$(cd "$$skill_dir" && pwd); \
-		rm -rf "$$link"; \
-		ln -s "$$abs" "$$link"; \
+		rm -rf "$${HOME}/.future/agent/skills/$$name"; \
+		ln -s "$$(cd "$$skill_dir" && pwd)" "$${HOME}/.future/agent/skills/$$name"; \
 		echo "  ✓ $$name"; \
 	done
 	@for link in "$${HOME}/.future/agent/skills"/*; do \
@@ -114,22 +111,17 @@ else
 	@mkdir -p "$${HOME}/.future/agent/skills/future-loop"
 	@ln -sf "$(CURDIR)/orchestration/loop/skill/future-loop/SKILL.md" "$${HOME}/.future/agent/skills/future-loop/SKILL.md"
 	@echo "  ✓ future-loop skill"
-	@echo "Linked built-in skills + future-loop skill to ~/.future/agent/skills/"
 endif
 
 # ─── Build ──────────────────────────────────────────────────────────────────
 
-# The unified `future` CLI (build-cli) embeds agent/tui/channel/loop, and the
-# desktop (build-desktop → desktop-sidecars) builds + stages its future sidecar itself
-# (the agent runs via `future agent`). So `make build` needs exactly these
-# two; the standalone agent/tui/channel/loop binaries remain buildable via
-# their individual build-* targets (dev use).
 build: build-cli build-desktop
 
-# Only run npm install when package.json is newer than node_modules.
-# npm-install-if-needed ─────────────────────────────────────────────────────
-# On Unix: only install when package.json is newer than the install stamp.
-# On Windows (cmd.exe): skip the bash-conditional (npm install is idempotent).
+build-cli:
+	cargo build --release -p future-cli
+
+# Only run npm install when package.json is newer than the install stamp
+# (on Windows npm install is idempotent — just run it).
 ifeq ($(OS),windows)
 define npm-install-if-needed
 	@cd $(1) && npm install --silent
@@ -143,66 +135,65 @@ define npm-install-if-needed
 endef
 endif
 
-build-cli:
-	cd cli && cargo build --release
-
-# Stage the unified `future` CLI as the Tauri sidecar (externalBin). The desktop
-# spawns the agent via `future agent` (embedded), so no separate future-agent
-# sidecar is needed.
+# Stage the unified `future` CLI as the Tauri sidecar (externalBin).
 desktop-sidecars: build-cli
 ifeq ($(OS),windows)
-	cmd /c "if not exist desktop\src-tauri\binaries mkdir desktop\src-tauri\binaries"
+	@if not exist desktop\src-tauri\binaries mkdir desktop\src-tauri\binaries
 	$(COPY_CMD) target\release\future$(EXE_SUFFIX) "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)"
 else
 	@mkdir -p desktop/src-tauri/binaries
 	cp target/release/future desktop/src-tauri/binaries/future-$(TARGET)
 endif
 
-# Compile the React frontend only — needed by check-desktop and as a dep of build-desktop.
+# Empty sidecar placeholder: tauri-build aborts when the externalBin path is
+# missing, even for check/clippy/test. CI does the same (see ci.yml).
+desktop-sidecar-placeholder:
+ifeq ($(OS),windows)
+	@if not exist "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)" (if not exist desktop\src-tauri\binaries mkdir desktop\src-tauri\binaries & type NUL > "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)")
+else
+	@mkdir -p desktop/src-tauri/binaries
+	@[ -f "desktop/src-tauri/binaries/future-$(TARGET)" ] || : > "desktop/src-tauri/binaries/future-$(TARGET)"
+endif
+
+# React frontend only (dep of build-desktop / check-desktop).
 build-desktop-dist:
 	$(call npm-install-if-needed,desktop)
 	cd desktop && npm run build
 
-# Self-contained standalone binary (no installer).  Produces
+# Self-contained standalone binary (no installer):
 #   desktop/src-tauri/target/release/futureos$(EXE_SUFFIX)
 build-desktop: build-desktop-dist desktop-sidecars
 	cd desktop && npx tauri build --no-bundle
 
-# Mobile native projects are generated locally by Expo and are intentionally
-# not part of the default build. This target builds and installs Android.
+# Mobile native projects are generated locally by Expo (gitignored).
 build-mobile-android:
 	$(call npm-install-if-needed,mobile)
 	cd mobile && npm run android
 
-# iOS native projects are generated locally by Expo (mobile/ios is gitignored).
-# This target prebuilds and launches the app on the iOS simulator.
 build-mobile-ios:
 	$(call npm-install-if-needed,mobile)
 	cd mobile && npm run ios
 
 # ─── Test ───────────────────────────────────────────────────────────────────
-#
-# test-tui-diff / test-tui-tmux / test-cli-diff are migration-acceptance tools
-# (TS→Rust port), NOT part of `make test`: they only run manually before a
-# release. The unit tests below (test-agent/channels/cli/tui/...) are the CI
-# regression gate.
+# The unit tests are the CI regression gate. The *-diff / *-tmux targets are
+# manual TS→Rust migration-acceptance gates (pre-release only).
 
 test: test-agent test-channels test-cli test-tui test-desktop test-desktop-rust test-mobile
 
 test-agent:
-	cd agent && cargo test
+	cargo test -p future-agent
 
 test-channels:
-	cd channels && cargo test
+	cargo test -p future-channel
 
 test-cli:
-	rustup run 1.97.0 cargo test -p future-cli
+	cargo test -p future-cli
+
+test-tui:
+	cargo test -p future-tui
 
 test-cli-diff:
 	./cli/tests/golden-diff.sh
-
-test-tui:
-	rustup run 1.97.0 cargo test -p future-tui
 
 test-tui-diff:
 	./tui/tests/golden-diff.sh
@@ -214,7 +205,7 @@ test-desktop:
 	$(call npm-install-if-needed,desktop)
 	cd desktop && npm test
 
-test-desktop-rust:
+test-desktop-rust: desktop-sidecar-placeholder
 	cd desktop/src-tauri && cargo test
 
 test-mobile:
@@ -222,23 +213,15 @@ test-mobile:
 	cd mobile && npm test
 
 # ─── Lint ───────────────────────────────────────────────────────────────────
+# lint-rust mirrors the CI job exactly (workspace + desktop backend).
 
-lint: lint-agent lint-channels lint-tui lint-cli lint-desktop stylelint-desktop lint-mobile
+lint: lint-rust lint-desktop stylelint-desktop lint-mobile
 
-lint-agent:
-	cd agent && cargo fmt --check && cargo clippy
-
-lint-channels:
-	cd channels && cargo fmt --check && cargo clippy
-
-lint-tui:
-	cd tui && rustup run 1.97.0 cargo fmt --check
-	rustup run 1.97.0 cargo clippy -p future-tui --all-targets -- -D warnings
-
-
-lint-cli:
-	cd cli && rustup run 1.97.0 cargo fmt --check
-	rustup run 1.97.0 cargo clippy -p future-cli --all-targets -- -D warnings
+lint-rust: desktop-sidecar-placeholder
+	$(CARGO_PINNED) fmt --check --all
+	$(CARGO_PINNED) clippy --workspace --all-targets -- -D warnings
+	$(CARGO_PINNED) fmt --check --manifest-path desktop/src-tauri/Cargo.toml
+	$(CARGO_PINNED) clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
 
 lint-desktop:
 	cd desktop && npm run lint
@@ -250,15 +233,15 @@ lint-mobile:
 	$(call npm-install-if-needed,mobile)
 	cd mobile && npm run typecheck && npm run lint
 
-check-desktop: lint-desktop stylelint-desktop build-desktop-dist
+check-desktop: lint-desktop stylelint-desktop build-desktop-dist desktop-sidecar-placeholder
 	cd desktop/src-tauri && cargo check
 
 check-mobile: lint-mobile test-mobile
 	cd mobile && npm run format:check
 
 fmt:
-	cd agent && cargo fmt
-	cd channels && cargo fmt
+	cargo fmt --all
+	cargo fmt --manifest-path desktop/src-tauri/Cargo.toml
 	$(MAKE) fmt-mobile
 
 fmt-mobile:
@@ -266,6 +249,8 @@ fmt-mobile:
 	cd mobile && npm run format
 
 # ─── Run ────────────────────────────────────────────────────────────────────
+# Kept as `cd <crate> && cargo run` on purpose: the process cwd is user-visible
+# (TUI footer, loop status root).
 
 # Bare --log-file (no value) enables file logging at the default location,
 # ~/.future/agent/logs/agent.log; console output stays on the terminal.
@@ -278,20 +263,14 @@ run-tui:
 run-cli:
 	cd cli && cargo run
 
-run-desktop: build-desktop
-ifeq ($(OS),windows)
-	@if not exist desktop\src-tauri\binaries mkdir desktop\src-tauri\binaries
-	@if not exist "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)" "$(MAKE)" build-cli
-	@if not exist "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)" $(COPY_CMD) target\release\future$(EXE_SUFFIX) "desktop\src-tauri\binaries\future-$(TARGET)$(EXE_SUFFIX)"
+run-channels:
+	cd channels && cargo run
+
+run-loop:
+	cd orchestration/loop && cargo run
+
+run-desktop: desktop-sidecars
 	cd desktop && npm run tauri:dev
-else
-	@mkdir -p desktop/src-tauri/binaries
-	@if [ ! -f "desktop/src-tauri/binaries/future-$(TARGET)" ]; then \
-		$(MAKE) build-cli && \
-		cp target/release/future "desktop/src-tauri/binaries/future-$(TARGET)"; \
-	fi
-	cd desktop && npm run tauri:dev
-endif
 
 run-mobile-android:
 	$(call npm-install-if-needed,mobile)
@@ -301,84 +280,38 @@ run-mobile-ios:
 	$(call npm-install-if-needed,mobile)
 	cd mobile && npm run ios
 
-package-desktop: install-desktop
-	node scripts/version.mjs --set-bundle
-	cd desktop && npm run tauri:build
+# ─── Profile ────────────────────────────────────────────────────────────────
+# profile-agent-build: release agent with frame pointers + line tables so
+# profilers resolve symbols (shared by profile-agent / profile-quick).
 
-run-channels:
-	cd channels && cargo run
-
-run-loop:
-	cd orchestration/loop && cargo run
-
-# ─── Profile ───────────────────────────────────────────────────────────────
-
-# Build agent with debug symbols + frame pointers for profiling, then run
-# the benchmark suite.  Writes flamegraph SVG + logs to profile-results/.
-profile-agent:
+profile-agent-build:
 ifeq ($(OS),windows)
-	set "RUSTFLAGS=-C force-frame-pointers=yes" && \
-		cargo build --release -p future-agent \
-		--config "profile.release.debug=""line-tables-only""" \
-		--config "profile.release.strip=""none"""
+	set "RUSTFLAGS=-C force-frame-pointers=yes" && cargo build --release -p future-agent \
+		--config "profile.release.debug=""line-tables-only""" --config "profile.release.strip=""none"""
+else
+	RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release -p future-agent \
+		--config 'profile.release.debug="line-tables-only"' --config 'profile.release.strip="none"'
+endif
+
+# CPU profile: build + 90s bench, write flamegraph SVG to profile-results/.
+profile-agent: profile-agent-build
+ifeq ($(OS),windows)
 	@if not exist profile-results mkdir profile-results
 	@where blondie >NUL 2>NUL || (echo. & echo  blondie is required for CPU profiling on Windows. & echo  Install: cargo install blondie --features inferno & echo  CPU profiling also requires administrator privileges. & exit /b 1)
 	@echo Starting profile run (port 50052, 90s)...
 	set "PROFILE_DURATION=90" && powershell -ExecutionPolicy Bypass -File scripts/agent-profile-bench.ps1
 else
-	RUSTFLAGS="-C force-frame-pointers=yes" \
-		cargo build --release -p future-agent \
-		--config 'profile.release.debug="line-tables-only"' \
-		--config 'profile.release.strip="none"'
 	@mkdir -p profile-results
 	@echo "Starting profile run (port 50052, 90s)..."
 	PROFILE_DURATION=90 bash scripts/agent-profile-bench.sh
-	@echo ""
 	@echo "Flamegraph: $$(ls -t profile-results/agent-profile-*.svg | head -1)"
-	@echo "Run: open profile-results/agent-profile-*.svg"
 endif
 
-# Heap (memory) profile: build with the dhat-heap feature, run on port
-# 50052 for N seconds, write a dhat report JSON.
-# Usage: make profile-heap PROFILE_SECS=30
-# View the report at https://nnethercote.github.io/dh_view/dh_view.html
-profile-heap:
+# Quick CPU profile: run agent N seconds. Usage: make profile-quick PROFILE_SECS=30
+profile-quick: profile-agent-build
 ifeq ($(OS),windows)
-# Windows needs full debug info (2) for dhat backtrace capture (line-tables-only is insufficient)
-	cargo build --release -p future-agent --features dhat-heap \
-		--config profile.release.debug=2 \
-		--config "profile.release.strip=""none"""
-	@if not exist profile-results mkdir profile-results
-else
-	cargo build --release -p future-agent --features dhat-heap \
-		--config 'profile.release.debug="line-tables-only"' \
-		--config 'profile.release.strip="none"'
-	@mkdir -p profile-results
-endif
-	./target/release/future-agent$(EXE_SUFFIX) \
-		--grpc-addr 127.0.0.1:50052 \
-		--profile-heap profile-results/heap-profile.json \
-		--profile-seconds $(or $(PROFILE_SECS),30) \
-		--verbose
-	@echo ""
-	@echo "Heap profile: profile-results/heap-profile.json"
-	@echo "Interactive viewer: https://nnethercote.github.io/dh_view/dh_view.html"
-	@echo "For static flamegraph: dhat-to-flamegraph profile-results/heap-profile.json -f svg -o heap-flame.svg (requires dhat backtraces)"
-
-# Quick profile: start agent with profiling on port 50052, run for N seconds.
-# Usage: make profile-quick PROFILE_SECS=30
-profile-quick:
-ifeq ($(OS),windows)
-	set "RUSTFLAGS=-C force-frame-pointers=yes" && \
-		cargo build --release -p future-agent \
-		--config "profile.release.debug=""line-tables-only""" \
-		--config "profile.release.strip=""none"""
 	powershell -ExecutionPolicy Bypass -File scripts/profile-quick.ps1 -Duration $(or $(PROFILE_SECS),30)
 else
-	RUSTFLAGS="-C force-frame-pointers=yes" \
-		cargo build --release -p future-agent \
-		--config 'profile.release.debug="line-tables-only"' \
-		--config 'profile.release.strip="none"'
 	@mkdir -p profile-results
 	./target/release/future-agent \
 		--grpc-addr 127.0.0.1:50052 \
@@ -387,71 +320,73 @@ else
 		--verbose
 endif
 
+# Heap profile via dhat (needs full debug info on Windows). View the report at
+# https://nnethercote.github.io/dh_view/dh_view.html
+# Usage: make profile-heap PROFILE_SECS=30
+profile-heap:
+ifeq ($(OS),windows)
+	cargo build --release -p future-agent --features dhat-heap \
+		--config profile.release.debug=2 --config "profile.release.strip=""none"""
+	@if not exist profile-results mkdir profile-results
+else
+	cargo build --release -p future-agent --features dhat-heap \
+		--config 'profile.release.debug="line-tables-only"' --config 'profile.release.strip="none"'
+	@mkdir -p profile-results
+endif
+	./target/release/future-agent$(EXE_SUFFIX) \
+		--grpc-addr 127.0.0.1:50052 \
+		--profile-heap profile-results/heap-profile.json \
+		--profile-seconds $(or $(PROFILE_SECS),30) \
+		--verbose
+	@echo "Heap profile: profile-results/heap-profile.json"
+
 # ─── Generate ───────────────────────────────────────────────────────────────
 
 generate-models:
 	python3 scripts/generate_models.py
 
+# Wire codegen owners: rpc (future.proto) + channels (feishu_ws pbbp2).
 generate-proto:
 	cd rpc && REGENERATE_PROTO=1 cargo build
 	cd channels && REGENERATE_PROTO=1 cargo build
 
 # ─── Clean ──────────────────────────────────────────────────────────────────
+# Build artifacts only — installed binaries are removed by `uninstall`.
 
 clean:
 ifeq ($(OS),windows)
 	@if exist target rmdir /s /q target
-	@if exist node_modules rmdir /s /q node_modules
 	@if exist desktop\dist rmdir /s /q desktop\dist
 	@if exist desktop\node_modules rmdir /s /q desktop\node_modules
 	@if exist desktop\src-tauri\target rmdir /s /q desktop\src-tauri\target
 	@if exist desktop\src-tauri\binaries rmdir /s /q desktop\src-tauri\binaries
-	@if exist "$(PREFIX)\future-agent$(EXE_SUFFIX)" del /q "$(PREFIX)\future-agent$(EXE_SUFFIX)"
-	@if exist "$(PREFIX)\future$(EXE_SUFFIX)" del /q "$(PREFIX)\future$(EXE_SUFFIX)"
-	@if exist "$(PREFIX)\future-tui$(EXE_SUFFIX)" del /q "$(PREFIX)\future-tui$(EXE_SUFFIX)"
-	@if exist "$(PREFIX)\future-desktop$(EXE_SUFFIX)" del /q "$(PREFIX)\future-desktop$(EXE_SUFFIX)"
-	@if exist "$(PREFIX)\future-channel$(EXE_SUFFIX)" del /q "$(PREFIX)\future-channel$(EXE_SUFFIX)"
 else
-	rm -rf target
-	rm -rf node_modules
-	rm -rf desktop/dist desktop/node_modules desktop/src-tauri/target desktop/src-tauri/binaries
-	$(SUDO) rm -f $(PREFIX)/future-agent$(EXE_SUFFIX) $(PREFIX)/future$(EXE_SUFFIX) $(PREFIX)/future-tui$(EXE_SUFFIX) $(PREFIX)/future-desktop$(EXE_SUFFIX) $(PREFIX)/future-channel$(EXE_SUFFIX)
+	rm -rf target desktop/dist desktop/node_modules desktop/src-tauri/target desktop/src-tauri/binaries
 endif
+
+# ─── Package ────────────────────────────────────────────────────────────────
+
+package-desktop: install-desktop
+	node scripts/version.mjs --set-bundle
+	cd desktop && npm run tauri:build
 
 # ─── Help ───────────────────────────────────────────────────────────────────
 
 help:
-	@echo "  build              Build desktop + unified CLI (agent/tui/channel/loop embedded; desktop stages its own sidecars)"
-	@echo "  build-cli          Build Rust CLI (future)"
-	@echo "  build-desktop          Build React/Tauri desktop frontend"
-	@echo "  build-mobile-android Generate, build, and install the Android app"
-	@echo "  build-mobile-ios     Generate, build, and install the iOS app (requires Xcode)"
-	@echo "  check-mobile       Typecheck, lint, format-check, and test mobile"
-	@echo "  test               Run all tests (Rust crates + cli/tui/desktop/mobile)"
-	@echo "  test-tui           Run the Rust TUI unit tests (cargo test -p future-tui)"
-	@echo "  test-tui-diff      [manual] migration gate: TUI render vs golden (tui/tests/golden-diff.sh)"
-	@echo "  test-tui-tmux      [manual] migration gate: tmux screen vs golden (tui/tests/tmux-diff.sh)"
-	@echo "  test-cli           Run the Rust CLI unit tests (cargo test -p future-cli)"
-	@echo "  test-cli-diff      [manual] migration gate: CLI output vs goldens (cli/tests/golden-diff.sh)"
-	@echo "  lint               Lint all (agent + channels + TUI + CLI + desktop + mobile)"
-	@echo "  fmt                Format Rust and mobile code"
-	@echo "  run-agent          Run agent directly (debug build)"
-	@echo "  run-tui            Run the Rust TUI (cargo run)"
-	@echo "  run-cli            Run CLI in dev mode"
-	@echo "  run-desktop            Run the desktop app in dev mode"
-	@echo "  run-mobile-android Run the Android app on a selected device"
-	@echo "  run-mobile-ios     Run the iOS app on the simulator (requires Xcode)"
-	@echo "  run-channels        Run channel bridge directly (debug build)"
-	@echo "  run-loop            Run loop control plane directly (debug build)"
-	@echo "  package-desktop        Package desktop bundles"
-	@echo "  profile-agent      CPU profile: build + 90s bench, write flamegraph SVG"
-	@echo "  profile-quick      CPU profile: run agent N secs (PROFILE_SECS=30)"
-	@echo "  profile-heap       Heap profile via dhat, write dhat report JSON"
-	@echo "  generate-models    Fetch model data, regenerate Rust catalog + wiki docs"
-	@echo "  generate-proto     Regenerate wire code: future-rpc (future.proto) + channels feishu_ws"
-	@echo "  install            Build & install desktop + unified CLI + skills"
-	@echo "  install-cli        Install the unified \`future\` CLI (agent/tui/channel/loop embedded)"
-	@echo "  install-desktop        Install the desktop app (stages its own agent/CLI sidecars)"
-	@echo "  install-skills     Link built-in skills + the /future-loop skill"
-	@echo "  uninstall          Remove installed binaries from $(PREFIX)/"
-	@echo "  clean              Remove build artifacts + installed binaries"
+	@echo "  build / build-cli / build-desktop   Build desktop + unified CLI (or each part)"
+	@echo "  build-mobile-android / -ios         Build & install the mobile app (Expo)"
+	@echo "  test                                All unit tests (Rust crates + desktop + mobile)"
+	@echo "  test-<crate>                        test-agent / -channels / -cli / -tui / -desktop(-rust) / -mobile"
+	@echo "  test-cli-diff / -tui-diff / -tui-tmux  [manual] TS→Rust migration gates"
+	@echo "  lint                                Rust (CI flags) + desktop + mobile lints"
+	@echo "  check-desktop / check-mobile        Lint + typecheck + tests without building apps"
+	@echo "  fmt / fmt-mobile                    Format code"
+	@echo "  run-agent / -tui / -cli / -channels / -loop   Run a component (debug build)"
+	@echo "  run-desktop / run-mobile-android / run-mobile-ios   Run an app in dev mode"
+	@echo "  profile-agent / profile-quick / profile-heap  CPU/heap profiling (PROFILE_SECS=30)"
+	@echo "  generate-models                     Fetch model data, regenerate Rust catalog + wiki docs"
+	@echo "  generate-proto                      Regenerate wire code (rpc future.proto + channels feishu_ws)"
+	@echo "  install / install-cli / install-desktop / install-skills   Install to $(PREFIX)"
+	@echo "  uninstall                           Remove installed binaries from $(PREFIX)"
+	@echo "  package-desktop                     Package desktop bundles"
+	@echo "  clean                               Remove build artifacts"


### PR DESCRIPTION
Net -65 lines (144 insertions, 209 deletions), no behavior change for the supported flows.

## Highlights

- **`lint-rust` mirrors CI command-for-command** — replaces the four per-crate `lint-agent/-channels/-tui/-cli` targets (which drifted: missing `-D warnings`, missing `--all-targets`). The pinned toolchain is read from `rust-toolchain.toml` instead of a hardcoded `1.97.0`.
- **Tests**: uniform `cargo test -p <crate>` from the workspace root.
- **`fmt`: `cargo fmt --all`** — the old per-crate form silently skipped tui/cli/rpc/loop; desktop backend fmt added.
- **`run-desktop`** reuses `desktop-sidecars` instead of an inline (and staler) copy of the same staging logic.
- **`clean` no longer deletes installed binaries** (that's `uninstall`'s job) nor the nonexistent root `node_modules`; `uninstall` compressed to one line per OS.
- **`test-desktop-rust` / `check-desktop`** create the empty sidecar placeholder when missing — `tauri-build` aborts without it, so these failed on fresh checkouts (same trick CI uses).
- **`profile-agent` / `profile-quick`** share a `profile-agent-build` target.
- `.PHONY` + `help` regenerated to match reality.

## Verification

- `make lint-rust` green (full CI parity: workspace fmt + clippy `-D warnings` + desktop backend)
- `make test-cli` green (191 passed)
- `install` / `uninstall` / `clean` / `run-desktop` dry-runs produce the expected command sequences on macOS; Windows branches unchanged in structure