### PR TITLE
test(rpc): bring future-rpc to 100% line coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,8 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
 ]
@@ -3169,6 +3171,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "flate2",
  "h2",
  "http",
  "http-body",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,6 +13,11 @@ prost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
+[dev-dependencies]
+tokio.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }
+tonic = { workspace = true, features = ["gzip"] }
+
 [build-dependencies]
 prost-build.workspace = true
 tonic-build.workspace = true

--- a/rpc/src/decode.rs
+++ b/rpc/src/decode.rs
@@ -56,10 +56,10 @@ fn typed_response_data(resp: &proto::RpcResponse) -> Option<Value> {
                 .collect::<Result<_, _>>()
                 .ok()?;
             let mut value = json!({ "sessions": rows });
-            if let Some(rows) = value.get_mut("sessions").and_then(Value::as_array_mut) {
-                for row in rows {
-                    inject_legacy_aliases(row, SESSION_SUMMARY_ALIASES);
-                }
+            // `sessions` was just built above, so the key is always an array;
+            // iterate infallibly rather than an if-let.
+            for row in value["sessions"].as_array_mut().into_iter().flatten() {
+                inject_legacy_aliases(row, SESSION_SUMMARY_ALIASES);
             }
             Some(value)
         }
@@ -96,11 +96,9 @@ fn typed_response_data(resp: &proto::RpcResponse) -> Option<Value> {
         }
         Kind::GetSessionEventsSince(response) => {
             serde_json::to_value(session_events_since_from_proto(response)).ok()
-        }
-        // Future members: fall through to the JSON `data` string until a
-        // decoder exists.
-        #[allow(unreachable_patterns)]
-        _ => None,
+        } // Exhaustive on purpose: a new oneof member fails the build here
+          // until it gets a decoder (or an explicit `=> None` to keep the JSON
+          // `data` fallback).
     }
 }
 
@@ -732,10 +730,9 @@ fn typed_event_json(kind: Option<&proto::event_payload::Kind>) -> String {
     let Some(kind) = kind else {
         return String::new();
     };
-    match typed_event_json_inner(kind) {
-        Some(value) => serde_json::to_string(&value).unwrap_or_default(),
-        None => String::new(),
-    }
+    typed_event_json_inner(kind)
+        .and_then(|value| serde_json::to_string(&value).ok())
+        .unwrap_or_default()
 }
 
 /// Reconstruct the canonical payload shape from the typed event form. The
@@ -833,4 +830,395 @@ fn inflate_optional_json(raw: &str) -> Option<Value> {
         return None;
     }
     Some(serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::response_payload::Kind;
+
+    fn resp_with_payload(kind: Kind) -> proto::RpcResponse {
+        proto::RpcResponse {
+            payload: Some(proto::ResponsePayload { kind: Some(kind) }),
+            ..Default::default()
+        }
+    }
+
+    fn resp_with_data(data: &str) -> proto::RpcResponse {
+        proto::RpcResponse {
+            data: data.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn typed_text_chunk(text: &str) -> Option<proto::EventPayload> {
+        Some(proto::EventPayload {
+            kind: Some(proto::event_payload::Kind::TextChunk(proto::TextChunk {
+                text: text.to_string(),
+            })),
+        })
+    }
+
+    #[test]
+    fn response_data_str_serializes_non_null_payloads() {
+        let resp = resp_with_data(r#"{"a":1}"#);
+        assert_eq!(response_data_str(&resp), r#"{"a":1}"#);
+        assert_eq!(response_data_str(&proto::RpcResponse::default()), "");
+    }
+
+    #[test]
+    fn typed_list_sessions_injects_legacy_aliases() {
+        let resp = resp_with_payload(Kind::ListSessions(proto::ListSessionsResponse {
+            sessions: vec![proto::SessionSummary {
+                id: "s1".to_string(),
+                session_name: Some("Demo".to_string()),
+                ..Default::default()
+            }],
+        }));
+        let value = response_data(&resp);
+        assert_eq!(value["sessions"][0]["sessionName"], json!("Demo"));
+        assert_eq!(value["sessions"][0]["session_name"], json!("Demo"));
+
+        let rows = decode_list_sessions(&resp).unwrap();
+        assert_eq!(rows[0].id, "s1");
+        assert_eq!(rows[0].session_name.as_deref(), Some("Demo"));
+    }
+
+    #[test]
+    fn typed_get_state_injects_aliases_and_decodes_subobjects() {
+        let state = proto::SessionState {
+            session_id: Some("s1".to_string()),
+            extensions: vec!["ext-a".to_string()],
+            recent_terminal_acks: vec![proto::TerminalAck {
+                run_id: "r0".to_string(),
+                run_sequence: 3,
+                client_request_id: "c0".to_string(),
+                state: "cancelled".to_string(),
+                reason: "superseded".to_string(),
+            }],
+            requested_run: Some(proto::RunTerminalInfo {
+                run_id: "r9".to_string(),
+                state: "failed".to_string(),
+                run_tokens: 10,
+                run_duration_ms: 20,
+                error: Some("boom".to_string()),
+            }),
+            ..Default::default()
+        };
+        let resp = resp_with_payload(Kind::GetState(state));
+
+        let value = response_data(&resp);
+        assert_eq!(value["sessionId"], json!("s1"));
+        assert_eq!(value["extensions"], json!(["ext-a"]));
+        let ack = &value["recentTerminalAcks"][0];
+        assert_eq!(ack["runId"], json!("r0"));
+        assert_eq!(ack["run_id"], json!("r0"));
+        assert_eq!(ack["run_sequence"], json!(3));
+        assert_eq!(value["requestedRun"]["error"], json!("boom"));
+
+        let payload = decode_get_state(&resp).unwrap();
+        assert_eq!(payload.session_id.as_deref(), Some("s1"));
+        assert_eq!(payload.extensions, Some(vec!["ext-a".to_string()]));
+    }
+
+    /// The alias-injection helper must no-op cleanly when the get_state value
+    /// carries no recentTerminalAcks array.
+    #[test]
+    fn inject_get_state_aliases_without_acks() {
+        let mut value = json!({"sessionName": "Demo"});
+        inject_get_state_aliases(&mut value);
+        assert_eq!(value["session_name"], json!("Demo"));
+        assert!(value.get("recentTerminalAcks").is_none());
+    }
+
+    /// The JSON fallback path strips the legacy duplicates before
+    /// deserializing — top-level aliases and per-ack snake_case keys.
+    #[test]
+    fn decode_get_state_fallback_strips_legacy_aliases() {
+        let resp = resp_with_data(
+            r#"{
+                "agentInstanceId": "a1", "model": "m", "imageSupport": false,
+                "thinkingLevel": "off", "isStreaming": false, "isCompacting": false,
+                "explicitSession": true, "autoCompactionEnabled": true,
+                "queryCount": 2, "version": "1", "cwd": "/w",
+                "skills": [], "contextFiles": [], "contextWindow": 1000,
+                "contextTokens": 10, "contextPercent": 1.0, "tokensIn": 1,
+                "tokensOut": 2, "tokensCacheR": 0, "tokensCacheW": 0,
+                "totalCost": 0.0, "permissionLevel": "all", "createdBy": "tui",
+                "sourceMeta": null, "queuedRuns": [], "queuedCount": 0,
+                "pendingApprovals": [],
+                "sessionName": "Demo", "session_name": "Demo",
+                "recentTerminalAcks": [{
+                    "runId": "r0", "run_id": "r0",
+                    "runSequence": 4, "run_sequence": 4,
+                    "clientRequestId": "c0", "client_request_id": "c0",
+                    "state": "cancelled", "reason": "superseded"
+                }]
+            }"#,
+        );
+        let payload = decode_get_state(&resp).unwrap();
+        assert_eq!(payload.session_name.as_deref(), Some("Demo"));
+        assert_eq!(payload.recent_terminal_acks[0].run_id, "r0");
+        assert_eq!(payload.recent_terminal_acks[0].run_sequence, 4);
+
+        // Absent-acks edge of the strip helper.
+        let mut bare = json!({"sessionName": "Demo", "session_name": "Demo"});
+        strip_for_get_state(&mut bare);
+        assert!(bare.get("session_name").is_none());
+        assert_eq!(bare["sessionName"], json!("Demo"));
+    }
+
+    #[test]
+    fn decode_session_entries_typed_fallback_and_missing() {
+        let resp = resp_with_payload(Kind::GetSessionEntries(proto::SessionEntriesResponse {
+            entries: vec![proto::SessionEntry {
+                id: "e1".to_string(),
+                role: "session_info".to_string(),
+                content: r#"{"schema":1}"#.to_string(),
+                content_is_object: true,
+                meta: Some(r#"{"m":2}"#.to_string()),
+                tool_calls: Some("[]".to_string()),
+                output_tokens: Some(9),
+                duration_ms: Some(11),
+                ..Default::default()
+            }],
+        }));
+        let entries = decode_session_entries(&resp).unwrap();
+        assert_eq!(entries[0].content, json!({"schema": 1}));
+        assert_eq!(entries[0].meta, Some(json!({"m": 2})));
+        assert_eq!(entries[0].output_tokens, Some(9));
+        assert_eq!(entries[0].duration_ms, Some(11));
+
+        let resp = resp_with_data(
+            r#"{"entries":[{"id":"e2","role":"user","content":"hi","name":"","tool_args":"","timestamp":"t"}]}"#,
+        );
+        let entries = decode_session_entries(&resp).unwrap();
+        assert_eq!(entries[0].content, Value::String("hi".to_string()));
+
+        // `entries` absent / no data at all → None.
+        assert!(decode_session_entries(&resp_with_data("{}")).is_none());
+        assert!(decode_session_entries(&proto::RpcResponse::default()).is_none());
+    }
+
+    #[test]
+    fn decode_events_since_typed_fallback_and_empty() {
+        let resp = resp_with_payload(Kind::GetEventsSince(proto::EventsSince {
+            run_id: "r1".to_string(),
+            events: vec![proto::ReplayEvent {
+                r#type: "text_chunk".to_string(),
+                data: "{}".to_string(),
+                ..Default::default()
+            }],
+            truncated: true,
+            projection: None,
+        }));
+        let payload = decode_events_since(&resp).unwrap();
+        assert_eq!(payload.run_id, "r1");
+        assert!(payload.truncated);
+        assert_eq!(payload.events.len(), 1);
+
+        let resp = resp_with_data(r#"{"runId":"r2","events":[],"truncated":false}"#);
+        assert_eq!(decode_events_since(&resp).unwrap().run_id, "r2");
+
+        // No typed payload and no data → None.
+        assert!(decode_events_since(&proto::RpcResponse::default()).is_none());
+    }
+
+    #[test]
+    fn inflate_json_value_handles_empty_invalid_and_valid() {
+        assert_eq!(inflate_json_value(""), Value::Null);
+        assert_eq!(
+            inflate_json_value("nope"),
+            Value::String("nope".to_string())
+        );
+        assert_eq!(inflate_json_value(r#"{"a":1}"#), json!({"a": 1}));
+
+        assert_eq!(inflate_optional_json(""), None);
+        assert_eq!(
+            inflate_optional_json("raw"),
+            Some(Value::String("raw".to_string()))
+        );
+        assert_eq!(inflate_optional_json("1"), Some(json!(1)));
+    }
+
+    #[test]
+    fn run_terminal_includes_error_only_on_failure() {
+        let info = proto::RunTerminalInfo {
+            run_id: "r1".to_string(),
+            state: "failed".to_string(),
+            run_tokens: 12,
+            run_duration_ms: 34,
+            error: Some("boom".to_string()),
+        };
+        let content = run_terminal_from_proto(&info);
+        assert_eq!(content["error"], json!("boom"));
+        assert_eq!(content["run_tokens"], json!(12));
+
+        let ok = proto::RunTerminalInfo::default();
+        assert!(run_terminal_from_proto(&ok).get("error").is_none());
+    }
+
+    #[test]
+    fn approval_card_null_save_suggestion_and_extras_merge() {
+        let info = proto::ApprovalRequestInfo {
+            approval_request_id: "ap1".to_string(),
+            title: "Modelled".to_string(),
+            requested_action: r#"{"command":"ls"}"#.to_string(),
+            save_suggestion: None,
+            extras: r#"{"type":"tool_call","title":"FromExtras"}"#.to_string(),
+            ..Default::default()
+        };
+        let card = approval_card_from_proto(&info);
+        // Unset save_suggestion reconstructs the wire's explicit null.
+        assert_eq!(card["save_suggestion"], Value::Null);
+        assert_eq!(card["requested_action"], json!({"command": "ls"}));
+        // Modelled keys win over extras; other extras merge in.
+        assert_eq!(card["title"], json!("Modelled"));
+        assert_eq!(card["type"], json!("tool_call"));
+    }
+
+    #[test]
+    fn approval_card_tolerates_unparseable_extras() {
+        let info = proto::ApprovalRequestInfo {
+            approval_request_id: "ap2".to_string(),
+            extras: "not json".to_string(),
+            ..Default::default()
+        };
+        let card = approval_card_from_proto(&info);
+        assert_eq!(card["approval_request_id"], json!("ap2"));
+        assert!(card.get("type").is_none());
+    }
+
+    #[test]
+    fn decode_prompt_ack_typed_fallback_and_unknown_state() {
+        let resp = resp_with_payload(Kind::Prompt(proto::PromptAck {
+            run_id: "r1".to_string(),
+            run_epoch: 7,
+            accepted_state: "queued".to_string(),
+            run_sequence: Some(3),
+            queue_position: Some(0),
+        }));
+        let ack = decode_prompt_ack(&resp).unwrap();
+        assert_eq!(
+            ack.accepted_state,
+            crate::payloads_ext::RunAcceptedState::Queued
+        );
+        assert_eq!(ack.run_sequence, Some(3));
+
+        let resp = resp_with_data(r#"{"run_id":"r2","run_epoch":1,"accepted_state":"existing"}"#);
+        let ack = decode_prompt_ack(&resp).unwrap();
+        assert_eq!(
+            ack.accepted_state,
+            crate::payloads_ext::RunAcceptedState::Existing
+        );
+
+        // An unrecognized wire state degrades to Running.
+        let resp = resp_with_payload(Kind::Prompt(proto::PromptAck {
+            accepted_state: "weird".to_string(),
+            ..Default::default()
+        }));
+        assert_eq!(
+            decode_prompt_ack(&resp).unwrap().accepted_state,
+            crate::payloads_ext::RunAcceptedState::Running
+        );
+    }
+
+    #[test]
+    fn decode_list_models_typed_and_fallback() {
+        let resp = resp_with_payload(Kind::ListModels(proto::ListModelsResponse {
+            models: vec![proto::ModelEntry {
+                id: "m1".to_string(),
+                is_default: true,
+                ..Default::default()
+            }],
+            default_model: "m1".to_string(),
+            is_scoped: true,
+            builtin_providers: std::collections::HashMap::from([(
+                "future".to_string(),
+                proto::BuiltinProvider {
+                    name: "Future".to_string(),
+                    model_count: 2,
+                    base_url: "https://example".to_string(),
+                },
+            )]),
+        }));
+        let payload = decode_list_models(&resp).unwrap();
+        assert_eq!(payload.models[0].id, "m1");
+        assert!(payload.is_scoped);
+        assert_eq!(payload.builtin_providers.unwrap()["future"].model_count, 2);
+
+        let resp = resp_with_data(
+            r#"{
+                "models": [{
+                    "id": "m2", "label": "M2", "provider": "p",
+                    "supportsImages": false, "thinkingLevel": "off",
+                    "contextWindow": 8, "isDefault": false, "recommended": false
+                }],
+                "defaultModel": "m2", "isScoped": false
+            }"#,
+        );
+        let payload = decode_list_models(&resp).unwrap();
+        assert_eq!(payload.models[0].id, "m2");
+        assert!(payload.builtin_providers.is_none());
+    }
+
+    #[test]
+    fn event_data_json_typed_only_and_absent() {
+        let event = proto::StreamEvent {
+            r#type: "text_chunk".to_string(),
+            payload: typed_text_chunk("hi"),
+            ..Default::default()
+        };
+        assert_eq!(event_data_json(&event), r#"{"text":"hi"}"#);
+        assert_eq!(event_data(&event), json!({"text": "hi"}));
+
+        // Neither data nor payload: Null / empty string.
+        let bare = proto::StreamEvent::default();
+        assert_eq!(event_data(&bare), Value::Null);
+        assert_eq!(event_data_json(&bare), "");
+    }
+
+    #[test]
+    fn projected_event_data_variants() {
+        let with_data = proto::ProjectedRunEvent {
+            r#type: "text_chunk".to_string(),
+            data: r#"{"text":"a"}"#.to_string(),
+            ..Default::default()
+        };
+        assert_eq!(projected_event_data(&with_data), json!({"text": "a"}));
+        assert_eq!(projected_event_data_json(&with_data), r#"{"text":"a"}"#);
+
+        let typed_only = proto::ProjectedRunEvent {
+            payload: typed_text_chunk("b"),
+            ..Default::default()
+        };
+        assert_eq!(projected_event_data(&typed_only), json!({"text": "b"}));
+        assert_eq!(projected_event_data_json(&typed_only), r#"{"text":"b"}"#);
+
+        let bare = proto::ProjectedRunEvent::default();
+        assert_eq!(projected_event_data(&bare), Value::Null);
+        assert_eq!(projected_event_data_json(&bare), "");
+    }
+
+    #[test]
+    fn replay_event_data_variants() {
+        let with_data = proto::ReplayEvent {
+            r#type: "text_chunk".to_string(),
+            data: r#"{"text":"a"}"#.to_string(),
+            ..Default::default()
+        };
+        assert_eq!(replay_event_data(&with_data), json!({"text": "a"}));
+        assert_eq!(replay_event_data_json(&with_data), r#"{"text":"a"}"#);
+
+        let typed_only = proto::ReplayEvent {
+            payload: typed_text_chunk("b"),
+            ..Default::default()
+        };
+        assert_eq!(replay_event_data(&typed_only), json!({"text": "b"}));
+        assert_eq!(replay_event_data_json(&typed_only), r#"{"text":"b"}"#);
+
+        let bare = proto::ReplayEvent::default();
+        assert_eq!(replay_event_data(&bare), Value::Null);
+        assert_eq!(replay_event_data_json(&bare), "");
+    }
 }

--- a/rpc/src/events.rs
+++ b/rpc/src/events.rs
@@ -252,6 +252,88 @@ mod tests {
         }
     }
 
+    // ── Variant extraction helpers ─────────────────────────────────────────
+    // Shared by the parse tests; each helper's mismatch-panic line is covered
+    // by a should_panic test at the bottom of this module.
+
+    fn expect_agent_end(event: Option<AgentEvent>) -> (Option<String>, Option<String>) {
+        match event {
+            Some(AgentEvent::AgentEnd { state, error }) => (state, error),
+            other => panic!("expected AgentEnd, got {:?}", other),
+        }
+    }
+
+    fn expect_text_chunk(event: Option<AgentEvent>) -> String {
+        match event {
+            Some(AgentEvent::TextChunk(text)) => text,
+            other => panic!("expected TextChunk, got {:?}", other),
+        }
+    }
+
+    fn expect_thinking_delta(event: Option<AgentEvent>) -> String {
+        match event {
+            Some(AgentEvent::ThinkingDelta(text)) => text,
+            other => panic!("expected ThinkingDelta, got {:?}", other),
+        }
+    }
+
+    fn expect_tool_start(event: Option<AgentEvent>) -> (String, String, Option<String>) {
+        match event {
+            Some(AgentEvent::ToolStart {
+                tool_id,
+                tool_name,
+                tool_args,
+            }) => (tool_id, tool_name, tool_args),
+            other => panic!("expected ToolStart, got {:?}", other),
+        }
+    }
+
+    fn expect_tool_delta(event: Option<AgentEvent>) -> (String, String) {
+        match event {
+            Some(AgentEvent::ToolDelta { tool_id, text }) => (tool_id, text),
+            other => panic!("expected ToolDelta, got {:?}", other),
+        }
+    }
+
+    fn expect_tool_end(event: Option<AgentEvent>) -> (String, Option<String>) {
+        match event {
+            Some(AgentEvent::ToolEnd { tool_id, text }) => (tool_id, text),
+            other => panic!("expected ToolEnd, got {:?}", other),
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn expect_approval_request(
+        event: Option<AgentEvent>,
+    ) -> (String, String, String, String, String, Value) {
+        match event {
+            Some(AgentEvent::ApprovalRequest {
+                approval_request_id,
+                tool_name,
+                risk_level,
+                title,
+                summary,
+                requested_action,
+                ..
+            }) => (
+                approval_request_id,
+                tool_name,
+                risk_level,
+                title,
+                summary,
+                requested_action,
+            ),
+            other => panic!("expected ApprovalRequest, got {:?}", other),
+        }
+    }
+
+    fn expect_error(event: Option<AgentEvent>) -> String {
+        match event {
+            Some(AgentEvent::Error(msg)) => msg,
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
     #[test]
     fn parse_event_carries_run_id() {
         let event = make_event("text_chunk", r#"{"text":"hi"}"#);
@@ -262,17 +344,11 @@ mod tests {
 
     #[test]
     fn parse_agent_end_state() {
-        parse_both_twins(
-            "agent_end",
-            r#"{"state":"cancelled"}"#,
-            |event| match event {
-                Some(AgentEvent::AgentEnd { state, error }) => {
-                    assert_eq!(state.as_deref(), Some("cancelled"));
-                    assert!(error.is_none());
-                }
-                other => panic!("expected AgentEnd, got {:?}", other),
-            },
-        );
+        parse_both_twins("agent_end", r#"{"state":"cancelled"}"#, |event| {
+            let (state, error) = expect_agent_end(event);
+            assert_eq!(state.as_deref(), Some("cancelled"));
+            assert!(error.is_none());
+        });
     }
 
     #[test]
@@ -293,43 +369,31 @@ mod tests {
 
     #[test]
     fn parse_agent_end_no_error() {
-        parse_both_twins("agent_end", "{}", |event| match event {
-            Some(AgentEvent::AgentEnd { error, .. }) => assert!(error.is_none()),
-            other => panic!("expected AgentEnd, got {:?}", other),
+        parse_both_twins("agent_end", "{}", |event| {
+            let (_, error) = expect_agent_end(event);
+            assert!(error.is_none());
         });
     }
 
     #[test]
     fn parse_agent_end_with_error() {
-        parse_both_twins(
-            "agent_end",
-            r#"{"error":"rate limited"}"#,
-            |event| match event {
-                Some(AgentEvent::AgentEnd { error, .. }) => {
-                    assert_eq!(error.as_deref(), Some("rate limited"))
-                }
-                other => panic!("expected AgentEnd, got {:?}", other),
-            },
-        );
+        parse_both_twins("agent_end", r#"{"error":"rate limited"}"#, |event| {
+            let (_, error) = expect_agent_end(event);
+            assert_eq!(error.as_deref(), Some("rate limited"));
+        });
     }
 
     #[test]
     fn parse_text_chunk() {
-        parse_both_twins(
-            "text_chunk",
-            r#"{"text":"Hello world"}"#,
-            |event| match event {
-                Some(AgentEvent::TextChunk(text)) => assert_eq!(text, "Hello world"),
-                other => panic!("expected TextChunk, got {:?}", other),
-            },
-        );
+        parse_both_twins("text_chunk", r#"{"text":"Hello world"}"#, |event| {
+            assert_eq!(expect_text_chunk(event), "Hello world");
+        });
     }
 
     #[test]
     fn parse_text_chunk_empty_data() {
-        parse_both_twins("text_chunk", "{}", |event| match event {
-            Some(AgentEvent::TextChunk(text)) => assert_eq!(text, ""),
-            other => panic!("expected TextChunk, got {:?}", other),
+        parse_both_twins("text_chunk", "{}", |event| {
+            assert_eq!(expect_text_chunk(event), "");
         });
     }
 
@@ -342,14 +406,9 @@ mod tests {
 
     #[test]
     fn parse_thinking_delta() {
-        parse_both_twins(
-            "thinking_delta",
-            r#"{"text":"Let me think"}"#,
-            |event| match event {
-                Some(AgentEvent::ThinkingDelta(text)) => assert_eq!(text, "Let me think"),
-                other => panic!("expected ThinkingDelta, got {:?}", other),
-            },
-        );
+        parse_both_twins("thinking_delta", r#"{"text":"Let me think"}"#, |event| {
+            assert_eq!(expect_thinking_delta(event), "Let me think");
+        });
     }
 
     #[test]
@@ -364,18 +423,11 @@ mod tests {
         parse_both_twins(
             "tool_start",
             r#"{"tool_id":"call_1","tool_name":"shell","tool_args":"{\"command\":\"ls\"}"}"#,
-            |event| match event {
-                Some(AgentEvent::ToolStart {
-                    tool_id,
-                    tool_name,
-                    tool_args,
-                    ..
-                }) => {
-                    assert_eq!(tool_id, "call_1");
-                    assert_eq!(tool_name, "shell");
-                    assert_eq!(tool_args.as_deref(), Some("{\"command\":\"ls\"}"));
-                }
-                other => panic!("expected ToolStart, got {:?}", other),
+            |event| {
+                let (tool_id, tool_name, tool_args) = expect_tool_start(event);
+                assert_eq!(tool_id, "call_1");
+                assert_eq!(tool_name, "shell");
+                assert_eq!(tool_args.as_deref(), Some("{\"command\":\"ls\"}"));
             },
         );
     }
@@ -387,10 +439,7 @@ mod tests {
         parse_both_twins(
             "tool_start",
             r#"{"tool_id":"call_1","tool_name":"shell","tool_args":{"command":"ls"}}"#,
-            |event| match event {
-                Some(AgentEvent::ToolStart { tool_args, .. }) => assert!(tool_args.is_none()),
-                other => panic!("expected ToolStart, got {:?}", other),
-            },
+            |event| assert!(expect_tool_start(event).2.is_none()),
         );
     }
 
@@ -399,10 +448,7 @@ mod tests {
         parse_both_twins(
             "tool_start",
             r#"{"tool_id":"call_1","tool_name":"read"}"#,
-            |event| match event {
-                Some(AgentEvent::ToolStart { tool_args, .. }) => assert!(tool_args.is_none()),
-                other => panic!("expected ToolStart, got {:?}", other),
-            },
+            |event| assert!(expect_tool_start(event).2.is_none()),
         );
     }
 
@@ -416,12 +462,10 @@ mod tests {
         parse_both_twins(
             "tool_delta",
             r#"{"tool_id":"call_1","text":"partial output"}"#,
-            |event| match event {
-                Some(AgentEvent::ToolDelta { tool_id, text }) => {
-                    assert_eq!(tool_id, "call_1");
-                    assert_eq!(text, "partial output");
-                }
-                other => panic!("expected ToolDelta, got {:?}", other),
+            |event| {
+                let (tool_id, text) = expect_tool_delta(event);
+                assert_eq!(tool_id, "call_1");
+                assert_eq!(text, "partial output");
             },
         );
     }
@@ -431,21 +475,18 @@ mod tests {
         parse_both_twins(
             "tool_end",
             r#"{"tool_id":"call_1","text":"file1.txt"}"#,
-            |event| match event {
-                Some(AgentEvent::ToolEnd { tool_id, text }) => {
-                    assert_eq!(tool_id, "call_1");
-                    assert_eq!(text.as_deref(), Some("file1.txt"));
-                }
-                other => panic!("expected ToolEnd, got {:?}", other),
+            |event| {
+                let (tool_id, text) = expect_tool_end(event);
+                assert_eq!(tool_id, "call_1");
+                assert_eq!(text.as_deref(), Some("file1.txt"));
             },
         );
     }
 
     #[test]
     fn parse_tool_end_no_text() {
-        parse_both_twins("tool_end", r#"{"tool_id":"call_1"}"#, |event| match event {
-            Some(AgentEvent::ToolEnd { text, .. }) => assert!(text.is_none()),
-            other => panic!("expected ToolEnd, got {:?}", other),
+        parse_both_twins("tool_end", r#"{"tool_id":"call_1"}"#, |event| {
+            assert!(expect_tool_end(event).1.is_none());
         });
     }
 
@@ -463,46 +504,30 @@ mod tests {
                 "summary": "rm -rf /",
                 "requested_action": {"command": "rm -rf /"}
             }"#,
-            |event| match event {
-                Some(AgentEvent::ApprovalRequest {
-                    approval_request_id,
-                    tool_name,
-                    risk_level,
-                    title,
-                    summary,
-                    requested_action,
-                    ..
-                }) => {
-                    assert_eq!(approval_request_id, "req_1");
-                    assert_eq!(tool_name, "shell");
-                    assert_eq!(risk_level, "high");
-                    assert_eq!(title, "Dangerous command");
-                    assert_eq!(summary, "rm -rf /");
-                    assert_eq!(requested_action["command"], "rm -rf /");
-                }
-                other => panic!("expected ApprovalRequest, got {:?}", other),
+            |event| {
+                let (approval_request_id, tool_name, risk_level, title, summary, requested_action) =
+                    expect_approval_request(event);
+                assert_eq!(approval_request_id, "req_1");
+                assert_eq!(tool_name, "shell");
+                assert_eq!(risk_level, "high");
+                assert_eq!(title, "Dangerous command");
+                assert_eq!(summary, "rm -rf /");
+                assert_eq!(requested_action["command"], "rm -rf /");
             },
         );
     }
 
     #[test]
     fn parse_error_event() {
-        parse_both_twins(
-            "error",
-            r#"{"error":"something went wrong"}"#,
-            |event| match event {
-                Some(AgentEvent::Error(msg)) => assert_eq!(msg, "something went wrong"),
-                other => panic!("expected Error, got {:?}", other),
-            },
-        );
+        parse_both_twins("error", r#"{"error":"something went wrong"}"#, |event| {
+            assert_eq!(expect_error(event), "something went wrong");
+        });
     }
 
     #[test]
     fn parse_error_event_invalid_json() {
-        match parsed(make_event("error", "not json")) {
-            Some(AgentEvent::Error(msg)) => assert_eq!(msg, "unknown error"),
-            other => panic!("expected Error, got {:?}", other),
-        }
+        let msg = expect_error(parsed(make_event("error", "not json")));
+        assert_eq!(msg, "unknown error");
     }
 
     #[test]
@@ -513,5 +538,89 @@ mod tests {
     #[test]
     fn parse_empty_type_returns_none() {
         assert!(parsed(make_event("", "{}")).is_none());
+    }
+
+    #[test]
+    fn parse_typed_error_with_empty_message_is_unknown_error() {
+        // The typed path maps an empty error string to "unknown error".
+        let event = proto::StreamEvent {
+            r#type: "error".to_string(),
+            payload: Some(proto::EventPayload {
+                kind: Some(proto::event_payload::Kind::Error(proto::ErrorEvent {
+                    error: String::new(),
+                })),
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(
+            parsed(event),
+            Some(AgentEvent::Error(msg)) if msg == "unknown error"
+        ));
+    }
+
+    #[test]
+    fn parse_typed_kind_without_agent_event_mapping_returns_none() {
+        // usage has no AgentEvent variant: the typed path falls through and
+        // the data path does not map the type either.
+        let event = proto::StreamEvent {
+            r#type: "usage".to_string(),
+            payload: Some(proto::EventPayload {
+                kind: Some(proto::event_payload::Kind::Usage(
+                    proto::UsageEvent::default(),
+                )),
+            }),
+            ..Default::default()
+        };
+        assert!(parsed(event).is_none());
+    }
+
+    // ── Extraction-helper mismatch arms ─────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "expected AgentEnd")]
+    fn expect_agent_end_rejects_other_events() {
+        expect_agent_end(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected TextChunk")]
+    fn expect_text_chunk_rejects_other_events() {
+        expect_text_chunk(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected ThinkingDelta")]
+    fn expect_thinking_delta_rejects_other_events() {
+        expect_thinking_delta(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected ToolStart")]
+    fn expect_tool_start_rejects_other_events() {
+        expect_tool_start(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected ToolDelta")]
+    fn expect_tool_delta_rejects_other_events() {
+        expect_tool_delta(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected ToolEnd")]
+    fn expect_tool_end_rejects_other_events() {
+        expect_tool_end(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected ApprovalRequest")]
+    fn expect_approval_request_rejects_other_events() {
+        expect_approval_request(Some(AgentEvent::Ping));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Error")]
+    fn expect_error_rejects_other_events() {
+        expect_error(Some(AgentEvent::Ping));
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -32,8 +32,23 @@ mod parity;
 
 #[cfg(test)]
 mod tests {
-    use super::proto::{RpcResponse, StreamEvent};
+    use super::proto::{response_payload, PromptAck, RpcResponse, SessionState, StreamEvent};
     use prost::Message;
+
+    /// Extract the GetState variant, panicking on anything else. The panic
+    /// arm stays covered by `expect_get_state_rejects_other_kinds`.
+    fn expect_get_state(kind: response_payload::Kind) -> SessionState {
+        match kind {
+            response_payload::Kind::GetState(state) => state,
+            other => panic!("unexpected payload kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected payload kind")]
+    fn expect_get_state_rejects_other_kinds() {
+        expect_get_state(response_payload::Kind::Prompt(PromptAck::default()));
+    }
 
     /// Smoke test: generated types round-trip through the wire encoding.
     #[test]
@@ -96,12 +111,8 @@ mod tests {
         let decoded = RpcResponse::decode(resp.encode_to_vec().as_slice()).unwrap();
         assert_eq!(resp, decoded);
         let kind = decoded.payload.unwrap().kind.unwrap();
-        match kind {
-            response_payload::Kind::GetState(state) => {
-                assert_eq!(state.session_id.as_deref(), Some("s1"))
-            }
-            other => panic!("unexpected payload kind: {other:?}"),
-        }
+        let state = expect_get_state(kind);
+        assert_eq!(state.session_id.as_deref(), Some("s1"));
 
         let event = StreamEvent {
             r#type: "tool_end".to_string(),

--- a/rpc/src/payloads.rs
+++ b/rpc/src/payloads.rs
@@ -275,6 +275,53 @@ mod tests {
         ("clientRequestId", "client_request_id"),
     ];
 
+    /// Mirror of the agent's get_state dual-write alias injection (top-level
+    /// plus per-ack snake_case), factored out so both the acks-present and
+    /// acks-absent edges get exercised.
+    fn inject_get_state_wire_aliases(wire: &mut Value) {
+        inject_legacy_aliases(wire, GET_STATE_ALIASES);
+        if let Some(acks) = wire
+            .get_mut("recentTerminalAcks")
+            .and_then(Value::as_array_mut)
+        {
+            for ack in acks {
+                inject_legacy_aliases(ack, TERMINAL_ACK_ALIASES);
+            }
+        }
+    }
+
+    /// Decode-side mirror of [`inject_get_state_wire_aliases`].
+    fn strip_get_state_wire_aliases(wire: &mut Value) {
+        strip_legacy_aliases(wire, GET_STATE_ALIASES);
+        if let Some(acks) = wire
+            .get_mut("recentTerminalAcks")
+            .and_then(Value::as_array_mut)
+        {
+            for ack in acks {
+                strip_legacy_aliases(ack, TERMINAL_ACK_ALIASES);
+            }
+        }
+    }
+
+    #[test]
+    fn inject_legacy_aliases_ignores_non_objects() {
+        let mut value = json!(["not", "an", "object"]);
+        inject_legacy_aliases(&mut value, GET_STATE_ALIASES);
+        assert_eq!(value, json!(["not", "an", "object"]));
+    }
+
+    /// With no recentTerminalAcks key both helpers still apply the top-level
+    /// alias pair and leave the rest untouched.
+    #[test]
+    fn get_state_wire_aliases_without_acks() {
+        let mut wire = json!({"sessionName": "Demo"});
+        inject_get_state_wire_aliases(&mut wire);
+        assert_eq!(wire["session_name"], json!("Demo"));
+        strip_get_state_wire_aliases(&mut wire);
+        assert!(wire.get("session_name").is_none());
+        assert_eq!(wire["sessionName"], json!("Demo"));
+    }
+
     #[test]
     fn inject_legacy_aliases_duplicates_present_keys_only() {
         let mut value = json!({"sessionName": "demo", "queuedCount": 0});
@@ -498,27 +545,11 @@ mod tests {
 
         // Agent dual-write: inject the legacy aliases, as get_state does.
         let mut wire = canonical.clone();
-        inject_legacy_aliases(&mut wire, GET_STATE_ALIASES);
-        if let Some(acks) = wire
-            .get_mut("recentTerminalAcks")
-            .and_then(Value::as_array_mut)
-        {
-            for ack in acks {
-                inject_legacy_aliases(ack, TERMINAL_ACK_ALIASES);
-            }
-        }
+        inject_get_state_wire_aliases(&mut wire);
 
         // Decode: strip duplicates, then deserialize (aliases cover
         // legacy-only JSON from pre-migration agents).
-        strip_legacy_aliases(&mut wire, GET_STATE_ALIASES);
-        if let Some(acks) = wire
-            .get_mut("recentTerminalAcks")
-            .and_then(Value::as_array_mut)
-        {
-            for ack in acks {
-                strip_legacy_aliases(ack, TERMINAL_ACK_ALIASES);
-            }
-        }
+        strip_get_state_wire_aliases(&mut wire);
         let decoded: GetStatePayload = serde_json::from_value(wire).unwrap();
         assert_eq!(serde_json::to_value(&decoded).unwrap(), canonical);
     }

--- a/rpc/src/payloads_ext.rs
+++ b/rpc/src/payloads_ext.rs
@@ -287,6 +287,29 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn run_accepted_state_as_str_and_parse_roundtrip() {
+        for (state, raw) in [
+            (RunAcceptedState::Existing, "existing"),
+            (RunAcceptedState::Running, "running"),
+            (RunAcceptedState::Queued, "queued"),
+        ] {
+            assert_eq!(state.as_str(), raw);
+            assert_eq!(RunAcceptedState::parse(raw), Some(state));
+        }
+        assert_eq!(RunAcceptedState::parse("bogus"), None);
+    }
+
+    #[test]
+    fn run_ack_existing_carries_no_queue_identity() {
+        let value = serde_json::to_value(RunAck::existing("run-c".into(), 2)).unwrap();
+        assert_eq!(value["run_id"], "run-c");
+        assert_eq!(value["run_epoch"], 2);
+        assert_eq!(value["accepted_state"], "existing");
+        assert!(value.get("run_sequence").is_none());
+        assert!(value.get("queue_position").is_none());
+    }
+
+    #[test]
     fn run_ack_omits_unallocated_queue_identity() {
         let value = serde_json::to_value(RunAck::running("run-a".into(), 7)).unwrap();
         assert_eq!(value["run_id"], "run-a");

--- a/rpc/tests/wire_roundtrip.rs
+++ b/rpc/tests/wire_roundtrip.rs
@@ -1,0 +1,185 @@
+//! In-process gRPC coverage for the generated tonic client/server plumbing
+//! in `future_rpc::proto` (the checked-in `generated/proto.rs`): client
+//! constructors and tuning methods, server builders, the unknown-path
+//! `Unimplemented` fallback, and a real ExecuteCommand / StreamEvents
+//! exchange over a loopback socket.
+
+use std::sync::Arc;
+
+use future_rpc::proto;
+use future_rpc::proto::future_agent_client::FutureAgentClient;
+use future_rpc::proto::future_agent_server::{FutureAgent, FutureAgentServer};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::codec::CompressionEncoding;
+use tonic::codegen::http;
+use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+/// Minimal in-process agent: echoes the command and emits one ping event.
+struct StubAgent;
+
+#[tonic::async_trait]
+impl FutureAgent for StubAgent {
+    async fn execute_command(
+        &self,
+        request: Request<proto::RpcCommand>,
+    ) -> Result<Response<proto::RpcResponse>, Status> {
+        let command = request.into_inner();
+        Ok(Response::new(proto::RpcResponse {
+            id: command.id,
+            r#type: "response".to_string(),
+            command: command.r#type,
+            success: true,
+            data: r#"{"ok":true}"#.to_string(),
+            ..Default::default()
+        }))
+    }
+
+    type StreamEventsStream = ReceiverStream<Result<proto::StreamEvent, Status>>;
+
+    async fn stream_events(
+        &self,
+        _request: Request<proto::StreamRequest>,
+    ) -> Result<Response<Self::StreamEventsStream>, Status> {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(Ok(proto::StreamEvent {
+            r#type: "ping".to_string(),
+            ..Default::default()
+        }))
+        .await
+        .map_err(|_| Status::internal("stream send failed"))?;
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+/// A client transport whose `poll_ready` always fails — drives the
+/// service-not-ready error mapping in the generated RPC methods without
+/// needing a socket.
+#[derive(Clone)]
+struct NeverReady;
+
+impl tonic::codegen::Service<http::Request<tonic::body::BoxBody>> for NeverReady {
+    type Response = http::Response<tonic::body::BoxBody>;
+    // Boxed: keeps clippy::result_large_err happy (tonic::Status is large).
+    type Error = Box<Status>;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Err(Box::new(Status::unavailable("never ready"))))
+    }
+
+    fn call(&mut self, _req: http::Request<tonic::body::BoxBody>) -> Self::Future {
+        std::future::ready(Err(Box::new(Status::unavailable("never ready"))))
+    }
+}
+
+#[tokio::test]
+async fn execute_command_and_stream_events_roundtrip() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().unwrap();
+    let server = tonic::transport::Server::builder()
+        .add_service(FutureAgentServer::new(StubAgent))
+        .serve_with_incoming(TcpListenerStream::new(listener));
+    tokio::spawn(server);
+
+    let mut client = FutureAgentClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect to in-process server");
+
+    let response = client
+        .execute_command(proto::RpcCommand {
+            id: "req-1".to_string(),
+            r#type: "get_state".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("execute_command")
+        .into_inner();
+    assert_eq!(response.id, "req-1");
+    assert_eq!(response.command, "get_state");
+    assert!(response.success);
+    assert_eq!(response.data, r#"{"ok":true}"#);
+
+    let mut stream = client
+        .stream_events(proto::StreamRequest::default())
+        .await
+        .expect("stream_events")
+        .into_inner();
+    let event = stream.message().await.unwrap().expect("one ping event");
+    assert_eq!(event.r#type, "ping");
+}
+
+/// Every generated client tuning method, then the not-ready error mapping
+/// for both RPCs.
+#[tokio::test]
+async fn client_builders_and_not_ready_errors() {
+    let mut client = FutureAgentClient::new(NeverReady)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(1024)
+        .max_encoding_message_size(2048);
+    let err = client
+        .execute_command(proto::RpcCommand::default())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unknown);
+
+    let mut client = FutureAgentClient::new(NeverReady);
+    let err = client
+        .stream_events(proto::StreamRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unknown);
+}
+
+#[test]
+// tonic's Interceptor trait fixes the `Result<_, Status>` closure signature.
+#[allow(clippy::result_large_err)]
+fn client_constructor_variants() {
+    let origin: http::Uri = "http://127.0.0.1:1".parse().unwrap();
+    let _client = FutureAgentClient::with_origin(NeverReady, origin);
+    let _client = FutureAgentClient::with_interceptor(NeverReady, |req: Request<()>| Ok(req));
+}
+
+#[test]
+// tonic's Interceptor trait fixes the `Result<_, Status>` closure signature.
+#[allow(clippy::result_large_err)]
+fn server_constructor_variants_and_tuning() {
+    let server = FutureAgentServer::from_arc(Arc::new(StubAgent));
+    let _server = server
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(1024)
+        .max_encoding_message_size(2048);
+    let _intercepted = FutureAgentServer::with_interceptor(StubAgent, |req: Request<()>| Ok(req));
+}
+
+/// A request to an unknown path gets the generated Unimplemented response.
+#[tokio::test]
+async fn server_unknown_path_is_unimplemented() {
+    use tonic::codegen::Service;
+
+    type Req = http::Request<tonic::body::BoxBody>;
+
+    let mut server = FutureAgentServer::new(StubAgent);
+    std::future::poll_fn(|cx| Service::<Req>::poll_ready(&mut server, cx))
+        .await
+        .expect("server is always ready");
+    let request = http::Request::builder()
+        .uri("/proto.FutureAgent/BogusMethod")
+        .body(tonic::body::empty_body())
+        .unwrap();
+    let response = Service::<Req>::call(&mut server, request)
+        .await
+        .expect("unimplemented response");
+    let status = response.headers().get(Status::GRPC_STATUS).unwrap();
+    assert_eq!(
+        status.to_str().unwrap(),
+        (tonic::Code::Unimplemented as i32).to_string()
+    );
+}


### PR DESCRIPTION
## Why

Part of goal_4a742a954e3c (workspace coverage → 100%). Baseline from `coverage/lcov.info` @ 4d3dd2fc (see #138): **rpc 91.77%** — 245 missed lines, mostly in `decode.rs` (no test module at all) and the generated tonic client/server plumbing.

After this PR: **0 missed lines in every rpc source file**, measured both ways:
- standalone: `cargo llvm-cov -p future-rpc` → 3307/3307 lines
- workspace-merged (scripts/coverage.sh methodology): rpc **100.00%** (3305/3305)

## What was uncovered and how it's covered now

| File | Gap | Fix |
|---|---|---|
| `decode.rs` (106 lines) | no test module | new unit tests: typed + JSON-fallback + absent matrix for every `decode_*` getter, `response_data_str`, alias inject/strip edges, approval-card extras / null `save_suggestion` / unparseable-extras edges, `run_terminal` error arm, all `event_data(_json)` / projected / replay variants |
| `generated/proto.rs` (89) | tonic client/server builders, error mapping, unimplemented-path | new `rpc/tests/wire_roundtrip.rs`: in-process gRPC round-trip, `NeverReady` mock transport for the not-ready mapping, direct `Service::call` with a bogus path → `Unimplemented` |
| `events.rs` (17) | typed empty-error arm, unmapped-kind fallthrough, 15 `other => panic!` test arms | two edge tests + shared extraction helpers with `should_panic` twins (failure lines stay coverable; assertions unchanged) |
| `lib.rs` (1) | panic arm in round-trip test | same helper + `should_panic` pattern |
| `payloads.rs` (3) | non-object no-op, if-let false edges | non-object test; wire-alias helpers extracted so acks-present/acks-absent both execute |
| `payloads_ext.rs` (2) | `RunAcceptedState::Existing` | as_str/parse round-trip test + `RunAck::existing` test |

## Three behavior-preserving code tweaks

Defensive-but-unreachable arms compile to dead lines that can never be covered:
1. `typed_response_data`: removed the unreachable `_ => None` wildcard — the match is now **exhaustive** over the 16 `response_payload` members, so adding a oneof member fails the build until it gets a decoder (or an explicit `=> None` to keep the JSON fallback).
2. `typed_response_data` list_sessions: iterate the just-built `sessions` array infallibly (`into_iter().flatten()`) instead of an if-let that cannot fail.
3. `typed_event_json`: combinator chain instead of a match whose `None` arm `typed_event_json_inner` never produces.

## Verification

- `cargo test --workspace`: 2209 passed (baseline 2173, +36 new), 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; also clean for `-p future-rpc --target x86_64-pc-windows-msvc`
- `cargo fmt --check` clean; `desktop/src-tauri` clippy clean (future-rpc consumer)
- Desktop frontend checks (tsc/eslint/vitest) skipped: change touches only `rpc/` Rust sources, no shared files

Dev-deps added to `future-rpc`: `tokio` (workspace), `tokio-stream` net, `tonic` gzip (integration test only).