### PR TITLE
fix(tui): find_stream_cut out-of-bounds on unterminated blank tail

### DIFF
--- a/tui/src/components/chat_area.rs
+++ b/tui/src/components/chat_area.rs
@@ -143,10 +143,12 @@ fn find_stream_cut(text: &str) -> usize {
     let mut fence_char = '\0';
     let mut line_start = 0;
     while line_start < text.len() {
-        let nl = text[line_start..]
-            .find('\n')
-            .map(|i| line_start + i)
-            .unwrap_or(text.len());
+        // Only newline-terminated lines are considered: the unterminated
+        // tail is still growing (a blank-looking tail could become a fence
+        // or content) — and cutting at len+1 would slice out of bounds.
+        let Some(nl) = text[line_start..].find('\n').map(|i| line_start + i) else {
+            break;
+        };
         let line = &text[line_start..nl];
         if let Some(cap) = stream_fence_re().captures(line) {
             let ch = cap.get(1).unwrap().as_str().chars().next().unwrap();
@@ -1988,6 +1990,36 @@ mod tests {
         // blank lines inside a fence don't cut
         let fenced = "```\ncode\n\nmore\n```\n\n";
         assert_eq!(find_stream_cut(fenced), fenced.len());
+        // The unterminated tail line is never a cut point — even when it
+        // looks blank. Regression: "foo\n\n " used to return len+1 and the
+        // incremental renderer then sliced out of bounds (exit 101).
+        assert_eq!(find_stream_cut("foo\n\n "), 5);
+        assert_eq!(find_stream_cut(" "), 0);
+        assert_eq!(find_stream_cut("para\n\n  \n"), 9);
+    }
+
+    #[test]
+    fn streaming_render_tolerates_whitespace_only_tail() {
+        // End-to-end: the exact panic path from the crash log —
+        // render_streaming_markdown with a trailing blank-but-unterminated
+        // line must not panic.
+        let mut caches = std::collections::HashMap::new();
+        let mut md = MarkdownRenderer::new();
+        let frames = [
+            "para one\n",
+            "para one\n\n",
+            "para one\n\n ",
+            "para one\n\n  \npara two",
+        ];
+        for frame in frames {
+            let lines = ChatArea::render_streaming_markdown(&mut caches, "k", frame, 78, &mut md);
+            let joined = lines
+                .iter()
+                .map(|l| crate::utils::strip_ansi_codes(l))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(joined.contains("para one"), "frame {frame:?} lost content");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes the field-reported panic (caught by the new crash handler from #127):

```
panicked at tui/src/components/chat_area.rs:1001:55:
end byte index 6913 is out of bounds for string of length 6912
```

## Root cause

`find_stream_cut` processed the final, newline-less tail line via `unwrap_or(len)` and could return `len + 1` when that tail looked blank (e.g. streaming text ending in `"\n\n "`) — the incremental markdown renderer then sliced `&text[tail_start..cut]` out of bounds.

The TS original **breaks at the first unterminated line**; the port's tail processing was the divergence — and also semantically wrong: an unterminated blank-looking tail can still grow into a fence or content, so it is not a stable cut point anyway.

Latent since the port; exposed by #132, which made thinking stream through the incremental path (`pending=true` from `start_thinking`).

## Fix + tests

- Break at the unterminated tail (TS parity)
- Cut-point assertions for trailing-blank variants + an end-to-end `render_streaming_markdown` regression over the crashing frame sequence
- `cargo test -p future-tui`: 419 passed; fmt + clippy clean