### PR TITLE
chore(scripts): add cargo llvm-cov workspace coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ channel/
 /profile-results/
 /agent-profile.svg
 
+# Coverage reports (scripts/coverage.sh)
+/coverage/
+
 # loop control plane runtime state (never commit)
 .codex/
 .future/loop/

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -30,6 +30,7 @@ cargo llvm-cov clean --workspace
 cargo llvm-cov --workspace --no-report "$@"
 
 cargo llvm-cov report --lcov --output-path "$out_dir/lcov.info"
-cargo llvm-cov report --html --output-dir "$out_dir/html"
+# NOTE: --html writes into <output-dir>/html/, so pass the base dir.
+cargo llvm-cov report --html --output-dir "$out_dir"
 cargo llvm-cov report --text --output-path "$out_dir/summary.txt"
 cargo llvm-cov report --summary-only

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/coverage.sh — workspace test coverage via cargo llvm-cov.
+#
+# Usage:
+#   scripts/coverage.sh                 # full workspace run
+#   scripts/coverage.sh -p future-tui   # subset (extra args forwarded to
+#                                       # `cargo llvm-cov` test invocation)
+#
+# Outputs (under coverage/, gitignored):
+#   lcov.info    — LCOV report for CI / tooling
+#   html/        — browsable HTML report (open coverage/html/index.html)
+#   summary.txt  — per-file line-coverage table
+# Plus a totals table printed to stdout.
+#
+# Requires: cargo-llvm-cov (`cargo install cargo-llvm-cov`) and the
+# llvm-tools-preview rustup component for the pinned toolchain
+# (`rustup component add llvm-tools-preview`).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+out_dir=coverage
+mkdir -p "$out_dir"
+
+# Build and run the instrumented test binaries once, keeping the raw profile
+# data; the reports below are rendered from it without re-running tests.
+# `clean --workspace` drops only stale profile data, preserving the build cache
+# (target/llvm-cov-target) so re-runs after adding tests stay incremental.
+cargo llvm-cov clean --workspace
+cargo llvm-cov --workspace --no-report "$@"
+
+cargo llvm-cov report --lcov --output-path "$out_dir/lcov.info"
+cargo llvm-cov report --html --output-dir "$out_dir/html"
+cargo llvm-cov report --text --output-path "$out_dir/summary.txt"
+cargo llvm-cov report --summary-only


### PR DESCRIPTION
## What

Adds `scripts/coverage.sh`: a one-command workspace coverage runner around `cargo llvm-cov`.

- Builds + runs the instrumented test binaries **once** (`cargo llvm-cov --workspace --no-report`), then renders three reports from the stored profile data without re-running tests:
  - `coverage/lcov.info` — LCOV for CI/tooling
  - `coverage/html/` — browsable HTML report
  - `coverage/summary.txt` — per-file line-coverage table (+ totals on stdout)
- `cargo llvm-cov clean --workspace` drops only stale profile data, keeping the `target/llvm-cov-target` build cache so re-runs after adding tests stay incremental.
- Extra args are forwarded (e.g. `scripts/coverage.sh -p future-tui` for a single crate).
- `/coverage/` added to `.gitignore`.

Requires `cargo install cargo-llvm-cov` and `rustup component add llvm-tools-preview` (script/auto-installer prompts if missing).

## Why

Baseline + progress measurement for the workspace test-coverage push (agent / channels / rpc / tui / cli / orchestration-loop).

## Test

Script is tooling-only; verified `bash -n` and a live workspace baseline run locally (results in `coverage/`, gitignored).