### PR TITLE
fix(deps): upgrade nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -6931,9 +6931,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -58,6 +58,7 @@
     "fsevents@2.3.3": true
   },
   "overrides": {
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17"
   }
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -11565,24 +11565,6 @@
       "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmmirror.com/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -12393,6 +12375,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -54,7 +54,8 @@
   "overrides": {
     "uuid": ">=11.1.1",
     "js-yaml@3": "^3.15.1",
-    "js-yaml@4": "^4.3.1"
+    "js-yaml@4": "^4.3.1",
+    "nanoid": "^3.3.17"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary

- Upgrade `nanoid` from 3.3.16 → 3.3.18 in both `desktop` and `mobile` to close **GHSA-2v37-7h3g-55p8** (high): custom generators can loop indefinitely when size is zero.
- nanoid is a transitive dependency of `postcss`; added `"nanoid": "^3.3.17"` to `overrides` in both `package.json` files. Lockfiles now resolve 3.3.18.
- Constrained to 3.x (not `>=3.3.17` freely) because postcss requires the CJS build; nanoid 4+ is pure ESM and would break it.

## Out of scope (no patched version upstream)

Dependabot also flags these open alerts that **cannot** be fixed by upgrading:

- **image-size** (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq): latest published version is 2.0.2, which is itself within the vulnerable range (`<= 2.0.2`). Transitive dep of `metro` (React Native bundler); all metro versions (0.84–0.87) depend on it.
- **glib** (GHSA-wrw7-89jp-8q8g): 0.18.5 is pinned by tauri 2.x's GTK3 stack (`gtk 0.18` → `atk` → `glib`). The fix requires a GTK4 / tauri 3 migration.

Recommend dismissing these with "no patched version available."

## Test plan

- [x] `npm ci --dry-run` passes for both `desktop` and `mobile` (lockfiles in sync)
- [x] Verified postcss loads its nested nanoid 3.3.18 (CJS require works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)