### PR TITLE
fix(tui): set UTF-8 console input codepage on Windows

### DIFF
--- a/tui/src/terminal_windows.rs
+++ b/tui/src/terminal_windows.rs
@@ -25,17 +25,20 @@ use std::sync::Mutex;
 use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0};
 use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
 use windows_sys::Win32::System::Console::{
-    GetConsoleMode, GetConsoleOutputCP, GetConsoleScreenBufferInfo, GetStdHandle, SetConsoleMode,
-    SetConsoleOutputCP, CONSOLE_SCREEN_BUFFER_INFO, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT,
-    ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-    ENABLE_WINDOW_INPUT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    GetConsoleCP, GetConsoleMode, GetConsoleOutputCP, GetConsoleScreenBufferInfo, GetStdHandle,
+    SetConsoleCP, SetConsoleMode, SetConsoleOutputCP, CONSOLE_SCREEN_BUFFER_INFO,
+    ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING, ENABLE_WINDOW_INPUT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
 };
 use windows_sys::Win32::System::Threading::WaitForSingleObject;
 
-/// UTF-8 code page. The Rust renderer emits UTF-8 bytes (same as POSIX);
-/// Windows consoles default to the OEM/ANSI code page (e.g. 936/GBK on
-/// zh-CN systems), which renders UTF-8 as mojibake. We switch the output
-/// code page to UTF-8 while the TUI is active and restore it on exit.
+/// UTF-8 code page. The renderer emits UTF-8 bytes and the input pipeline
+/// (StdinBuffer → keys) parses UTF-8, but Windows consoles default to the
+/// OEM/ANSI code page (e.g. 936/GBK on zh-CN systems). We switch BOTH the
+/// output code page (rendered text) and the input code page (IME-typed
+/// characters, which conhost encodes per the input code page before
+/// delivering them to ReadFile) to UTF-8 while the TUI is active, and
+/// restore the originals on exit.
 const CP_UTF8: u32 = 65001;
 
 use super::ReadWait;
@@ -64,6 +67,7 @@ fn console_output() -> HANDLE {
 struct RawState {
     orig_in_mode: u32,
     orig_out_mode: u32,
+    orig_in_cp: u32,
     orig_out_cp: u32,
     raw_enabled: bool,
 }
@@ -111,6 +115,7 @@ impl Backend {
             state: Mutex::new(RawState {
                 orig_in_mode: in_mode,
                 orig_out_mode: out_mode,
+                orig_in_cp: unsafe { GetConsoleCP() },
                 orig_out_cp: unsafe { GetConsoleOutputCP() },
                 raw_enabled: false,
             }),
@@ -126,7 +131,8 @@ impl Backend {
     /// Raw mode: clear the cooked-input flags, enable VT input (so keys arrive
     /// as ANSI escape sequences, exactly like POSIX) and window events; enable
     /// VT processing on output so ANSI rendering works. Also switches the
-    /// console output code page to UTF-8 (the renderer emits UTF-8 bytes).
+    /// console input AND output code pages to UTF-8 (the renderer emits UTF-8
+    /// bytes; conhost encodes IME-typed characters per the input code page).
     pub(crate) fn enable_raw(&self) -> io::Result<()> {
         let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
         if st.raw_enabled {
@@ -141,6 +147,7 @@ impl Backend {
         }
         st.orig_in_mode = in_mode;
         st.orig_out_mode = out_mode;
+        st.orig_in_cp = unsafe { GetConsoleCP() };
         st.orig_out_cp = unsafe { GetConsoleOutputCP() };
         let raw_in = (in_mode & !INPUT_RAW_MASK) | INPUT_VT_FLAGS;
         let vt_out = out_mode | OUTPUT_VT_FLAG;
@@ -182,11 +189,28 @@ impl Backend {
                 ),
             ));
         }
+        // UTF-8 input code page — IME-typed non-ASCII characters (Chinese
+        // etc.) are encoded by conhost per the input code page before they
+        // reach ReadFile; without UTF-8 they arrive as GBK bytes and the
+        // UTF-8-parsing input pipeline turns them into mojibake in the input
+        // box. Restored in `restore_raw`.
+        if unsafe { SetConsoleCP(CP_UTF8) } == 0 {
+            let cp_err = io::Error::last_os_error(); // capture BEFORE rolling back
+            let _ = unsafe { SetConsoleMode(self.stdin.0, st.orig_in_mode) };
+            let _ = unsafe { SetConsoleMode(self.stdout.0, st.orig_out_mode) };
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "failed to switch the console input code page to UTF-8 (error {cp_err}): \
+                     IME-typed text would be garbled"
+                ),
+            ));
+        }
         st.raw_enabled = true;
         Ok(())
     }
 
-    /// Restore the original console modes and output code page (idempotent).
+    /// Restore the original console modes and code pages (idempotent).
     pub(crate) fn restore_raw(&self) {
         let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
         if !st.raw_enabled {
@@ -195,6 +219,7 @@ impl Backend {
         st.raw_enabled = false;
         let _ = unsafe { SetConsoleMode(self.stdin.0, st.orig_in_mode) };
         let _ = unsafe { SetConsoleMode(self.stdout.0, st.orig_out_mode) };
+        let _ = unsafe { SetConsoleCP(st.orig_in_cp) };
         let _ = unsafe { SetConsoleOutputCP(st.orig_out_cp) };
     }
 


### PR DESCRIPTION
## Problem

After PR #133 (output codepage → UTF-8) the TUI renders correctly on Windows, but **typing Chinese into the input box still shows garbage** (`老师好` → `??ʦ??`).

Root cause: PR #133 only switched the OUTPUT codepage. conhost encodes IME-typed non-ASCII characters per the **input** codepage before delivering them to `ReadFile` — which was still 936/GBK on zh-CN systems. The input pipeline (StdinBuffer → keys) parses UTF-8, so GBK bytes became mojibake in the input box.

## Fix (`tui/src/terminal_windows.rs`)

- `enable_raw()`: also call `SetConsoleCP(65001)` (input codepage); save the original via `GetConsoleCP()` and restore it in `restore_raw()`
- Capture the error before rolling back console modes (same pattern as the output-codepage fix)

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo clippy -p future-tui --target x86_64-pc-windows-msvc --all-targets -- -D warnings` ✅ (the changed code is `cfg(windows)` — not covered by the macOS workspace clippy)
- `cargo test -p future-tui` (418 passed) ✅

Runtime verification on Windows still needed (IME input with Chinese in Windows Terminal / conhost).