### PR TITLE
ci(docs): publish English wiki to OSS docs/en/ prefix

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,15 +1,16 @@
 name: Publish Docs
 
-# Publish the Chinese wiki (docs/wiki/zh/) to Aliyun OSS (docs/ prefix). Manual
-# trigger only — run it from the Actions tab ("Run workflow") or with
+# Publish the Chinese wiki (docs/wiki/zh/) to Aliyun OSS (docs/ prefix) and the
+# English wiki (docs/wiki/en/) to the docs/en/ prefix. Manual trigger only —
+# run it from the Actions tab ("Run workflow") or with
 # `gh workflow run publish-wiki.yml`.
 #
-# Only the Chinese pages are published; the English pages under docs/wiki/en/
-# are not pushed to OSS.
+# The console serves these docs through /platform/v1/docs; the frontend picks
+# the language via ?lang=en (en → docs/en/ prefix) or the root prefix (zh).
 #
-# OSS publish uploads and updates the current Chinese pages. It deliberately
-# does not delete objects that disappeared locally: the publishing credential
-# has no DeleteObject permission.
+# OSS publish uploads and updates the current pages. It deliberately does not
+# delete objects that disappeared locally: the publishing credential has no
+# DeleteObject permission.
 
 on:
   workflow_dispatch:
@@ -48,4 +49,13 @@ jobs:
           set -euo pipefail
           echo "==> Syncing docs/wiki/zh/ → docs/"
           ossutil sync docs/wiki/zh/ "oss://$OSS_BUCKET/docs/" -f
+          echo "==> Done."
+
+      # English pages go to the docs/en/ prefix — the console requests them
+      # with ?lang=en through the /platform/v1/docs proxy.
+      - name: Publish docs/wiki/en to OSS
+        run: |
+          set -euo pipefail
+          echo "==> Syncing docs/wiki/en/ → docs/en/"
+          ossutil sync docs/wiki/en/ "oss://$OSS_BUCKET/docs/en/" -f
           echo "==> Done."


### PR DESCRIPTION
## 背景
console 英文版需要加载英文文档。英文文档在 `docs/wiki/en/`，但 publish-wiki.yml 只发布中文。

## 变更
- 新增一步：`ossutil sync docs/wiki/en/ → oss://$OSS_BUCKET/docs/en/`
- 同步更新 workflow 头部注释

配合 future-server e6dfa8c（docs_proxy 支持 ?lang=en，前端 en locale 带该参数），
英文文档发布后 console 英文版即可加载英文 docs。

## 验证
- workflow 语法 OK（无 lint 错误）
- 发布动作需人工触发 `gh workflow run publish-wiki.yml`（OSS 凭据在 repo secrets）