### PR TITLE
fix(channels): resolve home directory via dirs crate on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "dirs 5.0.1",
  "future-rpc",
  "futures",
  "futures-util",

--- a/channels/Cargo.toml
+++ b/channels/Cargo.toml
@@ -28,6 +28,7 @@ serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+dirs = "5"
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/channels/src/config.rs
+++ b/channels/src/config.rs
@@ -95,7 +95,10 @@ fn default_grpc_addr() -> String {
     "http://127.0.0.1:50051".into()
 }
 fn default_cwd() -> String {
-    std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .to_string_lossy()
+        .into_owned()
 }
 fn default_model() -> String {
     "future/deepseek-v4-pro".into()
@@ -192,11 +195,13 @@ impl Default for FeishuChannelConfig {
     }
 }
 
+/// Home directory via the `dirs` crate (cross-platform): on Windows it
+/// resolves `USERPROFILE` (`C:\Users\<user>`), on POSIX `$HOME`. The old
+/// `$HOME`-only lookup fell back to a literal `~` directory on Windows
+/// (cmd/PowerShell set no `HOME`), silently writing the config into a
+/// `~` folder next to the working directory.
 fn home_dir() -> PathBuf {
-    std::env::var("HOME")
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("~"))
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"))
 }
 
 #[cfg(test)]

--- a/channels/src/feishu/bridge.rs
+++ b/channels/src/feishu/bridge.rs
@@ -1028,12 +1028,11 @@ impl Bridge {
     }
 }
 
+/// Base dir for channel data (files etc.), anchored at the user's home
+/// directory via `dirs` (cross-platform: `USERPROFILE` on Windows, `$HOME`
+/// on POSIX).
 fn dirs_next_path() -> std::path::PathBuf {
-    std::env::var("HOME")
-        .ok()
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::path::PathBuf::from("~"))
-        .join(".future")
+    dirs::home_dir().unwrap_or_default().join(".future")
 }
 
 /// Save a downloaded file to ~/.future/channels/feishu/files/{filename}.


### PR DESCRIPTION
## Problem

`home_dir()` (`channels/src/config.rs`) and `dirs_next_path()` (`channels/src/feishu/bridge.rs`) read only the `HOME` env var and fell back to a literal `"~"` directory:

- **cmd/PowerShell** set no `HOME` → config/files landed in a literal `~` folder **next to the working directory** (`D:\\future-os\\~\\.future\\channels\\config.json`) instead of `C:\\Users\\<user>\\.future\\...`
- **Git Bash / MSYS2** `HOME=/c/Users/<user>` is an MSYS-style path — Rust resolved it as `D:\\c\\Users\\<user>\\.future\\...`

`default_cwd()` (the agent's default working directory in the channel config) had the same issue (fell back to `/tmp` on Windows).

## Fix

- Add `dirs = "5"` dependency (same version agent/tui already use) and replace both helpers with `dirs::home_dir()` — resolves `USERPROFILE` on Windows, `$HOME` on POSIX
- `default_cwd()` falls back to the home dir instead of `/tmp`

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p future-channel` (109 passed) ✅, `cargo test -p future-agent` (854 passed) ✅