### PR TITLE
fix(tui): clamp streaming markdown cut to text length

### DIFF
--- a/tui/src/components/chat_area.rs
+++ b/tui/src/components/chat_area.rs
@@ -157,7 +157,9 @@ fn find_stream_cut(text: &str) -> usize {
                 in_fence = false;
             }
         } else if !in_fence && line.trim().is_empty() {
-            cut = nl + 1;
+            // A blank final line without a trailing newline yields nl ==
+            // text.len(); cut must stay within bounds (panic on slice).
+            cut = (nl + 1).min(text.len());
         }
         line_start = nl + 1;
     }
@@ -1988,6 +1990,22 @@ mod tests {
         // blank lines inside a fence don't cut
         let fenced = "```\ncode\n\nmore\n```\n\n";
         assert_eq!(find_stream_cut(fenced), fenced.len());
+    }
+
+    #[test]
+    fn find_stream_cut_never_exceeds_len() {
+        // Blank final line with no trailing newline: cut must clamp to len
+        // (previously returned len+1 → byte-index slice panic).
+        let s = "para one\n\npara two\n ";
+        let cut = find_stream_cut(s);
+        assert!(cut <= s.len());
+        // Same with multi-byte UTF-8 (e.g. CJK streamed text on Windows).
+        let s = "第一段\n\n第二段\n ";
+        let cut = find_stream_cut(s);
+        assert!(cut <= s.len());
+        assert!(s.is_char_boundary(cut));
+        // Ends exactly with a newline is already at len.
+        assert_eq!(find_stream_cut("a\n\n"), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`future-tui` panics on Windows while streaming a response that ends with a blank line and **no trailing newline**:

```
future-tui panicked: panicked at tui\src\components\chat_area.rs:1001:55:
end byte index 631 is out of bounds for string of length 630
```

## Root cause

`find_stream_cut` computes `cut = nl + 1` for the last blank line. When the text has no trailing newline, `nl == text.len()`, so `cut` becomes `len + 1` — one past the end. The subsequent slices in `render_streaming_markdown` (`&text[tail_start..cut]`, `text[..cut]`) then panic on the byte index.

## Fix

Clamp: `cut = (nl + 1).min(text.len())`. Since `find_stream_cut` returns a byte offset used directly in string slices, clamping at the source guarantees all downstream slices are in bounds (incl. multi-byte UTF-8, e.g. CJK text on Windows).

## Tests

- New regression test `find_stream_cut_never_exceeds_len` covering ASCII and CJK blank-final-line cases.
- `cargo test -p future-tui` passes; workspace clippy `-D warnings` (incl. `x86_64-pc-windows-msvc` target) clean; `cargo fmt --check` clean.