### PR TITLE
test(loop): future-loop coverage 77.72% → 98.43% lines + 4 runtime bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
               - 'channels/**'
               - 'tui/**'
               - 'cli/**'
+              - 'orchestration/**'
             desktop_tauri:
               - 'desktop/src-tauri/**'
               - '.cargo/**'

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -11,6 +11,13 @@ use future_rpc::proto::future_agent_client::FutureAgentClient;
 use future_rpc::proto::{RpcCommand, StreamEvent, StreamRequest};
 use serde_json::Value;
 
+/// Agent gRPC address (`host:port`). Defaults to the local agent; overridable
+/// via FUTURE_LOOP_AGENT_ADDR so tests can point the control plane at a mock
+/// server (mirrors the BROWSER_LAUNCHER_OVERRIDE test-hook precedent in cli).
+pub fn agent_addr() -> String {
+    std::env::var("FUTURE_LOOP_AGENT_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string())
+}
+
 /// What the agent reported at the end of one bounded turn (agent_end).
 #[derive(Debug, Clone)]
 pub struct RunSummary {

--- a/orchestration/loop/src/benchmark/adapter.rs
+++ b/orchestration/loop/src/benchmark/adapter.rs
@@ -179,7 +179,12 @@ impl GrpcLoopxAdapter {
     }
 
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {
-        tokio::runtime::Handle::current().block_on(fut)
+        // The adapter is sync but called from cmd_benchmark_run INSIDE the
+        // console runtime — a bare Handle::block_on would panic there
+        // ("cannot start a runtime from within a runtime"). block_in_place
+        // moves the current worker aside and drives the future to
+        // completion; the console runtime is always multi_thread.
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
     }
 }
 

--- a/orchestration/loop/src/benchmark/qualification.rs
+++ b/orchestration/loop/src/benchmark/qualification.rs
@@ -298,6 +298,33 @@ mod tests {
         assert!(!result.passed);
         assert_eq!(result.rounds_used, 0);
         assert_eq!(result.failure_class, "runner_error");
+        // Exercise the unreachable-by-design stub arms so coverage sees them
+        // (they must bail, never panic-free return).
+        let request = case.request();
+        let handle = super::super::adapter::RunHandle {
+            run_id: "r".to_string(),
+            external_id: "e".to_string(),
+        };
+        let observation = super::super::adapter::Observation {
+            terminal_state: "completed".to_string(),
+            error: None,
+            tools: vec![],
+            evidence: String::new(),
+            tokens_in: 0,
+            tokens_out: 0,
+            cost: 0.0,
+        };
+        assert_eq!(adapter.id(), "broken");
+        assert!(adapter.launch(&request).is_err());
+        assert!(adapter.observe(&handle).is_err());
+        assert!(adapter.ingest(&request, &handle, &observation).is_err());
+        let ingest = super::super::adapter::IngestResult {
+            benchmark_run: Default::default(),
+            observation,
+            passed: false,
+        };
+        assert!(adapter.classify(&request, &ingest).is_err());
+        assert!(adapter.ledger(&request, &ingest, None, 0).is_err());
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1952,65 +1952,81 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     result
 }
 
+/// One steer poll step: read newly appended ledger lines since `offset` and
+/// inject any `todo_updated` text for `todo_id` into the session. Returns
+/// the new offset. Extracted from the watch loop for testability.
+#[doc(hidden)] // test-visible seam for steer_todo_updates
+pub async fn steer_poll_once(
+    events_path: &std::path::Path,
+    offset: u64,
+    todo_id: &str,
+    client: &mut Option<crate::agent_client::AgentClient>,
+    session_id: &str,
+) -> u64 {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(meta) = std::fs::metadata(events_path) else {
+        return offset;
+    };
+    if meta.len() <= offset {
+        return offset;
+    }
+    let mut buf = String::new();
+    let mut new_offset = offset;
+    {
+        let Ok(mut f) = std::fs::File::open(events_path) else {
+            return offset;
+        };
+        if f.seek(SeekFrom::Start(offset)).is_err() {
+            return offset;
+        }
+        if f.read_to_string(&mut buf).is_err() {
+            return offset;
+        }
+        new_offset = meta.len();
+    }
+    for line in buf.lines() {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if v.get("kind").and_then(|k| k.as_str()) != Some("todo_updated") {
+            continue;
+        }
+        if v.get("todo_id").and_then(|t| t.as_str()) != Some(todo_id) {
+            continue;
+        }
+        let Some(new_text) = v.get("text").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        if client.is_none() {
+            *client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr())
+                .await
+                .ok();
+        }
+        if let Some(c) = client.as_mut() {
+            let msg = format!(
+                "ORCHESTRATOR STEERING (todo {todo_id} updated mid-turn — new instructions below; adjust your current work accordingly):\n{new_text}"
+            );
+            if c.steer(session_id, &msg).await.is_err() {
+                *client = None; // reconnect on the next event
+            }
+        }
+    }
+    new_offset
+}
+
 /// Mid-turn steering watcher: tail the goal ledger; when the orchestrator
 /// updates the CURRENT todo's text mid-turn (`todo update --text`), inject the
 /// new instructions into the running session via the `steer` RPC (drained by
 /// the agent at its next step boundary). Runs as a background task for the
 /// duration of one turn; never completes on its own (all error paths retry).
 async fn steer_todo_updates(events_path: std::path::PathBuf, todo_id: String, session_id: String) {
-    use std::io::{Read, Seek, SeekFrom};
     let mut offset = std::fs::metadata(&events_path)
         .map(|m| m.len())
         .unwrap_or(0);
     let mut client: Option<crate::agent_client::AgentClient> = None;
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-        let Ok(meta) = std::fs::metadata(&events_path) else {
-            continue;
-        };
-        if meta.len() <= offset {
-            continue;
-        }
-        let mut buf = String::new();
-        {
-            let Ok(mut f) = std::fs::File::open(&events_path) else {
-                continue;
-            };
-            if f.seek(SeekFrom::Start(offset)).is_err() {
-                continue;
-            }
-            if f.read_to_string(&mut buf).is_err() {
-                continue;
-            }
-            offset = meta.len();
-        }
-        for line in buf.lines() {
-            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
-                continue;
-            };
-            if v.get("kind").and_then(|k| k.as_str()) != Some("todo_updated") {
-                continue;
-            }
-            if v.get("todo_id").and_then(|t| t.as_str()) != Some(todo_id.as_str()) {
-                continue;
-            }
-            let Some(new_text) = v.get("text").and_then(|t| t.as_str()) else {
-                continue;
-            };
-            if client.is_none() {
-                client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr())
-                    .await
-                    .ok();
-            }
-            if let Some(c) = client.as_mut() {
-                let msg = format!(
-                    "ORCHESTRATOR STEERING (todo {todo_id} updated mid-turn — new instructions below; adjust your current work accordingly):\n{new_text}"
-                );
-                if c.steer(&session_id, &msg).await.is_err() {
-                    client = None; // reconnect on the next event
-                }
-            }
-        }
+        offset = steer_poll_once(&events_path, offset, &todo_id, &mut client, &session_id).await;
     }
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1973,7 +1973,6 @@ pub async fn steer_poll_once(
         return offset;
     }
     let mut buf = String::new();
-    let mut new_offset = offset;
     {
         let Ok(mut f) = std::fs::File::open(events_path) else {
             return offset;
@@ -1984,8 +1983,8 @@ pub async fn steer_poll_once(
         if f.read_to_string(&mut buf).is_err() {
             return offset;
         }
-        new_offset = meta.len();
     }
+    let new_offset = meta.len();
     for line in buf.lines() {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
@@ -5139,7 +5138,7 @@ mod coverage_tests {
         // sync_compat on a goal with no ledger → Ok no-op; refresh_next_action
         // on the same → not-found error.
         sync_compat(&store, "goal_ghost").unwrap();
-        assert!(refresh_next_action(&mut store, "goal_ghost").is_err());
+        assert!(refresh_next_action(&store, "goal_ghost").is_err());
         // And the write path for a real goal (produces ACTIVE_GOAL_STATE.md).
         let goal = Goal::new("gs", "sync goal", "/tmp");
         store.register(&goal).unwrap();
@@ -5149,7 +5148,7 @@ mod coverage_tests {
                 ts: 1,
             })
             .unwrap();
-        refresh_next_action(&mut store, "gs").unwrap();
+        refresh_next_action(&store, "gs").unwrap();
         sync_compat(&store, "gs").unwrap();
         assert!(store.goal_dir("gs").join("ACTIVE_GOAL_STATE.md").exists());
     }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4914,16 +4914,13 @@ mod coverage_tests {
 
     #[test]
     fn event_touches_todo_matrix() {
+        let mut wrongly_touched = false;
         for ev in all_events("todo_1") {
-            let touches = event_touches_todo(&ev, "todo_1");
-            let touches_other = event_touches_todo(&ev, "todo_other");
-            // Every todo-carrying variant matches its todo; none matches a
-            // different id. Goal-level variants never touch.
-            if touches_other {
-                panic!("{ev:?} must not touch todo_other");
-            }
-            let _ = touches;
+            let _touches = event_touches_todo(&ev, "todo_1");
+            // No event variant may match a different todo id.
+            wrongly_touched |= event_touches_todo(&ev, "todo_other");
         }
+        assert!(!wrongly_touched);
         assert!(event_touches_todo(&Event::TodoAdded {
             goal_id: "g".into(),
             todo: Todo::advancement("todo_1", "task"),
@@ -5075,5 +5072,32 @@ mod coverage_tests {
         print_status_json(&store, None).unwrap();
         print_status_json(&store, Some("gj".to_string())).unwrap();
         assert!(print_status_json(&store, Some("goal_nope".to_string())).is_err());
+    }
+
+    #[test]
+    fn sync_helpers_tolerate_missing_goals() {
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-console-sync-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let root = dir.to_string_lossy().into_owned();
+        let mut store = Store::open(&root).unwrap();
+        // sync_compat on a goal with no ledger → Ok no-op; refresh_next_action
+        // on the same → not-found error.
+        sync_compat(&store, "goal_ghost").unwrap();
+        assert!(refresh_next_action(&mut store, "goal_ghost").is_err());
+        // And the write path for a real goal (produces ACTIVE_GOAL_STATE.md).
+        let goal = Goal::new("gs", "sync goal", "/tmp");
+        store.register(&goal).unwrap();
+        store
+            .append(Event::GoalStarted { goal_id: "gs".into(), ts: 1 })
+            .unwrap();
+        refresh_next_action(&mut store, "gs").unwrap();
+        sync_compat(&store, "gs").unwrap();
+        assert!(store.goal_dir("gs").join("ACTIVE_GOAL_STATE.md").exists());
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -148,7 +148,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "replay" => cmd_replay(&store, &args[1..]),
         "canary" => cmd_canary(&store, &args[1..]),
         "version" => cmd_version(&store, &args[1..]),
-        "doctor" => cmd_doctor(&store, &args[1..]),
+        "doctor" => cmd_doctor(&store, &args[1..]).await,
         "history" => cmd_history(&store, &args[1..]),
         "turn" => cmd_turn(&store, &args[1..]),
         "todo-event" => cmd_todo_event(&store, &args[1..]),
@@ -1811,7 +1811,7 @@ fn scheduler_record_failure(store: &Store, args: &[String]) -> Result<()> {
 /// agent (auth.json / models.json merged with the built-in catalog).
 async fn cmd_models(args: &[String]) -> Result<()> {
     let json = args.iter().any(|a| a == "--format" || a == "--json");
-    let mut client = crate::agent_client::AgentClient::connect("127.0.0.1:50051").await?;
+    let mut client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
     let data = client.list_models().await?;
     let models = data["models"].as_array().cloned().unwrap_or_default();
     let default_model = data["defaultModel"].as_str().unwrap_or("");
@@ -1918,7 +1918,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     // (and stays unit-testable without an agent server).
     let agent_id = ensure_run_identity(store, &goal_id, agent_id.as_deref(), anonymous)?;
 
-    let mut client = crate::agent_client::AgentClient::connect("127.0.0.1:50051").await?;
+    let mut client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
     let goal0 = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
@@ -1998,7 +1998,7 @@ async fn steer_todo_updates(events_path: std::path::PathBuf, todo_id: String, se
                 continue;
             };
             if client.is_none() {
-                client = crate::agent_client::AgentClient::connect("127.0.0.1:50051")
+                client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr())
                     .await
                     .ok();
             }
@@ -2275,7 +2275,7 @@ async fn run_turns(
             })?;
             println!("   poll result: {result} (no_change_count={no_change_count})");
         }
-        if succeeded {
+        if succeeded && mode != crate::contract::TurnMode::MonitorPoll {
             store.append(Event::TodoCompleted {
                 goal_id: goal_id.to_string(),
                 todo_id: todo_id.clone(),
@@ -4155,7 +4155,7 @@ fn cmd_diagnose(store: &Store, args: &[String]) -> Result<()> {
 
 /// `loopx doctor [--goal G] [--agent-addr ADDR]` — run the diagnostic
 /// surface: canary release-gate + per-goal ledger/decision checks.
-fn cmd_doctor(store: &Store, args: &[String]) -> Result<()> {
+async fn cmd_doctor(store: &Store, args: &[String]) -> Result<()> {
     let mut goal_filter = None;
     let mut agent_addr = None;
     parse_pairs(args, |k, v| match k {
@@ -4202,12 +4202,11 @@ fn cmd_doctor(store: &Store, args: &[String]) -> Result<()> {
             Err(e) => failures.push(format!("goal {goal_id}: {e}")),
         }
     }
-    // gRPC reachability probe (only when --agent-addr is given).
+    // gRPC reachability probe (only when --agent-addr is given). Awaited
+    // directly — a nested block_on here would panic inside console::run's
+    // runtime (the probe used to build its own current_thread runtime).
     if let Some(addr) = &agent_addr {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        let probe = runtime.block_on(async {
+        let probe = async {
             let mut client = crate::agent_client::AgentClient::connect(addr).await?;
             let session = client.new_session("/tmp").await?;
             let totals = client.session_totals(&session).await?;
@@ -4215,7 +4214,8 @@ fn cmd_doctor(store: &Store, args: &[String]) -> Result<()> {
                 "session {session} live (tokens_in={} tokens_out={})",
                 totals.tokens_in, totals.tokens_out
             ))
-        });
+        }
+        .await;
         match probe {
             Ok(detail) => println!("  [ok] agent gRPC {addr}: {detail}"),
             Err(e) => {

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1811,7 +1811,8 @@ fn scheduler_record_failure(store: &Store, args: &[String]) -> Result<()> {
 /// agent (auth.json / models.json merged with the built-in catalog).
 async fn cmd_models(args: &[String]) -> Result<()> {
     let json = args.iter().any(|a| a == "--format" || a == "--json");
-    let mut client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
+    let mut client =
+        crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
     let data = client.list_models().await?;
     let models = data["models"].as_array().cloned().unwrap_or_default();
     let default_model = data["defaultModel"].as_str().unwrap_or("");
@@ -1918,7 +1919,8 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     // (and stays unit-testable without an agent server).
     let agent_id = ensure_run_identity(store, &goal_id, agent_id.as_deref(), anonymous)?;
 
-    let mut client = crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
+    let mut client =
+        crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await?;
     let goal0 = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
@@ -4786,7 +4788,10 @@ mod coverage_tests {
 
     fn all_events(todo_id: &str) -> Vec<Event> {
         vec![
-            Event::GoalStarted { goal_id: "g".into(), ts: 1 },
+            Event::GoalStarted {
+                goal_id: "g".into(),
+                ts: 1,
+            },
             Event::TodoAdded {
                 goal_id: "g".into(),
                 todo: Todo::advancement(todo_id, "task"),
@@ -4800,7 +4805,11 @@ mod coverage_tests {
                 evidence: Some("e".into()),
                 ts: 1,
             },
-            Event::TodoSuperseded { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::TodoSuperseded {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                ts: 1,
+            },
             Event::TodoUpdated {
                 goal_id: "g".into(),
                 todo_id: todo_id.into(),
@@ -4813,7 +4822,11 @@ mod coverage_tests {
                 blocks: None,
                 ts: 1,
             },
-            Event::GoalCancelled { goal_id: "g".into(), reason: "r".into(), ts: 1 },
+            Event::GoalCancelled {
+                goal_id: "g".into(),
+                reason: "r".into(),
+                ts: 1,
+            },
             Event::GateResolved {
                 goal_id: "g".into(),
                 todo_id: todo_id.into(),
@@ -4821,8 +4834,16 @@ mod coverage_tests {
                 note: None,
                 ts: 1,
             },
-            Event::GapSatisfied { goal_id: "g".into(), gap_id: "gap1".into(), ts: 1 },
-            Event::RunRecorded { goal_id: "g".into(), record: record(todo_id), ts: 1 },
+            Event::GapSatisfied {
+                goal_id: "g".into(),
+                gap_id: "gap1".into(),
+                ts: 1,
+            },
+            Event::RunRecorded {
+                goal_id: "g".into(),
+                record: record(todo_id),
+                ts: 1,
+            },
             Event::TodoClaimed {
                 goal_id: "g".into(),
                 todo_id: todo_id.into(),
@@ -4830,22 +4851,38 @@ mod coverage_tests {
                 lease_expires_at: 9,
                 ts: 1,
             },
-            Event::AgentRegistered { goal_id: "g".into(), agent_id: "a".into(), ts: 1 },
+            Event::AgentRegistered {
+                goal_id: "g".into(),
+                agent_id: "a".into(),
+                ts: 1,
+            },
             Event::AgentOnboarded {
                 goal_id: "g".into(),
                 agent_id: "a".into(),
                 capabilities: vec!["shell".into()],
                 ts: 1,
             },
-            Event::ReplanAcked { goal_id: "g".into(), delta_kinds: vec!["vision_patch".into()], ts: 1 },
-            Event::ProfileSet { goal_id: "g".into(), outcome_floor_streak_threshold: 2, ts: 1 },
+            Event::ReplanAcked {
+                goal_id: "g".into(),
+                delta_kinds: vec!["vision_patch".into()],
+                ts: 1,
+            },
+            Event::ProfileSet {
+                goal_id: "g".into(),
+                outcome_floor_streak_threshold: 2,
+                ts: 1,
+            },
             Event::AuthoritySet {
                 goal_id: "g".into(),
                 write_scope: vec!["src".into()],
                 requires_approval: vec!["publish".into()],
                 ts: 1,
             },
-            Event::TodoArchived { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::TodoArchived {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                ts: 1,
+            },
             Event::MonitorPolled {
                 goal_id: "g".into(),
                 todo_id: todo_id.into(),
@@ -4880,7 +4917,11 @@ mod coverage_tests {
                 agent_id: "a".into(),
                 ts: 1,
             },
-            Event::TodoExpired { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::TodoExpired {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                ts: 1,
+            },
             Event::SupervisorProposed {
                 goal_id: "g".into(),
                 supervisor_agent_id: "sup".into(),
@@ -4921,13 +4962,19 @@ mod coverage_tests {
             wrongly_touched |= event_touches_todo(&ev, "todo_other");
         }
         assert!(!wrongly_touched);
-        assert!(event_touches_todo(&Event::TodoAdded {
-            goal_id: "g".into(),
-            todo: Todo::advancement("todo_1", "task"),
-            ts: 1,
-        }, "todo_1"));
+        assert!(event_touches_todo(
+            &Event::TodoAdded {
+                goal_id: "g".into(),
+                todo: Todo::advancement("todo_1", "task"),
+                ts: 1,
+            },
+            "todo_1"
+        ));
         assert!(!event_touches_todo(
-            &Event::GoalStarted { goal_id: "g".into(), ts: 1 },
+            &Event::GoalStarted {
+                goal_id: "g".into(),
+                ts: 1
+            },
             "todo_1"
         ));
     }
@@ -4971,8 +5018,8 @@ mod coverage_tests {
         let mut seen: Vec<(String, String)> = vec![];
         parse_pairs(
             &[
-                "--flag".to_string(),       // boolean-ish flag at end
-                "positional".to_string(),   // skipped
+                "--flag".to_string(),     // boolean-ish flag at end
+                "positional".to_string(), // skipped
                 "--key".to_string(),
                 "value".to_string(),
                 "--no-follow-up".to_string(), // known boolean, followed by value-less
@@ -5065,7 +5112,10 @@ mod coverage_tests {
         let goal = Goal::new("gj", "json goal", "/tmp");
         store.register(&goal).unwrap();
         store
-            .append(Event::GoalStarted { goal_id: "gj".into(), ts: 1 })
+            .append(Event::GoalStarted {
+                goal_id: "gj".into(),
+                ts: 1,
+            })
             .unwrap();
         // No filter → iterates the registry; with filter → single goal;
         // unknown filter → error.
@@ -5094,7 +5144,10 @@ mod coverage_tests {
         let goal = Goal::new("gs", "sync goal", "/tmp");
         store.register(&goal).unwrap();
         store
-            .append(Event::GoalStarted { goal_id: "gs".into(), ts: 1 })
+            .append(Event::GoalStarted {
+                goal_id: "gs".into(),
+                ts: 1,
+            })
             .unwrap();
         refresh_next_action(&mut store, "gs").unwrap();
         sync_compat(&store, "gs").unwrap();

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4739,3 +4739,325 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     println!("todo {todo_id} updated ✔");
     Ok(())
 }
+
+// ── in-module coverage tests ───────────────────────────────────────────────
+// Helpers and render paths that the CLI surface cannot reach (private fns,
+// defensive arms, non-todo event descriptions, the `future loop` prog name).
+
+#[cfg(test)]
+mod coverage_tests {
+    use super::*;
+    use crate::state::{Goal, RunRecord, TaskClass, Todo, TodoStatus};
+    use crate::store::Event;
+
+    fn record(todo_id: &str) -> RunRecord {
+        RunRecord {
+            turn: 1,
+            todo_id: todo_id.to_string(),
+            run_id: "run-1".to_string(),
+            terminal_state: "completed".to_string(),
+            error: None,
+            tokens_in_delta: 1,
+            tokens_out_delta: 2,
+            cost_delta: 0.1,
+            tools: vec!["shell".to_string()],
+            evidence: "proof".to_string(),
+            recorded_at: 1_700_000_000,
+            spend_source: Some("run".to_string()),
+            validation: None,
+        }
+    }
+
+    fn all_events(todo_id: &str) -> Vec<Event> {
+        vec![
+            Event::GoalStarted { goal_id: "g".into(), ts: 1 },
+            Event::TodoAdded {
+                goal_id: "g".into(),
+                todo: Todo::advancement(todo_id, "task"),
+                ts: 1,
+            },
+            Event::TodoCompleted {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                no_follow_up: true,
+                successor_ids: vec!["s1".into()],
+                evidence: Some("e".into()),
+                ts: 1,
+            },
+            Event::TodoSuperseded { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::TodoUpdated {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                text: Some("t".into()),
+                status: None,
+                evidence: None,
+                note: None,
+                priority: None,
+                resume_when: None,
+                blocks: None,
+                ts: 1,
+            },
+            Event::GoalCancelled { goal_id: "g".into(), reason: "r".into(), ts: 1 },
+            Event::GateResolved {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                decision: "d".into(),
+                note: None,
+                ts: 1,
+            },
+            Event::GapSatisfied { goal_id: "g".into(), gap_id: "gap1".into(), ts: 1 },
+            Event::RunRecorded { goal_id: "g".into(), record: record(todo_id), ts: 1 },
+            Event::TodoClaimed {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                agent_id: "a".into(),
+                lease_expires_at: 9,
+                ts: 1,
+            },
+            Event::AgentRegistered { goal_id: "g".into(), agent_id: "a".into(), ts: 1 },
+            Event::AgentOnboarded {
+                goal_id: "g".into(),
+                agent_id: "a".into(),
+                capabilities: vec!["shell".into()],
+                ts: 1,
+            },
+            Event::ReplanAcked { goal_id: "g".into(), delta_kinds: vec!["vision_patch".into()], ts: 1 },
+            Event::ProfileSet { goal_id: "g".into(), outcome_floor_streak_threshold: 2, ts: 1 },
+            Event::AuthoritySet {
+                goal_id: "g".into(),
+                write_scope: vec!["src".into()],
+                requires_approval: vec!["publish".into()],
+                ts: 1,
+            },
+            Event::TodoArchived { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::MonitorPolled {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                result: "changed".into(),
+                no_change_count: 0,
+                ts: 1,
+            },
+            Event::QuotaSpent {
+                goal_id: "g".into(),
+                run_id: "r1".into(),
+                todo_id: todo_id.into(),
+                source: "run".into(),
+                slots: 1,
+                ts: 1,
+            },
+            Event::EvidenceAttached {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                evidence: "e".into(),
+                ts: 1,
+            },
+            Event::TodoRenewed {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                agent_id: "a".into(),
+                lease_expires_at: 9,
+                ts: 1,
+            },
+            Event::TodoReleased {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                agent_id: "a".into(),
+                ts: 1,
+            },
+            Event::TodoExpired { goal_id: "g".into(), todo_id: todo_id.into(), ts: 1 },
+            Event::SupervisorProposed {
+                goal_id: "g".into(),
+                supervisor_agent_id: "sup".into(),
+                decision_id: "d1".into(),
+                decision_kind: "observe".into(),
+                target_agent_id: "w1".into(),
+                required_host_capabilities: vec![],
+                decision: "watch".into(),
+                ts: 1,
+            },
+            Event::SupervisorReceiptRecorded {
+                goal_id: "g".into(),
+                decision_id: "d1".into(),
+                receipt_id: "r1".into(),
+                adapter_id: "ad".into(),
+                outcome: "executed".into(),
+                authority_ref: Some("auth".into()),
+                rollback_ref: None,
+                ts: 1,
+            },
+        ]
+    }
+
+    #[test]
+    fn describe_event_covers_every_variant() {
+        for ev in all_events("todo_1") {
+            let s = describe_event(&ev);
+            assert!(!s.is_empty(), "{ev:?}");
+        }
+    }
+
+    #[test]
+    fn event_touches_todo_matrix() {
+        for ev in all_events("todo_1") {
+            let touches = event_touches_todo(&ev, "todo_1");
+            let touches_other = event_touches_todo(&ev, "todo_other");
+            // Every todo-carrying variant matches its todo; none matches a
+            // different id. Goal-level variants never touch.
+            if touches_other {
+                panic!("{ev:?} must not touch todo_other");
+            }
+            let _ = touches;
+        }
+        assert!(event_touches_todo(&Event::TodoAdded {
+            goal_id: "g".into(),
+            todo: Todo::advancement("todo_1", "task"),
+            ts: 1,
+        }, "todo_1"));
+        assert!(!event_touches_todo(
+            &Event::GoalStarted { goal_id: "g".into(), ts: 1 },
+            "todo_1"
+        ));
+    }
+
+    #[test]
+    fn human_dur_ranges() {
+        assert_eq!(human_dur(59), "59s");
+        assert_eq!(human_dur(90), "1m30s");
+        assert_eq!(human_dur(3600), "1h0m");
+        assert_eq!(human_dur(3705), "1h1m");
+    }
+
+    #[test]
+    fn status_label_matrix() {
+        let mut t = Todo::advancement("t", "x");
+        t.status = TodoStatus::Done;
+        t.no_follow_up = true;
+        assert_eq!(status_label(&t), "done(no-follow-up)");
+        t.no_follow_up = false;
+        t.successor_ids = vec!["s".into()];
+        assert_eq!(status_label(&t), "done(+successor)");
+        t.successor_ids = vec![];
+        assert_eq!(status_label(&t), "done");
+        t.status = TodoStatus::Superseded;
+        assert_eq!(status_label(&t), "superseded");
+        for (class, label) in [
+            (TaskClass::Advancement, "open"),
+            (TaskClass::UserGate, "GATE"),
+            (TaskClass::UserAction, "action"),
+            (TaskClass::Monitor, "monitor"),
+            (TaskClass::Blocker, "blocker"),
+        ] {
+            let mut t = Todo::advancement("t", "x");
+            t.class = class;
+            assert_eq!(status_label(&t), label);
+        }
+    }
+
+    #[test]
+    fn parse_pairs_edge_cases() {
+        let mut seen: Vec<(String, String)> = vec![];
+        parse_pairs(
+            &[
+                "--flag".to_string(),       // boolean-ish flag at end
+                "positional".to_string(),   // skipped
+                "--key".to_string(),
+                "value".to_string(),
+                "--no-follow-up".to_string(), // known boolean, followed by value-less
+                "--after-bool".to_string(),
+            ],
+            |k, v| seen.push((k.to_string(), v)),
+        );
+        // "--flag" is followed by a non-flag arg → consumes it as its value
+        // (parse_pairs has no arity table; only the four known booleans are
+        // value-less).
+        assert!(seen.contains(&("--flag".to_string(), "positional".to_string())));
+        assert!(seen.contains(&("--key".to_string(), "value".to_string())));
+        assert!(seen.contains(&("--no-follow-up".to_string(), "true".to_string())));
+        // "--after-bool" at the end gets "true".
+        assert!(seen.contains(&("--after-bool".to_string(), "true".to_string())));
+        assert!(!seen.iter().any(|(k, _)| k == "positional"));
+    }
+
+    #[test]
+    fn join_ids_both() {
+        assert_eq!(join_ids(&[]), "(none)");
+        assert_eq!(join_ids(&["a".to_string(), "b".to_string()]), "a, b");
+    }
+
+    #[test]
+    fn print_goal_status_full() {
+        // Acceptance gaps (satisfied + open), monitor metadata, projection
+        // gap, history — every print arm.
+        let mut goal = Goal::new("g1", "objective", "/tmp")
+            .with_acceptance(vec![("gap1", "needs proof"), ("gap2", "more proof")]);
+        goal.satisfy_gap("gap2");
+        goal.todos.push(Todo::advancement("t1", "open task"));
+        let mut mon = Todo::monitor("m1", "watch", std::time::Duration::from_secs(60));
+        mon.monitor_target = Some("file:x".into());
+        mon.monitor_policy = Some("exists".into());
+        mon.monitor_cadence = Some("15m".into());
+        goal.todos.push(mon);
+        goal.history.push(record("t1"));
+        // No next_action → "-" arm; the frontier disagrees → projection gap.
+        print_goal_status(&goal);
+        goal.next_action = Some("open task".into());
+        print_goal_status(&goal);
+    }
+
+    #[test]
+    fn prog_and_help_surface() {
+        // prog() falls back to the standalone name before run() sets it, or
+        // reflects the OnceLock afterwards — either way it is exercised.
+        let _ = prog();
+        // cli_help adapts the USAGE line when invoked as `future loop`.
+        let _ = PROG.set("future loop".to_string());
+        let registry = build_cli_registry();
+        cli_help(&registry, false).unwrap();
+        cli_help(&registry, true).unwrap();
+    }
+
+    #[test]
+    fn root_dir_env_override() {
+        std::env::set_var("FUTURE_LOOP_ROOT", "/tmp/loop-root-dir-test");
+        assert_eq!(root_dir(), "/tmp/loop-root-dir-test");
+        std::env::remove_var("FUTURE_LOOP_ROOT");
+        assert!(root_dir().ends_with("/.future/loop"), "{}", root_dir());
+    }
+
+    #[test]
+    fn gen_id_format() {
+        let id = gen_id("todo");
+        assert!(id.starts_with("todo_"), "{id}");
+        assert_eq!(id.len(), "todo_".len() + 12);
+    }
+
+    #[test]
+    fn capability_hook_unknown_capability_bails() {
+        let err = cmd_capability_hook("ghost-cmd", "ghost_cap", &[]).unwrap_err();
+        assert!(format!("{err:#}").contains("unknown capability"));
+    }
+
+    #[test]
+    fn print_status_json_paths() {
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-console-json-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let root = dir.to_string_lossy().into_owned();
+        let mut store = Store::open(&root).unwrap();
+        let goal = Goal::new("gj", "json goal", "/tmp");
+        store.register(&goal).unwrap();
+        store
+            .append(Event::GoalStarted { goal_id: "gj".into(), ts: 1 })
+            .unwrap();
+        // No filter → iterates the registry; with filter → single goal;
+        // unknown filter → error.
+        print_status_json(&store, None).unwrap();
+        print_status_json(&store, Some("gj".to_string())).unwrap();
+        assert!(print_status_json(&store, Some("goal_nope".to_string())).is_err());
+    }
+}

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -537,6 +537,10 @@ impl Store {
                         lease = Some((agent, exp));
                     }
                     "todo_released" => lease = None,
+                    // Mirror replay (apply): an expiry record clears the
+                    // claim too, so a steal/expiry is honored by the atomic
+                    // claim path exactly like by projection replay.
+                    "todo_expired" => lease = None,
                     _ => {}
                 }
             }

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -70,7 +70,10 @@ fn session_and_command_happy_paths() {
         let session = client.new_session("/tmp").await.unwrap();
         assert_eq!(session, "mock-session-1");
 
-        client.append_system_prompt(&session, "boundary").await.unwrap();
+        client
+            .append_system_prompt(&session, "boundary")
+            .await
+            .unwrap();
         client.steer(&session, "note").await.unwrap();
         client.set_model(&session, "future/k3").await.unwrap();
         client.set_thinking_level(&session, "low").await.unwrap();
@@ -98,7 +101,10 @@ fn session_and_command_happy_paths() {
             "list_models",
             "delete_session",
         ] {
-            assert!(recorded.contains(&expected.to_string()), "missing {expected}");
+            assert!(
+                recorded.contains(&expected.to_string()),
+                "missing {expected}"
+            );
         }
     });
 }
@@ -140,7 +146,8 @@ fn command_error_paths() {
 
         // prompt payload without run_id.
         let mut st = MockState::default();
-        st.raw.insert("prompt".to_string(), "{\"nope\":1}".to_string());
+        st.raw
+            .insert("prompt".to_string(), "{\"nope\":1}".to_string());
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.prompt("s", "m", "r").await.unwrap_err();
@@ -191,7 +198,12 @@ fn run_turn_skips_foreign_and_malformed_events() {
         let events = vec![
             // Stale tail from another run — ignored.
             ev("other-run", 0, "text_chunk", "{\"text\":\"foreign\"}"),
-            ev("other-run", 1, "tool_start", "{\"tool_name\":\"foreign_tool\"}"),
+            ev(
+                "other-run",
+                1,
+                "tool_start",
+                "{\"tool_name\":\"foreign_tool\"}",
+            ),
             // Empty data → parse_data None → skipped.
             ev("mine", 2, "ping", ""),
             // Invalid JSON data → skipped.
@@ -405,7 +417,12 @@ fn execute_turn_with_decision_summary_and_prev() {
 #[test]
 fn execute_turn_error_turn_skips_validator() {
     rt().block_on(async {
-        let events = vec![ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"x\"}")];
+        let events = vec![ev(
+            "mock-run-1",
+            0,
+            "agent_end",
+            "{\"state\":\"error\",\"error\":\"x\"}",
+        )];
         let (addr, _) = spawn_mock(MockState {
             events,
             ..Default::default()

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -303,6 +303,30 @@ fn run_turn_error_event_and_stream_failure() {
     });
 }
 
+#[test]
+fn run_turn_live_log_without_tool_name() {
+    rt().block_on(async {
+        // tool_start WITHOUT tool_name → the live-log line has no tool field.
+        let events = vec![
+            ev("mine", 0, "tool_start", "{}"),
+            ev("mine", 1, "agent_end", "{\"state\":\"completed\"}"),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("live.jsonl");
+        let summary = client.run_turn("sess", "mine", Some(&live)).await.unwrap();
+        assert!(summary.tools.is_empty());
+        let log = std::fs::read_to_string(&live).unwrap();
+        assert!(log.contains("tool_start"), "{log}");
+        assert!(!log.contains("\"tool\":"), "{log}");
+    });
+}
+
 // ── execute_turn ───────────────────────────────────────────────────────────
 
 #[test]
@@ -452,6 +476,25 @@ fn turn_succeeded_matrix() {
         Some(1),
     ));
     assert!(!turn_succeeded(&r));
+}
+
+#[test]
+fn writeback_missing_todo_guards() {
+    // monitor poll for a todo that does not exist → early return, no panic.
+    let (mut goal, _) = sample_goal_with_todo();
+    let mut record = sample_record("completed");
+    record.todo_id = "ghost".into();
+    writeback(&mut goal, &record, Some(true), None);
+    writeback(&mut goal, &record, Some(false), None);
+    assert!(goal.history.is_empty());
+    // succeeded turn for a missing todo → completion skipped, history pushed.
+    writeback(&mut goal, &record, None, Some((true, vec![])));
+    assert_eq!(goal.history.len(), 1);
+    // failed turn for a missing todo → no failed_attempts bump.
+    let mut failed = sample_record("error");
+    failed.todo_id = "ghost".into();
+    writeback(&mut goal, &failed, None, None);
+    assert_eq!(goal.todos.len(), 1);
 }
 
 #[test]

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -121,33 +121,44 @@ fn command_error_paths() {
         assert!(msg.contains("mock failure for new_session"), "{msg}");
 
         // Transport-level gRPC error (tonic status).
-        let mut st = MockState::default();
-        st.grpc_error = true;
+        let st = MockState {
+            grpc_error: true,
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.list_models().await.unwrap_err();
         assert!(format!("{err:#}").contains("gRPC 'list_models' failed"));
 
         // invalid JSON payload.
-        let mut st = MockState::default();
-        st.invalid_json.insert("list_models".to_string());
+        let st = MockState {
+            invalid_json: ["list_models".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.list_models().await.unwrap_err();
         assert!(format!("{err:#}").contains("invalid JSON"));
 
         // new_session payload without sessionId.
-        let mut st = MockState::default();
-        st.raw.insert("new_session".to_string(), "{}".to_string());
+        let st = MockState {
+            raw: [("new_session".to_string(), "{}".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.new_session("/tmp").await.unwrap_err();
         assert!(format!("{err:#}").contains("missing sessionId"));
 
         // prompt payload without run_id.
-        let mut st = MockState::default();
-        st.raw
-            .insert("prompt".to_string(), "{\"nope\":1}".to_string());
+        let st = MockState {
+            raw: [("prompt".to_string(), "{\"nope\":1}".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.prompt("s", "m", "r").await.unwrap_err();
@@ -295,8 +306,10 @@ fn run_turn_error_event_and_stream_failure() {
         assert!(format!("{err:#}").contains("stream error"));
 
         // Attach failure.
-        let mut st = MockState::default();
-        st.stream_error = true;
+        let st = MockState {
+            stream_error: true,
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let err = client.run_turn("sess", "mine", None).await.unwrap_err();

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -1,0 +1,511 @@
+//! Coverage drive for `agent_client.rs` (thin gRPC transport) and
+//! `executor.rs` (turn execution + writeback) against an in-process mock
+//! FutureAgent server.
+
+mod common;
+
+use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
+use future_loop::agent_client::AgentClient;
+use future_loop::executor::{execute_turn, turn_succeeded, writeback};
+use future_loop::state::{Goal, RunRecord, Todo, TodoStatus};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn sample_goal_with_todo() -> (Goal, Todo) {
+    let mut goal = Goal::new("goal_x", "cover the executor", "/tmp");
+    let todo = Todo::advancement("todo_x", "write the artifact");
+    goal.todos.push(todo.clone());
+    (goal, todo)
+}
+
+fn sample_record(state: &str) -> RunRecord {
+    RunRecord {
+        turn: 1,
+        todo_id: "todo_x".into(),
+        run_id: "run-x".into(),
+        terminal_state: state.into(),
+        error: None,
+        tokens_in_delta: 1,
+        tokens_out_delta: 2,
+        cost_delta: 0.01,
+        tools: vec!["shell".into()],
+        evidence: "artifact written".into(),
+        recorded_at: 1_700_000_000,
+        spend_source: None,
+        validation: None,
+    }
+}
+
+// ── connect / call transport ───────────────────────────────────────────────
+
+#[test]
+fn connect_failure_is_wrapped() {
+    rt().block_on(async {
+        // Port 1 is never listenable.
+        let err = match AgentClient::connect("127.0.0.1:1").await {
+            Ok(_) => panic!("connect to port 1 should fail"),
+            Err(e) => e,
+        };
+        assert!(format!("{err:#}").contains("Failed to connect"));
+        // The http:// prefix is stripped before dialing.
+        let err = match AgentClient::connect("http://127.0.0.1:1").await {
+            Ok(_) => panic!("connect to port 1 should fail"),
+            Err(e) => e,
+        };
+        assert!(format!("{err:#}").contains("Failed to connect"));
+    });
+}
+
+#[test]
+fn session_and_command_happy_paths() {
+    rt().block_on(async {
+        let (addr, shared) = spawn_mock(MockState::default()).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+
+        let session = client.new_session("/tmp").await.unwrap();
+        assert_eq!(session, "mock-session-1");
+
+        client.append_system_prompt(&session, "boundary").await.unwrap();
+        client.steer(&session, "note").await.unwrap();
+        client.set_model(&session, "future/k3").await.unwrap();
+        client.set_thinking_level(&session, "low").await.unwrap();
+
+        let run_id = client.prompt(&session, "do work", "req-1").await.unwrap();
+        assert_eq!(run_id, "mock-run-1");
+
+        let totals = client.session_totals(&session).await.unwrap();
+        assert_eq!(totals.tokens_in, 0);
+
+        let models = client.list_models().await.unwrap();
+        assert!(models["models"].is_array());
+
+        client.delete_session(&session).await.unwrap();
+
+        let recorded = shared.lock().unwrap().recorded.clone();
+        for expected in [
+            "new_session",
+            "append_system_prompt",
+            "steer",
+            "set_model",
+            "set_thinking_level",
+            "prompt",
+            "get_state",
+            "list_models",
+            "delete_session",
+        ] {
+            assert!(recorded.contains(&expected.to_string()), "missing {expected}");
+        }
+    });
+}
+
+#[test]
+fn command_error_paths() {
+    rt().block_on(async {
+        // success=false with an error message.
+        let (addr, _) = spawn_mock(MockState::fail("new_session")).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.new_session("/tmp").await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("mock_error"), "{msg}");
+        assert!(msg.contains("mock failure for new_session"), "{msg}");
+
+        // Transport-level gRPC error (tonic status).
+        let mut st = MockState::default();
+        st.grpc_error = true;
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.list_models().await.unwrap_err();
+        assert!(format!("{err:#}").contains("gRPC 'list_models' failed"));
+
+        // invalid JSON payload.
+        let mut st = MockState::default();
+        st.invalid_json.insert("list_models".to_string());
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.list_models().await.unwrap_err();
+        assert!(format!("{err:#}").contains("invalid JSON"));
+
+        // new_session payload without sessionId.
+        let mut st = MockState::default();
+        st.raw.insert("new_session".to_string(), "{}".to_string());
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.new_session("/tmp").await.unwrap_err();
+        assert!(format!("{err:#}").contains("missing sessionId"));
+
+        // prompt payload without run_id.
+        let mut st = MockState::default();
+        st.raw.insert("prompt".to_string(), "{\"nope\":1}".to_string());
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.prompt("s", "m", "r").await.unwrap_err();
+        assert!(format!("{err:#}").contains("missing run_id"));
+    });
+}
+
+#[test]
+fn abort_is_transport_covered() {
+    rt().block_on(async {
+        let (addr, _) = spawn_mock(MockState::default()).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        client.abort("sess").await.unwrap();
+    });
+}
+
+// ── run_turn event stream handling ─────────────────────────────────────────
+
+#[test]
+fn run_turn_completed_with_live_log() {
+    rt().block_on(async {
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("live.jsonl");
+        let summary = client
+            .run_turn("sess", "mock-run-1", Some(&live))
+            .await
+            .unwrap();
+        assert_eq!(summary.terminal_state, "completed");
+        assert_eq!(summary.tools, vec!["shell".to_string()]);
+        assert!(summary.text.contains("artifact written"));
+        assert!(summary.usage.is_some());
+        assert_eq!(summary.duration_ms, Some(7));
+        let log = std::fs::read_to_string(&live).unwrap();
+        assert!(log.contains("tool_start"), "{log}");
+        assert!(log.contains("\"tool\":\"shell\""), "{log}");
+    });
+}
+
+#[test]
+fn run_turn_skips_foreign_and_malformed_events() {
+    rt().block_on(async {
+        let events = vec![
+            // Stale tail from another run — ignored.
+            ev("other-run", 0, "text_chunk", "{\"text\":\"foreign\"}"),
+            ev("other-run", 1, "tool_start", "{\"tool_name\":\"foreign_tool\"}"),
+            // Empty data → parse_data None → skipped.
+            ev("mine", 2, "ping", ""),
+            // Invalid JSON data → skipped.
+            ev("mine", 3, "ping", "{nope"),
+            // tool_start without tool_name → no push.
+            ev("mine", 4, "tool_start", "{}"),
+            // text_chunk without text → no append.
+            ev("mine", 5, "text_chunk", "{}"),
+            // agent_end without state → default "completed", with error.
+            ev("mine", 6, "agent_end", "{\"error\":\"soft fail\"}"),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        assert_eq!(summary.terminal_state, "completed");
+        assert_eq!(summary.error.as_deref(), Some("soft fail"));
+        assert!(summary.tools.is_empty());
+        assert!(summary.text.is_empty());
+    });
+}
+
+#[test]
+fn run_turn_long_text_truncates_at_char_boundary() {
+    rt().block_on(async {
+        // 8100 chars with a multibyte char straddling the 8000 boundary.
+        let mut text = "a".repeat(7998);
+        text.push('界'); // 3 bytes at offset 7998..8001
+        text.push_str(&"b".repeat(200));
+        let data = format!("{{\"text\":\"{text}\"}}");
+        let events = vec![
+            ev("mine", 0, "text_chunk", &data),
+            ev("mine", 1, "agent_end", "{\"state\":\"completed\"}"),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        assert!(summary.text.len() <= 8003, "{}", summary.text.len());
+        assert!(summary.text.starts_with("aaaa"));
+    });
+}
+
+#[test]
+fn run_turn_error_event_and_stream_failure() {
+    rt().block_on(async {
+        // Explicit error event ends the turn as error.
+        let events = vec![
+            ev("mine", 0, "text_chunk", "{\"text\":\"partial\"}"),
+            ev("mine", 1, "error", "{\"error\":\"boom\"}"),
+            ev("mine", 2, "agent_end", "{\"state\":\"completed\"}"),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        assert_eq!(summary.terminal_state, "error");
+        assert_eq!(summary.error.as_deref(), Some("boom"));
+
+        // Error event without payload → "unknown error".
+        let events = vec![ev("mine", 0, "error", "{}")];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        assert_eq!(summary.error.as_deref(), Some("unknown error"));
+
+        // Mid-stream transport failure.
+        let mut st = MockState {
+            events: vec![ev("mine", 0, "text_chunk", "{\"text\":\"x\"}")],
+            ..Default::default()
+        };
+        st.stream_fail_after = Some(1);
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.run_turn("sess", "mine", None).await.unwrap_err();
+        assert!(format!("{err:#}").contains("stream error"));
+
+        // Attach failure.
+        let mut st = MockState::default();
+        st.stream_error = true;
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client.run_turn("sess", "mine", None).await.unwrap_err();
+        assert!(format!("{err:#}").contains("Failed to attach"));
+
+        // Stream closes without agent_end → incomplete.
+        let events = vec![ev("mine", 0, "text_chunk", "{\"text\":\"x\"}")];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        assert_eq!(summary.terminal_state, "incomplete");
+    });
+}
+
+// ── execute_turn ───────────────────────────────────────────────────────────
+
+#[test]
+fn execute_turn_completed_no_validator() {
+    rt().block_on(async {
+        let (addr, shared) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            tokens_in: 10,
+            tokens_out: 20,
+            cost: 0.5,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, todo) = sample_goal_with_todo();
+        let dir = tempfile::tempdir().unwrap();
+        let runs_dir = dir.path().join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        // boundary_injected=false → append_system_prompt happens first.
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            1,
+            None,
+            false,
+            None,
+            Some(runs_dir.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(record.terminal_state, "completed");
+        assert_eq!(record.run_id, "mock-run-1");
+        // get_state returns the same totals before/after → zero deltas.
+        assert_eq!(record.tokens_in_delta, 0);
+        assert!(record.validation.is_none(), "no validator ⇒ not required");
+        assert!(runs_dir.join("mock-run-1.live.jsonl").exists());
+        assert!(shared
+            .lock()
+            .unwrap()
+            .recorded
+            .contains(&"append_system_prompt".to_string()));
+    });
+}
+
+#[test]
+fn execute_turn_with_decision_summary_and_prev() {
+    rt().block_on(async {
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, todo) = sample_goal_with_todo();
+        let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+        let prev = sample_record("completed");
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            2,
+            Some(&prev),
+            true,
+            Some(&packet),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(record.terminal_state, "completed");
+    });
+}
+
+#[test]
+fn execute_turn_error_turn_skips_validator() {
+    rt().block_on(async {
+        let events = vec![ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"x\"}")];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, mut todo) = sample_goal_with_todo();
+        todo.validator = Some("exit 0".to_string());
+        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
+            .await
+            .unwrap();
+        assert_eq!(record.terminal_state, "error");
+        assert!(record.validation.is_none(), "failed turn never validates");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn execute_turn_validator_pass_and_fail() {
+    rt().block_on(async {
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, mut todo) = sample_goal_with_todo();
+        todo.validator = Some("exit 0".to_string());
+        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
+            .await
+            .unwrap();
+        let v = record.validation.unwrap();
+        assert!(v.ok, "validator exit 0 passes: {}", v.summary);
+
+        // Fresh client/session for the failing validator.
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, mut todo) = sample_goal_with_todo();
+        todo.validator = Some("exit 3".to_string());
+        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
+            .await
+            .unwrap();
+        let v = record.validation.unwrap();
+        assert!(!v.ok, "validator exit 3 fails");
+        assert_eq!(v.exit_code, Some(3));
+    });
+}
+
+// ── turn_succeeded / writeback (pure) ──────────────────────────────────────
+
+#[test]
+fn turn_succeeded_matrix() {
+    let mut r = sample_record("completed");
+    assert!(turn_succeeded(&r));
+    r.terminal_state = "error".into();
+    assert!(!turn_succeeded(&r));
+    // Validation gates success.
+    let mut r = sample_record("completed");
+    r.validation = Some(future_loop::state::task_validation_receipt(
+        future_loop::state::ValidationStatus::Failed,
+        "exit 1",
+        "failed",
+        Some(future_loop::state::RecoveryKind::RepairRequired),
+        Some(1),
+    ));
+    assert!(!turn_succeeded(&r));
+}
+
+#[test]
+fn writeback_monitor_paths() {
+    let (mut goal, todo) = sample_goal_with_todo();
+    let mut monitor = todo.clone();
+    monitor.id = "mon_1".into();
+    monitor.class = future_loop::state::TaskClass::Monitor;
+    goal.todos.push(monitor);
+    let mut record = sample_record("completed");
+    record.todo_id = "mon_1".into();
+
+    // changed → monitor done, history appended.
+    writeback(&mut goal, &record, Some(true), None);
+    let m = goal.todo("mon_1").unwrap();
+    assert_eq!(m.status, TodoStatus::Done);
+    assert_eq!(goal.history.len(), 1);
+
+    // no-change → counter bumped, deferred, NOT recorded in history.
+    let (mut goal, _) = sample_goal_with_todo();
+    let mut monitor = Todo::advancement("mon_1", "watch");
+    monitor.class = future_loop::state::TaskClass::Monitor;
+    goal.todos.push(monitor);
+    let mut record = sample_record("completed");
+    record.todo_id = "mon_1".into();
+    writeback(&mut goal, &record, Some(false), None);
+    let m = goal.todo("mon_1").unwrap();
+    assert_eq!(m.consecutive_no_change, 1);
+    assert!(m.resume_when.is_some());
+    assert!(goal.history.is_empty());
+}
+
+#[test]
+fn writeback_completion_and_repair_paths() {
+    // success with explicit completion intent.
+    let (mut goal, _) = sample_goal_with_todo();
+    let record = sample_record("completed");
+    writeback(&mut goal, &record, None, Some((true, vec![])));
+    assert_eq!(goal.todo("todo_x").unwrap().status, TodoStatus::Done);
+    assert!(goal.todo("todo_x").unwrap().no_follow_up);
+    assert_eq!(goal.history.len(), 1);
+    assert_eq!(goal.outcome_streak, 0, "material turn resets the streak");
+
+    // success with completion None → defaults to no-follow-up.
+    let (mut goal, _) = sample_goal_with_todo();
+    writeback(&mut goal, &sample_record("completed"), None, None);
+    assert!(goal.todo("todo_x").unwrap().no_follow_up);
+
+    // failure → repair attempt + outcome streak (no tools/evidence).
+    let (mut goal, _) = sample_goal_with_todo();
+    let mut record = sample_record("error");
+    record.tools = vec![];
+    record.evidence = String::new();
+    writeback(&mut goal, &record, None, None);
+    assert_eq!(goal.todo("todo_x").unwrap().failed_attempts, 1);
+    assert_eq!(goal.outcome_streak, 1);
+}

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -8,9 +8,9 @@
 mod common;
 
 use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
-use common::{
-    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, todo_id_by_text,
-};
+#[cfg(unix)]
+use common::todo_id_by_text;
+use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
 use future_loop::state::{now_epoch, TodoStatus};
 
 fn rt() -> tokio::runtime::Runtime {
@@ -430,8 +430,10 @@ fn run_with_model_and_thinking_flags() {
 #[test]
 fn run_max_turn_secs_graceful_timeout() {
     let cr = cli_root();
-    let mut st = MockState::default();
-    st.hang_stream = true;
+    let st = MockState {
+        hang_stream: true,
+        ..Default::default()
+    };
     let (_rt, _shared) = mock_env(st);
     let goal = init_goal(&cr, "hanging turn");
     // The turn stream never yields; the wall-clock budget stops the run gracefully.
@@ -462,8 +464,10 @@ fn models_text_and_json() {
 #[test]
 fn models_sparse_payload_defaults() {
     let _cr = cli_root();
-    let mut st = MockState::default();
-    st.models_payload = Some("{\"models\":[{\"id\":\"bare\"}]}".to_string());
+    let st = MockState {
+        models_payload: Some("{\"models\":[{\"id\":\"bare\"}]}".to_string()),
+        ..Default::default()
+    };
     let (_rt, _shared) = mock_env(st);
     cli_ok(&["models"]);
 }

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -9,10 +9,9 @@ mod common;
 
 use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
 use common::{
-    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store,
-    todo_id_by_text,
+    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, todo_id_by_text,
 };
-use future_loop::state::{TodoStatus, now_epoch};
+use future_loop::state::{now_epoch, TodoStatus};
 
 fn rt() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
@@ -113,30 +112,34 @@ fn run_max_turns_bails() {
     let goal = init_goal(&cr, "many todos");
     add_todo(&cr, &goal, "task two");
     add_todo(&cr, &goal, "task three");
-    let err = cli_err(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turns",
-        "2",
-    ]);
+    let err = cli_err(&["run", "--goal", &goal, "--anonymous", "--max-turns", "2"]);
     assert!(err.contains("max-turns"), "{err}");
 }
 
 #[test]
 fn run_failing_turns_exhaust_repair_budget() {
     let cr = cli_root();
-    let events = vec![
-        ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"boom\"}"),
-    ];
+    let events = vec![ev(
+        "mock-run-1",
+        0,
+        "agent_end",
+        "{\"state\":\"error\",\"error\":\"boom\"}",
+    )];
     let (_rt, shared) = mock_env(MockState {
         events,
         ..Default::default()
     });
     let goal = init_goal(&cr, "failing turns");
     let onboarding = first_todo_id(&cr.root, &goal);
-    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+    ]);
     // Pre-seed a todo that already consumed one repair attempt (the ledger
     // does not persist failed_attempts from failed runs — see coverage
     // report), so this turn's failure crosses MAX_REPAIR_ATTEMPTS(=1).
@@ -157,7 +160,11 @@ fn run_failing_turns_exhaust_repair_budget() {
     // seeded value — so assert the LOOP BEHAVIOR: exactly one prompt, i.e.
     // the budget break fired instead of the max-turns bail.)
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "6"]);
-    assert_eq!(shared.lock().unwrap().prompts, 1, "repair budget break after one turn");
+    assert_eq!(
+        shared.lock().unwrap().prompts,
+        1,
+        "repair budget break after one turn"
+    );
 }
 
 #[test]
@@ -181,7 +188,11 @@ fn run_open_gate_breaks_with_ask_user() {
         "approve the plan?",
     ]);
     cli_ok(&["run", "--goal", &goal, "--anonymous"]);
-    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn executed behind a gate");
+    assert_eq!(
+        shared.lock().unwrap().prompts,
+        0,
+        "no turn executed behind a gate"
+    );
 }
 
 /// Append a hand-crafted monitor todo directly to the ledger (due_in=0 →
@@ -210,9 +221,19 @@ fn run_monitor_poll_changed_and_no_change() {
     // and turn 2 is the poll; script the EXISTS evidence for the poll turn.
     let (_rt, _shared) = mock_env(MockState {
         events: vec![
-            ev("mock-run-1", 0, "text_chunk", "{\"text\":\"onboarding done\"}"),
+            ev(
+                "mock-run-1",
+                0,
+                "text_chunk",
+                "{\"text\":\"onboarding done\"}",
+            ),
             ev("mock-run-1", 1, "agent_end", "{\"state\":\"completed\"}"),
-            ev("mock-run-2", 0, "text_chunk", "{\"text\":\"the file EXISTS now\"}"),
+            ev(
+                "mock-run-2",
+                0,
+                "text_chunk",
+                "{\"text\":\"the file EXISTS now\"}",
+            ),
             ev("mock-run-2", 1, "agent_end", "{\"state\":\"completed\"}"),
         ],
         ..Default::default()
@@ -223,7 +244,11 @@ fn run_monitor_poll_changed_and_no_change() {
     let store = open_store(&cr);
     let g = store.replay(&goal).unwrap().unwrap();
     let m = g.todos.iter().find(|t| t.id == "mon_due").unwrap();
-    assert_eq!(m.status, TodoStatus::Done, "changed poll closes the monitor: {m:?}");
+    assert_eq!(
+        m.status,
+        TodoStatus::Done,
+        "changed poll closes the monitor: {m:?}"
+    );
 }
 
 #[test]
@@ -231,9 +256,19 @@ fn run_monitor_poll_no_change_never_spends() {
     let cr = cli_root();
     let (_rt, _shared) = mock_env(MockState {
         events: vec![
-            ev("mock-run-1", 0, "text_chunk", "{\"text\":\"nothing new yet\"}"),
+            ev(
+                "mock-run-1",
+                0,
+                "text_chunk",
+                "{\"text\":\"nothing new yet\"}",
+            ),
             ev("mock-run-1", 1, "agent_end", "{\"state\":\"completed\"}"),
-            ev("mock-run-2", 0, "text_chunk", "{\"text\":\"onboarding done\"}"),
+            ev(
+                "mock-run-2",
+                0,
+                "text_chunk",
+                "{\"text\":\"onboarding done\"}",
+            ),
             ev("mock-run-2", 1, "agent_end", "{\"state\":\"completed\"}"),
         ],
         ..Default::default()
@@ -267,7 +302,15 @@ fn run_monitor_not_due_waits() {
     // Complete the only advancement todo so the (not-due) monitor is all that
     // remains → WaitMonitor → graceful "waiting…" stop.
     let onboarding = first_todo_id(&cr.root, &goal);
-    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+    ]);
     append_monitor(&cr, &goal, "mon_future", 3600);
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
     assert_eq!(shared.lock().unwrap().prompts, 0, "no turn while waiting");
@@ -283,9 +326,24 @@ fn run_validator_pass_completes_todo() {
     });
     let goal = init_goal(&cr, "validator pass");
     let onboarding = first_todo_id(&cr.root, &goal);
-    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
     cli_ok(&[
-        "todo", "add", "--goal", &goal, "--text", "validated real task", "--verify", "exit 0",
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "validated real task",
+        "--verify",
+        "exit 0",
     ]);
     let vt = todo_id_by_text(&cr.root, &goal, "validated real task");
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
@@ -306,19 +364,43 @@ fn run_validator_budget_exhaustion_stops_run() {
     });
     let goal = init_goal(&cr, "validator budget");
     let onboarding = first_todo_id(&cr.root, &goal);
-    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
     cli_ok(&[
-        "todo", "add", "--goal", &goal, "--text", "never validates", "--verify",
-        "exit 1", "--max-validation-attempts", "1",
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "never validates",
+        "--verify",
+        "exit 1",
+        "--max-validation-attempts",
+        "1",
     ]);
     // Validation budget (1) hit after the first failed validation → stop, Ok.
     // Assert the loop stopped after exactly one turn (the budget branch
     // fired); the ledger keeps the todo open.
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "6"]);
-    assert_eq!(shared.lock().unwrap().prompts, 1, "validation budget break after one turn");
+    assert_eq!(
+        shared.lock().unwrap().prompts,
+        1,
+        "validation budget break after one turn"
+    );
     let store = open_store(&cr);
     let g = store.replay(&goal).unwrap().unwrap();
-    let todo = g.todos.iter().find(|t| t.text.contains("never validates")).unwrap();
+    let todo = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("never validates"))
+        .unwrap();
     assert_eq!(todo.status, TodoStatus::Open, "todo stays open: {todo:?}");
 }
 

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -1,0 +1,427 @@
+//! Coverage drive for the gRPC-backed console commands: `run`, `models`,
+//! and the `doctor --agent-addr` probe — all against the in-process mock
+//! FutureAgent (FUTURE_LOOP_AGENT_ADDR points the CLI at the mock).
+//!
+//! Everything here is serialized through CLI_LOCK (process-global env), and
+//! each test spawns its own mock server on an ephemeral port.
+
+mod common;
+
+use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
+use common::{
+    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store,
+    todo_id_by_text,
+};
+use future_loop::state::{TodoStatus, now_epoch};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Spawn a mock agent and point the CLI at it. Returns the runtime guard
+/// (keeps the server task alive) and the shared state.
+fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::SharedState) {
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(state));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    (rt, shared)
+}
+
+// ── run identity gate (no server needed) ───────────────────────────────────
+
+#[test]
+fn run_requires_agent_id_or_anonymous() {
+    let cr = cli_root();
+    let goal = init_goal(&cr, "identity gate");
+    let err = cli_err(&["run", "--goal", &goal]);
+    assert!(err.contains("requires --agent-id"), "{err}");
+}
+
+#[test]
+fn run_missing_goal_fails() {
+    let _cr = cli_root();
+    let err = cli_err(&["run", "--goal", "goal_nope", "--agent-id", "a1"]);
+    assert!(err.contains("not found"), "{err}");
+}
+
+// ── run turn loop against the mock ─────────────────────────────────────────
+
+#[test]
+fn run_anonymous_single_todo_to_terminal() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "single todo closure");
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    assert!(g.todos.iter().all(|t| t.status == TodoStatus::Done));
+    assert!(g.terminal_closure().is_some(), "validated closure");
+    assert_eq!(g.history.len(), 1);
+    assert_eq!(shared.lock().unwrap().prompts, 1);
+}
+
+#[test]
+fn run_with_agent_id_auto_registers_and_chains_successors() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: vec![
+            ev("mock-run-1", 0, "tool_start", "{\"tool_name\":\"write\"}"),
+            ev("mock-run-1", 1, "text_chunk", "{\"text\":\"one done\"}"),
+            ev("mock-run-1", 2, "agent_end", "{\"state\":\"completed\"}"),
+            ev("mock-run-2", 0, "tool_start", "{\"tool_name\":\"write\"}"),
+            ev("mock-run-2", 1, "text_chunk", "{\"text\":\"two done\"}"),
+            ev("mock-run-2", 2, "agent_end", "{\"state\":\"completed\"}"),
+        ],
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "two todos");
+    add_todo(&cr, &goal, "second task");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "worker-7",
+        "--lease-secs",
+        "120",
+        "--max-turns",
+        "5",
+    ]);
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    assert!(g.todos.iter().all(|t| t.status == TodoStatus::Done));
+    assert!(g.registered_agents.contains(&"worker-7".to_string()));
+    assert_eq!(shared.lock().unwrap().prompts, 2);
+    // The first completion names the second todo as successor.
+    let first = g.todos.first().unwrap();
+    assert_eq!(first.successor_ids.len(), 1, "successor chain: {first:?}");
+}
+
+#[test]
+fn run_max_turns_bails() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "many todos");
+    add_todo(&cr, &goal, "task two");
+    add_todo(&cr, &goal, "task three");
+    let err = cli_err(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turns",
+        "2",
+    ]);
+    assert!(err.contains("max-turns"), "{err}");
+}
+
+#[test]
+fn run_failing_turns_exhaust_repair_budget() {
+    let cr = cli_root();
+    let events = vec![
+        ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"boom\"}"),
+    ];
+    let (_rt, shared) = mock_env(MockState {
+        events,
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "failing turns");
+    let onboarding = first_todo_id(&cr.root, &goal);
+    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    // Pre-seed a todo that already consumed one repair attempt (the ledger
+    // does not persist failed_attempts from failed runs — see coverage
+    // report), so this turn's failure crosses MAX_REPAIR_ATTEMPTS(=1).
+    let mut seeded = future_loop::state::Todo::advancement("todo_seeded", "keeps failing");
+    seeded.failed_attempts = 1;
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::TodoAdded {
+            goal_id: goal.clone(),
+            todo: seeded,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store.set_next_action(&goal, "keeps failing").unwrap();
+    drop(store);
+    // Repair budget exhausted after this turn's failure → graceful stop.
+    // (failed_attempts is not event-sourced — the replayed ledger keeps the
+    // seeded value — so assert the LOOP BEHAVIOR: exactly one prompt, i.e.
+    // the budget break fired instead of the max-turns bail.)
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "6"]);
+    assert_eq!(shared.lock().unwrap().prompts, 1, "repair budget break after one turn");
+}
+
+#[test]
+fn run_open_gate_breaks_with_ask_user() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "gate blocks the run");
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "plan approval gate",
+        "--class",
+        "user_gate",
+        "--gate-question",
+        "approve the plan?",
+    ]);
+    cli_ok(&["run", "--goal", &goal, "--anonymous"]);
+    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn executed behind a gate");
+}
+
+/// Append a hand-crafted monitor todo directly to the ledger (due_in=0 →
+/// already due; the CLI cannot express sub-minute cadences).
+fn append_monitor(cr: &common::CliRoot, goal: &str, id: &str, due_in_secs: u64) {
+    let mut store = open_store(cr);
+    let todo = future_loop::state::Todo::monitor(
+        id,
+        "watch the artifact",
+        std::time::Duration::from_secs(due_in_secs),
+    );
+    store
+        .append(future_loop::store::Event::TodoAdded {
+            goal_id: goal.to_string(),
+            todo,
+            ts: future_loop::state::now_epoch(),
+        })
+        .unwrap();
+    store.set_next_action(goal, "watch the artifact").unwrap();
+}
+
+#[test]
+fn run_monitor_poll_changed_and_no_change() {
+    let cr = cli_root();
+    // Advancement outranks a due monitor, so turn 1 is the onboarding todo
+    // and turn 2 is the poll; script the EXISTS evidence for the poll turn.
+    let (_rt, _shared) = mock_env(MockState {
+        events: vec![
+            ev("mock-run-1", 0, "text_chunk", "{\"text\":\"onboarding done\"}"),
+            ev("mock-run-1", 1, "agent_end", "{\"state\":\"completed\"}"),
+            ev("mock-run-2", 0, "text_chunk", "{\"text\":\"the file EXISTS now\"}"),
+            ev("mock-run-2", 1, "agent_end", "{\"state\":\"completed\"}"),
+        ],
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "monitor poll");
+    append_monitor(&cr, &goal, "mon_due", 0);
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "4"]);
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    let m = g.todos.iter().find(|t| t.id == "mon_due").unwrap();
+    assert_eq!(m.status, TodoStatus::Done, "changed poll closes the monitor: {m:?}");
+}
+
+#[test]
+fn run_monitor_poll_no_change_never_spends() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: vec![
+            ev("mock-run-1", 0, "text_chunk", "{\"text\":\"nothing new yet\"}"),
+            ev("mock-run-1", 1, "agent_end", "{\"state\":\"completed\"}"),
+            ev("mock-run-2", 0, "text_chunk", "{\"text\":\"onboarding done\"}"),
+            ev("mock-run-2", 1, "agent_end", "{\"state\":\"completed\"}"),
+        ],
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "monitor no-change");
+    append_monitor(&cr, &goal, "mon_due", 0);
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "4"]);
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    let m = g.todos.iter().find(|t| t.id == "mon_due").unwrap();
+    assert_eq!(m.consecutive_no_change, 1, "no-change counter: {m:?}");
+    assert_ne!(m.status, TodoStatus::Done);
+    // A no-change poll never spends quota (other turns may).
+    let spent_on_monitor = store
+        .events(&goal)
+        .unwrap()
+        .iter()
+        .filter(|se| matches!(&se.event, future_loop::store::Event::QuotaSpent { todo_id, .. } if todo_id == "mon_due"))
+        .count();
+    assert_eq!(spent_on_monitor, 0);
+}
+
+#[test]
+fn run_monitor_not_due_waits() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "monitor waiting");
+    // Complete the only advancement todo so the (not-due) monitor is all that
+    // remains → WaitMonitor → graceful "waiting…" stop.
+    let onboarding = first_todo_id(&cr.root, &goal);
+    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    append_monitor(&cr, &goal, "mon_future", 3600);
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
+    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn while waiting");
+}
+
+#[cfg(unix)]
+#[test]
+fn run_validator_pass_completes_todo() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "validator pass");
+    let onboarding = first_todo_id(&cr.root, &goal);
+    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    cli_ok(&[
+        "todo", "add", "--goal", &goal, "--text", "validated real task", "--verify", "exit 0",
+    ]);
+    let vt = todo_id_by_text(&cr.root, &goal, "validated real task");
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    let todo = g.todos.iter().find(|t| t.id == vt).unwrap();
+    assert_eq!(todo.status, TodoStatus::Done, "validator passed → done");
+    let record = g.history.last().unwrap();
+    assert!(record.validation.as_ref().unwrap().ok);
+}
+
+#[test]
+fn run_validator_budget_exhaustion_stops_run() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "validator budget");
+    let onboarding = first_todo_id(&cr.root, &goal);
+    cli_ok(&["todo", "complete", "--goal", &goal, "--todo-id", &onboarding, "--no-follow-up"]);
+    cli_ok(&[
+        "todo", "add", "--goal", &goal, "--text", "never validates", "--verify",
+        "exit 1", "--max-validation-attempts", "1",
+    ]);
+    // Validation budget (1) hit after the first failed validation → stop, Ok.
+    // Assert the loop stopped after exactly one turn (the budget branch
+    // fired); the ledger keeps the todo open.
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "6"]);
+    assert_eq!(shared.lock().unwrap().prompts, 1, "validation budget break after one turn");
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    let todo = g.todos.iter().find(|t| t.text.contains("never validates")).unwrap();
+    assert_eq!(todo.status, TodoStatus::Open, "todo stays open: {todo:?}");
+}
+
+#[test]
+fn run_with_model_and_thinking_flags() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "model flags");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--model",
+        "future/k3",
+        "--thinking-level",
+        "low",
+    ]);
+    let recorded = shared.lock().unwrap().recorded.clone();
+    assert!(recorded.contains(&"set_model".to_string()));
+    assert!(recorded.contains(&"set_thinking_level".to_string()));
+}
+
+#[test]
+fn run_max_turn_secs_graceful_timeout() {
+    let cr = cli_root();
+    let mut st = MockState::default();
+    st.hang_stream = true;
+    let (_rt, _shared) = mock_env(st);
+    let goal = init_goal(&cr, "hanging turn");
+    // The turn stream never yields; the wall-clock budget stops the run gracefully.
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "1",
+        "--max-turns",
+        "3",
+    ]);
+}
+
+// ── models ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn models_text_and_json() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState::default());
+    cli_ok(&["models"]);
+    cli_ok(&["models", "--format", "json"]);
+    cli_ok(&["models", "--json"]);
+    let _ = cr;
+}
+
+#[test]
+fn models_sparse_payload_defaults() {
+    let _cr = cli_root();
+    let mut st = MockState::default();
+    st.models_payload = Some("{\"models\":[{\"id\":\"bare\"}]}".to_string());
+    let (_rt, _shared) = mock_env(st);
+    cli_ok(&["models"]);
+}
+
+#[test]
+fn models_unreachable_agent_errors() {
+    let _cr = cli_root();
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", "127.0.0.1:1");
+    let err = cli_err(&["models"]);
+    assert!(err.contains("Failed to connect"), "{err}");
+}
+
+// ── doctor ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn doctor_fresh_root_and_goal_filter() {
+    let cr = cli_root();
+    cli_ok(&["doctor"]);
+    let goal = init_goal(&cr, "doctor goal");
+    cli_ok(&["doctor", "--goal", &goal]);
+    let err = cli_err(&["doctor", "--goal", "goal_nope"]);
+    assert!(err.contains("not found"), "{err}");
+}
+
+#[test]
+fn doctor_agent_probe() {
+    let _cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState::default());
+    let addr = std::env::var("FUTURE_LOOP_AGENT_ADDR").unwrap();
+    cli_ok(&["doctor", "--agent-addr", &addr]);
+    let err = cli_err(&["doctor", "--agent-addr", "127.0.0.1:1"]);
+    assert!(err.contains("gRPC"), "{err}");
+}
+
+// ── cli (error-path sanity through the mock-free surface) ──────────────────
+
+#[test]
+fn cli_result_helper_passthrough() {
+    let cr = cli_root();
+    // `cli` returns Ok for a trivial command; keep the helper itself honest.
+    assert!(cli(&["version"]).is_ok());
+    let _ = cr;
+}

--- a/orchestration/loop/tests/backfill_drive.rs
+++ b/orchestration/loop/tests/backfill_drive.rs
@@ -42,14 +42,24 @@ fn parse_markdown_full_branch_matrix() {
     let done = &records[1];
     assert_eq!(done.status, "done");
     assert!(done.no_followup);
-    assert_eq!(done.evidence.as_deref(), Some("great success"), "url-decoded");
+    assert_eq!(
+        done.evidence.as_deref(),
+        Some("great success"),
+        "url-decoded"
+    );
     assert_eq!(done.note.as_deref(), Some("check+plus"));
     assert_eq!(records[2].status, "deferred");
     // Continuation text joins the todo text.
-    let cont = records.iter().find(|r| r.text.contains("continuation text")).unwrap();
+    let cont = records
+        .iter()
+        .find(|r| r.text.contains("continuation text"))
+        .unwrap();
     assert!(cont.text.contains("Continued task"));
     // User-role records.
-    let user_action = records.iter().find(|r| r.text.contains("Decide scope")).unwrap();
+    let user_action = records
+        .iter()
+        .find(|r| r.text.contains("Decide scope"))
+        .unwrap();
     assert_eq!(user_action.role, "user");
     assert_eq!(user_action.task_class.as_deref(), Some("user_action"));
 }
@@ -96,7 +106,9 @@ fn backfill_events_class_priority_and_privacy() {
     assert_eq!(p0, Some(future_loop::state::Priority::P0));
     // A record without todo_id gets a content-derived id (deterministic).
     let digest_todo = outcome.events.iter().find_map(|e| match &e.event {
-        future_loop::store::Event::TodoAdded { todo, .. } if todo.text.contains("Deferred task") => {
+        future_loop::store::Event::TodoAdded { todo, .. }
+            if todo.text.contains("Deferred task") =>
+        {
             Some(todo.id.clone())
         }
         _ => None,
@@ -133,9 +145,7 @@ fn active_state_markdown_read_paths() {
     // Missing file → error mentioning the path.
     assert!(active_state_markdown(&cwd, "goal_x").is_err());
     // Present file → contents.
-    let p = dir
-        .path()
-        .join(".future/loop/goals/goal_x");
+    let p = dir.path().join(".future/loop/goals/goal_x");
     std::fs::create_dir_all(&p).unwrap();
     std::fs::write(p.join("ACTIVE_GOAL_STATE.md"), "# state").unwrap();
     assert_eq!(active_state_markdown(&cwd, "goal_x").unwrap(), "# state");

--- a/orchestration/loop/tests/backfill_drive.rs
+++ b/orchestration/loop/tests/backfill_drive.rs
@@ -1,0 +1,142 @@
+//! Coverage drive for `backfill.rs` — markdown parsing branches (sections,
+//! markers, metadata keys, continuations), class/priority derivation,
+//! privacy redaction, and the workbench file reader.
+
+use future_loop::backfill::{
+    active_state_markdown, backfill_event_id, backfill_todo_events, parse_markdown_todos,
+};
+use future_loop::projection::privacy::PrivacyLevel;
+use future_loop::state::TaskClass;
+
+/// A workbench exercising every parser branch.
+const FULL_MD: &str = "---\nstatus: active\n---\n\n# Active Goal State\n\n\
+## Not A Todo Section\n\n\
+- [ ] ignored line (no role yet)\n\n\
+## Agent Todo\n\n\
+- [ ] [P0] First task\n  <!-- future-loop:todo todo_id=todo_a1 status=open action_kind=shell claimed_by=agent-1 monitor_target=file:x monitor_policy=exists cadence=15m goal_bound=true updated_at=2026-08-05T12:00:00+00:00 -->\n\
+- [x] [P2] Done task\n  <!-- future-loop:todo todo_id=todo_a2 status=done no_followup=true evidence=great%20success completed_at=2026-08-05T13:00:00+00:00 updated_at=not-a-date note=check%2Bplus -->\n\
+- [-] Deferred task\n\
+- [ ] \n\
+- [ ] Continued task\n  this continuation text joins the record\n\
+- [malformed line without close bracket\n\n\
+## User Todo / Owner Review\n\n\
+- [ ] Decide scope\n  <!-- future-loop:todo task_class=user_action -->\n\
+- [ ] Gate without explicit class (user default)\n\
+- [ ] External blocker\n  <!-- future-loop:todo task_class=blocker -->\n\
+- [ ] Watch the deploy\n  <!-- future-loop:todo task_class=continuous_monitor -->\n\
+- [ ] Explicit monitor\n  <!-- future-loop:todo task_class=monitor global_gate=true -->\n";
+
+#[test]
+fn parse_markdown_full_branch_matrix() {
+    let records = parse_markdown_todos(FULL_MD);
+    // 9 records (the no-role line and the empty-text line are skipped; the
+    // malformed no-bracket line is skipped).
+    assert_eq!(records.len(), 9, "{records:?}");
+    let first = &records[0];
+    assert_eq!(first.role, "agent");
+    assert_eq!(first.monitor_target.as_deref(), Some("file:x"));
+    assert_eq!(first.monitor_policy.as_deref(), Some("exists"));
+    assert_eq!(first.cadence.as_deref(), Some("15m"));
+    assert!(first.goal_bound);
+    assert_eq!(first.claimed_by.as_deref(), Some("agent-1"));
+    let done = &records[1];
+    assert_eq!(done.status, "done");
+    assert!(done.no_followup);
+    assert_eq!(done.evidence.as_deref(), Some("great success"), "url-decoded");
+    assert_eq!(done.note.as_deref(), Some("check+plus"));
+    assert_eq!(records[2].status, "deferred");
+    // Continuation text joins the todo text.
+    let cont = records.iter().find(|r| r.text.contains("continuation text")).unwrap();
+    assert!(cont.text.contains("Continued task"));
+    // User-role records.
+    let user_action = records.iter().find(|r| r.text.contains("Decide scope")).unwrap();
+    assert_eq!(user_action.role, "user");
+    assert_eq!(user_action.task_class.as_deref(), Some("user_action"));
+}
+
+#[test]
+fn backfill_events_class_priority_and_privacy() {
+    let outcome = backfill_todo_events(FULL_MD, "g1", PrivacyLevel::LocalPrivate).unwrap();
+    // 8 todos; events = adds + 1 claim (agent-1) + 1 complete (done task).
+    let completes: Vec<_> = outcome
+        .events
+        .iter()
+        .filter(|e| matches!(e.event, future_loop::store::Event::TodoCompleted { .. }))
+        .collect();
+    assert_eq!(completes.len(), 1);
+    let claims: Vec<_> = outcome
+        .events
+        .iter()
+        .filter(|e| matches!(e.event, future_loop::store::Event::TodoClaimed { .. }))
+        .collect();
+    assert_eq!(claims.len(), 1);
+    let classes: Vec<TaskClass> = outcome
+        .events
+        .iter()
+        .filter_map(|e| match &e.event {
+            future_loop::store::Event::TodoAdded { todo, .. } => Some(todo.class),
+            _ => None,
+        })
+        .collect();
+    assert!(classes.contains(&TaskClass::UserAction));
+    assert!(classes.contains(&TaskClass::UserGate), "user default class");
+    assert!(classes.contains(&TaskClass::Blocker));
+    assert_eq!(
+        classes.iter().filter(|c| **c == TaskClass::Monitor).count(),
+        2,
+        "continuous_monitor and monitor both map to Monitor"
+    );
+    // Priorities from [P0]/[P2] prefixes.
+    let p0 = outcome.events.iter().find_map(|e| match &e.event {
+        future_loop::store::Event::TodoAdded { todo, .. } if todo.text.contains("First task") => {
+            Some(todo.priority)
+        }
+        _ => None,
+    });
+    assert_eq!(p0, Some(future_loop::state::Priority::P0));
+    // A record without todo_id gets a content-derived id (deterministic).
+    let digest_todo = outcome.events.iter().find_map(|e| match &e.event {
+        future_loop::store::Event::TodoAdded { todo, .. } if todo.text.contains("Deferred task") => {
+            Some(todo.id.clone())
+        }
+        _ => None,
+    });
+    assert!(digest_todo.as_deref().unwrap().starts_with("todo-"));
+    // Public-safe privacy passes evidence through the redactor (secret
+    // patterns would be masked; plain text passes through).
+    let public = backfill_todo_events(FULL_MD, "g1", PrivacyLevel::PublicSafe).unwrap();
+    let ev = public.events.iter().find_map(|e| match &e.event {
+        future_loop::store::Event::TodoAdded { todo, .. } if todo.id == "todo_a2" => {
+            todo.evidence.clone()
+        }
+        _ => None,
+    });
+    assert!(ev.is_some());
+    // Empty goal id / no records → errors.
+    assert!(backfill_todo_events(FULL_MD, "", PrivacyLevel::LocalPrivate).is_err());
+    assert!(backfill_todo_events("# nothing", "g1", PrivacyLevel::LocalPrivate).is_err());
+}
+
+#[test]
+fn backfill_ids_are_deterministic() {
+    assert_eq!(
+        backfill_event_id("g", "t", "add"),
+        backfill_event_id("g", "t", "add")
+    );
+    assert!(backfill_event_id("g", "t", "add").starts_with("backfill-add-"));
+}
+
+#[test]
+fn active_state_markdown_read_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let cwd = dir.path().to_string_lossy().into_owned();
+    // Missing file → error mentioning the path.
+    assert!(active_state_markdown(&cwd, "goal_x").is_err());
+    // Present file → contents.
+    let p = dir
+        .path()
+        .join(".future/loop/goals/goal_x");
+    std::fs::create_dir_all(&p).unwrap();
+    std::fs::write(p.join("ACTIVE_GOAL_STATE.md"), "# state").unwrap();
+    assert_eq!(active_state_markdown(&cwd, "goal_x").unwrap(), "# state");
+}

--- a/orchestration/loop/tests/benchmark_drive.rs
+++ b/orchestration/loop/tests/benchmark_drive.rs
@@ -278,8 +278,10 @@ fn grpc_adapter_error_paths() {
         let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
         assert!(run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).is_err());
         // observe: stream attach failure.
-        let mut st = MockState::default();
-        st.stream_error = true;
+        let st = MockState {
+            stream_error: true,
+            ..Default::default()
+        };
         let (addr, _) = spawn_mock(st).await;
         let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
         assert!(run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).is_err());

--- a/orchestration/loop/tests/benchmark_drive.rs
+++ b/orchestration/loop/tests/benchmark_drive.rs
@@ -1,0 +1,253 @@
+//! Coverage drive for `benchmark/`: qualification flow control (bails,
+//! budget exhaustion, preflight failures), adapter stage errors, the gRPC
+//! adapter against the mock agent, and the run-ledger edges.
+
+mod common;
+
+use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
+use future_loop::benchmark::adapter::{
+    AdapterClassification, BenchmarkAdapter, GrpcLoopxAdapter, IngestResult, LaunchResult,
+    Observation, PreflightResult, RunHandle, ScriptedAdapter,
+};
+use future_loop::benchmark::ledger::{
+    build_benchmark_run_ledger_entry, classify_failure, derive_benchmark_run_id, BenchmarkLedger,
+    BenchmarkRun, RoundRewardTrace,
+};
+use future_loop::benchmark::qualification::{run_qualification_case, QualificationCase};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn case(bench: &str, case: &str, rounds: u32) -> QualificationCase {
+    QualificationCase::new(bench, case, "do the task", rounds)
+}
+
+// ── qualification flow control ─────────────────────────────────────────────
+
+#[test]
+fn qualification_flow_control() {
+    // max_rounds == 0 → bail.
+    let mut adapter = ScriptedAdapter::new(vec!["completed".to_string()]);
+    assert!(run_qualification_case(&mut adapter, &case("b", "c", 0), None).is_err());
+
+    // Preflight returns Err (transport-style failure) → propagates.
+    struct PreflightErr;
+    impl BenchmarkAdapter for PreflightErr {
+        fn id(&self) -> &str {
+            "pre-err"
+        }
+        fn preflight(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest) -> anyhow::Result<PreflightResult> {
+            anyhow::bail!("preflight exploded")
+        }
+        fn launch(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest) -> anyhow::Result<LaunchResult> {
+            unreachable!()
+        }
+        fn observe(&mut self, _: &RunHandle) -> anyhow::Result<Observation> {
+            unreachable!()
+        }
+        fn ingest(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest, _: &RunHandle, _: &Observation) -> anyhow::Result<IngestResult> {
+            unreachable!()
+        }
+        fn classify(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest, _: &IngestResult) -> anyhow::Result<AdapterClassification> {
+            unreachable!()
+        }
+        fn ledger(
+            &mut self,
+            _: &future_loop::benchmark::adapter::BenchmarkRequest,
+            _: &IngestResult,
+            _: Option<&std::path::Path>,
+            _: u64,
+        ) -> anyhow::Result<future_loop::benchmark::adapter::LedgerUpdate> {
+            unreachable!()
+        }
+    }
+    let mut a = PreflightErr;
+    assert!(run_qualification_case(&mut a, &case("b", "c", 2), None).is_err());
+
+    // All rounds fail (non-error terminal → loop runs to budget) → exhausted.
+    let mut failing = ScriptedAdapter::new(vec!["incomplete".to_string()]);
+    let result = run_qualification_case(&mut failing, &case("b", "c", 2), None).unwrap();
+    assert!(!result.passed);
+    assert_eq!(result.failure_class, "budget_exhausted");
+    assert_eq!(result.rounds_used, 2);
+    assert_eq!(result.headline.first_success_round, None);
+}
+
+#[test]
+fn scripted_adapter_edges() {
+    // Empty task → preflight bail.
+    let mut a = ScriptedAdapter::new(vec![]);
+    let mut c = case("b", "c", 1);
+    c.task = "   ".to_string();
+    assert!(run_qualification_case(&mut a, &c, None).is_err());
+    // Empty script → observe falls back to "completed".
+    let mut a = ScriptedAdapter::new(vec![]);
+    let result = run_qualification_case(&mut a, &case("b", "c", 1), None).unwrap();
+    assert!(result.passed);
+    // Script shorter than rounds → the last entry repeats. A non-error
+    // failure keeps the loop going; round 2 passes and stops it.
+    let mut a = ScriptedAdapter::new(vec!["incomplete".to_string(), "completed".to_string()]);
+    let result = run_qualification_case(&mut a, &case("b", "c", 3), None).unwrap();
+    assert!(result.passed, "second round passes and stops the loop");
+    assert_eq!(result.rounds_used, 2);
+    assert_eq!(result.headline.first_success_round, Some(2));
+    assert_eq!(result.headline.best_score, 1.0);
+    assert_eq!(result.headline.final_score, 1.0);
+    assert_eq!(result.headline.declared_done_score, 1.0);
+    assert_eq!(result.failure_class, "success");
+    assert_eq!(result.failure_scope, "case");
+}
+
+// ── ledger ─────────────────────────────────────────────────────────────────
+
+fn run_with(bench: &str, status: &str, passed: bool, final_round: u32, budget: u32) -> BenchmarkRun {
+    BenchmarkRun {
+        benchmark_id: bench.to_string(),
+        case_ids: vec!["c1".to_string()],
+        arm_id: "arm".to_string(),
+        route: "r".to_string(),
+        mode: "product".to_string(),
+        agent_model: "m".to_string(),
+        job_name: "j".to_string(),
+        round_reward_trace: RoundRewardTrace::from_records(
+            vec![future_loop::benchmark::ledger::RoundRewardRecord {
+                agent_round: final_round,
+                passed,
+                reward: if passed { 1.0 } else { 0.0 },
+            }],
+            budget,
+        ),
+        terminal_status: status.to_string(),
+        notes: String::new(),
+    }
+}
+
+#[test]
+fn classify_failure_matrix() {
+    assert_eq!(classify_failure(&run_with("b", "runner_error", false, 1, 5)).0, "runner_error");
+    assert_eq!(classify_failure(&run_with("b", "aborted", false, 1, 5)).0, "aborted");
+    assert_eq!(classify_failure(&run_with("b", "completed", true, 1, 5)).0, "success");
+    assert_eq!(
+        classify_failure(&run_with("b", "completed", false, 5, 5)).0,
+        "budget_exhausted"
+    );
+    assert_eq!(classify_failure(&run_with("b", "completed", false, 1, 5)).0, "case_failure");
+    assert_eq!(classify_failure(&run_with("b", "mystery", false, 1, 5)).0, "unknown");
+    // Empty trace → runner_error regardless.
+    let mut run = run_with("b", "completed", false, 1, 5);
+    run.round_reward_trace = RoundRewardTrace::default();
+    assert_eq!(classify_failure(&run).0, "runner_error");
+}
+
+#[test]
+fn ledger_entry_builder_and_store() {
+    // Long notes are compacted with an ellipsis; declared-done builder sets fields.
+    let mut run = run_with("bench-x", "completed", true, 1, 5);
+    run.notes = "x".repeat(500);
+    let entry = build_benchmark_run_ledger_entry(&run, 1_700_000_000);
+    assert!(entry.notes.len() < 500, "compacted: {}", entry.notes.len());
+    assert!(entry.notes.ends_with('…'));
+    assert_eq!(entry.benchmark_id, "bench-x");
+    assert!(entry.passed);
+    // derive id stable + distinct on content change.
+    assert_eq!(derive_benchmark_run_id(&run), derive_benchmark_run_id(&run));
+    let other = run_with("bench-y", "completed", true, 1, 5);
+    assert_ne!(derive_benchmark_run_id(&run), derive_benchmark_run_id(&other));
+    // Trace with declared done.
+    let trace = RoundRewardTrace::from_records(vec![], 5).with_declared_done(2, 1.0);
+    assert!(trace.agent_declared_done);
+    assert_eq!(trace.declared_done_round, Some(2));
+    assert_eq!(trace.declared_done_score, Some(1.0));
+
+    // Store: open/append (idempotent dup)/query/aggregate/corrupt line.
+    let dir = tempfile::tempdir().unwrap();
+    let mut ledger = BenchmarkLedger::open(dir.path()).unwrap();
+    assert!(ledger.append(entry.clone()).unwrap());
+    assert!(!ledger.append(entry.clone()).unwrap(), "duplicate run_id is a no-op");
+    assert_eq!(ledger.entries().len(), 1);
+    assert!(!ledger.path().as_os_str().is_empty());
+    assert_eq!(ledger.query(Some("bench-x"), Some("c1"), None).len(), 1);
+    assert_eq!(ledger.query(Some("other"), None, None).len(), 0);
+    assert_eq!(ledger.query(None, Some("c1"), None).len(), 1);
+    assert_eq!(ledger.query(None, Some("nope"), None).len(), 0);
+    let agg = ledger.aggregate(Some("bench-x"));
+    assert_eq!(agg["run_count"], serde_json::json!(1));
+    let agg_all = ledger.aggregate(None);
+    assert_eq!(agg_all["run_count"], serde_json::json!(1));
+    // Corrupt line → open fails with line context.
+    std::fs::write(ledger.path(), "{corrupt\n").unwrap();
+    let err = BenchmarkLedger::open(dir.path()).unwrap_err();
+    assert!(format!("{err:#}").contains("corrupt"), "{err:#}");
+}
+
+// ── gRPC adapter against the mock agent ────────────────────────────────────
+
+#[test]
+fn grpc_adapter_full_surface() {
+    rt().block_on(async {
+        let (addr, _shared) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp")
+            .await
+            .unwrap()
+            .with_model("future/k3")
+            .with_thinking_level("low");
+        assert_eq!(adapter.id(), "grpc-loopx");
+        assert!(!adapter.session_id().is_empty());
+        // Full qualification through the mock (covers launch/observe/ingest/
+        // classify/ledger arms end to end).
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = case("gb", "cb", 2);
+        c.expected_evidence = Some("artifact".to_string());
+        let result = run_qualification_case(&mut adapter, &c, Some(dir.path())).unwrap();
+        assert!(result.passed, "{result:?}");
+        // Ledger received one idempotent entry.
+        let mut ledger = BenchmarkLedger::open(dir.path()).unwrap();
+        assert_eq!(ledger.entries().len(), 1);
+        let _ = &mut ledger;
+    });
+}
+
+#[test]
+fn grpc_adapter_error_paths() {
+    rt().block_on(async {
+        // connect failure.
+        assert!(GrpcLoopxAdapter::connect("127.0.0.1:1", "/tmp").await.is_err());
+        // preflight: empty task → ok:false.
+        let (addr, _) = spawn_mock(MockState::default()).await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
+        let mut c = case("gb", "cb", 1);
+        c.task = String::new();
+        let result = run_qualification_case(&mut adapter, &c, None).unwrap();
+        assert!(!result.passed);
+        assert_eq!(result.failure_class, "runner_error");
+        assert_eq!(result.rounds_used, 0);
+        // launch: prompt fails → round error propagates.
+        let (addr, _) = spawn_mock(MockState::fail("prompt")).await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
+        assert!(run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).is_err());
+        // observe: stream attach failure.
+        let mut st = MockState::default();
+        st.stream_error = true;
+        let (addr, _) = spawn_mock(st).await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
+        assert!(run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).is_err());
+        // terminal error round → runner_error classification.
+        let (addr, _) = spawn_mock(MockState {
+            events: vec![ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"dead\"}")],
+            ..Default::default()
+        })
+        .await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
+        let result = run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).unwrap();
+        assert!(!result.passed);
+        assert_eq!(result.failure_class, "runner_error");
+    });
+}

--- a/orchestration/loop/tests/benchmark_drive.rs
+++ b/orchestration/loop/tests/benchmark_drive.rs
@@ -40,19 +40,34 @@ fn qualification_flow_control() {
         fn id(&self) -> &str {
             "pre-err"
         }
-        fn preflight(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest) -> anyhow::Result<PreflightResult> {
+        fn preflight(
+            &mut self,
+            _: &future_loop::benchmark::adapter::BenchmarkRequest,
+        ) -> anyhow::Result<PreflightResult> {
             anyhow::bail!("preflight exploded")
         }
-        fn launch(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest) -> anyhow::Result<LaunchResult> {
+        fn launch(
+            &mut self,
+            _: &future_loop::benchmark::adapter::BenchmarkRequest,
+        ) -> anyhow::Result<LaunchResult> {
             unreachable!()
         }
         fn observe(&mut self, _: &RunHandle) -> anyhow::Result<Observation> {
             unreachable!()
         }
-        fn ingest(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest, _: &RunHandle, _: &Observation) -> anyhow::Result<IngestResult> {
+        fn ingest(
+            &mut self,
+            _: &future_loop::benchmark::adapter::BenchmarkRequest,
+            _: &RunHandle,
+            _: &Observation,
+        ) -> anyhow::Result<IngestResult> {
             unreachable!()
         }
-        fn classify(&mut self, _: &future_loop::benchmark::adapter::BenchmarkRequest, _: &IngestResult) -> anyhow::Result<AdapterClassification> {
+        fn classify(
+            &mut self,
+            _: &future_loop::benchmark::adapter::BenchmarkRequest,
+            _: &IngestResult,
+        ) -> anyhow::Result<AdapterClassification> {
             unreachable!()
         }
         fn ledger(
@@ -104,7 +119,13 @@ fn scripted_adapter_edges() {
 
 // ── ledger ─────────────────────────────────────────────────────────────────
 
-fn run_with(bench: &str, status: &str, passed: bool, final_round: u32, budget: u32) -> BenchmarkRun {
+fn run_with(
+    bench: &str,
+    status: &str,
+    passed: bool,
+    final_round: u32,
+    budget: u32,
+) -> BenchmarkRun {
     BenchmarkRun {
         benchmark_id: bench.to_string(),
         case_ids: vec!["c1".to_string()],
@@ -128,15 +149,30 @@ fn run_with(bench: &str, status: &str, passed: bool, final_round: u32, budget: u
 
 #[test]
 fn classify_failure_matrix() {
-    assert_eq!(classify_failure(&run_with("b", "runner_error", false, 1, 5)).0, "runner_error");
-    assert_eq!(classify_failure(&run_with("b", "aborted", false, 1, 5)).0, "aborted");
-    assert_eq!(classify_failure(&run_with("b", "completed", true, 1, 5)).0, "success");
+    assert_eq!(
+        classify_failure(&run_with("b", "runner_error", false, 1, 5)).0,
+        "runner_error"
+    );
+    assert_eq!(
+        classify_failure(&run_with("b", "aborted", false, 1, 5)).0,
+        "aborted"
+    );
+    assert_eq!(
+        classify_failure(&run_with("b", "completed", true, 1, 5)).0,
+        "success"
+    );
     assert_eq!(
         classify_failure(&run_with("b", "completed", false, 5, 5)).0,
         "budget_exhausted"
     );
-    assert_eq!(classify_failure(&run_with("b", "completed", false, 1, 5)).0, "case_failure");
-    assert_eq!(classify_failure(&run_with("b", "mystery", false, 1, 5)).0, "unknown");
+    assert_eq!(
+        classify_failure(&run_with("b", "completed", false, 1, 5)).0,
+        "case_failure"
+    );
+    assert_eq!(
+        classify_failure(&run_with("b", "mystery", false, 1, 5)).0,
+        "unknown"
+    );
     // Empty trace → runner_error regardless.
     let mut run = run_with("b", "completed", false, 1, 5);
     run.round_reward_trace = RoundRewardTrace::default();
@@ -156,7 +192,10 @@ fn ledger_entry_builder_and_store() {
     // derive id stable + distinct on content change.
     assert_eq!(derive_benchmark_run_id(&run), derive_benchmark_run_id(&run));
     let other = run_with("bench-y", "completed", true, 1, 5);
-    assert_ne!(derive_benchmark_run_id(&run), derive_benchmark_run_id(&other));
+    assert_ne!(
+        derive_benchmark_run_id(&run),
+        derive_benchmark_run_id(&other)
+    );
     // Trace with declared done.
     let trace = RoundRewardTrace::from_records(vec![], 5).with_declared_done(2, 1.0);
     assert!(trace.agent_declared_done);
@@ -167,7 +206,10 @@ fn ledger_entry_builder_and_store() {
     let dir = tempfile::tempdir().unwrap();
     let mut ledger = BenchmarkLedger::open(dir.path()).unwrap();
     assert!(ledger.append(entry.clone()).unwrap());
-    assert!(!ledger.append(entry.clone()).unwrap(), "duplicate run_id is a no-op");
+    assert!(
+        !ledger.append(entry.clone()).unwrap(),
+        "duplicate run_id is a no-op"
+    );
     assert_eq!(ledger.entries().len(), 1);
     assert!(!ledger.path().as_os_str().is_empty());
     assert_eq!(ledger.query(Some("bench-x"), Some("c1"), None).len(), 1);
@@ -219,7 +261,9 @@ fn grpc_adapter_full_surface() {
 fn grpc_adapter_error_paths() {
     rt().block_on(async {
         // connect failure.
-        assert!(GrpcLoopxAdapter::connect("127.0.0.1:1", "/tmp").await.is_err());
+        assert!(GrpcLoopxAdapter::connect("127.0.0.1:1", "/tmp")
+            .await
+            .is_err());
         // preflight: empty task → ok:false.
         let (addr, _) = spawn_mock(MockState::default()).await;
         let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
@@ -241,7 +285,12 @@ fn grpc_adapter_error_paths() {
         assert!(run_qualification_case(&mut adapter, &case("gb", "cb", 1), None).is_err());
         // terminal error round → runner_error classification.
         let (addr, _) = spawn_mock(MockState {
-            events: vec![ev("mock-run-1", 0, "agent_end", "{\"state\":\"error\",\"error\":\"dead\"}")],
+            events: vec![ev(
+                "mock-run-1",
+                0,
+                "agent_end",
+                "{\"state\":\"error\",\"error\":\"dead\"}",
+            )],
             ..Default::default()
         })
         .await;

--- a/orchestration/loop/tests/benchmark_drive.rs
+++ b/orchestration/loop/tests/benchmark_drive.rs
@@ -251,3 +251,25 @@ fn grpc_adapter_error_paths() {
         assert_eq!(result.failure_class, "runner_error");
     });
 }
+
+#[test]
+fn grpc_adapter_classify_failed_and_scripted_id() {
+    // ScriptedAdapter::id() accessor.
+    let a = ScriptedAdapter::new(vec![]);
+    assert_eq!(a.id(), "scripted");
+    rt().block_on(async {
+        // A completed turn whose evidence LACKS the expected marker → the
+        // round does not pass, but is not a runner error → "failed".
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut adapter = GrpcLoopxAdapter::connect(&addr, "/tmp").await.unwrap();
+        let mut c = case("gb", "cb", 1);
+        c.expected_evidence = Some("STRING_NOT_IN_OUTPUT".to_string());
+        let result = run_qualification_case(&mut adapter, &c, None).unwrap();
+        assert!(!result.passed);
+        assert_eq!(result.failure_class, "budget_exhausted");
+    });
+}

--- a/orchestration/loop/tests/canary_drive.rs
+++ b/orchestration/loop/tests/canary_drive.rs
@@ -1,0 +1,166 @@
+//! Coverage drive for `canary/mod.rs` — the per-check failure arms need
+//! goals in deliberately broken states (empty/corrupt/conflicting ledgers,
+//! projection gaps, extension-state files).
+
+mod common;
+
+use common::{cli_root, init_goal, open_store, CliRoot};
+use future_loop::canary::run_smoke;
+use future_loop::state::Goal;
+use future_loop::store::Store;
+
+fn check<'a>(
+    result: &'a future_loop::canary::SmokeRunResult,
+    id: &str,
+) -> &'a future_loop::canary::SmokeCheckOutcome {
+    result
+        .checks
+        .iter()
+        .find(|c| c.id == id)
+        .unwrap_or_else(|| panic!("check {id} ran"))
+}
+
+#[test]
+fn smoke_on_healthy_populated_store() {
+    let cr = cli_root();
+    let _gid = init_goal(&cr, "healthy canary");
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    assert!(result.all_passed, "{:?}", result.checks.iter().map(|c| (&c.id, c.passed, &c.detail)).collect::<Vec<_>>());
+    // Non-vacuous detail arms (a goal exists → checks actually examined it).
+    assert!(check(&result, "ledger_integrity").detail.contains("goal"));
+    assert!(check(&result, "decision_determinism").detail.contains("deterministic"));
+    assert!(check(&result, "quota_should_run").detail.contains("goal"));
+    assert!(check(&result, "todo_frontier").detail.contains("frontier consistent"));
+    assert!(check(&result, "status_projection").detail.contains("status consistent"));
+    assert!(check(&result, "canary_self").passed);
+}
+
+#[test]
+fn smoke_empty_and_corrupt_ledgers_fail() {
+    let cr = cli_root();
+    // Registered goal with NO events file → empty-ledger failure.
+    {
+        let mut store = open_store(&cr);
+        store.register(&Goal::new("goal_empty", "no events", "/tmp")).unwrap();
+    }
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    let c = check(&result, "ledger_integrity");
+    assert!(!c.passed, "{c:?}");
+    assert!(c.detail.contains("empty ledger"), "{c:?}");
+    // Corrupt ledger line → events() error arm.
+    {
+        let store = open_store(&cr);
+        let dir = store.goal_dir("goal_empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("events.jsonl"), "{broken json\n").unwrap();
+    }
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    let c = check(&result, "ledger_integrity");
+    assert!(!c.passed);
+    assert!(c.detail.contains("goal_empty"), "{c:?}");
+}
+
+#[test]
+fn smoke_conflicting_ledger_fails_verify_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "conflict canary");
+    {
+        let store = open_store(&cr);
+        let path = store.goal_dir(&gid).join("events.jsonl");
+        let a = serde_json::json!({"event_id":"e-dup","kind":"goal_started","goal_id":gid,"ts":1});
+        let b = serde_json::json!({"event_id":"e-dup","kind":"goal_started","goal_id":gid,"ts":2});
+        std::fs::write(&path, format!("{}\n{}\n", a, b)).unwrap();
+    }
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    let c = check(&result, "ledger_integrity");
+    assert!(!c.passed, "{c:?}");
+    assert!(c.detail.contains("conflict"), "{c:?}");
+    assert!(!result.all_passed);
+}
+
+#[test]
+fn smoke_projection_gap_fails_frontier() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "gap canary");
+    {
+        let store = open_store(&cr);
+        // Complete the only todo, then point next_action at phantom work.
+        let g = store.replay(&gid).unwrap().unwrap();
+        let first = g.todos.first().unwrap().id.clone();
+        drop(g);
+        let mut store = open_store(&cr);
+        store
+            .append(future_loop::store::Event::TodoCompleted {
+                goal_id: gid.clone(),
+                todo_id: first,
+                no_follow_up: true,
+                successor_ids: vec![],
+                evidence: None,
+                ts: future_loop::state::now_epoch(),
+            })
+            .unwrap();
+        store.set_next_action(&gid, "phantom work with no todo").unwrap();
+    }
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    let c = check(&result, "todo_frontier");
+    assert!(!c.passed, "{c:?}");
+    assert!(c.detail.contains("no matching open agent todo"), "{c:?}");
+}
+
+#[test]
+fn smoke_extension_state_arms() {
+    let cr: CliRoot = cli_root();
+    // A valid extension state file → "N extension(s) readable".
+    {
+        let dir = std::path::Path::new(&cr.root).join("extensions");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("state.json"),
+            "{\"schema_version\":\"future_loop_extension_state_v0\",\"extensions\":{}}",
+        )
+        .unwrap();
+        let store = open_store(&cr);
+        let result = run_smoke(&store, "release-gate").unwrap();
+        let c = check(&result, "extension_state");
+        assert!(c.passed, "{c:?}");
+        assert!(c.detail.contains("extension"), "{c:?}");
+    }
+    // A corrupt one → check fails.
+    {
+        std::fs::write(
+            std::path::Path::new(&cr.root).join("extensions/state.json"),
+            "{corrupt",
+        )
+        .unwrap();
+        let store = open_store(&cr);
+        let result = run_smoke(&store, "release-gate").unwrap();
+        let c = check(&result, "extension_state");
+        assert!(!c.passed, "{c:?}");
+        assert!(c.detail.contains("corrupt"), "{c:?}");
+    }
+}
+
+#[test]
+fn smoke_backup_check_with_backup() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "backup canary");
+    {
+        let store = open_store(&cr);
+        store.backup_goal(&gid).unwrap();
+    }
+    let store = open_store(&cr);
+    let result = run_smoke(&store, "release-gate").unwrap();
+    assert!(check(&result, "backup_dir").passed);
+}
+
+#[test]
+fn smoke_unknown_profile_errors() {
+    let cr = cli_root();
+    let store = open_store(&cr);
+    assert!(run_smoke(&store, "no-such-profile").is_err());
+}

--- a/orchestration/loop/tests/canary_drive.rs
+++ b/orchestration/loop/tests/canary_drive.rs
@@ -26,13 +26,27 @@ fn smoke_on_healthy_populated_store() {
     let _gid = init_goal(&cr, "healthy canary");
     let store = open_store(&cr);
     let result = run_smoke(&store, "release-gate").unwrap();
-    assert!(result.all_passed, "{:?}", result.checks.iter().map(|c| (&c.id, c.passed, &c.detail)).collect::<Vec<_>>());
+    assert!(
+        result.all_passed,
+        "{:?}",
+        result
+            .checks
+            .iter()
+            .map(|c| (&c.id, c.passed, &c.detail))
+            .collect::<Vec<_>>()
+    );
     // Non-vacuous detail arms (a goal exists → checks actually examined it).
     assert!(check(&result, "ledger_integrity").detail.contains("goal"));
-    assert!(check(&result, "decision_determinism").detail.contains("deterministic"));
+    assert!(check(&result, "decision_determinism")
+        .detail
+        .contains("deterministic"));
     assert!(check(&result, "quota_should_run").detail.contains("goal"));
-    assert!(check(&result, "todo_frontier").detail.contains("frontier consistent"));
-    assert!(check(&result, "status_projection").detail.contains("status consistent"));
+    assert!(check(&result, "todo_frontier")
+        .detail
+        .contains("frontier consistent"));
+    assert!(check(&result, "status_projection")
+        .detail
+        .contains("status consistent"));
     assert!(check(&result, "canary_self").passed);
 }
 
@@ -42,7 +56,9 @@ fn smoke_empty_and_corrupt_ledgers_fail() {
     // Registered goal with NO events file → empty-ledger failure.
     {
         let mut store = open_store(&cr);
-        store.register(&Goal::new("goal_empty", "no events", "/tmp")).unwrap();
+        store
+            .register(&Goal::new("goal_empty", "no events", "/tmp"))
+            .unwrap();
     }
     let store = open_store(&cr);
     let result = run_smoke(&store, "release-gate").unwrap();
@@ -103,7 +119,9 @@ fn smoke_projection_gap_fails_frontier() {
                 ts: future_loop::state::now_epoch(),
             })
             .unwrap();
-        store.set_next_action(&gid, "phantom work with no todo").unwrap();
+        store
+            .set_next_action(&gid, "phantom work with no todo")
+            .unwrap();
     }
     let store = open_store(&cr);
     let result = run_smoke(&store, "release-gate").unwrap();

--- a/orchestration/loop/tests/canary_drive.rs
+++ b/orchestration/loop/tests/canary_drive.rs
@@ -7,6 +7,7 @@ mod common;
 use common::{cli_root, init_goal, open_store, CliRoot};
 use future_loop::canary::run_smoke;
 use future_loop::state::Goal;
+#[cfg(unix)]
 use future_loop::store::Store;
 
 fn check<'a>(

--- a/orchestration/loop/tests/canary_drive.rs
+++ b/orchestration/loop/tests/canary_drive.rs
@@ -164,3 +164,23 @@ fn smoke_unknown_profile_errors() {
     let store = open_store(&cr);
     assert!(run_smoke(&store, "no-such-profile").is_err());
 }
+
+#[cfg(unix)]
+#[test]
+fn smoke_unwritable_root_fails_check() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("ro-root");
+    std::fs::create_dir_all(&root).unwrap();
+    let mut perms = std::fs::metadata(&root).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&root, perms).unwrap();
+    let store = Store::open(root.to_str().unwrap()).unwrap();
+    let result = run_smoke(&store, "release-gate").unwrap();
+    let c = check(&result, "root_writable");
+    assert!(!c.passed, "{c:?}");
+    // Restore writability so the tempdir can be cleaned up.
+    let mut perms = std::fs::metadata(&root).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&root, perms).unwrap();
+}

--- a/orchestration/loop/tests/capabilities_drive.rs
+++ b/orchestration/loop/tests/capabilities_drive.rs
@@ -172,7 +172,7 @@ fn record(id: &str) -> CapabilityRecord {
 fn catalog_registration_errors() {
     let mut catalog = CapabilityCatalog::with_builtin();
     // Empty id.
-    let mut r = record("");
+    let r = record("");
     assert!(catalog.register_capability(r.clone()).is_err());
     // Empty required field (title).
     let mut r = record("cap-x");

--- a/orchestration/loop/tests/capabilities_drive.rs
+++ b/orchestration/loop/tests/capabilities_drive.rs
@@ -1,0 +1,179 @@
+//! Coverage drive for `capabilities/`: every builtin capability's propose
+//! keyword matrix, the provider lifecycle state machine, and the catalog
+//! registration validation arms.
+
+use future_loop::capabilities::catalog::{CapabilityCatalog, CapabilityRecord};
+use future_loop::capabilities::lifecycle::{
+    CapabilityProvider, ProviderLifecycle, ProviderStage, CAPABILITY_ORIGINS,
+};
+use future_loop::capabilities::{CapabilityRegistry, ProposalKind};
+
+fn propose(name: &str, input: &str) -> Vec<future_loop::capabilities::TypedProposal> {
+    let registry = CapabilityRegistry::with_builtin();
+    let cap = registry.get(name).unwrap_or_else(|| panic!("{name} registered"));
+    cap.propose(input)
+}
+
+fn kinds(ps: &[future_loop::capabilities::TypedProposal]) -> Vec<ProposalKind> {
+    ps.iter().map(|p| p.kind.clone()).collect()
+}
+
+// ── keyword routers ────────────────────────────────────────────────────────
+
+#[test]
+fn simple_router_capabilities() {
+    // (capability, [inputs that hit each rule arm])
+    let cases: &[(&str, &[&str])] = &[
+        ("material_lifecycle", &["archive it", "归档", "废弃", "nothing relevant", ""]),
+        ("change_quality", &["all pass + diff written", "tests fail", "all pass", ""]),
+        ("explore", &["hypothesis here", "假设", "探索", "none", ""]),
+        ("integration_branch", &["branch it", "集成", "none", ""]),
+        ("value_connectors", &["connector plan", "连接", "none", ""]),
+        ("reward_memory", &["reward this", "评价", "none", ""]),
+        ("semantic_preference", &["prefer dark mode", "偏好", "none", ""]),
+        ("decision_context", &["decide this", "决策", "none", ""]),
+        ("agent_turn_recall", &["recall the turn", "回忆", "none", ""]),
+        ("content_ops", &["content publish", "发布", "none", ""]),
+        ("context_providers", &["provider context", "上下文", "none", ""]),
+        ("periodic_report", &["report weekly", "报告", "none", ""]),
+        ("auto_research", &["research this", "调研", "none", ""]),
+    ];
+    for (name, inputs) in cases {
+        for input in *inputs {
+            let ps = propose(name, input);
+            assert!(!ps.is_empty(), "{name} / {input:?}");
+        }
+    }
+}
+
+// ── issue_fix deep branches ────────────────────────────────────────────────
+
+#[test]
+fn issue_fix_branch_matrix() {
+    // Empty.
+    assert_eq!(kinds(&propose("issue_fix", "")), vec![ProposalKind::NoFollowUp]);
+    // Full signal (repro+error+expected) → investigate/fix/validate trio.
+    let ps = propose(
+        "issue_fix",
+        "title: crash on empty input\nerror: panicked at src/main.rs:42\nrepro: run with no args\nexpected: prints usage and exits 0\nscope: cli",
+    );
+    assert_eq!(ps.len(), 3, "{ps:?}");
+    // The `scope`/`expected` metadata keys parse into the observation.
+    // Authority read-only gates BEFORE any fix.
+    assert_eq!(
+        kinds(&propose("issue_fix", "title: t\nerror: e\nrepro: r\nauthority: read-only")),
+        vec![ProposalKind::Gate]
+    );
+    // Regression with repro+error → bounded repair.
+    let ps = propose(
+        "issue_fix",
+        "title: regression\nerror: tests fail\nrepro: run ci\nbody: this previously worked; a regression returned",
+    );
+    assert!(ps[0].reason.to_lowercase().contains("repair"), "{ps:?}");
+    // Partial signal (exactly one of repro/error/expected, enough words) → investigate.
+    let ps = propose(
+        "issue_fix",
+        "error: the thing broke in a way that takes many words to describe properly here",
+    );
+    assert_eq!(ps.len(), 1);
+    assert!(ps[0].reason.contains("investigate"), "{ps:?}");
+    // Too little signal → triage.
+    let ps = propose("issue_fix", "it broke");
+    assert!(ps[0].todo.as_ref().unwrap().text.contains("Triage"), "{ps:?}");
+}
+
+// ── provider lifecycle ─────────────────────────────────────────────────────
+
+#[test]
+fn provider_lifecycle_machine() {
+    for (stage, label) in [
+        (ProviderStage::Declared, "declared"),
+        (ProviderStage::Installed, "installed"),
+        (ProviderStage::Enabled, "enabled"),
+        (ProviderStage::Ready, "ready"),
+    ] {
+        assert_eq!(stage.label(), label);
+        assert_eq!(format!("{stage}"), label);
+    }
+    // for_origin: builtin auto-installs; external requires declared.
+    let lc = ProviderLifecycle::for_origin("builtin", true, false).unwrap();
+    assert!(lc.installed && lc.enabled && lc.ready);
+    let _ = ProviderLifecycle::for_origin("external", false, false);
+    // Transitions + error arms.
+    let mut lc = ProviderLifecycle::for_origin("external", true, false).unwrap();
+    assert!(!lc.installed);
+    lc.install().unwrap();
+    assert!(lc.installed);
+    lc.enable().unwrap();
+    lc.disable().unwrap();
+    assert!(!lc.enabled && !lc.ready);
+    lc.uninstall().unwrap();
+    assert!(!lc.installed);
+    let mut undeclared = ProviderLifecycle {
+        declared: false,
+        installed: false,
+        enabled: false,
+        ready: false,
+    };
+    assert!(undeclared.install().is_err());
+    // Provider registration validation.
+    assert!(CapabilityProvider::new("", "builtin", None, true, false).is_err());
+    assert!(CapabilityProvider::new("p", "unsupported-origin", None, true, false).is_err());
+    let p = CapabilityProvider::new("p", "builtin", Some("1.0".into()), true, false).unwrap();
+    assert_eq!(p.version.as_deref(), Some("1.0"));
+    assert!(CAPABILITY_ORIGINS.contains(&"builtin"));
+}
+
+// ── catalog registration validation ────────────────────────────────────────
+
+fn record(id: &str) -> CapabilityRecord {
+    CapabilityRecord {
+        id: id.to_string(),
+        title: "T".into(),
+        status: "available".into(),
+        stage: 1,
+        provider_id: "future-loop".into(),
+        origin: "builtin".into(),
+        visibility: "public".into(),
+        user_value: "v".into(),
+        next_real_step: "s".into(),
+        commands: vec![],
+        packets: vec![],
+    }
+}
+
+#[test]
+fn catalog_registration_errors() {
+    let mut catalog = CapabilityCatalog::with_builtin();
+    // Empty id.
+    let mut r = record("");
+    assert!(catalog.register_capability(r.clone()).is_err());
+    // Empty required field (title).
+    let mut r = record("cap-x");
+    r.title = "  ".into();
+    assert!(catalog.register_capability(r).is_err());
+    // Bad origin / visibility.
+    let mut r = record("cap-x");
+    r.origin = "nope".into();
+    assert!(catalog.register_capability(r).is_err());
+    let mut r = record("cap-x");
+    r.visibility = "nope".into();
+    assert!(catalog.register_capability(r).is_err());
+    // Unknown provider.
+    let mut r = record("cap-x");
+    r.provider_id = "ghost-provider".into();
+    assert!(catalog.register_capability(r).is_err());
+    // Origin mismatch with the provider.
+    let mut r = record("cap-x");
+    r.origin = "external".into();
+    assert!(catalog.register_capability(r).is_err());
+    // Duplicate id (an existing builtin).
+    let r = record("issue_fix");
+    assert!(catalog.register_capability(r).is_err());
+    // provider_lifecycle_for: unknown capability → None; builtin → Some.
+    assert!(catalog.provider_lifecycle_for("cap-ghost").is_none());
+    assert!(catalog.provider_lifecycle_for("issue_fix").is_some());
+    // provider lookup miss/hit.
+    assert!(catalog.provider("ghost").is_none());
+    assert!(!catalog.providers().is_empty());
+}

--- a/orchestration/loop/tests/capabilities_drive.rs
+++ b/orchestration/loop/tests/capabilities_drive.rs
@@ -10,7 +10,9 @@ use future_loop::capabilities::{CapabilityRegistry, ProposalKind};
 
 fn propose(name: &str, input: &str) -> Vec<future_loop::capabilities::TypedProposal> {
     let registry = CapabilityRegistry::with_builtin();
-    let cap = registry.get(name).unwrap_or_else(|| panic!("{name} registered"));
+    let cap = registry
+        .get(name)
+        .unwrap_or_else(|| panic!("{name} registered"));
     cap.propose(input)
 }
 
@@ -24,17 +26,32 @@ fn kinds(ps: &[future_loop::capabilities::TypedProposal]) -> Vec<ProposalKind> {
 fn simple_router_capabilities() {
     // (capability, [inputs that hit each rule arm])
     let cases: &[(&str, &[&str])] = &[
-        ("material_lifecycle", &["archive it", "归档", "废弃", "nothing relevant", ""]),
-        ("change_quality", &["all pass + diff written", "tests fail", "all pass", ""]),
+        (
+            "material_lifecycle",
+            &["archive it", "归档", "废弃", "nothing relevant", ""],
+        ),
+        (
+            "change_quality",
+            &["all pass + diff written", "tests fail", "all pass", ""],
+        ),
         ("explore", &["hypothesis here", "假设", "探索", "none", ""]),
         ("integration_branch", &["branch it", "集成", "none", ""]),
         ("value_connectors", &["connector plan", "连接", "none", ""]),
         ("reward_memory", &["reward this", "评价", "none", ""]),
-        ("semantic_preference", &["prefer dark mode", "偏好", "none", ""]),
+        (
+            "semantic_preference",
+            &["prefer dark mode", "偏好", "none", ""],
+        ),
         ("decision_context", &["decide this", "决策", "none", ""]),
-        ("agent_turn_recall", &["recall the turn", "回忆", "none", ""]),
+        (
+            "agent_turn_recall",
+            &["recall the turn", "回忆", "none", ""],
+        ),
         ("content_ops", &["content publish", "发布", "none", ""]),
-        ("context_providers", &["provider context", "上下文", "none", ""]),
+        (
+            "context_providers",
+            &["provider context", "上下文", "none", ""],
+        ),
         ("periodic_report", &["report weekly", "报告", "none", ""]),
         ("auto_research", &["research this", "调研", "none", ""]),
     ];
@@ -51,7 +68,10 @@ fn simple_router_capabilities() {
 #[test]
 fn issue_fix_branch_matrix() {
     // Empty.
-    assert_eq!(kinds(&propose("issue_fix", "")), vec![ProposalKind::NoFollowUp]);
+    assert_eq!(
+        kinds(&propose("issue_fix", "")),
+        vec![ProposalKind::NoFollowUp]
+    );
     // Full signal (repro+error+expected) → investigate/fix/validate trio.
     let ps = propose(
         "issue_fix",
@@ -61,7 +81,10 @@ fn issue_fix_branch_matrix() {
     // The `scope`/`expected` metadata keys parse into the observation.
     // Authority read-only gates BEFORE any fix.
     assert_eq!(
-        kinds(&propose("issue_fix", "title: t\nerror: e\nrepro: r\nauthority: read-only")),
+        kinds(&propose(
+            "issue_fix",
+            "title: t\nerror: e\nrepro: r\nauthority: read-only"
+        )),
         vec![ProposalKind::Gate]
     );
     // Regression with repro+error → bounded repair.
@@ -79,7 +102,10 @@ fn issue_fix_branch_matrix() {
     assert!(ps[0].reason.contains("investigate"), "{ps:?}");
     // Too little signal → triage.
     let ps = propose("issue_fix", "it broke");
-    assert!(ps[0].todo.as_ref().unwrap().text.contains("Triage"), "{ps:?}");
+    assert!(
+        ps[0].todo.as_ref().unwrap().text.contains("Triage"),
+        "{ps:?}"
+    );
 }
 
 // ── provider lifecycle ─────────────────────────────────────────────────────

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -1,0 +1,199 @@
+//! In-process mock of the FutureAgent gRPC service (ExecuteCommand +
+//! StreamEvents — the only two RPCs the loop control plane consumes).
+//!
+//! The mock is scripted through `MockState`: per-command failures, invalid
+//! JSON payloads, a never-yielding event stream (for wall-clock timeout
+//! paths), and a scripted event list for `run_turn`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use future_rpc::proto::future_agent_server::{FutureAgent, FutureAgentServer};
+use future_rpc::proto::{RpcCommand, RpcResponse, StreamEvent, StreamRequest};
+
+#[derive(Default)]
+pub struct MockState {
+    pub sessions_created: u64,
+    pub prompts: u64,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost: f64,
+    /// Events replayed by stream_events (any run).
+    pub events: Vec<StreamEvent>,
+    /// Command types that answer success=false with a mock error.
+    pub fail_commands: HashSet<String>,
+    /// Command types that answer success=true with a non-JSON payload.
+    pub invalid_json: HashSet<String>,
+    /// ExecuteCommand fails at the transport level (tonic::Status error).
+    pub grpc_error: bool,
+    /// stream_events returns a stream that never yields (timeout tests).
+    pub hang_stream: bool,
+    /// stream_events fails immediately with a tonic status.
+    pub stream_error: bool,
+    /// After N scripted events the stream yields one tonic error (mid-stream
+    /// failure path in run_turn).
+    pub stream_fail_after: Option<usize>,
+    /// Per-command raw `data` payload override (valid JSON or not).
+    pub raw: HashMap<String, String>,
+    pub models_payload: Option<String>,
+    /// Command types seen, in order (for assertions).
+    pub recorded: Vec<String>,
+}
+
+impl MockState {
+    pub fn fail(cmd: &str) -> Self {
+        let mut s = Self::default();
+        s.fail_commands.insert(cmd.to_string());
+        s
+    }
+}
+
+pub type SharedState = Arc<Mutex<MockState>>;
+
+pub struct MockAgent {
+    state: SharedState,
+}
+
+fn response(cmd: &RpcCommand, success: bool, data: String, error: String) -> tonic::Response<RpcResponse> {
+    tonic::Response::new(RpcResponse {
+        id: cmd.id.clone(),
+        r#type: "response".to_string(),
+        command: cmd.r#type.clone(),
+        success,
+        data,
+        error,
+        error_code: if success { String::new() } else { "mock_error".to_string() },
+        error_data: String::new(),
+        payload: None,
+    })
+}
+
+#[tonic::async_trait]
+impl FutureAgent for MockAgent {
+    async fn execute_command(
+        &self,
+        request: tonic::Request<RpcCommand>,
+    ) -> Result<tonic::Response<RpcResponse>, tonic::Status> {
+        let cmd = request.into_inner();
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        st.recorded.push(cmd.r#type.clone());
+        if st.grpc_error {
+            return Err(tonic::Status::unavailable("mock transport failure"));
+        }
+        if st.fail_commands.contains(&cmd.r#type) {
+            return Ok(response(
+                &cmd,
+                false,
+                String::new(),
+                format!("mock failure for {}", cmd.r#type),
+            ));
+        }
+        if st.invalid_json.contains(&cmd.r#type) {
+            return Ok(response(&cmd, true, "{not-json".to_string(), String::new()));
+        }
+        if let Some(raw) = st.raw.get(&cmd.r#type) {
+            return Ok(response(&cmd, true, raw.clone(), String::new()));
+        }
+        let data = match cmd.r#type.as_str() {
+            "new_session" => {
+                st.sessions_created += 1;
+                format!("{{\"sessionId\":\"mock-session-{}\"}}", st.sessions_created)
+            }
+            "get_state" => format!(
+                "{{\"tokensIn\":{},\"tokensOut\":{},\"totalCost\":{}}}",
+                st.tokens_in, st.tokens_out, st.cost
+            ),
+            "prompt" => {
+                st.prompts += 1;
+                format!("{{\"run_id\":\"mock-run-{}\"}}", st.prompts)
+            }
+            "list_models" => st.models_payload.clone().unwrap_or_else(|| {
+                "{\"models\":[{\"id\":\"k3\",\"provider\":\"future\",\"label\":\"K3\",\
+                 \"thinkingLevel\":\"xhigh\",\"contextWindow\":256000,\"recommended\":true,\
+                 \"isDefault\":true},{\"id\":\"plain\"}],\"defaultModel\":\"future/k3\"}"
+                    .to_string()
+            }),
+            // Trivial acks (set_model / set_thinking_level / append_system_prompt /
+            // steer / delete_session / abort): empty data → Value::Null path.
+            _ => String::new(),
+        };
+        Ok(response(&cmd, true, data, String::new()))
+    }
+
+    type StreamEventsStream =
+        std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<StreamEvent, tonic::Status>> + Send>>;
+
+    async fn stream_events(
+        &self,
+        request: tonic::Request<StreamRequest>,
+    ) -> Result<tonic::Response<Self::StreamEventsStream>, tonic::Status> {
+        let _ = request.into_inner();
+        let st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if st.stream_error {
+            return Err(tonic::Status::internal("mock stream attach failure"));
+        }
+        if st.hang_stream {
+            return Ok(tonic::Response::new(Box::pin(tokio_stream::pending())));
+        }
+        let mut items: Vec<Result<StreamEvent, tonic::Status>> =
+            st.events.iter().cloned().map(Ok).collect();
+        if let Some(n) = st.stream_fail_after {
+            if items.len() >= n {
+                items.insert(n, Err(tonic::Status::data_loss("mock mid-stream failure")));
+            }
+        }
+        Ok(tonic::Response::new(Box::pin(tokio_stream::iter(items))))
+    }
+}
+
+/// A scripted event for the mock stream. `data` is the JSON payload string.
+pub fn ev(run_id: &str, idx: i64, kind: &str, data: &str) -> StreamEvent {
+    StreamEvent {
+        r#type: kind.to_string(),
+        data: data.to_string(),
+        run_id: run_id.to_string(),
+        idx,
+        ..Default::default()
+    }
+}
+
+/// The standard successful run: one tool, some text, agent_end completed.
+pub fn completed_events(run_id: &str) -> Vec<StreamEvent> {
+    vec![
+        ev(run_id, 0, "agent_start", "{}"),
+        ev(run_id, 1, "tool_start", "{\"tool_name\":\"shell\"}"),
+        ev(run_id, 2, "text_chunk", "{\"text\":\"artifact written\"}"),
+        ev(
+            run_id,
+            3,
+            "agent_end",
+            "{\"state\":\"completed\",\"usage\":{\"output_tokens\":5},\"duration_ms\":7}",
+        ),
+    ]
+}
+
+/// Serve the mock on an ephemeral port. Returns (addr, shared state).
+pub async fn spawn_mock(state: MockState) -> (String, SharedState) {
+    spawn_mock_on("127.0.0.1:0", state)
+        .await
+        .expect("ephemeral bind always works")
+}
+
+/// Serve the mock on a fixed address; None when the port is unavailable
+/// (e.g. a real agent already holds 127.0.0.1:50051 — tests must skip then,
+/// never talk to the real agent).
+pub async fn spawn_mock_on(addr: &str, state: MockState) -> Option<(String, SharedState)> {
+    let listener = tokio::net::TcpListener::bind(addr).await.ok()?;
+    let local = listener.local_addr().ok()?.to_string();
+    let shared = Arc::new(Mutex::new(state));
+    let svc = MockAgent {
+        state: shared.clone(),
+    };
+    tokio::spawn(async move {
+        let _ = tonic::transport::Server::builder()
+            .add_service(FutureAgentServer::new(svc))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await;
+    });
+    Some((local, shared))
+}

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -54,7 +54,12 @@ pub struct MockAgent {
     state: SharedState,
 }
 
-fn response(cmd: &RpcCommand, success: bool, data: String, error: String) -> tonic::Response<RpcResponse> {
+fn response(
+    cmd: &RpcCommand,
+    success: bool,
+    data: String,
+    error: String,
+) -> tonic::Response<RpcResponse> {
     tonic::Response::new(RpcResponse {
         id: cmd.id.clone(),
         r#type: "response".to_string(),
@@ -62,7 +67,11 @@ fn response(cmd: &RpcCommand, success: bool, data: String, error: String) -> ton
         success,
         data,
         error,
-        error_code: if success { String::new() } else { "mock_error".to_string() },
+        error_code: if success {
+            String::new()
+        } else {
+            "mock_error".to_string()
+        },
         error_data: String::new(),
         payload: None,
     })
@@ -120,8 +129,9 @@ impl FutureAgent for MockAgent {
         Ok(response(&cmd, true, data, String::new()))
     }
 
-    type StreamEventsStream =
-        std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<StreamEvent, tonic::Status>> + Send>>;
+    type StreamEventsStream = std::pin::Pin<
+        Box<dyn tokio_stream::Stream<Item = Result<StreamEvent, tonic::Status>> + Send>,
+    >;
 
     async fn stream_events(
         &self,

--- a/orchestration/loop/tests/common/mod.rs
+++ b/orchestration/loop/tests/common/mod.rs
@@ -109,3 +109,22 @@ pub fn first_todo_id(root: &str, goal: &str) -> String {
 pub fn open_store(cr: &CliRoot) -> future_loop::store::Store {
     future_loop::store::Store::open(&cr.root).unwrap()
 }
+
+/// A run record for seeding runs.jsonl / RunRecorded events.
+pub fn run_record(todo_id: &str, state: &str, recorded_at: u64) -> future_loop::state::RunRecord {
+    future_loop::state::RunRecord {
+        turn: 1,
+        todo_id: todo_id.to_string(),
+        run_id: format!("run-{todo_id}-{recorded_at}"),
+        terminal_state: state.to_string(),
+        error: None,
+        tokens_in_delta: 10,
+        tokens_out_delta: 20,
+        cost_delta: 0.001,
+        tools: vec!["shell".to_string()],
+        evidence: "artifact validated".to_string(),
+        recorded_at,
+        spend_source: Some("run".to_string()),
+        validation: None,
+    }
+}

--- a/orchestration/loop/tests/common/mod.rs
+++ b/orchestration/loop/tests/common/mod.rs
@@ -1,0 +1,111 @@
+//! Shared helpers for the future-loop coverage drive tests.
+//!
+//! Each integration-test binary compiles this module and uses a subset of it.
+#![allow(dead_code)]
+//!
+//! Two invocation styles exist side by side:
+//!   * in-process (`cli*`) — fast, but shares the process-global
+//!     FUTURE_LOOP_ROOT, so every invocation is serialized behind CLI_LOCK
+//!     and each test gets its own tempdir root.
+//!   * subprocess (`bin*` in the subprocess drive file) — isolated env, and
+//!     the only safe way to cover `std::process::exit` / stdin-driven paths.
+
+pub mod mock_agent;
+
+use std::sync::MutexGuard;
+
+/// Serializes in-process CLI invocations (FUTURE_LOOP_ROOT is process-global;
+/// tests run on parallel threads).
+pub static CLI_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Holds the lock + tempdir for one in-process CLI scenario.
+pub struct CliRoot {
+    pub _guard: MutexGuard<'static, ()>,
+    pub _dir: tempfile::TempDir,
+    /// Loop state root (FUTURE_LOOP_ROOT).
+    pub root: String,
+    /// Scratch cwd for goals (kept inside the tempdir).
+    pub cwd: String,
+}
+
+pub fn cli_root() -> CliRoot {
+    let guard = CLI_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("loop-root");
+    std::fs::create_dir_all(&root).unwrap();
+    let cwd = dir.path().join("cwd");
+    std::fs::create_dir_all(&cwd).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", &root);
+    CliRoot {
+        _guard: guard,
+        _dir: dir,
+        root: root.to_string_lossy().into_owned(),
+        cwd: cwd.to_string_lossy().into_owned(),
+    }
+}
+
+/// Invoke the real CLI entry in-process.
+pub fn cli(args: &[&str]) -> Result<(), String> {
+    future_loop::console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+pub fn cli_ok(args: &[&str]) {
+    cli(args).unwrap_or_else(|e| panic!("cli {args:?} should succeed: {e}"));
+}
+
+pub fn cli_err(args: &[&str]) -> String {
+    match cli(args) {
+        Ok(()) => panic!("cli {args:?} should fail"),
+        Err(e) => e,
+    }
+}
+
+/// `goal init` with an explicit id + cwd inside the temp root.
+pub fn init_goal(cr: &CliRoot, objective: &str) -> String {
+    let gid = format!("goal_{}", &uuid::Uuid::new_v4().simple().to_string()[..12]);
+    cli_ok(&[
+        "goal",
+        "init",
+        "--objective",
+        objective,
+        "--goal-id",
+        &gid,
+        "--cwd",
+        &cr.cwd,
+    ]);
+    gid
+}
+
+/// Add a plain advancement todo; returns its id.
+pub fn add_todo(cr: &CliRoot, goal: &str, text: &str) -> String {
+    cli_ok(&["todo", "add", "--goal", goal, "--text", text]);
+    todo_id_by_text(&cr.root, goal, text)
+}
+
+pub fn todo_id_by_text(root: &str, goal: &str, needle: &str) -> String {
+    let store = future_loop::store::Store::open(root).unwrap();
+    let g = store.replay(goal).unwrap().unwrap();
+    g.todos
+        .iter()
+        .find(|t| t.text.contains(needle))
+        .map(|t| t.id.clone())
+        .unwrap_or_else(|| panic!("no todo containing {needle:?}"))
+}
+
+/// The onboarding todo added by `goal init` (always the first todo).
+pub fn first_todo_id(root: &str, goal: &str) -> String {
+    let store = future_loop::store::Store::open(root).unwrap();
+    let g = store.replay(goal).unwrap().unwrap();
+    g.todos
+        .first()
+        .map(|t| t.id.clone())
+        .expect("goal has the onboarding todo")
+}
+
+pub fn open_store(cr: &CliRoot) -> future_loop::store::Store {
+    future_loop::store::Store::open(&cr.root).unwrap()
+}

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -1,0 +1,540 @@
+//! Coverage drive — console command group A: goal / todo / gate / lease /
+//! agent / backup / authority / replan / profile. All in-process through
+//! `console::run` with serialized roots.
+
+mod common;
+
+use common::{
+    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store,
+    todo_id_by_text,
+};
+use future_loop::state::{now_epoch, TodoStatus};
+use future_loop::store::{Event, Store};
+
+// ── goal ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn goal_init_variants_and_errors() {
+    let cr = cli_root();
+    // Missing --objective.
+    let err = cli_err(&["goal", "init", "--goal-id", "goal_x"]);
+    assert!(err.contains("--objective"), "{err}");
+    // `goal` with no args at all takes the init path and fails the same way.
+    let err = cli_err(&["goal"]);
+    assert!(err.contains("--objective"), "{err}");
+    // --goal-doc writes GOAL.md into the goal cwd.
+    let gid = init_goal(&cr, "doc goal");
+    cli_ok(&[
+        "goal", "init", "--objective", "with doc", "--goal-id", "goal_withdoc", "--cwd", &cr.cwd,
+        "--goal-doc", "# Hello",
+    ]);
+    let doc = std::path::Path::new(&cr.cwd).join("GOAL.md");
+    assert_eq!(std::fs::read_to_string(doc).unwrap(), "# Hello\n");
+    let _ = gid;
+}
+
+#[test]
+fn goal_cancel_and_delete() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "cancel me");
+    cli_ok(&["goal", "cancel", "--goal", &gid, "--reason", "no longer needed"]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    assert_eq!(g.status, "cancelled");
+    // Cancel: missing goal id / unknown goal.
+    assert!(cli_err(&["goal", "cancel"]).contains("--goal required"));
+    assert!(cli_err(&["goal", "cancel", "--goal", "goal_nope"]).contains("not found"));
+
+    // Delete requires --force.
+    let gid2 = init_goal(&cr, "delete me");
+    assert!(cli_err(&["goal", "delete", "--goal", &gid2]).contains("--force"));
+    cli_ok(&["goal", "delete", "--goal", &gid2, "--force"]);
+    let store = open_store(&cr);
+    assert!(store.replay(&gid2).unwrap().is_none(), "deleted goal is gone");
+    assert!(cli_err(&["goal", "delete"]).contains("--goal required"));
+}
+
+// ── todo add (class/flag matrix) ───────────────────────────────────────────
+
+#[test]
+fn todo_add_class_matrix() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo classes");
+
+    // user_gate via (user, user_gate) and via (_, user_gate).
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--role", "user", "--class", "user_gate", "--text",
+        "gate one", "--gate-question", "q1?",
+    ]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--class", "user_gate", "--text", "gate two",
+    ]);
+    // user_action / blocker / monitor / unknown-class fallback.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--role", "user", "--class", "user_action", "--text",
+        "user does this",
+    ]);
+    let blocker = {
+        cli_ok(&[
+            "todo", "add", "--goal", &gid, "--class", "blocker", "--text", "blocked on ext",
+            "--blocks", "todo_later",
+        ]);
+        todo_id_by_text(&cr.root, &gid, "blocked on ext")
+    };
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--class", "monitor", "--text", "watch it",
+        "--cadence", "15m", "--monitor-target", "file:x", "--monitor-policy", "exists",
+    ]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--class", "bogus-class", "--text", "falls back",
+    ]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let b = g.todos.iter().find(|t| t.id == blocker).unwrap();
+    assert_eq!(b.blocked_by_gate.as_deref(), Some("todo_later"));
+    assert!(b.class == future_loop::state::TaskClass::Blocker);
+    let m = g.todos.iter().find(|t| t.text == "watch it").unwrap();
+    assert!(m.resume_when.is_some(), "cadence sets the first due time");
+    assert_eq!(m.monitor_target.as_deref(), Some("file:x"));
+    assert_eq!(m.monitor_policy.as_deref(), Some("exists"));
+    assert_eq!(m.monitor_cadence.as_deref(), Some("15m"));
+}
+
+#[test]
+fn todo_add_flag_matrix() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo flags");
+
+    // Full flag cocktail.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "kitchen sink", "--priority", "P0",
+        "--action-kind", "deploy", "--required-capability", "shell", "--title", "Sink",
+        "--task-repository", "repo-1", "--continuation-policy", "resume",
+        "--required-write-scope", "src, tests", "--capability-binding-ref", "bind-1",
+        "--note", "a note", "--goal-bound", "--verify", "exit 0",
+        "--max-validation-attempts", "2",
+    ]);
+    // Priority prefix retitles a default title but not a custom one.
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "plain P2", "--priority", "P2"]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "titled P0", "--priority", "P0", "--title",
+        "Custom Title",
+    ]);
+    // Bogus priority falls back to P1.
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "odd priority", "--priority", "P9"]);
+    // Defer paths: numeric --resume-when, textual --resume-when, --defer-secs.
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred num", "--resume-when", "30"]);
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred text", "--resume-when", "later"]);
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred secs", "--defer-secs", "5"]);
+    // --max-validation-attempts clamps to >= 1.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "clamped", "--max-validation-attempts", "0",
+    ]);
+    // --blocks on an advancement todo (dependency chain applies to all classes).
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "chained", "--blocks", "a,b"]);
+    // global-gate user_gate forces goal_bound.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "global gate", "--class", "user_gate",
+        "--global-gate",
+    ]);
+    // Bad cadence string: no resume derivation (stays monitor default).
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "bad cadence", "--class", "monitor",
+        "--cadence", "whenever",
+    ]);
+
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let sink = g.todos.iter().find(|t| t.text.contains("kitchen sink")).unwrap();
+    assert_eq!(sink.priority, future_loop::state::Priority::P0);
+    assert!(sink.text.starts_with("[P0] "), "{}", sink.text);
+    assert_eq!(sink.title, "Sink", "custom title is kept");
+    assert_eq!(sink.action_kind.as_deref(), Some("deploy"));
+    assert_eq!(sink.required_capability.as_deref(), Some("shell"));
+    assert_eq!(sink.task_repository.as_deref(), Some("repo-1"));
+    assert_eq!(sink.continuation_policy.as_deref(), Some("resume"));
+    assert_eq!(sink.required_write_scope, vec!["src".to_string(), "tests".to_string()]);
+    assert_eq!(sink.capability_binding_ref.as_deref(), Some("bind-1"));
+    assert_eq!(sink.note.as_deref(), Some("a note"));
+    assert!(sink.goal_bound);
+    assert_eq!(sink.validator.as_deref(), Some("exit 0"));
+    assert_eq!(sink.max_validation_attempts, 2);
+
+    let plain = g.todos.iter().find(|t| t.text.contains("plain P2")).unwrap();
+    assert!(plain.text.starts_with("[P2] "), "{}", plain.text);
+    assert!(plain.title.starts_with("[P2] "), "default title retitled: {}", plain.title);
+    let titled = g.todos.iter().find(|t| t.text.contains("titled P0")).unwrap();
+    assert_eq!(titled.title, "Custom Title");
+    let odd = g.todos.iter().find(|t| t.text.contains("odd priority")).unwrap();
+    assert_eq!(odd.priority, future_loop::state::Priority::P1);
+    for needle in ["deferred num", "deferred text", "deferred secs"] {
+        let t = g.todos.iter().find(|t| t.text.contains(needle)).unwrap();
+        assert_eq!(t.status, TodoStatus::Deferred, "{needle}");
+        assert!(t.resume_when.is_some(), "{needle}");
+    }
+    let clamped = g.todos.iter().find(|t| t.text.contains("clamped")).unwrap();
+    assert_eq!(clamped.max_validation_attempts, 1);
+    let chained = g.todos.iter().find(|t| t.text.contains("chained")).unwrap();
+    assert_eq!(chained.blocked_by_gate.as_deref(), Some("a,b"));
+    let gg = g.todos.iter().find(|t| t.text.contains("global gate")).unwrap();
+    assert!(gg.global_gate && gg.goal_bound, "global gate implies goal_bound");
+
+    // Error paths.
+    assert!(cli_err(&["todo", "add", "--text", "x"]).contains("--goal required"));
+    assert!(cli_err(&["todo", "add", "--goal", &gid]).contains("--text required"));
+    assert!(cli_err(&["todo", "add", "--goal", "goal_nope", "--text", "x"]).contains("not found"));
+    assert!(cli_err(&["todo"]).contains("add|claim|complete"));
+    assert!(cli_err(&["todo", "frobnicate"]).contains("unknown todo subcommand"));
+}
+
+// ── todo claim / complete ──────────────────────────────────────────────────
+
+#[test]
+fn todo_claim_paths() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "claim paths");
+    let t = first_todo_id(&cr.root, &gid);
+    // Unregistered agent is rejected.
+    let err = cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "ghost"]);
+    assert!(err.contains("not registered"), "{err}");
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w2"]);
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "120"]);
+    // Same-agent re-claim is idempotent (renew)…
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    // …but a DIFFERENT agent cannot take a live lease.
+    assert!(cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w2"])
+        .contains("cannot be claimed"));
+    // Missing todo / goal.
+    assert!(cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", "todo_nope", "--agent-id", "w1"])
+        .contains("cannot be claimed"));
+    assert!(cli_err(&["todo", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found"));
+    assert!(cli_err(&["todo", "claim", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["todo", "claim"]).contains("--goal required"));
+}
+
+#[test]
+fn todo_complete_contract() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "complete contract");
+    let first = first_todo_id(&cr.root, &gid);
+    // Silent completion is rejected.
+    assert!(cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", &first])
+        .contains("--no-follow-up or --successor"));
+    // Completion with a successor.
+    let s = add_todo(&cr, &gid, "successor task");
+    cli_ok(&[
+        "todo", "complete", "--goal", &gid, "--todo-id", &first, "--successor", &s,
+        "--evidence", "did the thing",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == first).unwrap();
+        assert_eq!(t.status, TodoStatus::Done);
+        assert_eq!(t.successor_ids, vec![s.clone()]);
+        assert_eq!(t.evidence.as_deref(), Some("did the thing"));
+    }
+    // Gate freeze: an open user gate blocks completing other todos.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "approval", "--class", "user_gate",
+        "--gate-question", "ok?",
+    ]);
+    let err = cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", &s, "--no-follow-up"]);
+    assert!(err.contains("open gate"), "{err}");
+    // Resolve the gate, then completion succeeds (a gate's text IS the
+    // question — Todo::user_gate takes the question as the todo text).
+    let gate = todo_id_by_text(&cr.root, &gid, "ok?");
+    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &gate, "--decision", "approved", "--note", "stamp"]);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &s, "--no-follow-up"]);
+    // Unknown todo / goal.
+    assert!(cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", "todo_nope", "--no-follow-up"])
+        .contains("not found"));
+    assert!(cli_err(&["todo", "complete", "--todo-id", &s]).contains("--goal required"));
+    assert!(cli_err(&["todo", "complete", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["todo", "complete", "--goal", "goal_nope", "--todo-id", &s, "--no-follow-up"])
+        .contains("not found"));
+}
+
+#[test]
+fn todo_complete_gate_class_bypasses_freeze() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "gate class complete");
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "gate A", "--class", "user_gate",
+    ]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "gate B", "--class", "user_gate",
+    ]);
+    let a = todo_id_by_text(&cr.root, &gid, "gate A");
+    // Completing a GATE-class todo is allowed even while another gate is open.
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &a, "--no-follow-up"]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    assert_eq!(g.todos.iter().find(|t| t.id == a).unwrap().status, TodoStatus::Done);
+}
+
+// ── todo archive / supersede / update ──────────────────────────────────────
+
+#[test]
+fn todo_archive_supersede_update() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "lifecycle");
+    let victim = add_todo(&cr, &gid, "archive me");
+    cli_ok(&["todo", "archive", "--goal", &gid, "--todo-id", &victim]);
+    assert!(cli_err(&["todo", "archive", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["todo", "archive", "--todo-id", &victim]).contains("--goal required"));
+    assert!(cli_err(&["todo", "archive", "--goal", "goal_nope", "--todo-id", &victim]).contains("not found"));
+
+    let sup = add_todo(&cr, &gid, "supersede me");
+    cli_ok(&["todo", "supersede", "--goal", &gid, "--todo-id", &sup, "--reason", "obsolete"]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        assert_eq!(
+            g.todos.iter().find(|t| t.id == sup).unwrap().status,
+            TodoStatus::Superseded
+        );
+    }
+    assert!(cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
+    // Supersede a done todo is rejected.
+    let done = add_todo(&cr, &gid, "done one");
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &done, "--no-follow-up"]);
+    assert!(cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", &done]).contains("already done"));
+
+    // update: full field set.
+    let u = add_todo(&cr, &gid, "update me");
+    cli_ok(&[
+        "todo", "update", "--goal", &gid, "--todo-id", &u, "--text", "updated text",
+        "--status", "blocked", "--evidence", "half done", "--note", "n", "--priority", "P0",
+        "--resume-when", "45", "--blocks", "x,y",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == u).unwrap();
+        assert!(t.text.contains("updated text"), "{}", t.text);
+        assert_eq!(t.evidence.as_deref(), Some("half done"));
+        assert_eq!(t.note.as_deref(), Some("n"));
+        assert_eq!(t.priority, future_loop::state::Priority::P0);
+        assert_eq!(t.blocked_by_gate.as_deref(), Some("x,y"));
+        assert!(t.resume_when.is_some(), "numeric resume-when sets a real deadline");
+    }
+    // Clear blocks, textual resume-when, unknown status ignored.
+    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--blocks", ""]);
+    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--resume-when", "when ready"]);
+    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--status", "bogus"]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == u).unwrap();
+        assert_eq!(t.blocked_by_gate, None);
+        assert_eq!(t.resume_when_text.as_deref(), Some("when ready"));
+    }
+    // --status done is rejected; unknown flags hard-error.
+    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--status", "done"])
+        .contains("not allowed"));
+    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--frobnicate", "1"])
+        .contains("unknown flag"));
+    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
+    assert!(cli_err(&["todo", "update", "--goal", "goal_nope", "--todo-id", &u]).contains("not found"));
+    assert!(cli_err(&["todo", "update", "--goal", &gid]).contains("--todo-id required"));
+}
+
+// ── gate ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn gate_resolve_errors() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "gate errors");
+    assert!(cli_err(&["gate", "resolve", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["gate", "resolve", "--todo-id", "t"]).contains("--goal required"));
+    assert!(cli_err(&["gate", "resolve", "--goal", &gid, "--todo-id", "t"]).contains("--decision required"));
+    assert!(cli_err(&["gate", "resolve", "--goal", "goal_nope", "--todo-id", "t", "--decision", "x"])
+        .contains("not found"));
+    // Resolving a non-gate todo still records the decision (no class check).
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &first, "--decision", "fine"]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let t = g.todos.iter().find(|t| t.id == first).unwrap();
+    assert_eq!(t.status, TodoStatus::Done);
+    assert_eq!(t.decision.as_deref(), Some("fine"));
+}
+
+// ── lease ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn lease_lifecycle() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "lease lifecycle");
+    let t = first_todo_id(&cr.root, &gid);
+
+    // status on a free todo.
+    cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
+    // claim / renew / release / expire.
+    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "60"]);
+    cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
+    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "120"]);
+    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    // release again → missing-lease path (no event, still ok).
+    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    // expire with no lease → had_lease=false path.
+    cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &t]);
+    // Minimum TTL is 1s (0 normalizes to the 45min default); lease timestamps
+    // have epoch-second resolution, so cross the boundary with a real sleep.
+    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "1"]);
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+    // status now reports EXPIRED; expire records the event (had_lease=true).
+    cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
+    cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &t]);
+    // Steal path: w2 claims, lease lapses, w3 takes it (TodoExpired+TodoClaimed).
+    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w2", "--lease-secs", "1"]);
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w3", "--lease-secs", "30"]);
+    // renew by the non-owner errors.
+    assert!(cli(&["lease", "renew", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]).is_err());
+    // Errors.
+    assert!(cli_err(&["lease"]).contains("subcommand"));
+    assert!(cli_err(&["lease", "claim", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["lease", "claim", "--todo-id", &t]).contains("--goal required"));
+    assert!(cli_err(&["lease", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found"));
+    assert!(cli_err(&["lease", "status", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
+    assert!(cli_err(&["lease", "frobnicate", "--goal", &gid, "--todo-id", &t]).contains("claim|renew|release|expire|status"));
+}
+
+// ── agent register / onboard / list ────────────────────────────────────────
+
+#[test]
+fn agent_registry_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "agents");
+    // list with no agents.
+    cli_ok(&["agent", "list", "--goal", &gid]);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w2", "--capability", "shell,github"]);
+    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w3", "--capabilities", "web"]);
+    // w1 holds a live lease → running row in `agent list`.
+    let t = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    cli_ok(&["agent", "list", "--goal", &gid]);
+    // Errors.
+    assert!(cli_err(&["agent", "register", "--goal", &gid]).contains("--agent-id required"));
+    assert!(cli_err(&["agent", "register", "--agent-id", "w1"]).contains("--goal required"));
+    assert!(cli_err(&["agent", "register", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+    assert!(cli_err(&["agent", "onboard", "--goal", &gid]).contains("--agent-id required"));
+    assert!(cli_err(&["agent", "onboard", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+    assert!(cli_err(&["agent", "list"]).contains("--goal required"));
+    assert!(cli_err(&["agent", "list", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── backup ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn backup_create_list_restore() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "backups");
+    cli_ok(&["backup", "--goal", &gid]);
+    {
+        let store = open_store(&cr);
+        let backups = store.backups(&gid);
+        assert_eq!(backups.len(), 1, "one backup created");
+        cli_ok(&["backup", "--goal", &gid, "--list"]);
+        // Restore from that backup dir.
+        cli_ok(&["backup", "--goal", &gid, "--restore", &backups[0]]);
+    }
+    assert!(cli_err(&["backup"]).contains("--goal required"));
+    assert!(cli_err(&["backup", "--goal", &gid, "--restore", "/nonexistent-dir-xyz"]).contains(""));
+}
+
+// ── authority / profile ────────────────────────────────────────────────────
+
+#[test]
+fn authority_and_profile() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "authority");
+    cli_ok(&[
+        "authority", "--goal", &gid, "--write-scope", "src,docs", "--require-approval",
+        "publish,deploy",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        assert_eq!(g.authority.write_scope, vec!["src".to_string(), "docs".to_string()]);
+        assert_eq!(
+            g.authority.requires_approval,
+            vec!["publish".to_string(), "deploy".to_string()]
+        );
+    }
+    assert!(cli_err(&["authority"]).contains("--goal required"));
+    assert!(cli_err(&["authority", "--goal", "goal_nope"]).contains("not found"));
+
+    cli_ok(&["profile", "set", "--goal", &gid, "--outcome-floor", "3"]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        assert_eq!(g.execution_profile.outcome_floor_streak_threshold, 3);
+    }
+    assert!(cli_err(&["profile", "set", "--goal", &gid, "--outcome-floor", "x"]).contains("number"));
+    assert!(cli_err(&["profile", "bogus", "--goal", &gid]).contains("must be `set`"));
+    assert!(cli_err(&["profile", "set"]).contains("--goal required"));
+    assert!(cli_err(&["profile", "set", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── replan ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn replan_ack_and_obligations() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "replan");
+    // No obligations initially.
+    cli_ok(&["replan", "obligations", "--goal", &gid]);
+    // Craft an unfulfilled obligation: an advancement todo completed without
+    // closure intent (bypasses the CLI completion contract via the raw event).
+    {
+        let mut store: Store = open_store(&cr);
+        let todo = future_loop::state::Todo::advancement("todo_unclosed", "no closure intent");
+        store
+            .append(Event::TodoAdded {
+                goal_id: gid.clone(),
+                todo,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::TodoCompleted {
+                goal_id: gid.clone(),
+                todo_id: "todo_unclosed".to_string(),
+                no_follow_up: false,
+                successor_ids: vec![],
+                evidence: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+    }
+    cli_ok(&["replan", "obligations", "--goal", &gid]);
+    // ack variants.
+    cli_ok(&["replan", "ack", "--goal", &gid, "--delta-kind", "vision_patch"]);
+    assert!(cli_err(&["replan", "ack", "--goal", &gid]).contains("--delta-kind"));
+    assert!(cli_err(&["replan", "ack", "--goal", &gid, "--delta-kind", "nope"])
+        .contains("frontier"));
+    assert!(cli_err(&["replan", "ack"]).contains("--goal required"));
+    assert!(cli_err(&["replan", "ack", "--goal", "goal_nope", "--delta-kind", "vision_patch"])
+        .contains("not found"));
+    assert!(cli_err(&["replan", "obligations"]).contains("--goal required"));
+    assert!(cli_err(&["replan", "obligations", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── top-level dispatch quirks ──────────────────────────────────────────────
+
+#[test]
+fn dispatch_help_and_unknown() {
+    let _cr = cli_root();
+    cli_ok(&[]);
+    cli_ok(&["--help"]);
+    cli_ok(&["help"]);
+    let err = cli_err(&["frobnicate"]);
+    assert!(err.contains("unknown command"), "{err}");
+    // --include-experimental is accepted globally.
+    cli_ok(&["--help", "--include-experimental"]);
+}

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -5,8 +5,7 @@
 mod common;
 
 use common::{
-    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store,
-    todo_id_by_text,
+    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, todo_id_by_text,
 };
 use future_loop::state::{now_epoch, TodoStatus};
 use future_loop::store::{Event, Store};
@@ -25,8 +24,16 @@ fn goal_init_variants_and_errors() {
     // --goal-doc writes GOAL.md into the goal cwd.
     let gid = init_goal(&cr, "doc goal");
     cli_ok(&[
-        "goal", "init", "--objective", "with doc", "--goal-id", "goal_withdoc", "--cwd", &cr.cwd,
-        "--goal-doc", "# Hello",
+        "goal",
+        "init",
+        "--objective",
+        "with doc",
+        "--goal-id",
+        "goal_withdoc",
+        "--cwd",
+        &cr.cwd,
+        "--goal-doc",
+        "# Hello",
     ]);
     let doc = std::path::Path::new(&cr.cwd).join("GOAL.md");
     assert_eq!(std::fs::read_to_string(doc).unwrap(), "# Hello\n");
@@ -37,7 +44,14 @@ fn goal_init_variants_and_errors() {
 fn goal_cancel_and_delete() {
     let cr = cli_root();
     let gid = init_goal(&cr, "cancel me");
-    cli_ok(&["goal", "cancel", "--goal", &gid, "--reason", "no longer needed"]);
+    cli_ok(&[
+        "goal",
+        "cancel",
+        "--goal",
+        &gid,
+        "--reason",
+        "no longer needed",
+    ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
     assert_eq!(g.status, "cancelled");
@@ -50,7 +64,10 @@ fn goal_cancel_and_delete() {
     assert!(cli_err(&["goal", "delete", "--goal", &gid2]).contains("--force"));
     cli_ok(&["goal", "delete", "--goal", &gid2, "--force"]);
     let store = open_store(&cr);
-    assert!(store.replay(&gid2).unwrap().is_none(), "deleted goal is gone");
+    assert!(
+        store.replay(&gid2).unwrap().is_none(),
+        "deleted goal is gone"
+    );
     assert!(cli_err(&["goal", "delete"]).contains("--goal required"));
 }
 
@@ -63,30 +80,82 @@ fn todo_add_class_matrix() {
 
     // user_gate via (user, user_gate) and via (_, user_gate).
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--role", "user", "--class", "user_gate", "--text",
-        "gate one", "--gate-question", "q1?",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--role",
+        "user",
+        "--class",
+        "user_gate",
+        "--text",
+        "gate one",
+        "--gate-question",
+        "q1?",
     ]);
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--class", "user_gate", "--text", "gate two",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--class",
+        "user_gate",
+        "--text",
+        "gate two",
     ]);
     // user_action / blocker / monitor / unknown-class fallback.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--role", "user", "--class", "user_action", "--text",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--role",
+        "user",
+        "--class",
+        "user_action",
+        "--text",
         "user does this",
     ]);
     let blocker = {
         cli_ok(&[
-            "todo", "add", "--goal", &gid, "--class", "blocker", "--text", "blocked on ext",
-            "--blocks", "todo_later",
+            "todo",
+            "add",
+            "--goal",
+            &gid,
+            "--class",
+            "blocker",
+            "--text",
+            "blocked on ext",
+            "--blocks",
+            "todo_later",
         ]);
         todo_id_by_text(&cr.root, &gid, "blocked on ext")
     };
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--class", "monitor", "--text", "watch it",
-        "--cadence", "15m", "--monitor-target", "file:x", "--monitor-policy", "exists",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--class",
+        "monitor",
+        "--text",
+        "watch it",
+        "--cadence",
+        "15m",
+        "--monitor-target",
+        "file:x",
+        "--monitor-policy",
+        "exists",
     ]);
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--class", "bogus-class", "--text", "falls back",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--class",
+        "bogus-class",
+        "--text",
+        "falls back",
     ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
@@ -107,45 +176,149 @@ fn todo_add_flag_matrix() {
 
     // Full flag cocktail.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "kitchen sink", "--priority", "P0",
-        "--action-kind", "deploy", "--required-capability", "shell", "--title", "Sink",
-        "--task-repository", "repo-1", "--continuation-policy", "resume",
-        "--required-write-scope", "src, tests", "--capability-binding-ref", "bind-1",
-        "--note", "a note", "--goal-bound", "--verify", "exit 0",
-        "--max-validation-attempts", "2",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "kitchen sink",
+        "--priority",
+        "P0",
+        "--action-kind",
+        "deploy",
+        "--required-capability",
+        "shell",
+        "--title",
+        "Sink",
+        "--task-repository",
+        "repo-1",
+        "--continuation-policy",
+        "resume",
+        "--required-write-scope",
+        "src, tests",
+        "--capability-binding-ref",
+        "bind-1",
+        "--note",
+        "a note",
+        "--goal-bound",
+        "--verify",
+        "exit 0",
+        "--max-validation-attempts",
+        "2",
     ]);
     // Priority prefix retitles a default title but not a custom one.
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "plain P2", "--priority", "P2"]);
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "titled P0", "--priority", "P0", "--title",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "plain P2",
+        "--priority",
+        "P2",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "titled P0",
+        "--priority",
+        "P0",
+        "--title",
         "Custom Title",
     ]);
     // Bogus priority falls back to P1.
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "odd priority", "--priority", "P9"]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "odd priority",
+        "--priority",
+        "P9",
+    ]);
     // Defer paths: numeric --resume-when, textual --resume-when, --defer-secs.
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred num", "--resume-when", "30"]);
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred text", "--resume-when", "later"]);
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "deferred secs", "--defer-secs", "5"]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "deferred num",
+        "--resume-when",
+        "30",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "deferred text",
+        "--resume-when",
+        "later",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "deferred secs",
+        "--defer-secs",
+        "5",
+    ]);
     // --max-validation-attempts clamps to >= 1.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "clamped", "--max-validation-attempts", "0",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "clamped",
+        "--max-validation-attempts",
+        "0",
     ]);
     // --blocks on an advancement todo (dependency chain applies to all classes).
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "chained", "--blocks", "a,b"]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "chained", "--blocks", "a,b",
+    ]);
     // global-gate user_gate forces goal_bound.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "global gate", "--class", "user_gate",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "global gate",
+        "--class",
+        "user_gate",
         "--global-gate",
     ]);
     // Bad cadence string: no resume derivation (stays monitor default).
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "bad cadence", "--class", "monitor",
-        "--cadence", "whenever",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "bad cadence",
+        "--class",
+        "monitor",
+        "--cadence",
+        "whenever",
     ]);
 
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
-    let sink = g.todos.iter().find(|t| t.text.contains("kitchen sink")).unwrap();
+    let sink = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("kitchen sink"))
+        .unwrap();
     assert_eq!(sink.priority, future_loop::state::Priority::P0);
     assert!(sink.text.starts_with("[P0] "), "{}", sink.text);
     assert_eq!(sink.title, "Sink", "custom title is kept");
@@ -153,19 +326,38 @@ fn todo_add_flag_matrix() {
     assert_eq!(sink.required_capability.as_deref(), Some("shell"));
     assert_eq!(sink.task_repository.as_deref(), Some("repo-1"));
     assert_eq!(sink.continuation_policy.as_deref(), Some("resume"));
-    assert_eq!(sink.required_write_scope, vec!["src".to_string(), "tests".to_string()]);
+    assert_eq!(
+        sink.required_write_scope,
+        vec!["src".to_string(), "tests".to_string()]
+    );
     assert_eq!(sink.capability_binding_ref.as_deref(), Some("bind-1"));
     assert_eq!(sink.note.as_deref(), Some("a note"));
     assert!(sink.goal_bound);
     assert_eq!(sink.validator.as_deref(), Some("exit 0"));
     assert_eq!(sink.max_validation_attempts, 2);
 
-    let plain = g.todos.iter().find(|t| t.text.contains("plain P2")).unwrap();
+    let plain = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("plain P2"))
+        .unwrap();
     assert!(plain.text.starts_with("[P2] "), "{}", plain.text);
-    assert!(plain.title.starts_with("[P2] "), "default title retitled: {}", plain.title);
-    let titled = g.todos.iter().find(|t| t.text.contains("titled P0")).unwrap();
+    assert!(
+        plain.title.starts_with("[P2] "),
+        "default title retitled: {}",
+        plain.title
+    );
+    let titled = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("titled P0"))
+        .unwrap();
     assert_eq!(titled.title, "Custom Title");
-    let odd = g.todos.iter().find(|t| t.text.contains("odd priority")).unwrap();
+    let odd = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("odd priority"))
+        .unwrap();
     assert_eq!(odd.priority, future_loop::state::Priority::P1);
     for needle in ["deferred num", "deferred text", "deferred secs"] {
         let t = g.todos.iter().find(|t| t.text.contains(needle)).unwrap();
@@ -176,8 +368,15 @@ fn todo_add_flag_matrix() {
     assert_eq!(clamped.max_validation_attempts, 1);
     let chained = g.todos.iter().find(|t| t.text.contains("chained")).unwrap();
     assert_eq!(chained.blocked_by_gate.as_deref(), Some("a,b"));
-    let gg = g.todos.iter().find(|t| t.text.contains("global gate")).unwrap();
-    assert!(gg.global_gate && gg.goal_bound, "global gate implies goal_bound");
+    let gg = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("global gate"))
+        .unwrap();
+    assert!(
+        gg.global_gate && gg.goal_bound,
+        "global gate implies goal_bound"
+    );
 
     // Error paths.
     assert!(cli_err(&["todo", "add", "--text", "x"]).contains("--goal required"));
@@ -195,20 +394,69 @@ fn todo_claim_paths() {
     let gid = init_goal(&cr, "claim paths");
     let t = first_todo_id(&cr.root, &gid);
     // Unregistered agent is rejected.
-    let err = cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "ghost"]);
+    let err = cli_err(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "ghost",
+    ]);
     assert!(err.contains("not registered"), "{err}");
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w2"]);
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "120"]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "120",
+    ]);
     // Same-agent re-claim is idempotent (renew)…
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+    ]);
     // …but a DIFFERENT agent cannot take a live lease.
-    assert!(cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w2"])
-        .contains("cannot be claimed"));
+    assert!(cli_err(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w2"
+    ])
+    .contains("cannot be claimed"));
     // Missing todo / goal.
-    assert!(cli_err(&["todo", "claim", "--goal", &gid, "--todo-id", "todo_nope", "--agent-id", "w1"])
-        .contains("cannot be claimed"));
-    assert!(cli_err(&["todo", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        "todo_nope",
+        "--agent-id",
+        "w1"
+    ])
+    .contains("cannot be claimed"));
+    assert!(
+        cli_err(&["todo", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found")
+    );
     assert!(cli_err(&["todo", "claim", "--goal", &gid]).contains("--todo-id required"));
     assert!(cli_err(&["todo", "claim"]).contains("--goal required"));
 }
@@ -219,13 +467,23 @@ fn todo_complete_contract() {
     let gid = init_goal(&cr, "complete contract");
     let first = first_todo_id(&cr.root, &gid);
     // Silent completion is rejected.
-    assert!(cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", &first])
-        .contains("--no-follow-up or --successor"));
+    assert!(
+        cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", &first])
+            .contains("--no-follow-up or --successor")
+    );
     // Completion with a successor.
     let s = add_todo(&cr, &gid, "successor task");
     cli_ok(&[
-        "todo", "complete", "--goal", &gid, "--todo-id", &first, "--successor", &s,
-        "--evidence", "did the thing",
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--successor",
+        &s,
+        "--evidence",
+        "did the thing",
     ]);
     {
         let store = open_store(&cr);
@@ -237,23 +495,74 @@ fn todo_complete_contract() {
     }
     // Gate freeze: an open user gate blocks completing other todos.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "approval", "--class", "user_gate",
-        "--gate-question", "ok?",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "approval",
+        "--class",
+        "user_gate",
+        "--gate-question",
+        "ok?",
     ]);
-    let err = cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", &s, "--no-follow-up"]);
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &s,
+        "--no-follow-up",
+    ]);
     assert!(err.contains("open gate"), "{err}");
     // Resolve the gate, then completion succeeds (a gate's text IS the
     // question — Todo::user_gate takes the question as the todo text).
     let gate = todo_id_by_text(&cr.root, &gid, "ok?");
-    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &gate, "--decision", "approved", "--note", "stamp"]);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &s, "--no-follow-up"]);
+    cli_ok(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &gate,
+        "--decision",
+        "approved",
+        "--note",
+        "stamp",
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &s,
+        "--no-follow-up",
+    ]);
     // Unknown todo / goal.
-    assert!(cli_err(&["todo", "complete", "--goal", &gid, "--todo-id", "todo_nope", "--no-follow-up"])
-        .contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        "todo_nope",
+        "--no-follow-up"
+    ])
+    .contains("not found"));
     assert!(cli_err(&["todo", "complete", "--todo-id", &s]).contains("--goal required"));
     assert!(cli_err(&["todo", "complete", "--goal", &gid]).contains("--todo-id required"));
-    assert!(cli_err(&["todo", "complete", "--goal", "goal_nope", "--todo-id", &s, "--no-follow-up"])
-        .contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        "goal_nope",
+        "--todo-id",
+        &s,
+        "--no-follow-up"
+    ])
+    .contains("not found"));
 }
 
 #[test]
@@ -261,17 +570,42 @@ fn todo_complete_gate_class_bypasses_freeze() {
     let cr = cli_root();
     let gid = init_goal(&cr, "gate class complete");
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "gate A", "--class", "user_gate",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "gate A",
+        "--class",
+        "user_gate",
     ]);
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "gate B", "--class", "user_gate",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "gate B",
+        "--class",
+        "user_gate",
     ]);
     let a = todo_id_by_text(&cr.root, &gid, "gate A");
     // Completing a GATE-class todo is allowed even while another gate is open.
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &a, "--no-follow-up"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &a,
+        "--no-follow-up",
+    ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
-    assert_eq!(g.todos.iter().find(|t| t.id == a).unwrap().status, TodoStatus::Done);
+    assert_eq!(
+        g.todos.iter().find(|t| t.id == a).unwrap().status,
+        TodoStatus::Done
+    );
 }
 
 // ── todo archive / supersede / update ──────────────────────────────────────
@@ -284,10 +618,27 @@ fn todo_archive_supersede_update() {
     cli_ok(&["todo", "archive", "--goal", &gid, "--todo-id", &victim]);
     assert!(cli_err(&["todo", "archive", "--goal", &gid]).contains("--todo-id required"));
     assert!(cli_err(&["todo", "archive", "--todo-id", &victim]).contains("--goal required"));
-    assert!(cli_err(&["todo", "archive", "--goal", "goal_nope", "--todo-id", &victim]).contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "archive",
+        "--goal",
+        "goal_nope",
+        "--todo-id",
+        &victim
+    ])
+    .contains("not found"));
 
     let sup = add_todo(&cr, &gid, "supersede me");
-    cli_ok(&["todo", "supersede", "--goal", &gid, "--todo-id", &sup, "--reason", "obsolete"]);
+    cli_ok(&[
+        "todo",
+        "supersede",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &sup,
+        "--reason",
+        "obsolete",
+    ]);
     {
         let store = open_store(&cr);
         let g = store.replay(&gid).unwrap().unwrap();
@@ -296,18 +647,54 @@ fn todo_archive_supersede_update() {
             TodoStatus::Superseded
         );
     }
-    assert!(cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "supersede",
+        "--goal",
+        &gid,
+        "--todo-id",
+        "todo_nope"
+    ])
+    .contains("not found"));
     // Supersede a done todo is rejected.
     let done = add_todo(&cr, &gid, "done one");
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &done, "--no-follow-up"]);
-    assert!(cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", &done]).contains("already done"));
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &done,
+        "--no-follow-up",
+    ]);
+    assert!(
+        cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", &done])
+            .contains("already done")
+    );
 
     // update: full field set.
     let u = add_todo(&cr, &gid, "update me");
     cli_ok(&[
-        "todo", "update", "--goal", &gid, "--todo-id", &u, "--text", "updated text",
-        "--status", "blocked", "--evidence", "half done", "--note", "n", "--priority", "P0",
-        "--resume-when", "45", "--blocks", "x,y",
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--text",
+        "updated text",
+        "--status",
+        "blocked",
+        "--evidence",
+        "half done",
+        "--note",
+        "n",
+        "--priority",
+        "P0",
+        "--resume-when",
+        "45",
+        "--blocks",
+        "x,y",
     ]);
     {
         let store = open_store(&cr);
@@ -318,12 +705,42 @@ fn todo_archive_supersede_update() {
         assert_eq!(t.note.as_deref(), Some("n"));
         assert_eq!(t.priority, future_loop::state::Priority::P0);
         assert_eq!(t.blocked_by_gate.as_deref(), Some("x,y"));
-        assert!(t.resume_when.is_some(), "numeric resume-when sets a real deadline");
+        assert!(
+            t.resume_when.is_some(),
+            "numeric resume-when sets a real deadline"
+        );
     }
     // Clear blocks, textual resume-when, unknown status ignored.
-    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--blocks", ""]);
-    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--resume-when", "when ready"]);
-    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--status", "bogus"]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--blocks",
+        "",
+    ]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--resume-when",
+        "when ready",
+    ]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--status",
+        "bogus",
+    ]);
     {
         let store = open_store(&cr);
         let g = store.replay(&gid).unwrap().unwrap();
@@ -332,12 +749,35 @@ fn todo_archive_supersede_update() {
         assert_eq!(t.resume_when_text.as_deref(), Some("when ready"));
     }
     // --status done is rejected; unknown flags hard-error.
-    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--status", "done"])
-        .contains("not allowed"));
-    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", &u, "--frobnicate", "1"])
-        .contains("unknown flag"));
-    assert!(cli_err(&["todo", "update", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
-    assert!(cli_err(&["todo", "update", "--goal", "goal_nope", "--todo-id", &u]).contains("not found"));
+    assert!(cli_err(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--status",
+        "done"
+    ])
+    .contains("not allowed"));
+    assert!(cli_err(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--frobnicate",
+        "1"
+    ])
+    .contains("unknown flag"));
+    assert!(
+        cli_err(&["todo", "update", "--goal", &gid, "--todo-id", "todo_nope"])
+            .contains("not found")
+    );
+    assert!(
+        cli_err(&["todo", "update", "--goal", "goal_nope", "--todo-id", &u]).contains("not found")
+    );
     assert!(cli_err(&["todo", "update", "--goal", &gid]).contains("--todo-id required"));
 }
 
@@ -349,12 +789,33 @@ fn gate_resolve_errors() {
     let gid = init_goal(&cr, "gate errors");
     assert!(cli_err(&["gate", "resolve", "--goal", &gid]).contains("--todo-id required"));
     assert!(cli_err(&["gate", "resolve", "--todo-id", "t"]).contains("--goal required"));
-    assert!(cli_err(&["gate", "resolve", "--goal", &gid, "--todo-id", "t"]).contains("--decision required"));
-    assert!(cli_err(&["gate", "resolve", "--goal", "goal_nope", "--todo-id", "t", "--decision", "x"])
-        .contains("not found"));
+    assert!(
+        cli_err(&["gate", "resolve", "--goal", &gid, "--todo-id", "t"])
+            .contains("--decision required")
+    );
+    assert!(cli_err(&[
+        "gate",
+        "resolve",
+        "--goal",
+        "goal_nope",
+        "--todo-id",
+        "t",
+        "--decision",
+        "x"
+    ])
+    .contains("not found"));
     // Resolving a non-gate todo still records the decision (no class check).
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &first, "--decision", "fine"]);
+    cli_ok(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--decision",
+        "fine",
+    ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
     let t = g.todos.iter().find(|t| t.id == first).unwrap();
@@ -373,34 +834,125 @@ fn lease_lifecycle() {
     // status on a free todo.
     cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
     // claim / renew / release / expire.
-    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "60"]);
+    cli_ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "60",
+    ]);
     cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
-    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "120"]);
-    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    cli_ok(&[
+        "lease",
+        "renew",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "120",
+    ]);
+    cli_ok(&[
+        "lease",
+        "release",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+    ]);
     // release again → missing-lease path (no event, still ok).
-    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    cli_ok(&[
+        "lease",
+        "release",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+    ]);
     // expire with no lease → had_lease=false path.
     cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &t]);
     // Minimum TTL is 1s (0 normalizes to the 45min default); lease timestamps
     // have epoch-second resolution, so cross the boundary with a real sleep.
-    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1", "--lease-secs", "1"]);
+    cli_ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "1",
+    ]);
     std::thread::sleep(std::time::Duration::from_millis(1200));
     // status now reports EXPIRED; expire records the event (had_lease=true).
     cli_ok(&["lease", "status", "--goal", &gid, "--todo-id", &t]);
     cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &t]);
     // Steal path: w2 claims, lease lapses, w3 takes it (TodoExpired+TodoClaimed).
-    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w2", "--lease-secs", "1"]);
+    cli_ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w2",
+        "--lease-secs",
+        "1",
+    ]);
     std::thread::sleep(std::time::Duration::from_millis(1200));
-    cli_ok(&["lease", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w3", "--lease-secs", "30"]);
+    cli_ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w3",
+        "--lease-secs",
+        "30",
+    ]);
     // renew by the non-owner errors.
-    assert!(cli(&["lease", "renew", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]).is_err());
+    assert!(cli(&[
+        "lease",
+        "renew",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1"
+    ])
+    .is_err());
     // Errors.
     assert!(cli_err(&["lease"]).contains("subcommand"));
     assert!(cli_err(&["lease", "claim", "--goal", &gid]).contains("--todo-id required"));
     assert!(cli_err(&["lease", "claim", "--todo-id", &t]).contains("--goal required"));
-    assert!(cli_err(&["lease", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found"));
-    assert!(cli_err(&["lease", "status", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
-    assert!(cli_err(&["lease", "frobnicate", "--goal", &gid, "--todo-id", &t]).contains("claim|renew|release|expire|status"));
+    assert!(
+        cli_err(&["lease", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found")
+    );
+    assert!(
+        cli_err(&["lease", "status", "--goal", &gid, "--todo-id", "todo_nope"])
+            .contains("not found")
+    );
+    assert!(
+        cli_err(&["lease", "frobnicate", "--goal", &gid, "--todo-id", &t])
+            .contains("claim|renew|release|expire|status")
+    );
 }
 
 // ── agent register / onboard / list ────────────────────────────────────────
@@ -412,18 +964,61 @@ fn agent_registry_surface() {
     // list with no agents.
     cli_ok(&["agent", "list", "--goal", &gid]);
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
-    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w2", "--capability", "shell,github"]);
-    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w3", "--capabilities", "web"]);
+    cli_ok(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "w2",
+        "--capability",
+        "shell,github",
+    ]);
+    cli_ok(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "w3",
+        "--capabilities",
+        "web",
+    ]);
     // w1 holds a live lease → running row in `agent list`.
     let t = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &t, "--agent-id", "w1"]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "w1",
+    ]);
     cli_ok(&["agent", "list", "--goal", &gid]);
     // Errors.
     assert!(cli_err(&["agent", "register", "--goal", &gid]).contains("--agent-id required"));
     assert!(cli_err(&["agent", "register", "--agent-id", "w1"]).contains("--goal required"));
-    assert!(cli_err(&["agent", "register", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+    assert!(cli_err(&[
+        "agent",
+        "register",
+        "--goal",
+        "goal_nope",
+        "--agent-id",
+        "w1"
+    ])
+    .contains("not found"));
     assert!(cli_err(&["agent", "onboard", "--goal", &gid]).contains("--agent-id required"));
-    assert!(cli_err(&["agent", "onboard", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+    assert!(cli_err(&[
+        "agent",
+        "onboard",
+        "--goal",
+        "goal_nope",
+        "--agent-id",
+        "w1"
+    ])
+    .contains("not found"));
     assert!(cli_err(&["agent", "list"]).contains("--goal required"));
     assert!(cli_err(&["agent", "list", "--goal", "goal_nope"]).contains("not found"));
 }
@@ -444,7 +1039,14 @@ fn backup_create_list_restore() {
         cli_ok(&["backup", "--goal", &gid, "--restore", &backups[0]]);
     }
     assert!(cli_err(&["backup"]).contains("--goal required"));
-    assert!(cli_err(&["backup", "--goal", &gid, "--restore", "/nonexistent-dir-xyz"]).contains(""));
+    assert!(cli_err(&[
+        "backup",
+        "--goal",
+        &gid,
+        "--restore",
+        "/nonexistent-dir-xyz"
+    ])
+    .contains(""));
 }
 
 // ── authority / profile ────────────────────────────────────────────────────
@@ -454,13 +1056,21 @@ fn authority_and_profile() {
     let cr = cli_root();
     let gid = init_goal(&cr, "authority");
     cli_ok(&[
-        "authority", "--goal", &gid, "--write-scope", "src,docs", "--require-approval",
+        "authority",
+        "--goal",
+        &gid,
+        "--write-scope",
+        "src,docs",
+        "--require-approval",
         "publish,deploy",
     ]);
     {
         let store = open_store(&cr);
         let g = store.replay(&gid).unwrap().unwrap();
-        assert_eq!(g.authority.write_scope, vec!["src".to_string(), "docs".to_string()]);
+        assert_eq!(
+            g.authority.write_scope,
+            vec!["src".to_string(), "docs".to_string()]
+        );
         assert_eq!(
             g.authority.requires_approval,
             vec!["publish".to_string(), "deploy".to_string()]
@@ -475,7 +1085,9 @@ fn authority_and_profile() {
         let g = store.replay(&gid).unwrap().unwrap();
         assert_eq!(g.execution_profile.outcome_floor_streak_threshold, 3);
     }
-    assert!(cli_err(&["profile", "set", "--goal", &gid, "--outcome-floor", "x"]).contains("number"));
+    assert!(
+        cli_err(&["profile", "set", "--goal", &gid, "--outcome-floor", "x"]).contains("number")
+    );
     assert!(cli_err(&["profile", "bogus", "--goal", &gid]).contains("must be `set`"));
     assert!(cli_err(&["profile", "set"]).contains("--goal required"));
     assert!(cli_err(&["profile", "set", "--goal", "goal_nope"]).contains("not found"));
@@ -514,13 +1126,28 @@ fn replan_ack_and_obligations() {
     }
     cli_ok(&["replan", "obligations", "--goal", &gid]);
     // ack variants.
-    cli_ok(&["replan", "ack", "--goal", &gid, "--delta-kind", "vision_patch"]);
+    cli_ok(&[
+        "replan",
+        "ack",
+        "--goal",
+        &gid,
+        "--delta-kind",
+        "vision_patch",
+    ]);
     assert!(cli_err(&["replan", "ack", "--goal", &gid]).contains("--delta-kind"));
-    assert!(cli_err(&["replan", "ack", "--goal", &gid, "--delta-kind", "nope"])
-        .contains("frontier"));
+    assert!(
+        cli_err(&["replan", "ack", "--goal", &gid, "--delta-kind", "nope"]).contains("frontier")
+    );
     assert!(cli_err(&["replan", "ack"]).contains("--goal required"));
-    assert!(cli_err(&["replan", "ack", "--goal", "goal_nope", "--delta-kind", "vision_patch"])
-        .contains("not found"));
+    assert!(cli_err(&[
+        "replan",
+        "ack",
+        "--goal",
+        "goal_nope",
+        "--delta-kind",
+        "vision_patch"
+    ])
+    .contains("not found"));
     assert!(cli_err(&["replan", "obligations"]).contains("--goal required"));
     assert!(cli_err(&["replan", "obligations", "--goal", "goal_nope"]).contains("not found"));
 }

--- a/orchestration/loop/tests/console_drive_b.rs
+++ b/orchestration/loop/tests/console_drive_b.rs
@@ -4,28 +4,9 @@
 
 mod common;
 
-use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
-use future_loop::state::{now_epoch, RunRecord};
+use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use future_loop::state::now_epoch;
 use future_loop::store::Event;
-
-/// A run record for seeding runs.jsonl / RunRecorded events.
-pub fn run_record(todo_id: &str, state: &str, recorded_at: u64) -> RunRecord {
-    RunRecord {
-        turn: 1,
-        todo_id: todo_id.to_string(),
-        run_id: format!("run-{todo_id}-{recorded_at}"),
-        terminal_state: state.to_string(),
-        error: None,
-        tokens_in_delta: 10,
-        tokens_out_delta: 20,
-        cost_delta: 0.001,
-        tools: vec!["shell".to_string()],
-        evidence: "artifact validated".to_string(),
-        recorded_at,
-        spend_source: Some("run".to_string()),
-        validation: None,
-    }
-}
 
 // ── status ─────────────────────────────────────────────────────────────────
 

--- a/orchestration/loop/tests/console_drive_b.rs
+++ b/orchestration/loop/tests/console_drive_b.rs
@@ -4,7 +4,9 @@
 
 mod common;
 
-use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use common::{
+    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record,
+};
 use future_loop::state::now_epoch;
 use future_loop::store::Event;
 
@@ -67,25 +69,66 @@ fn scheduler_surface() {
     cli_ok(&["scheduler", "tick", "--goal", &gid]);
     // custom progression / cadence class / action on a second agent.
     cli_ok(&[
-        "scheduler", "tick", "--goal", &gid, "--agent-id", "agent-b", "--cadence-class", "hourly",
-        "--progression", "15,30,60", "--action", "custom_reset",
+        "scheduler",
+        "tick",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "agent-b",
+        "--cadence-class",
+        "hourly",
+        "--progression",
+        "15,30,60",
+        "--action",
+        "custom_reset",
     ]);
     cli_ok(&["scheduler", "tick", "--goal", &gid, "--agent-id", "agent-b"]);
     // record-host-failure with and without existing state.
     cli_ok(&[
-        "scheduler", "record-host-failure", "--goal", &gid, "--target-rrule",
-        "FREQ=MINUTELY;INTERVAL=15", "--observed-rrule", "FREQ=MINUTELY;INTERVAL=30",
-        "--failure-kind", "host_stale_rrule", "--failure-count", "2",
+        "scheduler",
+        "record-host-failure",
+        "--goal",
+        &gid,
+        "--target-rrule",
+        "FREQ=MINUTELY;INTERVAL=15",
+        "--observed-rrule",
+        "FREQ=MINUTELY;INTERVAL=30",
+        "--failure-kind",
+        "host_stale_rrule",
+        "--failure-count",
+        "2",
     ]);
     cli_ok(&[
-        "scheduler", "record-host-failure", "--goal", &gid, "--agent-id", "agent-fresh",
-        "--target-rrule", "FREQ=HOURLY", "--failure-kind", "host_stale_rrule",
+        "scheduler",
+        "record-host-failure",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "agent-fresh",
+        "--target-rrule",
+        "FREQ=HOURLY",
+        "--failure-kind",
+        "host_stale_rrule",
     ]);
     // errors.
-    assert!(cli_err(&["scheduler", "record-host-failure", "--goal", &gid, "--failure-kind", "k"])
-        .contains("--target-rrule"));
-    assert!(cli_err(&["scheduler", "record-host-failure", "--goal", &gid, "--target-rrule", "R"])
-        .contains("--failure-kind"));
+    assert!(cli_err(&[
+        "scheduler",
+        "record-host-failure",
+        "--goal",
+        &gid,
+        "--failure-kind",
+        "k"
+    ])
+    .contains("--target-rrule"));
+    assert!(cli_err(&[
+        "scheduler",
+        "record-host-failure",
+        "--goal",
+        &gid,
+        "--target-rrule",
+        "R"
+    ])
+    .contains("--failure-kind"));
     assert!(cli_err(&["scheduler", "bogus", "--goal", &gid]).contains("tick"));
     assert!(cli_err(&["scheduler"]).contains("tick"));
     assert!(cli_err(&["scheduler", "tick"]).contains("--goal required"));
@@ -132,22 +175,49 @@ fn backfill_surface() {
     let md = std::path::Path::new(&cr.cwd).join("state.md");
     std::fs::write(&md, BACKFILL_MD).unwrap();
     // dry-run first, then the real append (idempotent producer).
-    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run"]);
+    cli_ok(&[
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        md.to_str().unwrap(),
+        "--dry-run",
+    ]);
     cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap()]);
     cli_ok(&[
-        "backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--privacy", "public_safe",
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        md.to_str().unwrap(),
+        "--privacy",
+        "public_safe",
     ]);
     // default --from: <cwd>/.future/loop/goals/<gid>/ACTIVE_GOAL_STATE.md? No —
     // the goal cwd's ACTIVE_GOAL_STATE.md; missing here → error.
     assert!(cli_err(&["backfill", "--goal", &gid]).contains(""));
     // bad privacy level / missing file / empty markdown.
-    assert!(cli_err(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--privacy", "bogus"])
-        .contains(""));
+    assert!(cli_err(&[
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        md.to_str().unwrap(),
+        "--privacy",
+        "bogus"
+    ])
+    .contains(""));
     assert!(cli_err(&["backfill", "--goal", &gid, "--from", "/nonexistent.md"]).contains("read"));
     let empty = std::path::Path::new(&cr.cwd).join("empty.md");
     std::fs::write(&empty, "# nothing here\n").unwrap();
-    assert!(cli_err(&["backfill", "--goal", &gid, "--from", empty.to_str().unwrap()])
-        .contains("no todo records"));
+    assert!(cli_err(&[
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        empty.to_str().unwrap()
+    ])
+    .contains("no todo records"));
     assert!(cli_err(&["backfill"]).contains("--goal required"));
     assert!(cli_err(&["backfill", "--goal", "goal_nope"]).contains("not found"));
 }
@@ -183,8 +253,12 @@ fn runs_surface() {
     {
         let store = open_store(&cr);
         let first = first_todo_id(&cr.root, &gid);
-        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
-        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
+        store
+            .append_run(&gid, &run_record(&first, "completed", now_epoch()))
+            .unwrap();
+        store
+            .append_run(&gid, &run_record(&first, "completed", now_epoch()))
+            .unwrap();
         future_loop::compat::write_run(
             &store.goal_dir(&gid),
             &gid,
@@ -209,18 +283,31 @@ fn runs_surface() {
     {
         let store = open_store(&cr);
         let first = first_todo_id(&cr.root, &gid2);
-        store.append_run(&gid2, &run_record(&first, "completed", 1)).unwrap();
+        store
+            .append_run(&gid2, &run_record(&first, "completed", 1))
+            .unwrap();
     }
     let first = first_todo_id(&cr.root, &gid2);
-    cli_ok(&["todo", "update", "--goal", &gid2, "--todo-id", &first, "--note", "state moved"]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid2,
+        "--todo-id",
+        &first,
+        "--note",
+        "state moved",
+    ]);
     cli_ok(&["runs", "stale", "--goal", &gid2]);
     // errors.
     assert!(cli_err(&["runs", "bogus", "--goal", &gid]).contains("history|compact"));
     assert!(cli_err(&["runs"]).contains("history|compact"));
     assert!(cli_err(&["runs", "history"]).contains("--goal required"));
     assert!(cli_err(&["runs", "history", "--goal", "goal_nope"]).contains("not found"));
-    assert!(cli_err(&["runs", "compact", "--goal", &gid, "--cutoff", "notanumber"])
-        .contains("epoch secs"));
+    assert!(
+        cli_err(&["runs", "compact", "--goal", &gid, "--cutoff", "notanumber"])
+            .contains("epoch secs")
+    );
 }
 
 // ── heartbeat-prompt ───────────────────────────────────────────────────────
@@ -235,7 +322,14 @@ fn heartbeat_prompt_surface() {
     cli_ok(&["heartbeat-prompt", "--goal", &gid, "--agent-id", "w1"]);
     // Open gate → user-action-required branch (+ fallback todo line).
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "approve?", "--class", "user_gate",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "approve?",
+        "--class",
+        "user_gate",
     ]);
     cli_ok(&["heartbeat-prompt", "--goal", &gid]);
     // A seeded failed todo → "repair attempt N" line, plus run history.
@@ -250,12 +344,23 @@ fn heartbeat_prompt_surface() {
                 ts: now_epoch(),
             })
             .unwrap();
-        store.append_run(&gid, &run_record("todo_failed", "error", now_epoch())).unwrap();
+        store
+            .append_run(&gid, &run_record("todo_failed", "error", now_epoch()))
+            .unwrap();
         store.set_next_action(&gid, "failed once").unwrap();
     }
     // Resolve the gate so the failed todo becomes the selected frontier.
     let gate = common::todo_id_by_text(&cr.root, &gid, "approve?");
-    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &gate, "--decision", "go"]);
+    cli_ok(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &gate,
+        "--decision",
+        "go",
+    ]);
     cli_ok(&["heartbeat-prompt", "--goal", &gid]);
     // Terminal mode: cancel the goal (cancelled → terminal packet).
     let gid2 = init_goal(&cr, "terminal heartbeat");
@@ -274,7 +379,15 @@ fn turn_surface() {
     let gid = init_goal(&cr, "turn goal");
     let first = first_todo_id(&cr.root, &gid);
     cli_ok(&["turn", "--goal", &gid, "--todo-id", &first]);
-    cli_ok(&["turn", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&[
+        "turn",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
     assert!(cli_err(&["turn", "--goal", &gid]).contains("--todo-id required"));
     assert!(cli_err(&["turn", "--todo-id", &first]).contains("--goal required"));
     assert!(cli_err(&["turn", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
@@ -288,31 +401,146 @@ fn todo_event_surface() {
     let first = first_todo_id(&cr.root, &gid);
     // Rich event trail for one todo: claim/renew/release/expire/complete…
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
-    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1", "--lease-secs", "30"]);
-    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
+    cli_ok(&[
+        "lease",
+        "renew",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "30",
+    ]);
+    cli_ok(&[
+        "lease",
+        "release",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
     cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &first]);
-    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &first, "--note", "n"]);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up", "--evidence", "done"]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--note",
+        "n",
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--evidence",
+        "done",
+    ]);
     cli_ok(&["todo-event", "--goal", &gid, "--todo-id", &first]);
     // Craft the remaining todo-touching variants (supersede/archive/monitor/
     // quota/evidence/run + a gate resolve on a second todo).
     {
         let mut store = open_store(&cr);
         let t2 = future_loop::state::Todo::advancement("todo_crafted", "crafted trail");
-        store.append(Event::TodoAdded { goal_id: gid.clone(), todo: t2, ts: now_epoch() }).unwrap();
-        store.append(Event::TodoSuperseded { goal_id: gid.clone(), todo_id: "todo_crafted".into(), ts: now_epoch() }).unwrap();
-        store.append(Event::TodoArchived { goal_id: gid.clone(), todo_id: "todo_crafted".into(), ts: now_epoch() }).unwrap();
-        store.append(Event::MonitorPolled { goal_id: gid.clone(), todo_id: "todo_crafted".into(), result: "no_change".into(), no_change_count: 1, ts: now_epoch() }).unwrap();
-        store.append(Event::QuotaSpent { goal_id: gid.clone(), run_id: "r1".into(), todo_id: "todo_crafted".into(), source: "run".into(), slots: 1, ts: now_epoch() }).unwrap();
-        store.append(Event::EvidenceAttached { goal_id: gid.clone(), todo_id: "todo_crafted".into(), evidence: "e".into(), ts: now_epoch() }).unwrap();
-        store.append(Event::GateResolved { goal_id: gid.clone(), todo_id: "todo_crafted".into(), decision: "d".into(), note: None, ts: now_epoch() }).unwrap();
-        store.append_run(&gid, &run_record("todo_crafted", "completed", now_epoch())).unwrap();
+        store
+            .append(Event::TodoAdded {
+                goal_id: gid.clone(),
+                todo: t2,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::TodoSuperseded {
+                goal_id: gid.clone(),
+                todo_id: "todo_crafted".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::TodoArchived {
+                goal_id: gid.clone(),
+                todo_id: "todo_crafted".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::MonitorPolled {
+                goal_id: gid.clone(),
+                todo_id: "todo_crafted".into(),
+                result: "no_change".into(),
+                no_change_count: 1,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::QuotaSpent {
+                goal_id: gid.clone(),
+                run_id: "r1".into(),
+                todo_id: "todo_crafted".into(),
+                source: "run".into(),
+                slots: 1,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::EvidenceAttached {
+                goal_id: gid.clone(),
+                todo_id: "todo_crafted".into(),
+                evidence: "e".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(Event::GateResolved {
+                goal_id: gid.clone(),
+                todo_id: "todo_crafted".into(),
+                decision: "d".into(),
+                note: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append_run(&gid, &run_record("todo_crafted", "completed", now_epoch()))
+            .unwrap();
         let mut s2 = open_store(&cr);
-        s2.append(Event::RunRecorded { goal_id: gid.clone(), record: run_record("todo_crafted", "completed", now_epoch()), ts: now_epoch() }).unwrap();
+        s2.append(Event::RunRecorded {
+            goal_id: gid.clone(),
+            record: run_record("todo_crafted", "completed", now_epoch()),
+            ts: now_epoch(),
+        })
+        .unwrap();
         // Non-todo events for the _ => false filter arms.
-        s2.append(Event::ReplanAcked { goal_id: gid.clone(), delta_kinds: vec!["vision_patch".into()], ts: now_epoch() }).unwrap();
-        s2.append(Event::GoalCancelled { goal_id: gid.clone(), reason: "r".into(), ts: now_epoch() }).unwrap();
+        s2.append(Event::ReplanAcked {
+            goal_id: gid.clone(),
+            delta_kinds: vec!["vision_patch".into()],
+            ts: now_epoch(),
+        })
+        .unwrap();
+        s2.append(Event::GoalCancelled {
+            goal_id: gid.clone(),
+            reason: "r".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
     }
     cli_ok(&["todo-event", "--goal", &gid, "--todo-id", "todo_crafted"]);
     // A todo id with no events.
@@ -329,16 +557,47 @@ fn evidence_log_surface() {
     cli_ok(&["evidence-log", "--goal", &gid]);
     cli_ok(&["evidence-log", "--goal", &gid, "--todo-id", "todo_ghost"]);
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up", "--evidence", "shipped"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--evidence",
+        "shipped",
+    ]);
     {
         let mut store = open_store(&cr);
-        store.append(Event::EvidenceAttached { goal_id: gid.clone(), todo_id: "todo_x".into(), evidence: "attached proof".into(), ts: now_epoch() }).unwrap();
-        store.append_run(&gid, &run_record("todo_x", "completed", now_epoch())).unwrap();
-        store.append(Event::RunRecorded { goal_id: gid.clone(), record: run_record("todo_x", "completed", now_epoch()), ts: now_epoch() }).unwrap();
+        store
+            .append(Event::EvidenceAttached {
+                goal_id: gid.clone(),
+                todo_id: "todo_x".into(),
+                evidence: "attached proof".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append_run(&gid, &run_record("todo_x", "completed", now_epoch()))
+            .unwrap();
+        store
+            .append(Event::RunRecorded {
+                goal_id: gid.clone(),
+                record: run_record("todo_x", "completed", now_epoch()),
+                ts: now_epoch(),
+            })
+            .unwrap();
         // A run with EMPTY evidence is skipped by the run-evidence arm.
         let mut r = run_record("todo_y", "completed", now_epoch());
         r.evidence = String::new();
-        store.append(Event::RunRecorded { goal_id: gid.clone(), record: r, ts: now_epoch() }).unwrap();
+        store
+            .append(Event::RunRecorded {
+                goal_id: gid.clone(),
+                record: r,
+                ts: now_epoch(),
+            })
+            .unwrap();
     }
     cli_ok(&["evidence-log", "--goal", &gid]);
     cli_ok(&["evidence-log", "--goal", &gid, "--todo-id", "todo_x"]);
@@ -358,7 +617,9 @@ fn diagnose_and_history_surface() {
     {
         let store = open_store(&cr);
         let first = first_todo_id(&cr.root, &gid);
-        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
+        store
+            .append_run(&gid, &run_record(&first, "completed", now_epoch()))
+            .unwrap();
         let mut bare = run_record(&first, "error", now_epoch());
         bare.evidence = String::new();
         bare.tools = vec![];

--- a/orchestration/loop/tests/console_drive_b.rs
+++ b/orchestration/loop/tests/console_drive_b.rs
@@ -4,9 +4,7 @@
 
 mod common;
 
-use common::{
-    add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record,
-};
+use common::{cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
 use future_loop::state::now_epoch;
 use future_loop::store::Event;
 

--- a/orchestration/loop/tests/console_drive_b.rs
+++ b/orchestration/loop/tests/console_drive_b.rs
@@ -1,0 +1,407 @@
+//! Coverage drive — console command group B: status / quota / scheduler /
+//! store / backfill / privacy / runs / heartbeat-prompt / turn / todo-event /
+//! evidence-log / diagnose / history / registry / version / canary.
+
+mod common;
+
+use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
+use future_loop::state::{now_epoch, RunRecord};
+use future_loop::store::Event;
+
+/// A run record for seeding runs.jsonl / RunRecorded events.
+pub fn run_record(todo_id: &str, state: &str, recorded_at: u64) -> RunRecord {
+    RunRecord {
+        turn: 1,
+        todo_id: todo_id.to_string(),
+        run_id: format!("run-{todo_id}-{recorded_at}"),
+        terminal_state: state.to_string(),
+        error: None,
+        tokens_in_delta: 10,
+        tokens_out_delta: 20,
+        cost_delta: 0.001,
+        tools: vec!["shell".to_string()],
+        evidence: "artifact validated".to_string(),
+        recorded_at,
+        spend_source: Some("run".to_string()),
+        validation: None,
+    }
+}
+
+// ── status ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn status_surface() {
+    let cr = cli_root();
+    // Empty registry.
+    cli_ok(&["status"]);
+    cli_ok(&["status", "--format", "json"]);
+    let gid = init_goal(&cr, "status goal");
+    cli_ok(&["status"]);
+    cli_ok(&["status", "--goal", &gid]);
+    cli_ok(&["status", "--format", "json"]);
+    cli_ok(&["status", "--format", "json", "--goal", &gid]);
+    assert!(cli_err(&["status", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&["status", "--format", "json", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── quota ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn quota_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "quota goal");
+    cli_ok(&["quota", "should-run", "--goal", &gid]);
+    cli_ok(&["quota", "should-run", "--goal", &gid, "--format", "json"]);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["quota", "should-run", "--goal", &gid, "--agent-id", "w1"]);
+    // usage: single goal (text + json), --all (text + json), neither → err.
+    cli_ok(&["quota", "usage", "--goal", &gid]);
+    cli_ok(&["quota", "usage", "--goal", &gid, "--format", "json"]);
+    cli_ok(&["quota", "usage", "--all"]);
+    cli_ok(&["quota", "usage", "--all", "--format", "json"]);
+    assert!(cli_err(&["quota", "usage"]).contains("--all"));
+    assert!(cli_err(&["quota", "usage", "--goal", "goal_nope"]).contains("not found"));
+    // spend.
+    cli_ok(&["quota", "spend", "--goal", &gid]);
+    assert!(cli_err(&["quota", "spend"]).contains("--goal required"));
+    assert!(cli_err(&["quota", "spend", "--goal", "goal_nope"]).contains("not found"));
+    // should-run errors.
+    assert!(cli_err(&["quota", "should-run"]).contains("--goal required"));
+    assert!(cli_err(&["quota", "should-run", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&["quota", "bogus", "--goal", &gid]).contains("should-run"));
+    assert!(cli_err(&["quota"]).contains("should-run"));
+}
+
+// ── scheduler ──────────────────────────────────────────────────────────────
+
+#[test]
+fn scheduler_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "scheduler goal");
+    // show with no state → hint line.
+    cli_ok(&["scheduler", "show", "--goal", &gid]);
+    // bootstrap tick, then advancing ticks.
+    cli_ok(&["scheduler", "tick", "--goal", &gid]);
+    cli_ok(&["scheduler", "show", "--goal", &gid]);
+    cli_ok(&["scheduler", "tick", "--goal", &gid]);
+    // custom progression / cadence class / action on a second agent.
+    cli_ok(&[
+        "scheduler", "tick", "--goal", &gid, "--agent-id", "agent-b", "--cadence-class", "hourly",
+        "--progression", "15,30,60", "--action", "custom_reset",
+    ]);
+    cli_ok(&["scheduler", "tick", "--goal", &gid, "--agent-id", "agent-b"]);
+    // record-host-failure with and without existing state.
+    cli_ok(&[
+        "scheduler", "record-host-failure", "--goal", &gid, "--target-rrule",
+        "FREQ=MINUTELY;INTERVAL=15", "--observed-rrule", "FREQ=MINUTELY;INTERVAL=30",
+        "--failure-kind", "host_stale_rrule", "--failure-count", "2",
+    ]);
+    cli_ok(&[
+        "scheduler", "record-host-failure", "--goal", &gid, "--agent-id", "agent-fresh",
+        "--target-rrule", "FREQ=HOURLY", "--failure-kind", "host_stale_rrule",
+    ]);
+    // errors.
+    assert!(cli_err(&["scheduler", "record-host-failure", "--goal", &gid, "--failure-kind", "k"])
+        .contains("--target-rrule"));
+    assert!(cli_err(&["scheduler", "record-host-failure", "--goal", &gid, "--target-rrule", "R"])
+        .contains("--failure-kind"));
+    assert!(cli_err(&["scheduler", "bogus", "--goal", &gid]).contains("tick"));
+    assert!(cli_err(&["scheduler"]).contains("tick"));
+    assert!(cli_err(&["scheduler", "tick"]).contains("--goal required"));
+    assert!(cli_err(&["scheduler", "tick", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── store ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn store_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "store goal");
+    cli_ok(&["store", "verify", "--goal", &gid]);
+    // migrate on a current-schema goal errors; removing the schema stamp
+    // makes the ledger read as LEGACY and the migration rewrites it.
+    assert!(cli_err(&["store", "migrate", "--goal", &gid]).contains("already on schema"));
+    {
+        let store = open_store(&cr);
+        let stamp = store.goal_dir(&gid).join("schema.json");
+        std::fs::remove_file(&stamp).unwrap();
+    }
+    cli_ok(&["store", "migrate", "--goal", &gid]);
+    // A goal dir with no ledger at all.
+    assert!(cli_err(&["store", "migrate", "--goal", "goal_nope"]).contains("no event ledger"));
+    cli_ok(&["store", "bridge", "--goal", &gid]);
+    assert!(cli_err(&["store", "bogus", "--goal", &gid]).contains("migrate"));
+    assert!(cli_err(&["store"]).contains("migrate"));
+    assert!(cli_err(&["store", "verify"]).contains("--goal required"));
+}
+
+// ── backfill ───────────────────────────────────────────────────────────────
+
+const BACKFILL_MD: &str = "---\nstatus: active\n---\n\n# Active Goal State\n\n\
+    ## Agent Todo\n\n\
+    - [ ] [P1] Run the check\n  <!-- future-loop:todo todo_id=todo_abc123 status=open action_kind=shell updated_at=2026-08-05T12:00:00+00:00 -->\n\
+    - [x] Ship the artifact\n  <!-- future-loop:todo todo_id=todo_def456 status=done no_followup=true evidence=done%20well completed_at=2026-08-05T13:00:00+00:00 updated_at=2026-08-05T13:00:00+00:00 -->\n\n\
+    ## User Todo / Owner Review Reading Queue\n\n\
+    - [ ] Decide the scope\n  <!-- future-loop:todo todo_id=todo_ghi789 status=open task_class=user_gate updated_at=2026-08-05T12:30:00+00:00 -->\n";
+
+#[test]
+fn backfill_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "backfill goal");
+    let md = std::path::Path::new(&cr.cwd).join("state.md");
+    std::fs::write(&md, BACKFILL_MD).unwrap();
+    // dry-run first, then the real append (idempotent producer).
+    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run"]);
+    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap()]);
+    cli_ok(&[
+        "backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--privacy", "public_safe",
+    ]);
+    // default --from: <cwd>/.future/loop/goals/<gid>/ACTIVE_GOAL_STATE.md? No —
+    // the goal cwd's ACTIVE_GOAL_STATE.md; missing here → error.
+    assert!(cli_err(&["backfill", "--goal", &gid]).contains(""));
+    // bad privacy level / missing file / empty markdown.
+    assert!(cli_err(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--privacy", "bogus"])
+        .contains(""));
+    assert!(cli_err(&["backfill", "--goal", &gid, "--from", "/nonexistent.md"]).contains("read"));
+    let empty = std::path::Path::new(&cr.cwd).join("empty.md");
+    std::fs::write(&empty, "# nothing here\n").unwrap();
+    assert!(cli_err(&["backfill", "--goal", &gid, "--from", empty.to_str().unwrap()])
+        .contains("no todo records"));
+    assert!(cli_err(&["backfill"]).contains("--goal required"));
+    assert!(cli_err(&["backfill", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── privacy ────────────────────────────────────────────────────────────────
+
+#[test]
+fn privacy_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "privacy goal");
+    cli_ok(&["privacy", "--goal", &gid]);
+    cli_ok(&["privacy", "--goal", &gid, "--format", "json"]);
+    cli_ok(&["privacy", "--goal", &gid, "--level", "local_private"]);
+    cli_ok(&["privacy", "--goal", &gid, "--level", "private_pointer"]);
+    // Run it twice: the status-cache stale flag path (digest comparison).
+    cli_ok(&["privacy", "--goal", &gid]);
+    assert!(cli_err(&["privacy", "--goal", &gid, "--level", "bogus"]).contains(""));
+    assert!(cli_err(&["privacy"]).contains("--goal required"));
+    assert!(cli_err(&["privacy", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── runs ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn runs_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "runs goal");
+    // history on a goal with no runs → None path.
+    cli_ok(&["runs", "history", "--goal", &gid]);
+    // Seed runs: the run INDEX consumes per-run files under
+    // <root>/goals/<gid>/runs/ (written by compat::write_run during a real
+    // run); runs.jsonl feeds goal.history.
+    {
+        let store = open_store(&cr);
+        let first = first_todo_id(&cr.root, &gid);
+        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
+        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
+        future_loop::compat::write_run(
+            &store.goal_dir(&gid),
+            &gid,
+            &run_record(&first, "completed", now_epoch()),
+        )
+        .unwrap();
+    }
+    // Build the index, then history has rows (text + json).
+    cli_ok(&["runs", "index", "--goal", &gid, "--rebuild"]);
+    cli_ok(&["runs", "history", "--goal", &gid]);
+    cli_ok(&["runs", "history", "--goal", &gid, "--format", "json"]);
+    // index without --rebuild → duplicate scan.
+    cli_ok(&["runs", "index", "--goal", &gid]);
+    // compact both modes.
+    cli_ok(&["runs", "compact", "--goal", &gid, "--keep", "1"]);
+    cli_ok(&["runs", "compact", "--goal", &gid, "--cutoff", "1"]);
+    // retention.
+    cli_ok(&["runs", "retention", "--goal", &gid, "--keep", "1"]);
+    // stale: None on a fresh goal; Some after state outruns the run ledger.
+    let gid2 = init_goal(&cr, "stale goal");
+    cli_ok(&["runs", "stale", "--goal", &gid2]);
+    {
+        let store = open_store(&cr);
+        let first = first_todo_id(&cr.root, &gid2);
+        store.append_run(&gid2, &run_record(&first, "completed", 1)).unwrap();
+    }
+    let first = first_todo_id(&cr.root, &gid2);
+    cli_ok(&["todo", "update", "--goal", &gid2, "--todo-id", &first, "--note", "state moved"]);
+    cli_ok(&["runs", "stale", "--goal", &gid2]);
+    // errors.
+    assert!(cli_err(&["runs", "bogus", "--goal", &gid]).contains("history|compact"));
+    assert!(cli_err(&["runs"]).contains("history|compact"));
+    assert!(cli_err(&["runs", "history"]).contains("--goal required"));
+    assert!(cli_err(&["runs", "history", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&["runs", "compact", "--goal", &gid, "--cutoff", "notanumber"])
+        .contains("epoch secs"));
+}
+
+// ── heartbeat-prompt ───────────────────────────────────────────────────────
+
+#[test]
+fn heartbeat_prompt_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "heartbeat goal");
+    // Base: selected todo, no gate, no history.
+    cli_ok(&["heartbeat-prompt", "--goal", &gid]);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["heartbeat-prompt", "--goal", &gid, "--agent-id", "w1"]);
+    // Open gate → user-action-required branch (+ fallback todo line).
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "approve?", "--class", "user_gate",
+    ]);
+    cli_ok(&["heartbeat-prompt", "--goal", &gid]);
+    // A seeded failed todo → "repair attempt N" line, plus run history.
+    {
+        let mut store = open_store(&cr);
+        let mut t = future_loop::state::Todo::advancement("todo_failed", "failed once");
+        t.failed_attempts = 1;
+        store
+            .append(Event::TodoAdded {
+                goal_id: gid.clone(),
+                todo: t,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store.append_run(&gid, &run_record("todo_failed", "error", now_epoch())).unwrap();
+        store.set_next_action(&gid, "failed once").unwrap();
+    }
+    // Resolve the gate so the failed todo becomes the selected frontier.
+    let gate = common::todo_id_by_text(&cr.root, &gid, "approve?");
+    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &gate, "--decision", "go"]);
+    cli_ok(&["heartbeat-prompt", "--goal", &gid]);
+    // Terminal mode: cancel the goal (cancelled → terminal packet).
+    let gid2 = init_goal(&cr, "terminal heartbeat");
+    cli_ok(&["goal", "cancel", "--goal", &gid2]);
+    cli_ok(&["heartbeat-prompt", "--goal", &gid2]);
+    // errors.
+    assert!(cli_err(&["heartbeat-prompt"]).contains("--goal required"));
+    assert!(cli_err(&["heartbeat-prompt", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── turn / todo-event / evidence-log / diagnose / history ──────────────────
+
+#[test]
+fn turn_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "turn goal");
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["turn", "--goal", &gid, "--todo-id", &first]);
+    cli_ok(&["turn", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    assert!(cli_err(&["turn", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["turn", "--todo-id", &first]).contains("--goal required"));
+    assert!(cli_err(&["turn", "--goal", &gid, "--todo-id", "todo_nope"]).contains("not found"));
+    assert!(cli_err(&["turn", "--goal", "goal_nope", "--todo-id", &first]).contains("not found"));
+}
+
+#[test]
+fn todo_event_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo-event goal");
+    let first = first_todo_id(&cr.root, &gid);
+    // Rich event trail for one todo: claim/renew/release/expire/complete…
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1", "--lease-secs", "30"]);
+    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &first]);
+    cli_ok(&["todo", "update", "--goal", &gid, "--todo-id", &first, "--note", "n"]);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up", "--evidence", "done"]);
+    cli_ok(&["todo-event", "--goal", &gid, "--todo-id", &first]);
+    // Craft the remaining todo-touching variants (supersede/archive/monitor/
+    // quota/evidence/run + a gate resolve on a second todo).
+    {
+        let mut store = open_store(&cr);
+        let t2 = future_loop::state::Todo::advancement("todo_crafted", "crafted trail");
+        store.append(Event::TodoAdded { goal_id: gid.clone(), todo: t2, ts: now_epoch() }).unwrap();
+        store.append(Event::TodoSuperseded { goal_id: gid.clone(), todo_id: "todo_crafted".into(), ts: now_epoch() }).unwrap();
+        store.append(Event::TodoArchived { goal_id: gid.clone(), todo_id: "todo_crafted".into(), ts: now_epoch() }).unwrap();
+        store.append(Event::MonitorPolled { goal_id: gid.clone(), todo_id: "todo_crafted".into(), result: "no_change".into(), no_change_count: 1, ts: now_epoch() }).unwrap();
+        store.append(Event::QuotaSpent { goal_id: gid.clone(), run_id: "r1".into(), todo_id: "todo_crafted".into(), source: "run".into(), slots: 1, ts: now_epoch() }).unwrap();
+        store.append(Event::EvidenceAttached { goal_id: gid.clone(), todo_id: "todo_crafted".into(), evidence: "e".into(), ts: now_epoch() }).unwrap();
+        store.append(Event::GateResolved { goal_id: gid.clone(), todo_id: "todo_crafted".into(), decision: "d".into(), note: None, ts: now_epoch() }).unwrap();
+        store.append_run(&gid, &run_record("todo_crafted", "completed", now_epoch())).unwrap();
+        let mut s2 = open_store(&cr);
+        s2.append(Event::RunRecorded { goal_id: gid.clone(), record: run_record("todo_crafted", "completed", now_epoch()), ts: now_epoch() }).unwrap();
+        // Non-todo events for the _ => false filter arms.
+        s2.append(Event::ReplanAcked { goal_id: gid.clone(), delta_kinds: vec!["vision_patch".into()], ts: now_epoch() }).unwrap();
+        s2.append(Event::GoalCancelled { goal_id: gid.clone(), reason: "r".into(), ts: now_epoch() }).unwrap();
+    }
+    cli_ok(&["todo-event", "--goal", &gid, "--todo-id", "todo_crafted"]);
+    // A todo id with no events.
+    cli_ok(&["todo-event", "--goal", &gid, "--todo-id", "todo_ghost"]);
+    assert!(cli_err(&["todo-event", "--goal", &gid]).contains("--todo-id required"));
+    assert!(cli_err(&["todo-event", "--todo-id", &first]).contains("--goal required"));
+}
+
+#[test]
+fn evidence_log_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "evidence goal");
+    // Empty trail.
+    cli_ok(&["evidence-log", "--goal", &gid]);
+    cli_ok(&["evidence-log", "--goal", &gid, "--todo-id", "todo_ghost"]);
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up", "--evidence", "shipped"]);
+    {
+        let mut store = open_store(&cr);
+        store.append(Event::EvidenceAttached { goal_id: gid.clone(), todo_id: "todo_x".into(), evidence: "attached proof".into(), ts: now_epoch() }).unwrap();
+        store.append_run(&gid, &run_record("todo_x", "completed", now_epoch())).unwrap();
+        store.append(Event::RunRecorded { goal_id: gid.clone(), record: run_record("todo_x", "completed", now_epoch()), ts: now_epoch() }).unwrap();
+        // A run with EMPTY evidence is skipped by the run-evidence arm.
+        let mut r = run_record("todo_y", "completed", now_epoch());
+        r.evidence = String::new();
+        store.append(Event::RunRecorded { goal_id: gid.clone(), record: r, ts: now_epoch() }).unwrap();
+    }
+    cli_ok(&["evidence-log", "--goal", &gid]);
+    cli_ok(&["evidence-log", "--goal", &gid, "--todo-id", "todo_x"]);
+    cli_ok(&["evidence-log", "--goal", &gid, "--todo-id", &first]);
+    assert!(cli_err(&["evidence-log"]).contains("--goal required"));
+}
+
+#[test]
+fn diagnose_and_history_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "diag goal");
+    // No runs yet.
+    cli_ok(&["history", "--goal", &gid]);
+    cli_ok(&["diagnose", "--goal", &gid]);
+    cli_ok(&["diagnose", "--goal", &gid, "--format", "json"]);
+    // Seed runs (one with empty evidence, one with tools+evidence).
+    {
+        let store = open_store(&cr);
+        let first = first_todo_id(&cr.root, &gid);
+        store.append_run(&gid, &run_record(&first, "completed", now_epoch())).unwrap();
+        let mut bare = run_record(&first, "error", now_epoch());
+        bare.evidence = String::new();
+        bare.tools = vec![];
+        store.append_run(&gid, &bare).unwrap();
+    }
+    cli_ok(&["history", "--goal", &gid]);
+    cli_ok(&["diagnose", "--goal", &gid]);
+    cli_ok(&["diagnose", "--goal", &gid, "--format", "json"]);
+    assert!(cli_err(&["history"]).contains("--goal required"));
+    assert!(cli_err(&["history", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&["diagnose"]).contains("--goal required"));
+    assert!(cli_err(&["diagnose", "--goal", "goal_nope"]).contains("not found"));
+}
+
+// ── registry / version / canary ────────────────────────────────────────────
+
+#[test]
+fn registry_version_canary_surface() {
+    let _cr = cli_root();
+    cli_ok(&["registry"]);
+    cli_ok(&["registry", "--json"]);
+    cli_ok(&["registry", "--include-experimental"]);
+    cli_ok(&["version"]);
+    cli_ok(&["canary", "smoke"]);
+    cli_ok(&["canary", "smoke", "--json"]);
+    assert!(cli_err(&["canary", "smoke", "--profile", "no-such-profile"]).contains(""));
+}

--- a/orchestration/loop/tests/console_drive_c.rs
+++ b/orchestration/loop/tests/console_drive_c.rs
@@ -1,0 +1,435 @@
+//! Coverage drive — console command group C (P3/P4): capability / catalog /
+//! scope / lane / supervisor / handoff / task-graph / attention / inbox /
+//! extension / benchmark / replay, plus the per-capability command hooks.
+
+mod common;
+
+use common::mock_agent::{completed_events, spawn_mock, MockState};
+use common::{cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use future_loop::state::now_epoch;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+// ── capability ─────────────────────────────────────────────────────────────
+
+#[test]
+fn capability_surface() {
+    let _cr = cli_root();
+    cli_ok(&["capability", "list"]);
+    cli_ok(&["capability", "propose", "--name", "issue_fix", "--input", "crash on startup"]);
+    cli_ok(&["capability", "propose", "--name", "issue_fix"]);
+    assert!(cli_err(&["capability", "propose", "--name", "no_such_cap"])
+        .contains("unknown capability"));
+    assert!(cli_err(&["capability", "propose"]).contains("--name required"));
+    assert!(cli_err(&["capability", "bogus"]).contains("list"));
+    // commands: full listing, per-name, and an experimental gated name.
+    cli_ok(&["capability", "commands"]);
+    cli_ok(&["capability", "commands", "--include-experimental"]);
+    cli_ok(&["capability", "commands", "--name", "issue_fix"]);
+    cli_ok(&["capability", "commands", "--name", "no_such_cap"]);
+}
+
+#[test]
+fn capability_command_hook() {
+    let _cr = cli_root();
+    // `issue-fix` is a catalog command hook → dispatched via the `other` arm.
+    cli_ok(&["issue-fix", "--input", "panic in parser"]);
+    cli_ok(&["issue-fix"]);
+}
+
+// ── catalog ────────────────────────────────────────────────────────────────
+
+#[test]
+fn catalog_surface() {
+    let _cr = cli_root();
+    cli_ok(&["catalog"]);
+    cli_ok(&["catalog", "--name", "issue_fix"]);
+    cli_ok(&["catalog", "--name", "issue_fix", "--format", "json"]);
+    cli_ok(&["catalog", "--name", "issue_fix", "--json"]);
+    assert!(cli_err(&["catalog", "--name", "no_such_cap"]).contains("unknown capability"));
+}
+
+// ── scope / lane ───────────────────────────────────────────────────────────
+
+#[test]
+fn scope_and_lane_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "scope goal");
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1", "--exclude", "todo_x,todo_y"]);
+    // lane: no runs yet → None path. Then seed a run → recommendation paths.
+    cli_ok(&["lane", "--goal", &gid, "--agent-id", "w1"]);
+    {
+        let store = open_store(&cr);
+        store
+            .append_run(&gid, &common::run_record(&first, "completed", now_epoch()))
+            .unwrap();
+    }
+    cli_ok(&["lane", "--goal", &gid, "--agent-id", "w1"]);
+    // errors.
+    assert!(cli_err(&["scope", "--goal", &gid]).contains("--agent-id required"));
+    assert!(cli_err(&["scope", "--agent-id", "w1"]).contains("--goal required"));
+    assert!(cli_err(&["scope", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+    assert!(cli_err(&["lane", "--goal", &gid]).contains("--agent-id required"));
+    assert!(cli_err(&["lane", "--agent-id", "w1"]).contains("--goal required"));
+    assert!(cli_err(&["lane", "--goal", "goal_nope", "--agent-id", "w1"]).contains("not found"));
+}
+
+// ── supervisor ─────────────────────────────────────────────────────────────
+
+#[test]
+fn supervisor_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "supervisor goal");
+    cli_ok(&[
+        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d1",
+        "--target-agent-id", "w1", "--kind", "observe", "--summary", "watching",
+    ]);
+    cli_ok(&[
+        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d2",
+        "--target-agent-id", "w1", "--kind", "execute", "--capabilities", "shell,web",
+    ]);
+    for (decision, outcome, caps) in [
+        ("d2", "executed", "shell,web"),
+        ("d2", "failed", "shell"),
+        ("d2", "bogus-outcome", "shell"), // → Rejected via the catch-all arm
+    ] {
+        cli_ok(&[
+            "supervisor", "receipt", "--goal", &gid, "--decision-id", decision, "--receipt-id",
+            &format!("r-{outcome}"), "--adapter-id", "adapter-1", "--outcome", outcome,
+            "--authority-ref", "auth-1", "--host-capabilities", caps,
+        ]);
+    }
+    // An observe decision rejects host-execution receipts, and an executed
+    // receipt must carry the decision's required capabilities.
+    assert!(cli_err(&[
+        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d1", "--receipt-id", "r-bad",
+        "--adapter-id", "a", "--outcome", "executed",
+    ])
+    .contains("observe"));
+    assert!(cli_err(&[
+        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d2", "--receipt-id", "r-bad2",
+        "--adapter-id", "a", "--outcome", "executed", "--host-capabilities", "shell",
+    ])
+    .contains("capabilities"));
+    cli_ok(&["supervisor", "events", "--goal", &gid]);
+    // errors.
+    assert!(cli_err(&["supervisor", "propose", "--goal", &gid]).contains("--agent-id"));
+    assert!(cli_err(&[
+        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup",
+    ])
+    .contains("--decision-id"));
+    assert!(cli_err(&[
+        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d",
+    ])
+    .contains("--target-agent-id"));
+    assert!(cli_err(&["supervisor", "receipt", "--goal", &gid]).contains("--decision-id"));
+    assert!(cli_err(&[
+        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d",
+    ])
+    .contains("--receipt-id"));
+    assert!(cli_err(&[
+        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d", "--receipt-id", "r",
+    ])
+    .contains("--adapter-id"));
+    assert!(cli_err(&["supervisor", "events"]).contains("--goal required"));
+    assert!(cli_err(&["supervisor", "bogus", "--goal", &gid]).contains("propose|receipt|events"));
+}
+
+// ── handoff / task-graph / attention ───────────────────────────────────────
+
+#[test]
+fn handoff_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "handoff goal");
+    cli_ok(&["handoff", "--goal", &gid]);
+    cli_ok(&["handoff", "--goal", &gid, "--write"]);
+    let handoff = open_store(&cr).goal_dir(&gid).join("HANDOFF.md");
+    assert!(handoff.exists(), "handoff written");
+    // With a degraded run in history → delivery contract present.
+    {
+        let store = open_store(&cr);
+        let first = first_todo_id(&cr.root, &gid);
+        store
+            .append_run(&gid, &common::run_record(&first, "error", now_epoch()))
+            .unwrap();
+    }
+    cli_ok(&["handoff", "--goal", &gid]);
+    assert!(cli_err(&["handoff"]).contains("--goal required"));
+    assert!(cli_err(&["handoff", "--goal", "goal_nope"]).contains("not found"));
+}
+
+#[test]
+fn task_graph_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "graph goal");
+    // --blocks must reference real todos (the graph fails closed on unknown
+    // refs), so chain off the onboarding todo.
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "second", "--blocks", &first]);
+    cli_ok(&["task-graph", "--goal", &gid]);
+    // A cycle does NOT fail — it is reported (⚠ cycle) with no topo order.
+    let gid2 = init_goal(&cr, "cycle goal");
+    let x = first_todo_id(&cr.root, &gid2);
+    cli_ok(&["todo", "add", "--goal", &gid2, "--text", "y", "--blocks", &x]);
+    let y = common::todo_id_by_text(&cr.root, &gid2, "y");
+    cli_ok(&["todo", "update", "--goal", &gid2, "--todo-id", &x, "--blocks", &y]);
+    cli_ok(&["task-graph", "--goal", &gid2]);
+    // Unknown refs fail closed.
+    let gid3 = init_goal(&cr, "unknown ref goal");
+    cli_ok(&["todo", "add", "--goal", &gid3, "--text", "dangling", "--blocks", "todo_ghost"]);
+    assert!(cli_err(&["task-graph", "--goal", &gid3]).contains("unknown todo"));
+    assert!(cli_err(&["task-graph"]).contains("--goal required"));
+    assert!(cli_err(&["task-graph", "--goal", "goal_nope"]).contains("not found"));
+}
+
+#[test]
+fn attention_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "attention goal");
+    cli_ok(&["attention", "--goal", &gid]);
+    cli_ok(&["attention", "--all"]);
+    // A goal with an open gate ranks differently in the queue.
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "needs approval", "--class", "user_gate",
+    ]);
+    cli_ok(&["attention", "--goal", &gid]);
+    cli_ok(&["attention", "--all"]);
+    assert!(cli_err(&["attention"]).contains("--all"));
+    // Unknown goal id is skipped (no error).
+    cli_ok(&["attention", "--goal", "goal_nope"]);
+}
+
+// ── inbox ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn inbox_surface() {
+    let cr = cli_root();
+    // Empty project → zero pending.
+    cli_ok(&["inbox", "--project", &cr.cwd]);
+    // Craft inbox events under <project>/.future/loop/inbox/.
+    let inbox = std::path::Path::new(&cr.cwd).join(".future/loop/inbox");
+    std::fs::create_dir_all(&inbox).unwrap();
+    std::fs::write(
+        inbox.join("m1.json"),
+        r#"{"message_id":"m1","create_time":"2026-08-10T00:00:00Z","content":"@operator can you review?","reply_context_verified":false,"reply_to_operator":false}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        inbox.join("m2.json"),
+        r#"{"message_id":"m2","create_time":"2026-08-10T00:01:00Z","content":"reply here","reply_context_verified":true,"reply_to_operator":true}"#,
+    )
+    .unwrap();
+    // A malformed event file is skipped, a non-json file ignored.
+    std::fs::write(inbox.join("bad.json"), "{nope").unwrap();
+    std::fs::write(inbox.join("note.txt"), "hello").unwrap();
+    cli_ok(&["inbox", "--project", &cr.cwd]);
+    cli_ok(&["inbox", "--project", &cr.cwd, "--scope", "all", "--name", "operator"]);
+    cli_ok(&["inbox", "--project", &cr.cwd, "--scope", "mentions"]);
+}
+
+// ── extension ──────────────────────────────────────────────────────────────
+
+fn write_manifest(cr: &common::CliRoot, id: &str, version: &str) -> String {
+    let raw = serde_json::json!({
+        "schema_version": future_loop::extensions::manifest::EXTENSION_MANIFEST_SCHEMA_VERSION,
+        "id": id,
+        "version": version,
+        "requires_future_loop_api": ">=1,<3",
+        "permissions": ["shell"],
+        "runtime": {
+            "protocol": "command_json_v0",
+            "entrypoint": "sh",
+            "args": [],
+            "doctor_args": ["-c", "true"],
+            "required_permissions": ["shell"],
+            "timeout_seconds": 30
+        },
+        "provides": [{"id": format!("{id}_cap"), "kind": "domain_rule", "visibility": "public"}],
+        "implements": [{"capability_id": format!("{id}_cap"), "protocol": "command_json_v0"}]
+    });
+    let path = std::path::Path::new(&cr.cwd).join(format!("manifest-{id}-{version}.json"));
+    std::fs::write(&path, serde_json::to_string_pretty(&raw).unwrap()).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+#[test]
+fn extension_surface() {
+    let cr = cli_root();
+    // status/capabilities with no extensions installed.
+    cli_ok(&["extension", "status"]);
+    cli_ok(&["extension", "capabilities"]);
+    let m1 = write_manifest(&cr, "ext-a", "1.0.0");
+    // dry-run install, then executed install, then lifecycle.
+    cli_ok(&["extension", "install", "--manifest", &m1]);
+    cli_ok(&["extension", "install", "--manifest", &m1, "--execute"]);
+    cli_ok(&["extension", "status"]);
+    cli_ok(&["extension", "status", "--id", "ext-a"]);
+    cli_ok(&["extension", "capabilities"]);
+    let m2 = write_manifest(&cr, "ext-a", "1.1.0");
+    cli_ok(&["extension", "upgrade", "--manifest", &m2, "--execute"]);
+    cli_ok(&["extension", "disable", "--id", "ext-a", "--execute"]);
+    cli_ok(&["extension", "enable", "--id", "ext-a", "--execute"]);
+    cli_ok(&["extension", "rollback", "--id", "ext-a", "--execute"]);
+    // errors.
+    assert!(cli_err(&["extension", "install"]).contains("--manifest required"));
+    assert!(cli_err(&["extension", "install", "--manifest", "/nonexistent.json"]).contains(""));
+    let bad = std::path::Path::new(&cr.cwd).join("bad-manifest.json");
+    std::fs::write(&bad, "{\"schema_version\":\"nope\"}").unwrap();
+    assert!(cli_err(&["extension", "install", "--manifest", bad.to_str().unwrap()]).contains(""));
+    assert!(cli_err(&["extension", "enable"]).contains("--id required"));
+    assert!(cli_err(&["extension", "bogus"]).contains("install|upgrade"));
+}
+
+// ── benchmark ──────────────────────────────────────────────────────────────
+
+#[test]
+fn benchmark_protocol_and_ledger() {
+    let cr = cli_root();
+    cli_ok(&["benchmark", "protocol", "--route", "future-loop-product-mode"]);
+    cli_ok(&["benchmark", "protocol", "--route", "future-loop-product-mode", "--json"]);
+    cli_ok(&["benchmark", "protocol", "--route", "custom-route", "--max-rounds", "3"]);
+    assert!(cli_err(&["benchmark", "protocol"]).contains("--route required"));
+    // Empty ledger (text + json), then seeded via a scripted run below.
+    cli_ok(&["benchmark", "ledger"]);
+    cli_ok(&["benchmark", "ledger", "--json"]);
+    cli_ok(&["benchmark", "ledger", "--benchmark-id", "b1", "--case-id", "c1"]);
+    // errors.
+    assert!(cli_err(&["benchmark"]).contains("protocol|run|ledger"));
+    assert!(cli_err(&["benchmark", "bogus"]).contains("protocol|run|ledger"));
+    let _ = cr;
+}
+
+#[test]
+fn benchmark_run_scripted_dry_run() {
+    let cr = cli_root();
+    let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-ledger");
+    // No --agent-addr → deterministic scripted adapter.
+    cli_ok(&[
+        "benchmark", "run", "--benchmark-id", "b1", "--case-id", "c1", "--task", "do the thing",
+        "--ledger-dir", ledger_dir.to_str().unwrap(), "--expected-evidence", "completed",
+    ]);
+    // Ledger now has an entry → text render with rows.
+    cli_ok(&["benchmark", "ledger", "--dir", ledger_dir.to_str().unwrap()]);
+    // goal-start route picks the other default arm id.
+    cli_ok(&[
+        "benchmark", "run", "--benchmark-id", "b2", "--case-id", "c2", "--task", "t",
+        "--route", "future-loop-goal-start-product-mode", "--ledger-dir",
+        ledger_dir.to_str().unwrap(),
+    ]);
+    cli_ok(&[
+        "benchmark", "run", "--benchmark-id", "b3", "--case-id", "c3", "--task", "t",
+        "--arm-id", "custom_arm", "--max-rounds", "2", "--ledger-dir",
+        ledger_dir.to_str().unwrap(),
+    ]);
+    // errors.
+    assert!(cli_err(&["benchmark", "run"]).contains("--benchmark-id required"));
+    assert!(cli_err(&["benchmark", "run", "--benchmark-id", "b"]).contains("--case-id required"));
+    assert!(
+        cli_err(&["benchmark", "run", "--benchmark-id", "b", "--case-id", "c"])
+            .contains("--task required")
+    );
+}
+
+#[test]
+fn benchmark_run_grpc_adapter() {
+    let cr = cli_root();
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    }));
+    let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-ledger-grpc");
+    cli_ok(&[
+        "benchmark", "run", "--benchmark-id", "bg", "--case-id", "cg", "--task",
+        "write the artifact", "--agent-addr", &addr, "--expected-evidence", "artifact",
+        "--ledger-dir", ledger_dir.to_str().unwrap(),
+    ]);
+}
+
+// ── replay ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn replay_record_and_run() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "replay goal");
+    // Print mode.
+    cli_ok(&["replay", "record", "--goal", &gid]);
+    // --out: create then append. (Keep the agent REGISTERED — a case recorded
+    // for an unregistered agent captures the identity-gate packet, which the
+    // minimal case snapshot cannot replay faithfully; documented limitation.)
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    let case_file = std::path::Path::new(&cr.cwd).join("cases.json");
+    cli_ok(&["replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap()]);
+    cli_ok(&[
+        "replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap(), "--case-id",
+        "case-2", "--agent-id", "w1",
+    ]);
+    // Replay: the recorded cases must match the current kernel.
+    cli_ok(&["replay", "run", "--case", case_file.to_str().unwrap()]);
+    cli_ok(&["replay", "run", "--case", case_file.to_str().unwrap(), "--json"]);
+    // errors.
+    assert!(cli_err(&["replay", "record"]).contains("--goal required"));
+    assert!(cli_err(&["replay", "record", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&["replay", "run"]).contains("--case required"));
+    assert!(cli_err(&["replay", "run", "--case", "/nonexistent.json"]).contains(""));
+    assert!(cli_err(&["replay"]).contains("record|run|corpus"));
+    assert!(cli_err(&["replay", "bogus"]).contains("record|run|corpus"));
+}
+
+#[test]
+fn replay_corpus_surface() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "corpus goal");
+    // A base packet with no patches/ablations produces ZERO cases (error
+    // path); print mode needs at least one patch.
+    assert!(cli_err(&["replay", "corpus", "build", "--goal", &gid])
+        .contains("at least one case"));
+    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{\"quota_spent\": 0}"]);
+    // Full flag set: patches + out file (patches merge INTO the packet, so
+    // the candidate stays equivalent and the gate passes).
+    let corpus = std::path::Path::new(&cr.cwd).join("corpus.json");
+    cli_ok(&[
+        "replay", "corpus", "build", "--goal", &gid, "--out", corpus.to_str().unwrap(),
+        "--patch-name", "p", "--patch", "{\"quota_spent\": 1}",
+        "--patch", "{\"quota_spent\": 2}",
+    ]);
+    // Corpus run: text + json.
+    cli_ok(&["replay", "corpus", "run", "--corpus", corpus.to_str().unwrap()]);
+    cli_ok(&[
+        "replay", "corpus", "run", "--corpus", corpus.to_str().unwrap(), "--repeats", "2",
+        "--seed", "7", "--json",
+    ]);
+    // An ablation case the stub actor does NOT fail closed on → gate bail.
+    let bad_corpus = std::path::Path::new(&cr.cwd).join("corpus-bad.json");
+    cli_ok(&[
+        "replay", "corpus", "build", "--goal", &gid, "--out", bad_corpus.to_str().unwrap(),
+        "--ablate", "quota",
+    ]);
+    assert!(cli_err(&["replay", "corpus", "run", "--corpus", bad_corpus.to_str().unwrap()])
+        .contains("gate"));
+    // repeats bounds.
+    assert!(cli_err(&[
+        "replay", "corpus", "run", "--corpus", corpus.to_str().unwrap(), "--repeats", "1",
+    ])
+    .contains("between 2 and 20"));
+    // errors.
+    assert!(cli_err(&["replay", "corpus", "build"]).contains("--goal required"));
+    assert!(cli_err(&["replay", "corpus", "build", "--goal", "goal_nope"]).contains("not found"));
+    assert!(cli_err(&[
+        "replay", "corpus", "build", "--goal", &gid, "--patch", "{not json",
+    ])
+    .contains("JSON"));
+    assert!(cli_err(&["replay", "corpus", "run"]).contains("--corpus required"));
+    assert!(cli_err(&["replay", "corpus", "run", "--corpus", "/nonexistent.json"]).contains(""));
+    assert!(cli_err(&["replay", "corpus"]).contains("build|run"));
+    assert!(cli_err(&["replay", "corpus", "bogus"]).contains("build|run"));
+}

--- a/orchestration/loop/tests/console_drive_c.rs
+++ b/orchestration/loop/tests/console_drive_c.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use common::mock_agent::{completed_events, spawn_mock, MockState};
-use common::{cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use common::{cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
 use future_loop::state::now_epoch;
 
 fn rt() -> tokio::runtime::Runtime {

--- a/orchestration/loop/tests/console_drive_c.rs
+++ b/orchestration/loop/tests/console_drive_c.rs
@@ -21,10 +21,18 @@ fn rt() -> tokio::runtime::Runtime {
 fn capability_surface() {
     let _cr = cli_root();
     cli_ok(&["capability", "list"]);
-    cli_ok(&["capability", "propose", "--name", "issue_fix", "--input", "crash on startup"]);
+    cli_ok(&[
+        "capability",
+        "propose",
+        "--name",
+        "issue_fix",
+        "--input",
+        "crash on startup",
+    ]);
     cli_ok(&["capability", "propose", "--name", "issue_fix"]);
-    assert!(cli_err(&["capability", "propose", "--name", "no_such_cap"])
-        .contains("unknown capability"));
+    assert!(
+        cli_err(&["capability", "propose", "--name", "no_such_cap"]).contains("unknown capability")
+    );
     assert!(cli_err(&["capability", "propose"]).contains("--name required"));
     assert!(cli_err(&["capability", "bogus"]).contains("list"));
     // commands: full listing, per-name, and an experimental gated name.
@@ -62,9 +70,26 @@ fn scope_and_lane_surface() {
     let gid = init_goal(&cr, "scope goal");
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
     cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1"]);
-    cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1", "--exclude", "todo_x,todo_y"]);
+    cli_ok(&[
+        "scope",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "w1",
+        "--exclude",
+        "todo_x,todo_y",
+    ]);
     // lane: no runs yet → None path. Then seed a run → recommendation paths.
     cli_ok(&["lane", "--goal", &gid, "--agent-id", "w1"]);
     {
@@ -90,12 +115,36 @@ fn supervisor_surface() {
     let cr = cli_root();
     let gid = init_goal(&cr, "supervisor goal");
     cli_ok(&[
-        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d1",
-        "--target-agent-id", "w1", "--kind", "observe", "--summary", "watching",
+        "supervisor",
+        "propose",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "sup",
+        "--decision-id",
+        "d1",
+        "--target-agent-id",
+        "w1",
+        "--kind",
+        "observe",
+        "--summary",
+        "watching",
     ]);
     cli_ok(&[
-        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d2",
-        "--target-agent-id", "w1", "--kind", "execute", "--capabilities", "shell,web",
+        "supervisor",
+        "propose",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "sup",
+        "--decision-id",
+        "d2",
+        "--target-agent-id",
+        "w1",
+        "--kind",
+        "execute",
+        "--capabilities",
+        "shell,web",
     ]);
     for (decision, outcome, caps) in [
         ("d2", "executed", "shell,web"),
@@ -103,41 +152,95 @@ fn supervisor_surface() {
         ("d2", "bogus-outcome", "shell"), // → Rejected via the catch-all arm
     ] {
         cli_ok(&[
-            "supervisor", "receipt", "--goal", &gid, "--decision-id", decision, "--receipt-id",
-            &format!("r-{outcome}"), "--adapter-id", "adapter-1", "--outcome", outcome,
-            "--authority-ref", "auth-1", "--host-capabilities", caps,
+            "supervisor",
+            "receipt",
+            "--goal",
+            &gid,
+            "--decision-id",
+            decision,
+            "--receipt-id",
+            &format!("r-{outcome}"),
+            "--adapter-id",
+            "adapter-1",
+            "--outcome",
+            outcome,
+            "--authority-ref",
+            "auth-1",
+            "--host-capabilities",
+            caps,
         ]);
     }
     // An observe decision rejects host-execution receipts, and an executed
     // receipt must carry the decision's required capabilities.
     assert!(cli_err(&[
-        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d1", "--receipt-id", "r-bad",
-        "--adapter-id", "a", "--outcome", "executed",
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "d1",
+        "--receipt-id",
+        "r-bad",
+        "--adapter-id",
+        "a",
+        "--outcome",
+        "executed",
     ])
     .contains("observe"));
     assert!(cli_err(&[
-        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d2", "--receipt-id", "r-bad2",
-        "--adapter-id", "a", "--outcome", "executed", "--host-capabilities", "shell",
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "d2",
+        "--receipt-id",
+        "r-bad2",
+        "--adapter-id",
+        "a",
+        "--outcome",
+        "executed",
+        "--host-capabilities",
+        "shell",
     ])
     .contains("capabilities"));
     cli_ok(&["supervisor", "events", "--goal", &gid]);
     // errors.
     assert!(cli_err(&["supervisor", "propose", "--goal", &gid]).contains("--agent-id"));
+    assert!(
+        cli_err(&["supervisor", "propose", "--goal", &gid, "--agent-id", "sup",])
+            .contains("--decision-id")
+    );
     assert!(cli_err(&[
-        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup",
-    ])
-    .contains("--decision-id"));
-    assert!(cli_err(&[
-        "supervisor", "propose", "--goal", &gid, "--agent-id", "sup", "--decision-id", "d",
+        "supervisor",
+        "propose",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "sup",
+        "--decision-id",
+        "d",
     ])
     .contains("--target-agent-id"));
     assert!(cli_err(&["supervisor", "receipt", "--goal", &gid]).contains("--decision-id"));
     assert!(cli_err(&[
-        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d",
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "d",
     ])
     .contains("--receipt-id"));
     assert!(cli_err(&[
-        "supervisor", "receipt", "--goal", &gid, "--decision-id", "d", "--receipt-id", "r",
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "d",
+        "--receipt-id",
+        "r",
     ])
     .contains("--adapter-id"));
     assert!(cli_err(&["supervisor", "events"]).contains("--goal required"));
@@ -174,18 +277,40 @@ fn task_graph_surface() {
     // --blocks must reference real todos (the graph fails closed on unknown
     // refs), so chain off the onboarding todo.
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "second", "--blocks", &first]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "second", "--blocks", &first,
+    ]);
     cli_ok(&["task-graph", "--goal", &gid]);
     // A cycle does NOT fail — it is reported (⚠ cycle) with no topo order.
     let gid2 = init_goal(&cr, "cycle goal");
     let x = first_todo_id(&cr.root, &gid2);
-    cli_ok(&["todo", "add", "--goal", &gid2, "--text", "y", "--blocks", &x]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid2, "--text", "y", "--blocks", &x,
+    ]);
     let y = common::todo_id_by_text(&cr.root, &gid2, "y");
-    cli_ok(&["todo", "update", "--goal", &gid2, "--todo-id", &x, "--blocks", &y]);
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid2,
+        "--todo-id",
+        &x,
+        "--blocks",
+        &y,
+    ]);
     cli_ok(&["task-graph", "--goal", &gid2]);
     // Unknown refs fail closed.
     let gid3 = init_goal(&cr, "unknown ref goal");
-    cli_ok(&["todo", "add", "--goal", &gid3, "--text", "dangling", "--blocks", "todo_ghost"]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid3,
+        "--text",
+        "dangling",
+        "--blocks",
+        "todo_ghost",
+    ]);
     assert!(cli_err(&["task-graph", "--goal", &gid3]).contains("unknown todo"));
     assert!(cli_err(&["task-graph"]).contains("--goal required"));
     assert!(cli_err(&["task-graph", "--goal", "goal_nope"]).contains("not found"));
@@ -199,7 +324,14 @@ fn attention_surface() {
     cli_ok(&["attention", "--all"]);
     // A goal with an open gate ranks differently in the queue.
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "needs approval", "--class", "user_gate",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "needs approval",
+        "--class",
+        "user_gate",
     ]);
     cli_ok(&["attention", "--goal", &gid]);
     cli_ok(&["attention", "--all"]);
@@ -232,7 +364,15 @@ fn inbox_surface() {
     std::fs::write(inbox.join("bad.json"), "{nope").unwrap();
     std::fs::write(inbox.join("note.txt"), "hello").unwrap();
     cli_ok(&["inbox", "--project", &cr.cwd]);
-    cli_ok(&["inbox", "--project", &cr.cwd, "--scope", "all", "--name", "operator"]);
+    cli_ok(&[
+        "inbox",
+        "--project",
+        &cr.cwd,
+        "--scope",
+        "all",
+        "--name",
+        "operator",
+    ]);
     cli_ok(&["inbox", "--project", &cr.cwd, "--scope", "mentions"]);
 }
 
@@ -294,14 +434,39 @@ fn extension_surface() {
 #[test]
 fn benchmark_protocol_and_ledger() {
     let cr = cli_root();
-    cli_ok(&["benchmark", "protocol", "--route", "future-loop-product-mode"]);
-    cli_ok(&["benchmark", "protocol", "--route", "future-loop-product-mode", "--json"]);
-    cli_ok(&["benchmark", "protocol", "--route", "custom-route", "--max-rounds", "3"]);
+    cli_ok(&[
+        "benchmark",
+        "protocol",
+        "--route",
+        "future-loop-product-mode",
+    ]);
+    cli_ok(&[
+        "benchmark",
+        "protocol",
+        "--route",
+        "future-loop-product-mode",
+        "--json",
+    ]);
+    cli_ok(&[
+        "benchmark",
+        "protocol",
+        "--route",
+        "custom-route",
+        "--max-rounds",
+        "3",
+    ]);
     assert!(cli_err(&["benchmark", "protocol"]).contains("--route required"));
     // Empty ledger (text + json), then seeded via a scripted run below.
     cli_ok(&["benchmark", "ledger"]);
     cli_ok(&["benchmark", "ledger", "--json"]);
-    cli_ok(&["benchmark", "ledger", "--benchmark-id", "b1", "--case-id", "c1"]);
+    cli_ok(&[
+        "benchmark",
+        "ledger",
+        "--benchmark-id",
+        "b1",
+        "--case-id",
+        "c1",
+    ]);
     // errors.
     assert!(cli_err(&["benchmark"]).contains("protocol|run|ledger"));
     assert!(cli_err(&["benchmark", "bogus"]).contains("protocol|run|ledger"));
@@ -314,20 +479,50 @@ fn benchmark_run_scripted_dry_run() {
     let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-ledger");
     // No --agent-addr → deterministic scripted adapter.
     cli_ok(&[
-        "benchmark", "run", "--benchmark-id", "b1", "--case-id", "c1", "--task", "do the thing",
-        "--ledger-dir", ledger_dir.to_str().unwrap(), "--expected-evidence", "completed",
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "b1",
+        "--case-id",
+        "c1",
+        "--task",
+        "do the thing",
+        "--ledger-dir",
+        ledger_dir.to_str().unwrap(),
+        "--expected-evidence",
+        "completed",
     ]);
     // Ledger now has an entry → text render with rows.
     cli_ok(&["benchmark", "ledger", "--dir", ledger_dir.to_str().unwrap()]);
     // goal-start route picks the other default arm id.
     cli_ok(&[
-        "benchmark", "run", "--benchmark-id", "b2", "--case-id", "c2", "--task", "t",
-        "--route", "future-loop-goal-start-product-mode", "--ledger-dir",
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "b2",
+        "--case-id",
+        "c2",
+        "--task",
+        "t",
+        "--route",
+        "future-loop-goal-start-product-mode",
+        "--ledger-dir",
         ledger_dir.to_str().unwrap(),
     ]);
     cli_ok(&[
-        "benchmark", "run", "--benchmark-id", "b3", "--case-id", "c3", "--task", "t",
-        "--arm-id", "custom_arm", "--max-rounds", "2", "--ledger-dir",
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "b3",
+        "--case-id",
+        "c3",
+        "--task",
+        "t",
+        "--arm-id",
+        "custom_arm",
+        "--max-rounds",
+        "2",
+        "--ledger-dir",
         ledger_dir.to_str().unwrap(),
     ]);
     // errors.
@@ -349,9 +544,20 @@ fn benchmark_run_grpc_adapter() {
     }));
     let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-ledger-grpc");
     cli_ok(&[
-        "benchmark", "run", "--benchmark-id", "bg", "--case-id", "cg", "--task",
-        "write the artifact", "--agent-addr", &addr, "--expected-evidence", "artifact",
-        "--ledger-dir", ledger_dir.to_str().unwrap(),
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "bg",
+        "--case-id",
+        "cg",
+        "--task",
+        "write the artifact",
+        "--agent-addr",
+        &addr,
+        "--expected-evidence",
+        "artifact",
+        "--ledger-dir",
+        ledger_dir.to_str().unwrap(),
     ]);
 }
 
@@ -368,14 +574,35 @@ fn replay_record_and_run() {
     // minimal case snapshot cannot replay faithfully; documented limitation.)
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
     let case_file = std::path::Path::new(&cr.cwd).join("cases.json");
-    cli_ok(&["replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap()]);
     cli_ok(&[
-        "replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap(), "--case-id",
-        "case-2", "--agent-id", "w1",
+        "replay",
+        "record",
+        "--goal",
+        &gid,
+        "--out",
+        case_file.to_str().unwrap(),
+    ]);
+    cli_ok(&[
+        "replay",
+        "record",
+        "--goal",
+        &gid,
+        "--out",
+        case_file.to_str().unwrap(),
+        "--case-id",
+        "case-2",
+        "--agent-id",
+        "w1",
     ]);
     // Replay: the recorded cases must match the current kernel.
     cli_ok(&["replay", "run", "--case", case_file.to_str().unwrap()]);
-    cli_ok(&["replay", "run", "--case", case_file.to_str().unwrap(), "--json"]);
+    cli_ok(&[
+        "replay",
+        "run",
+        "--case",
+        case_file.to_str().unwrap(),
+        "--json",
+    ]);
     // errors.
     assert!(cli_err(&["replay", "record"]).contains("--goal required"));
     assert!(cli_err(&["replay", "record", "--goal", "goal_nope"]).contains("not found"));
@@ -391,41 +618,97 @@ fn replay_corpus_surface() {
     let gid = init_goal(&cr, "corpus goal");
     // A base packet with no patches/ablations produces ZERO cases (error
     // path); print mode needs at least one patch.
-    assert!(cli_err(&["replay", "corpus", "build", "--goal", &gid])
-        .contains("at least one case"));
-    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{\"quota_spent\": 0}"]);
+    assert!(cli_err(&["replay", "corpus", "build", "--goal", &gid]).contains("at least one case"));
+    cli_ok(&[
+        "replay",
+        "corpus",
+        "build",
+        "--goal",
+        &gid,
+        "--patch",
+        "{\"quota_spent\": 0}",
+    ]);
     // Full flag set: patches + out file (patches merge INTO the packet, so
     // the candidate stays equivalent and the gate passes).
     let corpus = std::path::Path::new(&cr.cwd).join("corpus.json");
     cli_ok(&[
-        "replay", "corpus", "build", "--goal", &gid, "--out", corpus.to_str().unwrap(),
-        "--patch-name", "p", "--patch", "{\"quota_spent\": 1}",
-        "--patch", "{\"quota_spent\": 2}",
+        "replay",
+        "corpus",
+        "build",
+        "--goal",
+        &gid,
+        "--out",
+        corpus.to_str().unwrap(),
+        "--patch-name",
+        "p",
+        "--patch",
+        "{\"quota_spent\": 1}",
+        "--patch",
+        "{\"quota_spent\": 2}",
     ]);
     // Corpus run: text + json.
-    cli_ok(&["replay", "corpus", "run", "--corpus", corpus.to_str().unwrap()]);
     cli_ok(&[
-        "replay", "corpus", "run", "--corpus", corpus.to_str().unwrap(), "--repeats", "2",
-        "--seed", "7", "--json",
+        "replay",
+        "corpus",
+        "run",
+        "--corpus",
+        corpus.to_str().unwrap(),
+    ]);
+    cli_ok(&[
+        "replay",
+        "corpus",
+        "run",
+        "--corpus",
+        corpus.to_str().unwrap(),
+        "--repeats",
+        "2",
+        "--seed",
+        "7",
+        "--json",
     ]);
     // An ablation case the stub actor does NOT fail closed on → gate bail.
     let bad_corpus = std::path::Path::new(&cr.cwd).join("corpus-bad.json");
     cli_ok(&[
-        "replay", "corpus", "build", "--goal", &gid, "--out", bad_corpus.to_str().unwrap(),
-        "--ablate", "quota",
+        "replay",
+        "corpus",
+        "build",
+        "--goal",
+        &gid,
+        "--out",
+        bad_corpus.to_str().unwrap(),
+        "--ablate",
+        "quota",
     ]);
-    assert!(cli_err(&["replay", "corpus", "run", "--corpus", bad_corpus.to_str().unwrap()])
-        .contains("gate"));
+    assert!(cli_err(&[
+        "replay",
+        "corpus",
+        "run",
+        "--corpus",
+        bad_corpus.to_str().unwrap()
+    ])
+    .contains("gate"));
     // repeats bounds.
     assert!(cli_err(&[
-        "replay", "corpus", "run", "--corpus", corpus.to_str().unwrap(), "--repeats", "1",
+        "replay",
+        "corpus",
+        "run",
+        "--corpus",
+        corpus.to_str().unwrap(),
+        "--repeats",
+        "1",
     ])
     .contains("between 2 and 20"));
     // errors.
     assert!(cli_err(&["replay", "corpus", "build"]).contains("--goal required"));
     assert!(cli_err(&["replay", "corpus", "build", "--goal", "goal_nope"]).contains("not found"));
     assert!(cli_err(&[
-        "replay", "corpus", "build", "--goal", &gid, "--patch", "{not json",
+        "replay",
+        "corpus",
+        "build",
+        "--goal",
+        &gid,
+        "--patch",
+        "{not json",
     ])
     .contains("JSON"));
     assert!(cli_err(&["replay", "corpus", "run"]).contains("--corpus required"));

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -1,0 +1,285 @@
+//! Coverage drive — subprocess-only paths: the stdio worker bridge (piped
+//! stdin), the blocking HTTP status server, and the `todo update --help`
+//! early process exit. These cannot run in-process (stdin ownership,
+//! blocking accept loop, exit(0)), so they spawn the real binary — which is
+//! instrumented, so the coverage still lands.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_future-loop")
+}
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-sub-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn run(root: &str, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(args)
+        .output()
+        .expect("binary runs");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// Spawn with piped stdin; write `input`, close, collect.
+fn run_stdin(root: &str, args: &[&str], input: &str) -> (String, String, i32) {
+    let mut child = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("binary spawns");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn init_goal(root: &str, objective: &str) -> String {
+    let gid = format!("goal_{}", &uuid::Uuid::new_v4().simple().to_string()[..12]);
+    let cwd = format!("{root}/cwd");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let (_, _, code) = run(
+        root,
+        &["goal", "init", "--objective", objective, "--goal-id", &gid, "--cwd", &cwd],
+    );
+    assert_eq!(code, 0);
+    gid
+}
+
+// ── worker-bridge ──────────────────────────────────────────────────────────
+
+#[test]
+fn worker_bridge_worker_finishes_on_eof_and_done() {
+    let root = tmp_root("bridge-eof");
+    let gid = init_goal(&root, "bridge eof");
+    // EOF on stdin → "worker finished".
+    let (out, _, code) = run_stdin(&root, &["worker-bridge", "--goal", &gid], "");
+    assert_eq!(code, 0, "{out}");
+    assert!(out.contains("BRIDGE packet:"), "{out}");
+    assert!(out.contains("worker finished"), "{out}");
+    // Explicit "BRIDGE done" line takes the same close path.
+    let (out, _, code) = run_stdin(&root, &["worker-bridge", "--goal", &gid], "BRIDGE done\n");
+    assert_eq!(code, 0, "{out}");
+    assert!(out.contains("worker finished"), "{out}");
+}
+
+#[test]
+fn worker_bridge_invalid_result_line() {
+    let root = tmp_root("bridge-bad");
+    let gid = init_goal(&root, "bridge invalid");
+    let (_, err, code) = run_stdin(&root, &["worker-bridge", "--goal", &gid], "not json\n");
+    assert_ne!(code, 0);
+    assert!(err.contains("invalid worker result"), "{err}");
+}
+
+#[test]
+fn worker_bridge_completed_turn_to_terminal() {
+    let root = tmp_root("bridge-done");
+    let gid = init_goal(&root, "bridge completes");
+    // One completed result for the onboarding todo → next decide is terminal.
+    let onboarding_text = "future loop status";
+    let result = format!(
+        "{{\"todo_id\":\"TODO\",\"terminal_state\":\"completed\",\"evidence\":\"validated\",\"tools\":[\"shell\"]}}\n"
+    );
+    // The bridge selects the todo; we must answer with ITS id. Read the first
+    // packet line to learn the id? Simpler: complete every todo via two
+    // turns — but we only have one todo. Use a two-phase exchange.
+    let mut child = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", &root)
+        .args(["worker-bridge", "--goal", &gid])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    // Read the packet line, extract todo_id, answer.
+    use std::io::{BufRead, BufReader};
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    assert!(line.contains("BRIDGE packet:"), "{line}");
+    let json_start = line.find('{').unwrap();
+    let packet: serde_json::Value = serde_json::from_str(&line[json_start..]).unwrap();
+    let todo_id = packet["todo_id"].as_str().unwrap().to_string();
+    assert!(packet["todo_text"].as_str().unwrap().contains(onboarding_text));
+    let answer = result.replace("TODO", &todo_id);
+    child.stdin.as_mut().unwrap().write_all(answer.as_bytes()).unwrap();
+    // writeback line, then the next decide reports terminal.
+    let mut line2 = String::new();
+    reader.read_line(&mut line2).unwrap();
+    assert!(line2.contains("BRIDGE writeback"), "{line2}");
+    let mut line3 = String::new();
+    reader.read_line(&mut line3).unwrap();
+    assert!(line3.contains("BRIDGE terminal"), "{line3}");
+    let status = child.wait().unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn worker_bridge_failed_turns_hit_max_turns() {
+    let root = tmp_root("bridge-max");
+    let gid = init_goal(&root, "bridge max turns");
+    let result = "{\"todo_id\":\"x\",\"terminal_state\":\"failed\",\"error\":\"boom\"}\n";
+    let input = result.repeat(8);
+    let (_, err, code) = run_stdin(
+        &root,
+        &["worker-bridge", "--goal", &gid, "--max-turns", "2"],
+        &input,
+    );
+    assert_ne!(code, 0);
+    assert!(err.contains("max-turns"), "{err}");
+}
+
+#[test]
+fn worker_bridge_stops_when_should_run_false() {
+    let root = tmp_root("bridge-stop");
+    let gid = init_goal(&root, "bridge stopped goal");
+    // Complete the onboarding todo, then leave only a not-due monitor →
+    // WaitMonitor (should_run=false, non-terminal) → BRIDGE stop.
+    let store = future_loop::store::Store::open(&root).unwrap();
+    let g = store.replay(&gid).unwrap().unwrap();
+    let onboarding = g.todos.first().unwrap().id.clone();
+    drop(g);
+    drop(store);
+    let (_, _, code) = run(
+        &root,
+        &["todo", "complete", "--goal", &gid, "--todo-id", &onboarding, "--no-follow-up"],
+    );
+    assert_eq!(code, 0);
+    let mut store = future_loop::store::Store::open(&root).unwrap();
+    store
+        .append(future_loop::store::Event::TodoAdded {
+            goal_id: gid.clone(),
+            todo: future_loop::state::Todo::monitor(
+                "mon_wait",
+                "watch it",
+                std::time::Duration::from_secs(3600),
+            ),
+            ts: future_loop::state::now_epoch(),
+        })
+        .unwrap();
+    // Keep the projection honest (next action = the monitor's text).
+    store.set_next_action(&gid, "watch it").unwrap();
+    drop(store);
+    let (out, _, code) = run_stdin(&root, &["worker-bridge", "--goal", &gid], "");
+    assert_eq!(code, 0, "{out}");
+    assert!(out.contains("BRIDGE stop"), "{out}");
+}
+
+#[test]
+fn worker_bridge_errors() {
+    let root = tmp_root("bridge-err");
+    let (_, err, code) = run(&root, &["worker-bridge"]);
+    assert_ne!(code, 0);
+    assert!(err.contains("--goal required"), "{err}");
+    let (_, err, code) = run(&root, &["worker-bridge", "--goal", "goal_nope"]);
+    assert_ne!(code, 0);
+    assert!(err.contains("not found"), "{err}");
+}
+
+// ── serve-status ───────────────────────────────────────────────────────────
+
+/// Find a free TCP port (best-effort; released before the server binds).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn http_get(port: u16, path: &str) -> String {
+    use std::io::Read;
+    let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .write_all(format!("GET {path} HTTP/1.1\r\nHost: x\r\n\r\n").as_bytes())
+        .unwrap();
+    let mut buf = String::new();
+    stream.read_to_string(&mut buf).unwrap();
+    buf
+}
+
+fn spawn_server(root: &str, port: u16) -> std::process::Child {
+    let mut child = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(["serve-status", "--port", &port.to_string()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    // Wait for the listen line.
+    use std::io::{BufRead, BufReader};
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    assert!(line.contains("listening"), "{line}");
+    child
+}
+
+#[test]
+fn serve_status_dashboard_and_json() {
+    let root = tmp_root("serve");
+    let gid = init_goal(&root, "serve goal");
+    let port = free_port();
+    let mut child = spawn_server(&root, port);
+    let dash = http_get(port, "/");
+    assert!(dash.contains("status"), "{dash}");
+    assert!(dash.contains(&gid), "{dash}");
+    let json = http_get(port, "/goals.json");
+    assert!(json.contains(&gid), "{json}");
+    // Unknown path → dashboard; garbage request line → dashboard default.
+    let other = http_get(port, "/nope");
+    assert!(other.contains("status"), "{other}");
+    {
+        use std::io::Read;
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream.write_all(b"GARBAGE\r\n\r\n").unwrap();
+        let mut buf = String::new();
+        stream.read_to_string(&mut buf).unwrap();
+        assert!(buf.contains("200 OK"), "{buf}");
+    }
+    child.kill().unwrap();
+
+    // Empty registry → "no goals" dashboard.
+    let root2 = tmp_root("serve-empty");
+    let port2 = free_port();
+    let mut child2 = spawn_server(&root2, port2);
+    let dash = http_get(port2, "/");
+    assert!(dash.contains("no goals"), "{dash}");
+    child2.kill().unwrap();
+}
+
+// ── todo update --help (process exit) ──────────────────────────────────────
+
+#[test]
+fn todo_update_help_exits_zero() {
+    let root = tmp_root("help-exit");
+    let (_, _, code) = run(&root, &["todo", "update", "--help"]);
+    assert_eq!(code, 0);
+}

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -66,7 +66,16 @@ fn init_goal(root: &str, objective: &str) -> String {
     std::fs::create_dir_all(&cwd).unwrap();
     let (_, _, code) = run(
         root,
-        &["goal", "init", "--objective", objective, "--goal-id", &gid, "--cwd", &cwd],
+        &[
+            "goal",
+            "init",
+            "--objective",
+            objective,
+            "--goal-id",
+            &gid,
+            "--cwd",
+            &cwd,
+        ],
     );
     assert_eq!(code, 0);
     gid
@@ -127,9 +136,17 @@ fn worker_bridge_completed_turn_to_terminal() {
     let json_start = line.find('{').unwrap();
     let packet: serde_json::Value = serde_json::from_str(&line[json_start..]).unwrap();
     let todo_id = packet["todo_id"].as_str().unwrap().to_string();
-    assert!(packet["todo_text"].as_str().unwrap().contains(onboarding_text));
+    assert!(packet["todo_text"]
+        .as_str()
+        .unwrap()
+        .contains(onboarding_text));
     let answer = result.replace("TODO", &todo_id);
-    child.stdin.as_mut().unwrap().write_all(answer.as_bytes()).unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(answer.as_bytes())
+        .unwrap();
     // writeback line, then the next decide reports terminal.
     let mut line2 = String::new();
     reader.read_line(&mut line2).unwrap();
@@ -161,7 +178,10 @@ fn worker_bridge_successor_chain_on_non_final_todo() {
     let root = tmp_root("bridge-succ");
     let gid = init_goal(&root, "bridge successors");
     // A second open todo → completing the selected one names it as successor.
-    let (_, _, code) = run(&root, &["todo", "add", "--goal", &gid, "--text", "second task"]);
+    let (_, _, code) = run(
+        &root,
+        &["todo", "add", "--goal", &gid, "--text", "second task"],
+    );
     assert_eq!(code, 0);
     let mut child = Command::new(bin())
         .env("FUTURE_LOOP_ROOT", &root)
@@ -181,7 +201,12 @@ fn worker_bridge_successor_chain_on_non_final_todo() {
     let answer = format!(
         "{{\"todo_id\":\"{todo_id}\",\"terminal_state\":\"completed\",\"evidence\":\"done\",\"tools\":[\"shell\"]}}\n"
     );
-    child.stdin.as_mut().unwrap().write_all(answer.as_bytes()).unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(answer.as_bytes())
+        .unwrap();
     // writeback print, then EOF (stdin closed) → worker finished close.
     drop(child.stdin.take());
     let mut rest = String::new();
@@ -209,7 +234,15 @@ fn worker_bridge_stops_when_should_run_false() {
     drop(store);
     let (_, _, code) = run(
         &root,
-        &["todo", "complete", "--goal", &gid, "--todo-id", &onboarding, "--no-follow-up"],
+        &[
+            "todo",
+            "complete",
+            "--goal",
+            &gid,
+            "--todo-id",
+            &onboarding,
+            "--no-follow-up",
+        ],
     );
     assert_eq!(code, 0);
     let mut store = future_loop::store::Store::open(&root).unwrap();

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -113,9 +113,8 @@ fn worker_bridge_completed_turn_to_terminal() {
     let gid = init_goal(&root, "bridge completes");
     // One completed result for the onboarding todo → next decide is terminal.
     let onboarding_text = "future loop status";
-    let result = format!(
-        "{{\"todo_id\":\"TODO\",\"terminal_state\":\"completed\",\"evidence\":\"validated\",\"tools\":[\"shell\"]}}\n"
-    );
+    let result =
+        "{\"todo_id\":\"TODO\",\"terminal_state\":\"completed\",\"evidence\":\"validated\",\"tools\":[\"shell\"]}\n".to_string();
     // The bridge selects the todo; we must answer with ITS id. Read the first
     // packet line to learn the id? Simpler: complete every todo via two
     // turns — but we only have one todo. Use a two-phase exchange.
@@ -338,6 +337,7 @@ fn serve_status_dashboard_and_json() {
         assert!(buf.contains("200 OK"), "{buf}");
     }
     child.kill().unwrap();
+    child.wait().unwrap();
 
     // Empty registry → "no goals" dashboard.
     let root2 = tmp_root("serve-empty");
@@ -346,6 +346,7 @@ fn serve_status_dashboard_and_json() {
     let dash = http_get(port2, "/");
     assert!(dash.contains("no goals"), "{dash}");
     child2.kill().unwrap();
+    child2.wait().unwrap();
 }
 
 // ── todo update --help (process exit) ──────────────────────────────────────

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -157,6 +157,46 @@ fn worker_bridge_failed_turns_hit_max_turns() {
 }
 
 #[test]
+fn worker_bridge_successor_chain_on_non_final_todo() {
+    let root = tmp_root("bridge-succ");
+    let gid = init_goal(&root, "bridge successors");
+    // A second open todo → completing the selected one names it as successor.
+    let (_, _, code) = run(&root, &["todo", "add", "--goal", &gid, "--text", "second task"]);
+    assert_eq!(code, 0);
+    let mut child = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", &root)
+        .args(["worker-bridge", "--goal", &gid, "--max-turns", "2"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    use std::io::{BufRead, BufReader, Read};
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let json_start = line.find('{').unwrap();
+    let packet: serde_json::Value = serde_json::from_str(&line[json_start..]).unwrap();
+    let todo_id = packet["todo_id"].as_str().unwrap().to_string();
+    let answer = format!(
+        "{{\"todo_id\":\"{todo_id}\",\"terminal_state\":\"completed\",\"evidence\":\"done\",\"tools\":[\"shell\"]}}\n"
+    );
+    child.stdin.as_mut().unwrap().write_all(answer.as_bytes()).unwrap();
+    // writeback print, then EOF (stdin closed) → worker finished close.
+    drop(child.stdin.take());
+    let mut rest = String::new();
+    Read::read_to_string(&mut reader, &mut rest).unwrap();
+    assert!(rest.contains("BRIDGE writeback"), "{rest}");
+    let status = child.wait().unwrap();
+    assert!(status.success());
+    // The completed todo carries the remaining one as its successor.
+    let store = future_loop::store::Store::open(&root).unwrap();
+    let g = store.replay(&gid).unwrap().unwrap();
+    let done = g.todos.iter().find(|t| t.id == todo_id).unwrap();
+    assert_eq!(done.successor_ids.len(), 1, "{done:?}");
+}
+
+#[test]
 fn worker_bridge_stops_when_should_run_false() {
     let root = tmp_root("bridge-stop");
     let gid = init_goal(&root, "bridge stopped goal");

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use common::mock_agent::{completed_events, spawn_mock, MockState};
-use common::{cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use common::{cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
 use future_loop::state::{now_epoch, Todo, TodoStatus};
 
 fn rt() -> tokio::runtime::Runtime {
@@ -370,8 +370,10 @@ fn steer_poll_once_arms() {
         let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess")
             .await;
         // steer failure → client reset (next matching event reconnects).
-        let mut st = MockState::default();
-        st.fail_commands.insert("steer".to_string());
+        let st = MockState {
+            fail_commands: ["steer".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
         let (addr2, _shared2) = spawn_mock(st).await;
         std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr2);
         let mut client2 = None;

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -44,7 +44,16 @@ fn unknown_flags_are_swallowed_everywhere() {
         vec!["store", "verify", "--goal", &gid, "--zz", "1"],
         vec!["store", "bridge", "--goal", &gid, "--zz", "1"],
         vec!["privacy", "--goal", &gid, "--zz", "1"],
-        vec!["lease", "status", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
+        vec![
+            "lease",
+            "status",
+            "--goal",
+            &gid,
+            "--todo-id",
+            &first,
+            "--zz",
+            "1",
+        ],
         vec!["runs", "history", "--goal", &gid, "--zz", "1"],
         vec!["runs", "index", "--goal", &gid, "--zz", "1"],
         vec!["runs", "retention", "--goal", &gid, "--zz", "1"],
@@ -69,7 +78,15 @@ fn unknown_flags_are_swallowed_everywhere() {
         vec!["doctor", "--goal", &gid, "--zz", "1"],
         vec!["history", "--goal", &gid, "--zz", "1"],
         vec!["turn", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
-        vec!["todo-event", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
+        vec![
+            "todo-event",
+            "--goal",
+            &gid,
+            "--todo-id",
+            &first,
+            "--zz",
+            "1",
+        ],
         vec!["evidence-log", "--goal", &gid, "--zz", "1"],
         vec!["benchmark", "protocol", "--route", "r", "--zz", "1"],
         vec!["benchmark", "ledger", "--zz", "1"],
@@ -82,34 +99,186 @@ fn unknown_flags_are_swallowed_everywhere() {
         cli_ok(&args);
     }
     // Mutating commands with an unknown flag.
-    cli_ok(&["goal", "init", "--objective", "g2", "--goal-id", "goal_zz", "--cwd", &cr.cwd, "--zz", "1"]);
-    cli_ok(&["goal", "cancel", "--goal", "goal_zz", "--zz", "1"]);
-    cli_ok(&["goal", "delete", "--goal", "goal_zz", "--force", "--zz", "1"]);
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "zz flag", "--zz", "1"]);
-    let zz = common::todo_id_by_text(&cr.root, &gid, "zz flag");
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &zz, "--agent-id", "w1", "--zz", "1"]);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &zz, "--no-follow-up", "--zz", "1"]);
-    cli_ok(&["todo", "archive", "--goal", &gid, "--todo-id", &zz, "--zz", "1"]);
-    let sup = common::add_todo(&cr, &gid, "zz supersede");
-    cli_ok(&["todo", "supersede", "--goal", &gid, "--todo-id", &sup, "--zz", "1"]);
-    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &first, "--decision", "d", "--zz", "1"]);
-    cli_ok(&["backup", "--goal", &gid, "--zz", "1"]);
-    cli_ok(&["authority", "--goal", &gid, "--write-scope", "src", "--zz", "1"]);
-    cli_ok(&["profile", "set", "--goal", &gid, "--outcome-floor", "2", "--zz", "1"]);
-    cli_ok(&["replan", "ack", "--goal", &gid, "--delta-kind", "vision_patch", "--zz", "1"]);
-    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w9", "--zz", "1"]);
-    cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &first, "--zz", "1"]);
-    cli_ok(&["supervisor", "propose", "--goal", &gid, "--agent-id", "s", "--decision-id", "dz", "--target-agent-id", "w1", "--kind", "execute", "--capabilities", "shell", "--zz", "1"]);
     cli_ok(&[
-        "supervisor", "receipt", "--goal", &gid, "--decision-id", "dz", "--receipt-id", "rz",
-        "--adapter-id", "a", "--outcome", "executed", "--host-capabilities", "shell",
-        "--authority-ref", "auth-1", "--zz", "1",
+        "goal",
+        "init",
+        "--objective",
+        "g2",
+        "--goal-id",
+        "goal_zz",
+        "--cwd",
+        &cr.cwd,
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&["goal", "cancel", "--goal", "goal_zz", "--zz", "1"]);
+    cli_ok(&[
+        "goal", "delete", "--goal", "goal_zz", "--force", "--zz", "1",
+    ]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "zz flag", "--zz", "1",
+    ]);
+    let zz = common::todo_id_by_text(&cr.root, &gid, "zz flag");
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &zz,
+        "--agent-id",
+        "w1",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &zz,
+        "--no-follow-up",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "todo",
+        "archive",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &zz,
+        "--zz",
+        "1",
+    ]);
+    let sup = common::add_todo(&cr, &gid, "zz supersede");
+    cli_ok(&[
+        "todo",
+        "supersede",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &sup,
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--decision",
+        "d",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&["backup", "--goal", &gid, "--zz", "1"]);
+    cli_ok(&[
+        "authority",
+        "--goal",
+        &gid,
+        "--write-scope",
+        "src",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "profile",
+        "set",
+        "--goal",
+        &gid,
+        "--outcome-floor",
+        "2",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "replan",
+        "ack",
+        "--goal",
+        &gid,
+        "--delta-kind",
+        "vision_patch",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "w9",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "lease",
+        "expire",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "supervisor",
+        "propose",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "s",
+        "--decision-id",
+        "dz",
+        "--target-agent-id",
+        "w1",
+        "--kind",
+        "execute",
+        "--capabilities",
+        "shell",
+        "--zz",
+        "1",
+    ]);
+    cli_ok(&[
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "dz",
+        "--receipt-id",
+        "rz",
+        "--adapter-id",
+        "a",
+        "--outcome",
+        "executed",
+        "--host-capabilities",
+        "shell",
+        "--authority-ref",
+        "auth-1",
+        "--zz",
+        "1",
     ]);
     let md = std::path::Path::new(&cr.cwd).join("bf.md");
     std::fs::write(&md, "## Agent Todo\n\n- [ ] Task one\n").unwrap();
-    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run", "--zz", "1"]);
+    cli_ok(&[
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        md.to_str().unwrap(),
+        "--dry-run",
+        "--zz",
+        "1",
+    ]);
     cli_ok(&["replay", "record", "--goal", &gid, "--zz", "1"]);
-    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--zz", "1"]);
+    cli_ok(&[
+        "replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--zz", "1",
+    ]);
 }
 
 // ── steer poll seam ────────────────────────────────────────────────────────
@@ -136,7 +305,14 @@ fn steer_poll_once_arms() {
         assert_eq!(off, 0);
         // Fresh append beyond the current length → poll processes new lines.
         let meta_len = std::fs::metadata(&events_path).unwrap().len();
-        let off = future_loop::console::steer_poll_once(&events_path, meta_len, "t1", &mut client, "sess").await;
+        let off = future_loop::console::steer_poll_once(
+            &events_path,
+            meta_len,
+            "t1",
+            &mut client,
+            "sess",
+        )
+        .await;
         assert_eq!(off, meta_len, "no new content");
         // Append a mix: bad json, wrong kind, wrong todo, no text, and a hit.
         let mut store = open_store(&cr);
@@ -171,21 +347,37 @@ fn steer_poll_once_arms() {
             .unwrap();
         let before = std::fs::metadata(&events_path).unwrap().len();
         assert!(before > off);
-        let off2 = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess").await;
+        let off2 =
+            future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess")
+                .await;
         assert_eq!(off2, before);
         // The todo_updated hit connected to the mock and steered.
-        assert!(shared.lock().unwrap().recorded.contains(&"steer".to_string()));
+        assert!(shared
+            .lock()
+            .unwrap()
+            .recorded
+            .contains(&"steer".to_string()));
         // A poll against a DIFFERENT todo id: no new steer call.
         let n = shared.lock().unwrap().recorded.len();
-        let _ = future_loop::console::steer_poll_once(&events_path, off, "other-todo", &mut client, "sess").await;
-        let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess").await;
+        let _ = future_loop::console::steer_poll_once(
+            &events_path,
+            off,
+            "other-todo",
+            &mut client,
+            "sess",
+        )
+        .await;
+        let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess")
+            .await;
         // steer failure → client reset (next matching event reconnects).
         let mut st = MockState::default();
         st.fail_commands.insert("steer".to_string());
         let (addr2, _shared2) = spawn_mock(st).await;
         std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr2);
         let mut client2 = None;
-        let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client2, "sess2").await;
+        let _ =
+            future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client2, "sess2")
+                .await;
         assert!(client2.is_none(), "failed steer resets the client");
         let _ = n;
     });
@@ -206,7 +398,11 @@ fn run_monitor_claim_race_stops_without_selection() {
     // the replayed struct).
     {
         let mut store = open_store(&cr);
-        let mon = Todo::monitor("mon_raced", "raced monitor", std::time::Duration::from_secs(0));
+        let mon = Todo::monitor(
+            "mon_raced",
+            "raced monitor",
+            std::time::Duration::from_secs(0),
+        );
         store
             .append(future_loop::store::Event::TodoAdded {
                 goal_id: goal.clone(),
@@ -227,8 +423,20 @@ fn run_monitor_claim_race_stops_without_selection() {
     }
     // Turn 1 completes the onboarding todo; turn 2 selects the due monitor,
     // loses the atomic claim 3×, and stops without executing it.
-    cli_ok(&["run", "--goal", &goal, "--agent-id", "racer", "--max-turns", "5"]);
-    assert_eq!(shared.lock().unwrap().prompts, 1, "only the onboarding turn ran");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "racer",
+        "--max-turns",
+        "5",
+    ]);
+    assert_eq!(
+        shared.lock().unwrap().prompts,
+        1,
+        "only the onboarding turn ran"
+    );
     let store = open_store(&cr);
     let g = store.replay(&goal).unwrap().unwrap();
     let m = g.todos.iter().find(|t| t.id == "mon_raced").unwrap();
@@ -246,7 +454,14 @@ fn run_with_time_budget_success_path() {
     });
     let goal = init_goal(&cr, "budget success");
     cli_ok(&[
-        "run", "--goal", &goal, "--anonymous", "--max-turn-secs", "600", "--max-turns", "3",
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "600",
+        "--max-turns",
+        "3",
     ]);
 }
 
@@ -272,7 +487,15 @@ fn status_closure_and_gap_arms() {
     // All todos done with closure intent → closure_proof "valid".
     let gid = init_goal(&cr, "closure valid");
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+    ]);
     cli_ok(&["status", "--goal", &gid]);
     // Projection gap → the ⚠ line.
     {
@@ -285,7 +508,9 @@ fn status_closure_and_gap_arms() {
     {
         // A registry entry pointing at a deleted goal dir: replay fails → skipped.
         let mut store = open_store(&cr);
-        store.register(&future_loop::state::Goal::new("goal_ghost", "x", "/tmp")).unwrap();
+        store
+            .register(&future_loop::state::Goal::new("goal_ghost", "x", "/tmp"))
+            .unwrap();
         cr2_dir = store.goal_dir("goal_ghost");
         let _ = cr2_dir;
     }
@@ -328,8 +553,16 @@ fn capability_hook_kind_arms() {
     // NoFollowUp via empty input; Gate via read-only authority (prints the
     // gate question line).
     cli_ok(&["issue-fix"]);
-    cli_ok(&["issue-fix", "--input", "title: bug\nerror: crash\nrepro: steps\nauthority: read-only"]);
-    cli_ok(&["issue-fix", "--input", "title: crash\nerror: panicked\nrepro: run it\nexpected: works fine\nscope: cli"]);
+    cli_ok(&[
+        "issue-fix",
+        "--input",
+        "title: bug\nerror: crash\nrepro: steps\nauthority: read-only",
+    ]);
+    cli_ok(&[
+        "issue-fix",
+        "--input",
+        "title: crash\nerror: panicked\nrepro: run it\nexpected: works fine\nscope: cli",
+    ]);
 }
 
 // ── runs index duplicate-group print arms ──────────────────────────────────
@@ -388,7 +621,11 @@ fn serve_status_command_arm() {
     std::thread::spawn(move || {
         let _ = future_loop::console::run(
             "future-loop",
-            vec!["serve-status".to_string(), "--port".to_string(), port.to_string()],
+            vec![
+                "serve-status".to_string(),
+                "--port".to_string(),
+                port.to_string(),
+            ],
         );
     });
     // Wait for the server, then hit it.

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -1,0 +1,406 @@
+//! Coverage sweep for console.rs remainder: unknown-flag parse arms across
+//! every command, the steer poll seam, the monitor claim-race re-decide
+//! loop, wall-clock-budget success arm, session-cleanup warning, and assorted
+//! print arms unreachable through the happy paths.
+
+mod common;
+
+use common::mock_agent::{completed_events, spawn_mock, MockState};
+use common::{cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record};
+use future_loop::state::{now_epoch, Todo, TodoStatus};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::SharedState) {
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(state));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    (rt, shared)
+}
+
+// ── unknown-flag parse arms (`_ => {}` in each parse_pairs closure) ────────
+
+#[test]
+fn unknown_flags_are_swallowed_everywhere() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "flag sweep");
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    // (args that must succeed with an extra --zz 1 flag attached)
+    let cases: Vec<Vec<&str>> = vec![
+        vec!["status", "--goal", &gid, "--zz", "1"],
+        vec!["status", "--format", "json", "--zz", "1"],
+        vec!["quota", "should-run", "--goal", &gid, "--zz", "1"],
+        vec!["quota", "usage", "--goal", &gid, "--zz", "1"],
+        vec!["quota", "usage", "--all", "--zz", "1"],
+        vec!["quota", "spend", "--goal", &gid, "--zz", "1"],
+        vec!["scheduler", "tick", "--goal", &gid, "--zz", "1"],
+        vec!["scheduler", "show", "--goal", &gid, "--zz", "1"],
+        vec!["store", "verify", "--goal", &gid, "--zz", "1"],
+        vec!["store", "bridge", "--goal", &gid, "--zz", "1"],
+        vec!["privacy", "--goal", &gid, "--zz", "1"],
+        vec!["lease", "status", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
+        vec!["runs", "history", "--goal", &gid, "--zz", "1"],
+        vec!["runs", "index", "--goal", &gid, "--zz", "1"],
+        vec!["runs", "retention", "--goal", &gid, "--zz", "1"],
+        vec!["runs", "stale", "--goal", &gid, "--zz", "1"],
+        vec!["heartbeat-prompt", "--goal", &gid, "--zz", "1"],
+        vec!["capability", "list", "--zz", "1"],
+        vec!["capability", "commands", "--zz", "1"],
+        vec!["capability", "propose", "--name", "issue_fix", "--zz", "1"],
+        vec!["catalog", "--zz", "1"],
+        vec!["catalog", "--name", "issue_fix", "--zz", "1"],
+        vec!["scope", "--goal", &gid, "--agent-id", "w1", "--zz", "1"],
+        vec!["lane", "--goal", &gid, "--agent-id", "w1", "--zz", "1"],
+        vec!["supervisor", "events", "--goal", &gid, "--zz", "1"],
+        vec!["handoff", "--goal", &gid, "--zz", "1"],
+        vec!["task-graph", "--goal", &gid, "--zz", "1"],
+        vec!["attention", "--goal", &gid, "--zz", "1"],
+        vec!["inbox", "--project", &cr.cwd, "--zz", "1"],
+        vec!["registry", "--zz", "1"],
+        vec!["version", "--zz", "1"],
+        vec!["canary", "smoke", "--zz", "1"],
+        vec!["diagnose", "--goal", &gid, "--zz", "1"],
+        vec!["doctor", "--goal", &gid, "--zz", "1"],
+        vec!["history", "--goal", &gid, "--zz", "1"],
+        vec!["turn", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
+        vec!["todo-event", "--goal", &gid, "--todo-id", &first, "--zz", "1"],
+        vec!["evidence-log", "--goal", &gid, "--zz", "1"],
+        vec!["benchmark", "protocol", "--route", "r", "--zz", "1"],
+        vec!["benchmark", "ledger", "--zz", "1"],
+        vec!["agent", "list", "--goal", &gid, "--zz", "1"],
+        vec!["extension", "status", "--zz", "1"],
+        vec!["extension", "capabilities", "--zz", "1"],
+        vec!["replan", "obligations", "--goal", &gid, "--zz", "1"],
+    ];
+    for args in cases {
+        cli_ok(&args);
+    }
+    // Mutating commands with an unknown flag.
+    cli_ok(&["goal", "init", "--objective", "g2", "--goal-id", "goal_zz", "--cwd", &cr.cwd, "--zz", "1"]);
+    cli_ok(&["goal", "cancel", "--goal", "goal_zz", "--zz", "1"]);
+    cli_ok(&["goal", "delete", "--goal", "goal_zz", "--force", "--zz", "1"]);
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "zz flag", "--zz", "1"]);
+    let zz = common::todo_id_by_text(&cr.root, &gid, "zz flag");
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &zz, "--agent-id", "w1", "--zz", "1"]);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &zz, "--no-follow-up", "--zz", "1"]);
+    cli_ok(&["todo", "archive", "--goal", &gid, "--todo-id", &zz, "--zz", "1"]);
+    let sup = common::add_todo(&cr, &gid, "zz supersede");
+    cli_ok(&["todo", "supersede", "--goal", &gid, "--todo-id", &sup, "--zz", "1"]);
+    cli_ok(&["gate", "resolve", "--goal", &gid, "--todo-id", &first, "--decision", "d", "--zz", "1"]);
+    cli_ok(&["backup", "--goal", &gid, "--zz", "1"]);
+    cli_ok(&["authority", "--goal", &gid, "--write-scope", "src", "--zz", "1"]);
+    cli_ok(&["profile", "set", "--goal", &gid, "--outcome-floor", "2", "--zz", "1"]);
+    cli_ok(&["replan", "ack", "--goal", &gid, "--delta-kind", "vision_patch", "--zz", "1"]);
+    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w9", "--zz", "1"]);
+    cli_ok(&["lease", "expire", "--goal", &gid, "--todo-id", &first, "--zz", "1"]);
+    cli_ok(&["supervisor", "propose", "--goal", &gid, "--agent-id", "s", "--decision-id", "dz", "--target-agent-id", "w1", "--kind", "execute", "--capabilities", "shell", "--zz", "1"]);
+    cli_ok(&[
+        "supervisor", "receipt", "--goal", &gid, "--decision-id", "dz", "--receipt-id", "rz",
+        "--adapter-id", "a", "--outcome", "executed", "--host-capabilities", "shell",
+        "--authority-ref", "auth-1", "--zz", "1",
+    ]);
+    let md = std::path::Path::new(&cr.cwd).join("bf.md");
+    std::fs::write(&md, "## Agent Todo\n\n- [ ] Task one\n").unwrap();
+    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run", "--zz", "1"]);
+    cli_ok(&["replay", "record", "--goal", &gid, "--zz", "1"]);
+    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--zz", "1"]);
+    cli_ok(&["extension", "status", "--id", "x", "--zz", "1"]);
+}
+
+// ── steer poll seam ────────────────────────────────────────────────────────
+
+#[test]
+fn steer_poll_once_arms() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState::default());
+    let gid = init_goal(&cr, "steer drive");
+    let events_path = open_store(&cr).goal_dir(&gid).join("events.jsonl");
+    let rt2 = rt();
+    rt2.block_on(async {
+        use std::io::Write as _;
+        let mut client = None;
+        // Missing file → offset unchanged.
+        let off = future_loop::console::steer_poll_once(
+            std::path::Path::new("/nonexistent/events.jsonl"),
+            0,
+            "t1",
+            &mut client,
+            "sess",
+        )
+        .await;
+        assert_eq!(off, 0);
+        // Fresh append beyond the current length → poll processes new lines.
+        let meta_len = std::fs::metadata(&events_path).unwrap().len();
+        let off = future_loop::console::steer_poll_once(&events_path, meta_len, "t1", &mut client, "sess").await;
+        assert_eq!(off, meta_len, "no new content");
+        // Append a mix: bad json, wrong kind, wrong todo, no text, and a hit.
+        let mut store = open_store(&cr);
+        store
+            .append(future_loop::store::Event::TodoAdded {
+                goal_id: gid.clone(),
+                todo: Todo::advancement("t1", "steer me"),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        // Hand-craft the todo_updated line variants (the CLI sets both text
+        // and kind via Event::TodoUpdated serialization).
+        store
+            .append(future_loop::store::Event::TodoUpdated {
+                goal_id: gid.clone(),
+                todo_id: "t1".into(),
+                text: Some("new instructions".into()),
+                status: None,
+                evidence: None,
+                note: None,
+                priority: None,
+                resume_when: None,
+                blocks: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&events_path)
+            .unwrap()
+            .write_all(b"{broken\n")
+            .unwrap();
+        let before = std::fs::metadata(&events_path).unwrap().len();
+        assert!(before > off);
+        let off2 = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess").await;
+        assert_eq!(off2, before);
+        // The todo_updated hit connected to the mock and steered.
+        assert!(shared.lock().unwrap().recorded.contains(&"steer".to_string()));
+        // A poll against a DIFFERENT todo id: no new steer call.
+        let n = shared.lock().unwrap().recorded.len();
+        let _ = future_loop::console::steer_poll_once(&events_path, off, "other-todo", &mut client, "sess").await;
+        let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client, "sess").await;
+        // steer failure → client reset (next matching event reconnects).
+        let mut st = MockState::default();
+        st.fail_commands.insert("steer".to_string());
+        let (addr2, _shared2) = spawn_mock(st).await;
+        std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr2);
+        let mut client2 = None;
+        let _ = future_loop::console::steer_poll_once(&events_path, off, "t1", &mut client2, "sess2").await;
+        assert!(client2.is_none(), "failed steer resets the client");
+        let _ = n;
+    });
+}
+
+// ── monitor claim-race re-decide loop ──────────────────────────────────────
+
+#[test]
+fn run_monitor_claim_race_stops_without_selection() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "claim race");
+    // A due monitor with a LIVE lease held by another agent — the lease must
+    // exist IN THE LEDGER (try_claim_todo reconstructs from events, not from
+    // the replayed struct).
+    {
+        let mut store = open_store(&cr);
+        let mon = Todo::monitor("mon_raced", "raced monitor", std::time::Duration::from_secs(0));
+        store
+            .append(future_loop::store::Event::TodoAdded {
+                goal_id: goal.clone(),
+                todo: mon,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store
+            .append(future_loop::store::Event::TodoClaimed {
+                goal_id: goal.clone(),
+                todo_id: "mon_raced".into(),
+                agent_id: "other-agent".into(),
+                lease_expires_at: now_epoch() + 3600,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store.set_next_action(&goal, "raced monitor").unwrap();
+    }
+    // Turn 1 completes the onboarding todo; turn 2 selects the due monitor,
+    // loses the atomic claim 3×, and stops without executing it.
+    cli_ok(&["run", "--goal", &goal, "--agent-id", "racer", "--max-turns", "5"]);
+    assert_eq!(shared.lock().unwrap().prompts, 1, "only the onboarding turn ran");
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    let m = g.todos.iter().find(|t| t.id == "mon_raced").unwrap();
+    assert_ne!(m.status, TodoStatus::Done, "raced monitor never executed");
+}
+
+// ── run: wall-clock budget success arm + session cleanup warning ───────────
+
+#[test]
+fn run_with_time_budget_success_path() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "budget success");
+    cli_ok(&[
+        "run", "--goal", &goal, "--anonymous", "--max-turn-secs", "600", "--max-turns", "3",
+    ]);
+}
+
+#[test]
+fn run_session_cleanup_failure_is_a_warning() {
+    let cr = cli_root();
+    let mut st = MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    };
+    st.fail_commands.insert("delete_session".to_string());
+    let (_rt, _shared) = mock_env(st);
+    let goal = init_goal(&cr, "cleanup warning");
+    // The run still succeeds; the cleanup failure is best-effort.
+    cli_ok(&["run", "--goal", &goal, "--anonymous"]);
+}
+
+// ── status print arms ──────────────────────────────────────────────────────
+
+#[test]
+fn status_closure_and_gap_arms() {
+    let cr = cli_root();
+    // All todos done with closure intent → closure_proof "valid".
+    let gid = init_goal(&cr, "closure valid");
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
+    cli_ok(&["status", "--goal", &gid]);
+    // Projection gap → the ⚠ line.
+    {
+        let store = open_store(&cr);
+        store.set_next_action(&gid, "phantom work").unwrap();
+    }
+    cli_ok(&["status", "--goal", &gid]);
+    // quota usage --all with a registry that replays nothing (ghost entry).
+    let cr2_dir;
+    {
+        // A registry entry pointing at a deleted goal dir: replay fails → skipped.
+        let mut store = open_store(&cr);
+        store.register(&future_loop::state::Goal::new("goal_ghost", "x", "/tmp")).unwrap();
+        cr2_dir = store.goal_dir("goal_ghost");
+        let _ = cr2_dir;
+    }
+    cli_ok(&["quota", "usage", "--all"]);
+}
+
+// ── scheduler: no-progression (single execution) arm ───────────────────────
+
+#[test]
+fn scheduler_tick_single_execution_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "sched single");
+    {
+        use future_loop::scheduler::state as st;
+        let store = open_store(&cr);
+        let state = st::build_scheduler_state(
+            &gid,
+            "codex-app",
+            st::CODEX_APP_SURFACE,
+            st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+            "tok",
+            "id",
+            0,
+            vec![], // single execution: no progression
+            "FREQ=MINUTELY;INTERVAL=15",
+            now_epoch(),
+            vec![],
+        )
+        .unwrap();
+        st::write_scheduler_state(&store.goal_dir(&gid), &state).unwrap();
+    }
+    cli_ok(&["scheduler", "tick", "--goal", &gid]);
+}
+
+// ── capability hook proposal-kind arms ─────────────────────────────────────
+
+#[test]
+fn capability_hook_kind_arms() {
+    let _cr = cli_root();
+    // NoFollowUp via empty input; Gate via read-only authority (prints the
+    // gate question line).
+    cli_ok(&["issue-fix"]);
+    cli_ok(&["issue-fix", "--input", "title: bug\nerror: crash\nrepro: steps\nauthority: read-only"]);
+    cli_ok(&["issue-fix", "--input", "title: crash\nerror: panicked\nrepro: run it\nexpected: works fine\nscope: cli"]);
+}
+
+// ── runs index duplicate-group print arms ──────────────────────────────────
+
+#[test]
+fn runs_index_duplicate_report() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "dup index");
+    {
+        let store = open_store(&cr);
+        let runs_dir = store.goal_dir(&gid).join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        std::fs::write(
+            runs_dir.join("index.jsonl"),
+            concat!(
+                "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"a.json\",\"classification\":\"work\"}\n",
+                "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"a.json\",\"classification\":\"work\"}\n",
+            ),
+        )
+        .unwrap();
+    }
+    cli_ok(&["runs", "index", "--goal", &gid]);
+}
+
+// ── handoff: delivery contract present arm ─────────────────────────────────
+
+#[test]
+fn handoff_delivery_contract_present() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "handoff contract");
+    {
+        let store = open_store(&cr);
+        // Two small-scale runs → small-batch streak hits the default threshold.
+        let mut r1 = run_record("t", "completed", now_epoch());
+        r1.evidence = "unit test passed".into();
+        let mut r2 = run_record("t", "completed", now_epoch());
+        r2.evidence = "unit test passed".into();
+        store.append_run(&gid, &r1).unwrap();
+        store.append_run(&gid, &r2).unwrap();
+    }
+    cli_ok(&["handoff", "--goal", &gid]);
+}
+
+// ── serve-status via the CLI (parse + serve, thread-leaked) ────────────────
+
+#[test]
+fn serve_status_command_arm() {
+    let cr = cli_root();
+    let _gid = init_goal(&cr, "serve via cli");
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    // cmd_serve_status blocks forever in serve() → run it on a leaked thread.
+    std::thread::spawn(move || {
+        let _ = future_loop::console::run(
+            "future-loop",
+            vec!["serve-status".to_string(), "--port".to_string(), port.to_string()],
+        );
+    });
+    // Wait for the server, then hit it.
+    let mut ok = false;
+    for _ in 0..100 {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            ok = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(ok, "serve-status came up");
+    let _ = cr;
+}

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -110,7 +110,6 @@ fn unknown_flags_are_swallowed_everywhere() {
     cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run", "--zz", "1"]);
     cli_ok(&["replay", "record", "--goal", &gid, "--zz", "1"]);
     cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--zz", "1"]);
-    cli_ok(&["extension", "status", "--id", "x", "--zz", "1"]);
 }
 
 // ── steer poll seam ────────────────────────────────────────────────────────

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -203,3 +203,13 @@ fn doctor_goal_replay_error_arm() {
     let err = cli_err(&["doctor", "--goal", &gid]);
     assert!(err.contains("failure"), "{err}");
 }
+
+#[test]
+fn capability_commands_experimental_note() {
+    let _cr = cli_root();
+    // pr_review_queue is experimental: without the flag its commands are
+    // hidden and the note prints; with the flag they list.
+    cli_ok(&["capability", "commands", "--name", "pr_review_queue"]);
+    cli_ok(&["capability", "commands", "--name", "pr_review_queue", "--include-experimental"]);
+    cli_ok(&["catalog", "--name", "pr_review_queue"]);
+}

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -25,7 +25,14 @@ fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::S
 fn goal_init_default_cwd_and_delete_errors() {
     let cr = cli_root();
     // No --cwd → falls back to the process current dir.
-    cli_ok(&["goal", "init", "--objective", "default cwd", "--goal-id", "goal_defcwd"]);
+    cli_ok(&[
+        "goal",
+        "init",
+        "--objective",
+        "default cwd",
+        "--goal-id",
+        "goal_defcwd",
+    ]);
     // delete --force on an unknown goal → store error surfaces.
     assert!(cli_err(&["goal", "delete", "--goal", "goal_ghost", "--force"]).contains("not found"));
     let _ = cr;
@@ -36,14 +43,52 @@ fn agent_list_with_lease_events() {
     let cr = cli_root();
     let gid = init_goal(&cr, "agent list lease events");
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w1", "--capability", "shell"]);
-    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
-    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1", "--lease-secs", "90"]);
+    cli_ok(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "w1",
+        "--capability",
+        "shell",
+    ]);
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
+    cli_ok(&[
+        "lease",
+        "renew",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+        "--lease-secs",
+        "90",
+    ]);
     // w1 shows a live lease; a second registered agent shows idle.
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w2"]);
     cli_ok(&["agent", "list", "--goal", &gid]);
     // Release then list (released event in the scan).
-    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&[
+        "lease",
+        "release",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "w1",
+    ]);
     cli_ok(&["agent", "list", "--goal", &gid]);
 }
 
@@ -76,7 +121,11 @@ fn run_replan_self_repair_then_stop() {
         store.set_next_action(&gid, "phantom work").unwrap();
     }
     cli_ok(&["run", "--goal", &gid, "--anonymous", "--max-turns", "4"]);
-    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn executed during replan");
+    assert_eq!(
+        shared.lock().unwrap().prompts,
+        0,
+        "no turn executed during replan"
+    );
     // The repair pass re-synced the next action.
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
@@ -108,7 +157,14 @@ fn backfill_dry_run_claim_print() {
     )
     .unwrap();
     // Dry-run prints the add/claim/complete event preview lines.
-    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run"]);
+    cli_ok(&[
+        "backfill",
+        "--goal",
+        &gid,
+        "--from",
+        md.to_str().unwrap(),
+        "--dry-run",
+    ]);
 }
 
 #[test]
@@ -126,7 +182,16 @@ fn scope_with_open_gate() {
     let cr = cli_root();
     let gid = init_goal(&cr, "scope gate");
     cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
-    cli_ok(&["todo", "add", "--goal", &gid, "--text", "approve?", "--class", "user_gate"]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "approve?",
+        "--class",
+        "user_gate",
+    ]);
     cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1"]);
 }
 
@@ -134,8 +199,16 @@ fn scope_with_open_gate() {
 fn benchmark_run_unreachable_agent() {
     let cr = cli_root();
     let err = cli_err(&[
-        "benchmark", "run", "--benchmark-id", "b", "--case-id", "c", "--task", "t",
-        "--agent-addr", "127.0.0.1:1",
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "b",
+        "--case-id",
+        "c",
+        "--task",
+        "t",
+        "--agent-addr",
+        "127.0.0.1:1",
     ]);
     assert!(err.contains(""), "{err}");
     let _ = cr;
@@ -146,11 +219,20 @@ fn replay_run_mismatch_prints_and_bails() {
     let cr = cli_root();
     let gid = init_goal(&cr, "replay mismatch");
     let case_file = std::path::Path::new(&cr.cwd).join("cases.json");
-    cli_ok(&["replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap()]);
+    cli_ok(&[
+        "replay",
+        "record",
+        "--goal",
+        &gid,
+        "--out",
+        case_file.to_str().unwrap(),
+    ]);
     // Tamper the recorded case: flip a decision field.
     let mut value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&case_file).unwrap()).unwrap();
-    let should_run = value["cases"][0]["decision"]["should_run"].as_bool().unwrap();
+    let should_run = value["cases"][0]["decision"]["should_run"]
+        .as_bool()
+        .unwrap();
     value["cases"][0]["decision"]
         .as_object_mut()
         .unwrap()
@@ -159,7 +241,13 @@ fn replay_run_mismatch_prints_and_bails() {
     let err = cli_err(&["replay", "run", "--case", case_file.to_str().unwrap()]);
     assert!(err.contains("drifted"), "{err}");
     // JSON mode prints the comparison object.
-    let err = cli_err(&["replay", "run", "--case", case_file.to_str().unwrap(), "--json"]);
+    let err = cli_err(&[
+        "replay",
+        "run",
+        "--case",
+        case_file.to_str().unwrap(),
+        "--json",
+    ]);
     assert!(err.contains("drifted"), "{err}");
 }
 
@@ -210,7 +298,13 @@ fn capability_commands_experimental_note() {
     // pr_review_queue is experimental: without the flag its commands are
     // hidden and the note prints; with the flag they list.
     cli_ok(&["capability", "commands", "--name", "pr_review_queue"]);
-    cli_ok(&["capability", "commands", "--name", "pr_review_queue", "--include-experimental"]);
+    cli_ok(&[
+        "capability",
+        "commands",
+        "--name",
+        "pr_review_queue",
+        "--include-experimental",
+    ]);
     cli_ok(&["catalog", "--name", "pr_review_queue"]);
 }
 
@@ -221,7 +315,15 @@ fn diagnose_and_doctor_with_projection_gap() {
     // Complete the only todo so agent_open == 0, then point next_action at
     // phantom work → a real projection gap.
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+    ]);
     {
         let store = open_store(&cr);
         store.set_next_action(&gid, "phantom work").unwrap();
@@ -234,14 +336,23 @@ fn diagnose_and_doctor_with_projection_gap() {
 #[test]
 fn benchmark_protocol_blind_route() {
     let _cr = cli_root();
-    cli_ok(&["benchmark", "protocol", "--route", "raw-codex-autonomous-max5"]);
+    cli_ok(&[
+        "benchmark",
+        "protocol",
+        "--route",
+        "raw-codex-autonomous-max5",
+    ]);
 }
 
 #[test]
 fn capability_propose_gate_print_arm() {
     let _cr = cli_root();
     cli_ok(&[
-        "capability", "propose", "--name", "issue_fix", "--input",
+        "capability",
+        "propose",
+        "--name",
+        "issue_fix",
+        "--input",
         "title: bug\nerror: crash\nrepro: steps\nauthority: read-only",
     ]);
 }
@@ -251,7 +362,11 @@ fn privacy_private_fields_print_arm() {
     let cr = cli_root();
     let home = std::env::var("HOME").unwrap_or_default();
     let gid = init_goal(&cr, "privacy fields");
-    common::add_todo(&cr, &gid, &format!("read {home}/.ssh/id_rsa and rotate the key"));
+    common::add_todo(
+        &cr,
+        &gid,
+        &format!("read {home}/.ssh/id_rsa and rotate the key"),
+    );
     cli_ok(&["privacy", "--goal", &gid]);
 }
 
@@ -260,7 +375,9 @@ fn corpus_build_trailing_flag_arms() {
     let cr = cli_root();
     let gid = init_goal(&cr, "corpus trailing");
     // --ablate / --patch at the very end with no value → skipped arms.
-    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--ablate"]);
+    cli_ok(&[
+        "replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--ablate",
+    ]);
     let _ = cr;
 }
 
@@ -273,9 +390,18 @@ fn runs_retention_with_candidates() {
         let runs_dir = store.goal_dir(&gid).join("runs");
         std::fs::create_dir_all(&runs_dir).unwrap();
         for (name, ts) in [
-            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
-            ("2021-01-01T00-00-00-00-00.json", "2021-01-01T00:00:00+00:00"),
-            ("2022-01-01T00-00-00-00-00.json", "2022-01-01T00:00:00+00:00"),
+            (
+                "2020-01-01T00-00-00-00-00.json",
+                "2020-01-01T00:00:00+00:00",
+            ),
+            (
+                "2021-01-01T00-00-00-00-00.json",
+                "2021-01-01T00:00:00+00:00",
+            ),
+            (
+                "2022-01-01T00-00-00-00-00.json",
+                "2022-01-01T00:00:00+00:00",
+            ),
         ] {
             std::fs::write(
                 runs_dir.join(name),
@@ -290,7 +416,12 @@ fn runs_retention_with_candidates() {
 #[test]
 fn benchmark_protocol_blind_route_print() {
     let _cr = cli_root();
-    cli_ok(&["benchmark", "protocol", "--route", "future-loop-blind-loop-treatment"]);
+    cli_ok(&[
+        "benchmark",
+        "protocol",
+        "--route",
+        "future-loop-blind-loop-treatment",
+    ]);
 }
 
 #[test]
@@ -302,9 +433,18 @@ fn runs_retention_candidates_print() {
         let runs_dir = store.goal_dir(&gid).join("runs");
         std::fs::create_dir_all(&runs_dir).unwrap();
         for (name, ts) in [
-            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
-            ("2021-01-01T00-00-00-00-00.json", "2021-01-01T00:00:00+00:00"),
-            ("2022-01-01T00-00-00-00-00.json", "2022-01-01T00:00:00+00:00"),
+            (
+                "2020-01-01T00-00-00-00-00.json",
+                "2020-01-01T00:00:00+00:00",
+            ),
+            (
+                "2021-01-01T00-00-00-00-00.json",
+                "2021-01-01T00:00:00+00:00",
+            ),
+            (
+                "2022-01-01T00-00-00-00-00.json",
+                "2022-01-01T00:00:00+00:00",
+            ),
         ] {
             std::fs::write(
                 runs_dir.join(name),
@@ -323,8 +463,17 @@ fn benchmark_run_stub_flag() {
     let cr = cli_root();
     let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-stub");
     cli_ok(&[
-        "benchmark", "run", "--benchmark-id", "bs", "--case-id", "cs", "--task", "t",
-        "--stub", "--ledger-dir", ledger_dir.to_str().unwrap(),
+        "benchmark",
+        "run",
+        "--benchmark-id",
+        "bs",
+        "--case-id",
+        "cs",
+        "--task",
+        "t",
+        "--stub",
+        "--ledger-dir",
+        ledger_dir.to_str().unwrap(),
     ]);
 }
 
@@ -332,7 +481,16 @@ fn benchmark_run_stub_flag() {
 fn corpus_build_positional_arg_arm() {
     let cr = cli_root();
     let gid = init_goal(&cr, "corpus positional");
-    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "positional-junk", "--patch", "{}"]);
+    cli_ok(&[
+        "replay",
+        "corpus",
+        "build",
+        "--goal",
+        &gid,
+        "positional-junk",
+        "--patch",
+        "{}",
+    ]);
 }
 
 #[test]
@@ -344,10 +502,26 @@ fn run_validator_inconclusive_print() {
     });
     let gid = init_goal(&cr, "validator inconclusive");
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "validated task", "--verify", "exit 0",
-        "--max-validation-attempts", "1",
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+    ]);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "validated task",
+        "--verify",
+        "exit 0",
+        "--max-validation-attempts",
+        "1",
     ]);
     // With an empty PATH the validator's `sh` cannot spawn → Inconclusive.
     let saved = std::env::var_os("PATH");

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -286,3 +286,75 @@ fn runs_retention_with_candidates() {
     }
     cli_ok(&["runs", "retention", "--goal", &gid, "--keep", "1"]);
 }
+
+#[test]
+fn benchmark_protocol_blind_route_print() {
+    let _cr = cli_root();
+    cli_ok(&["benchmark", "protocol", "--route", "future-loop-blind-loop-treatment"]);
+}
+
+#[test]
+fn runs_retention_candidates_print() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "retention print");
+    {
+        let store = open_store(&cr);
+        let runs_dir = store.goal_dir(&gid).join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        for (name, ts) in [
+            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
+            ("2021-01-01T00-00-00-00-00.json", "2021-01-01T00:00:00+00:00"),
+            ("2022-01-01T00-00-00-00-00.json", "2022-01-01T00:00:00+00:00"),
+        ] {
+            std::fs::write(
+                runs_dir.join(name),
+                format!("{{\"timestamp\":\"{ts}\",\"turn\":1,\"terminal_state\":\"completed\"}}"),
+            )
+            .unwrap();
+        }
+    }
+    // The retention projection reads the rebuilt index.
+    cli_ok(&["runs", "index", "--goal", &gid, "--rebuild"]);
+    cli_ok(&["runs", "retention", "--goal", &gid, "--keep", "1"]);
+}
+
+#[test]
+fn benchmark_run_stub_flag() {
+    let cr = cli_root();
+    let ledger_dir = std::path::Path::new(&cr.cwd).join("bench-stub");
+    cli_ok(&[
+        "benchmark", "run", "--benchmark-id", "bs", "--case-id", "cs", "--task", "t",
+        "--stub", "--ledger-dir", ledger_dir.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn corpus_build_positional_arg_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "corpus positional");
+    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "positional-junk", "--patch", "{}"]);
+}
+
+#[test]
+fn run_validator_inconclusive_print() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let gid = init_goal(&cr, "validator inconclusive");
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
+    cli_ok(&[
+        "todo", "add", "--goal", &gid, "--text", "validated task", "--verify", "exit 0",
+        "--max-validation-attempts", "1",
+    ]);
+    // With an empty PATH the validator's `sh` cannot spawn → Inconclusive.
+    let saved = std::env::var_os("PATH");
+    std::env::set_var("PATH", "/nonexistent-dir-xyz");
+    let result = cli(&["run", "--goal", &gid, "--anonymous", "--max-turns", "2"]);
+    if let Some(p) = saved {
+        std::env::set_var("PATH", p);
+    }
+    result.unwrap();
+}

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -213,3 +213,76 @@ fn capability_commands_experimental_note() {
     cli_ok(&["capability", "commands", "--name", "pr_review_queue", "--include-experimental"]);
     cli_ok(&["catalog", "--name", "pr_review_queue"]);
 }
+
+#[test]
+fn diagnose_and_doctor_with_projection_gap() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "gap surfaces");
+    // Complete the only todo so agent_open == 0, then point next_action at
+    // phantom work → a real projection gap.
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["todo", "complete", "--goal", &gid, "--todo-id", &first, "--no-follow-up"]);
+    {
+        let store = open_store(&cr);
+        store.set_next_action(&gid, "phantom work").unwrap();
+    }
+    cli_ok(&["diagnose", "--goal", &gid]);
+    let err = cli_err(&["doctor", "--goal", &gid]);
+    assert!(err.contains("gap") || err.contains("failure"), "{err}");
+}
+
+#[test]
+fn benchmark_protocol_blind_route() {
+    let _cr = cli_root();
+    cli_ok(&["benchmark", "protocol", "--route", "raw-codex-autonomous-max5"]);
+}
+
+#[test]
+fn capability_propose_gate_print_arm() {
+    let _cr = cli_root();
+    cli_ok(&[
+        "capability", "propose", "--name", "issue_fix", "--input",
+        "title: bug\nerror: crash\nrepro: steps\nauthority: read-only",
+    ]);
+}
+
+#[test]
+fn privacy_private_fields_print_arm() {
+    let cr = cli_root();
+    let home = std::env::var("HOME").unwrap_or_default();
+    let gid = init_goal(&cr, "privacy fields");
+    common::add_todo(&cr, &gid, &format!("read {home}/.ssh/id_rsa and rotate the key"));
+    cli_ok(&["privacy", "--goal", &gid]);
+}
+
+#[test]
+fn corpus_build_trailing_flag_arms() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "corpus trailing");
+    // --ablate / --patch at the very end with no value → skipped arms.
+    cli_ok(&["replay", "corpus", "build", "--goal", &gid, "--patch", "{}", "--ablate"]);
+    let _ = cr;
+}
+
+#[test]
+fn runs_retention_with_candidates() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "retention candidates");
+    {
+        let store = open_store(&cr);
+        let runs_dir = store.goal_dir(&gid).join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        for (name, ts) in [
+            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
+            ("2021-01-01T00-00-00-00-00.json", "2021-01-01T00:00:00+00:00"),
+            ("2022-01-01T00-00-00-00-00.json", "2022-01-01T00:00:00+00:00"),
+        ] {
+            std::fs::write(
+                runs_dir.join(name),
+                format!("{{\"timestamp\":\"{ts}\",\"turn\":1,\"terminal_state\":\"completed\"}}"),
+            )
+            .unwrap();
+        }
+    }
+    cli_ok(&["runs", "retention", "--goal", &gid, "--keep", "1"]);
+}

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -1,0 +1,205 @@
+//! Coverage sweep 2 for console.rs — the surgical remainder: default-cwd
+//! goal init, delete-force errors, agent-list lease events, the run-loop
+//! replan self-repair arm, backfill claim print, stale status cache, scoped
+//! gates, benchmark adapter connect error, replay mismatch prints, failing
+//! canary/doctor CLI paths.
+
+mod common;
+
+use common::mock_agent::{completed_events, spawn_mock, MockState};
+use common::{cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
+use future_loop::state::now_epoch;
+use future_loop::store::{Event, Store};
+
+fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::SharedState) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (addr, shared) = rt.block_on(spawn_mock(state));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    (rt, shared)
+}
+
+#[test]
+fn goal_init_default_cwd_and_delete_errors() {
+    let cr = cli_root();
+    // No --cwd → falls back to the process current dir.
+    cli_ok(&["goal", "init", "--objective", "default cwd", "--goal-id", "goal_defcwd"]);
+    // delete --force on an unknown goal → store error surfaces.
+    assert!(cli_err(&["goal", "delete", "--goal", "goal_ghost", "--force"]).contains("not found"));
+    let _ = cr;
+}
+
+#[test]
+fn agent_list_with_lease_events() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "agent list lease events");
+    let first = first_todo_id(&cr.root, &gid);
+    cli_ok(&["agent", "onboard", "--goal", &gid, "--agent-id", "w1", "--capability", "shell"]);
+    cli_ok(&["todo", "claim", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&["lease", "renew", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1", "--lease-secs", "90"]);
+    // w1 shows a live lease; a second registered agent shows idle.
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w2"]);
+    cli_ok(&["agent", "list", "--goal", &gid]);
+    // Release then list (released event in the scan).
+    cli_ok(&["lease", "release", "--goal", &gid, "--todo-id", &first, "--agent-id", "w1"]);
+    cli_ok(&["agent", "list", "--goal", &gid]);
+}
+
+#[test]
+fn run_replan_self_repair_then_stop() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let gid = init_goal(&cr, "replan repair");
+    {
+        // A completion WITHOUT closure intent → replan obligation; a stale
+        // next_action → projection gap. First turn repairs the gap and loops;
+        // second turn replans with no gap → graceful stop.
+        let mut store: Store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let first = g.todos.first().unwrap().id.clone();
+        drop(g);
+        store
+            .append(Event::TodoCompleted {
+                goal_id: gid.clone(),
+                todo_id: first,
+                no_follow_up: false,
+                successor_ids: vec![],
+                evidence: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        store.set_next_action(&gid, "phantom work").unwrap();
+    }
+    cli_ok(&["run", "--goal", &gid, "--anonymous", "--max-turns", "4"]);
+    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn executed during replan");
+    // The repair pass re-synced the next action.
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    assert_eq!(
+        g.next_action.as_deref(),
+        Some("all todos complete; no further action")
+    );
+}
+
+#[test]
+fn run_with_unknown_flag_and_model_env() {
+    let cr = cli_root();
+    let (_rt, _shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    let gid = init_goal(&cr, "run zz");
+    cli_ok(&["run", "--goal", &gid, "--anonymous", "--zz", "1"]);
+}
+
+#[test]
+fn backfill_dry_run_claim_print() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "backfill claim print");
+    let md = std::path::Path::new(&cr.cwd).join("state.md");
+    std::fs::write(
+        &md,
+        "## Agent Todo\n\n- [ ] Claimed task\n  <!-- future-loop:todo todo_id=todo_c1 status=open claimed_by=agent-9 -->\n- [x] Done task\n  <!-- future-loop:todo todo_id=todo_c2 status=done no_followup=true -->\n",
+    )
+    .unwrap();
+    // Dry-run prints the add/claim/complete event preview lines.
+    cli_ok(&["backfill", "--goal", &gid, "--from", md.to_str().unwrap(), "--dry-run"]);
+}
+
+#[test]
+fn privacy_stale_cache_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "privacy stale");
+    cli_ok(&["privacy", "--goal", &gid]);
+    // A new ledger event makes the persisted cache stale on the next read.
+    common::add_todo(&cr, &gid, "another task");
+    cli_ok(&["privacy", "--goal", &gid]);
+}
+
+#[test]
+fn scope_with_open_gate() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "scope gate");
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["todo", "add", "--goal", &gid, "--text", "approve?", "--class", "user_gate"]);
+    cli_ok(&["scope", "--goal", &gid, "--agent-id", "w1"]);
+}
+
+#[test]
+fn benchmark_run_unreachable_agent() {
+    let cr = cli_root();
+    let err = cli_err(&[
+        "benchmark", "run", "--benchmark-id", "b", "--case-id", "c", "--task", "t",
+        "--agent-addr", "127.0.0.1:1",
+    ]);
+    assert!(err.contains(""), "{err}");
+    let _ = cr;
+}
+
+#[test]
+fn replay_run_mismatch_prints_and_bails() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "replay mismatch");
+    let case_file = std::path::Path::new(&cr.cwd).join("cases.json");
+    cli_ok(&["replay", "record", "--goal", &gid, "--out", case_file.to_str().unwrap()]);
+    // Tamper the recorded case: flip a decision field.
+    let mut value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&case_file).unwrap()).unwrap();
+    let should_run = value["cases"][0]["decision"]["should_run"].as_bool().unwrap();
+    value["cases"][0]["decision"]
+        .as_object_mut()
+        .unwrap()
+        .insert("should_run".into(), serde_json::json!(!should_run));
+    std::fs::write(&case_file, serde_json::to_string(&value).unwrap()).unwrap();
+    let err = cli_err(&["replay", "run", "--case", case_file.to_str().unwrap()]);
+    assert!(err.contains("drifted"), "{err}");
+    // JSON mode prints the comparison object.
+    let err = cli_err(&["replay", "run", "--case", case_file.to_str().unwrap(), "--json"]);
+    assert!(err.contains("drifted"), "{err}");
+}
+
+#[test]
+fn canary_cli_failing_checks() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "canary cli fail");
+    {
+        let store = open_store(&cr);
+        let path = store.goal_dir(&gid).join("events.jsonl");
+        let a = serde_json::json!({"event_id":"e-dup","kind":"goal_started","goal_id":gid,"ts":1});
+        let b = serde_json::json!({"event_id":"e-dup","kind":"goal_started","goal_id":gid,"ts":2});
+        std::fs::write(&path, format!("{}\n{}\n", a, b)).unwrap();
+    }
+    // Text mode prints the FAIL lines and bails. NOTE: --json returns Ok
+    // even when checks fail (the JSON arm returns before the all_passed
+    // bail) — consumers must inspect the payload; flagged in the report.
+    let err = cli_err(&["canary", "smoke"]);
+    assert!(err.contains("failed"), "{err}");
+    cli_ok(&["canary", "smoke", "--json"]);
+    // doctor surfaces the same conflict as a failure list entry.
+    let err = cli_err(&["doctor", "--goal", &gid]);
+    assert!(err.contains("conflict"), "{err}");
+}
+
+#[test]
+fn doctor_goal_replay_error_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "doctor replay err");
+    {
+        use std::io::Write as _;
+        let store = open_store(&cr);
+        let path = store.goal_dir(&gid).join("events.jsonl");
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{broken\n")
+            .unwrap();
+    }
+    let err = cli_err(&["doctor", "--goal", &gid]);
+    assert!(err.contains("failure"), "{err}");
+}

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -180,9 +180,9 @@ fn canary_cli_failing_checks() {
     let err = cli_err(&["canary", "smoke"]);
     assert!(err.contains("failed"), "{err}");
     cli_ok(&["canary", "smoke", "--json"]);
-    // doctor surfaces the same conflict as a failure list entry.
+    // doctor surfaces the ledger problem as a failure list entry.
     let err = cli_err(&["doctor", "--goal", &gid]);
-    assert!(err.contains("conflict"), "{err}");
+    assert!(err.contains("failure"), "{err}");
 }
 
 #[test]

--- a/orchestration/loop/tests/executor_env_drive.rs
+++ b/orchestration/loop/tests/executor_env_drive.rs
@@ -1,0 +1,45 @@
+//! Executor validator spawn-failure arm: with an EMPTY PATH the hardcoded
+//! `sh` cannot be spawned → ValidationStatus::Inconclusive. In its own test
+//! binary because PATH is process-global.
+
+mod common;
+
+use common::mock_agent::{completed_events, spawn_mock, MockState};
+use future_loop::agent_client::AgentClient;
+use future_loop::executor::execute_turn;
+use future_loop::state::{Goal, Todo, ValidationStatus};
+
+#[test]
+fn validator_spawn_failure_is_inconclusive() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let (addr, _) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let mut goal = Goal::new("g", "exec", "/tmp");
+        let mut todo = Todo::advancement("t1", "validated");
+        todo.validator = Some("exit 0".to_string());
+        goal.todos.push(todo.clone());
+
+        let saved = std::env::var_os("PATH");
+        std::env::set_var("PATH", "/nonexistent-dir-xyz");
+        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
+            .await
+            .unwrap();
+        if let Some(p) = saved {
+            std::env::set_var("PATH", p);
+        }
+        let v = record.validation.unwrap();
+        if cfg!(unix) {
+            // No `sh` on PATH → spawn error → inconclusive.
+            assert_eq!(v.status, ValidationStatus::Inconclusive, "{}", v.summary);
+            assert!(!v.ok);
+        }
+    });
+}

--- a/orchestration/loop/tests/extensions_drive.rs
+++ b/orchestration/loop/tests/extensions_drive.rs
@@ -9,7 +9,9 @@ use future_loop::extensions::manifest::{
     load_extension_manifest, require_compatible_future_loop_api, validate_manifest_value,
     validate_protocol_token, ExtensionManifest, EXTENSION_MANIFEST_SCHEMA_VERSION,
 };
-use future_loop::extensions::readiness::{extension_doctor, resolve_runtime_entrypoint, DoctorStatus};
+use future_loop::extensions::readiness::{
+    extension_doctor, resolve_runtime_entrypoint, DoctorStatus,
+};
 use future_loop::extensions::runtime::{
     disable_extension, enable_extension, extension_catalog_entries, extension_status,
     install_extension, manifest_revision, rollback_extension,
@@ -17,7 +19,9 @@ use future_loop::extensions::runtime::{
 
 static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-fn manifest_json(overrides: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>)) -> serde_json::Value {
+fn manifest_json(
+    overrides: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+) -> serde_json::Value {
     let raw = serde_json::json!({
         "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": "ext-x",
@@ -52,35 +56,64 @@ fn manifest_top_level_errors() {
     // Not an object.
     assert!(validate_manifest_value(&serde_json::json!([]), "t").is_err());
     // Bad / legacy schema.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("schema_version".into(), "nope".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("schema_version".into(), "nope".into());
+        }),
+        "t"
+    )
     .is_err());
-    validate_manifest_value(&manifest_json(|m| {
-        m.insert("schema_version".into(), "loopx_extension_manifest_v0".into());
-    }), "t")
+    validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert(
+                "schema_version".into(),
+                "loopx_extension_manifest_v0".into(),
+            );
+        }),
+        "t",
+    )
     .unwrap();
     // Missing required strings.
-    for key in ["schema_version", "id", "version", "requires_future_loop_api"] {
-        assert!(validate_manifest_value(&manifest_json(|m| {
-            m.remove(key);
-        }), "t")
-        .is_err(), "{key}");
+    for key in [
+        "schema_version",
+        "id",
+        "version",
+        "requires_future_loop_api",
+    ] {
+        assert!(
+            validate_manifest_value(
+                &manifest_json(|m| {
+                    m.remove(key);
+                }),
+                "t"
+            )
+            .is_err(),
+            "{key}"
+        );
     }
     // permissions not an array / non-string items.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("permissions".into(), "shell".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("permissions".into(), "shell".into());
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("permissions".into(), serde_json::json!(["shell", 7]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("permissions".into(), serde_json::json!(["shell", 7]));
+        }),
+        "t"
+    )
     .is_err());
     // Empty manifest (no runtime/provides/implements) → error.
-    assert!(validate_manifest_value(&serde_json::json!({
-        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
-        "id": "e", "version": "1", "requires_future_loop_api": ">=1",
-    }), "t")
+    assert!(validate_manifest_value(
+        &serde_json::json!({
+            "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+            "id": "e", "version": "1", "requires_future_loop_api": ">=1",
+        }),
+        "t"
+    )
     .is_err());
 }
 
@@ -88,40 +121,71 @@ fn manifest_top_level_errors() {
 fn manifest_runtime_errors() {
     let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Bad protocol token.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap().insert("protocol".into(), "NOPE".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"]
+                .as_object_mut()
+                .unwrap()
+                .insert("protocol".into(), "NOPE".into());
+        }),
+        "t"
+    )
     .is_err());
     // Both entrypoint and python_module.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap().insert("python_module".into(), "mod".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"]
+                .as_object_mut()
+                .unwrap()
+                .insert("python_module".into(), "mod".into());
+        }),
+        "t"
+    )
     .is_err());
     // Neither entrypoint nor python_module.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap().remove("entrypoint");
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"].as_object_mut().unwrap().remove("entrypoint");
+        }),
+        "t"
+    )
     .is_err());
     // python_module-only runtime is valid.
-    validate_manifest_value(&manifest_json(|m| {
-        let rt = m["runtime"].as_object_mut().unwrap();
-        rt.remove("entrypoint");
-        rt.insert("python_module".into(), "ext_mod".into());
-    }), "t")
+    validate_manifest_value(
+        &manifest_json(|m| {
+            let rt = m["runtime"].as_object_mut().unwrap();
+            rt.remove("entrypoint");
+            rt.insert("python_module".into(), "ext_mod".into());
+        }),
+        "t",
+    )
     .unwrap();
     // Undeclared required_permissions.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap()
-            .insert("required_permissions".into(), serde_json::json!(["shell", "net"]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"].as_object_mut().unwrap().insert(
+                "required_permissions".into(),
+                serde_json::json!(["shell", "net"]),
+            );
+        }),
+        "t"
+    )
     .is_err());
     // timeout out of range.
     for t in [0, 121] {
-        assert!(validate_manifest_value(&manifest_json(|m| {
-            m["runtime"].as_object_mut().unwrap()
-                .insert("timeout_seconds".into(), serde_json::json!(t));
-        }), "t")
-        .is_err(), "{t}");
+        assert!(
+            validate_manifest_value(
+                &manifest_json(|m| {
+                    m["runtime"]
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("timeout_seconds".into(), serde_json::json!(t));
+                }),
+                "t"
+            )
+            .is_err(),
+            "{t}"
+        );
     }
 }
 
@@ -129,41 +193,83 @@ fn manifest_runtime_errors() {
 fn manifest_provides_implements_errors() {
     let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // provides not an array / item not an object / missing fields.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("provides".into(), "x".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("provides".into(), "x".into());
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("provides".into(), serde_json::json!(["x"]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("provides".into(), serde_json::json!(["x"]));
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("provides".into(), serde_json::json!([{"kind": "domain_rule"}]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert(
+                "provides".into(),
+                serde_json::json!([{"kind": "domain_rule"}]),
+            );
+        }),
+        "t"
+    )
     .is_err());
     // implements: not array / item not object / bad protocol / no runtime /
     // protocol mismatch.
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("implements".into(), "x".into());
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("implements".into(), "x".into());
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("implements".into(), serde_json::json!(["x"]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert("implements".into(), serde_json::json!(["x"]));
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "BAD"}]));
-    }), "t")
+    assert!(validate_manifest_value(
+        &manifest_json(|m| {
+            m.insert(
+                "implements".into(),
+                serde_json::json!([{"capability_id": "c", "protocol": "BAD"}]),
+            );
+        }),
+        "t"
+    )
     .is_err());
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.remove("runtime");
-        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "command_json_v0"}]));
-    }), "t")
-    .is_err(), "implements without runtime");
-    assert!(validate_manifest_value(&manifest_json(|m| {
-        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "other_proto_v1"}]));
-    }), "t")
-    .is_err(), "protocol mismatch");
+    assert!(
+        validate_manifest_value(
+            &manifest_json(|m| {
+                m.remove("runtime");
+                m.insert(
+                    "implements".into(),
+                    serde_json::json!([{"capability_id": "c", "protocol": "command_json_v0"}]),
+                );
+            }),
+            "t"
+        )
+        .is_err(),
+        "implements without runtime"
+    );
+    assert!(
+        validate_manifest_value(
+            &manifest_json(|m| {
+                m.insert(
+                    "implements".into(),
+                    serde_json::json!([{"capability_id": "c", "protocol": "other_proto_v1"}]),
+                );
+            }),
+            "t"
+        )
+        .is_err(),
+        "protocol mismatch"
+    );
     // load_extension_manifest: unreadable + invalid JSON.
     assert!(load_extension_manifest(std::path::Path::new("/nonexistent.json")).is_err());
     let dir = tempfile::tempdir().unwrap();
@@ -194,7 +300,10 @@ fn api_version_clause_matrix() {
     assert!(require_compatible_future_loop_api(">=1,<3").is_ok());
     assert!(require_compatible_future_loop_api("<=1").is_ok());
     assert!(require_compatible_future_loop_api("==1").is_ok());
-    assert!(require_compatible_future_loop_api("1").is_ok(), "bare number means ==");
+    assert!(
+        require_compatible_future_loop_api("1").is_ok(),
+        "bare number means =="
+    );
     assert!(require_compatible_future_loop_api(">0").is_ok());
     assert!(require_compatible_future_loop_api("<2").is_ok());
     assert!(require_compatible_future_loop_api(">=2").is_err());
@@ -220,49 +329,69 @@ fn readiness_branches() {
     };
     assert_eq!(report.status, expected);
     // Missing entrypoint → entrypoint_missing (both doctor-args arms).
-    let missing = validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap()
-            .insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
-    }), "t")
+    let missing = validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"]
+                .as_object_mut()
+                .unwrap()
+                .insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
+        }),
+        "t",
+    )
     .unwrap();
-    assert_eq!(extension_doctor(&missing).status, DoctorStatus::EntrypointMissing.label());
-    let missing_with_doctor_args = validate_manifest_value(&manifest_json(|m| {
-        let rt = m["runtime"].as_object_mut().unwrap();
-        rt.insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
-        rt.insert("doctor_args".into(), serde_json::json!(["--check"]));
-    }), "t")
+    assert_eq!(
+        extension_doctor(&missing).status,
+        DoctorStatus::EntrypointMissing.label()
+    );
+    let missing_with_doctor_args = validate_manifest_value(
+        &manifest_json(|m| {
+            let rt = m["runtime"].as_object_mut().unwrap();
+            rt.insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
+            rt.insert("doctor_args".into(), serde_json::json!(["--check"]));
+        }),
+        "t",
+    )
     .unwrap();
     assert_eq!(
         extension_doctor(&missing_with_doctor_args).status,
         DoctorStatus::EntrypointMissing.label()
     );
     // resolve_runtime_entrypoint: absolute-path fallback and None arm.
-    let abs = validate_manifest_value(&manifest_json(|m| {
-        m["runtime"].as_object_mut().unwrap().insert(
-            "entrypoint".into(),
-            if cfg!(unix) { "/bin/sh" } else { "sh" }.into(),
-        );
-    }), "t")
+    let abs = validate_manifest_value(
+        &manifest_json(|m| {
+            m["runtime"].as_object_mut().unwrap().insert(
+                "entrypoint".into(),
+                if cfg!(unix) { "/bin/sh" } else { "sh" }.into(),
+            );
+        }),
+        "t",
+    )
     .unwrap();
     let resolved = resolve_runtime_entrypoint(abs.runtime.as_ref().unwrap());
     if cfg!(unix) {
         assert!(resolved.is_some());
     }
     // No runtime at all → None.
-    let no_rt = validate_manifest_value(&serde_json::json!({
-        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
-        "id": "e", "version": "1", "requires_future_loop_api": ">=1",
-        "provides": [{"id": "c", "kind": "k"}],
-    }), "t")
+    let no_rt = validate_manifest_value(
+        &serde_json::json!({
+            "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+            "id": "e", "version": "1", "requires_future_loop_api": ">=1",
+            "provides": [{"id": "c", "kind": "k"}],
+        }),
+        "t",
+    )
     .unwrap();
     assert!(no_rt.runtime.is_none());
     // python_module resolution (needs python3/python on PATH — whatever the
     // host has; both arms acceptable).
-    let py = validate_manifest_value(&manifest_json(|m| {
-        let rt = m["runtime"].as_object_mut().unwrap();
-        rt.remove("entrypoint");
-        rt.insert("python_module".into(), "ext_mod".into());
-    }), "t")
+    let py = validate_manifest_value(
+        &manifest_json(|m| {
+            let rt = m["runtime"].as_object_mut().unwrap();
+            rt.remove("entrypoint");
+            rt.insert("python_module".into(), "ext_mod".into());
+        }),
+        "t",
+    )
     .unwrap();
     let _ = resolve_runtime_entrypoint(py.runtime.as_ref().unwrap());
     // PATH removed entirely → which() returns None (process-global: locked).
@@ -298,9 +427,12 @@ fn runtime_lifecycle_errors() {
     // rollback with no prior upgrade → no rollback revision.
     assert!(rollback_extension("ext-x", &state_file, false).is_err());
     // Upgrade to a new revision, then rollback works (execute + dry-run).
-    let m2 = validate_manifest_value(&manifest_json(|mm| {
-        mm.insert("version".into(), "1.1.0".into());
-    }), "t")
+    let m2 = validate_manifest_value(
+        &manifest_json(|mm| {
+            mm.insert("version".into(), "1.1.0".into());
+        }),
+        "t",
+    )
     .unwrap();
     install_extension(&m2, &state_file, "upgrade", true).unwrap();
     rollback_extension("ext-x", &state_file, false).unwrap();
@@ -309,7 +441,11 @@ fn runtime_lifecycle_errors() {
     std::fs::write(&state_file, "{corrupt").unwrap();
     assert!(extension_status(&state_file, None).is_err());
     // Bad schema token in state.
-    std::fs::write(&state_file, "{\"schema_version\":\"nope\",\"extensions\":{}}").unwrap();
+    std::fs::write(
+        &state_file,
+        "{\"schema_version\":\"nope\",\"extensions\":{}}",
+    )
+    .unwrap();
     assert!(extension_status(&state_file, None).is_err());
     // status/catalog on a missing state file → empty.
     let missing = dir.path().join("absent.json");

--- a/orchestration/loop/tests/extensions_drive.rs
+++ b/orchestration/loop/tests/extensions_drive.rs
@@ -1,0 +1,326 @@
+//! Coverage drive for `extensions/`: manifest validation error matrix,
+//! protocol tokens, API-version clauses, readiness (doctor) branches, and
+//! the runtime lifecycle validation arms.
+//!
+//! All tests serialize on one lock: readiness resolves commands against
+//! PATH, and one test mutates PATH (process-global).
+
+use future_loop::extensions::manifest::{
+    load_extension_manifest, require_compatible_future_loop_api, validate_manifest_value,
+    validate_protocol_token, ExtensionManifest, EXTENSION_MANIFEST_SCHEMA_VERSION,
+};
+use future_loop::extensions::readiness::{extension_doctor, resolve_runtime_entrypoint, DoctorStatus};
+use future_loop::extensions::runtime::{
+    disable_extension, enable_extension, extension_catalog_entries, extension_status,
+    install_extension, manifest_revision, rollback_extension,
+};
+
+static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn manifest_json(overrides: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>)) -> serde_json::Value {
+    let raw = serde_json::json!({
+        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+        "id": "ext-x",
+        "version": "1.0.0",
+        "requires_future_loop_api": ">=1,<3",
+        "permissions": ["shell"],
+        "runtime": {
+            "protocol": "command_json_v0",
+            "entrypoint": "sh",
+            "args": [],
+            "doctor_args": [],
+            "required_permissions": ["shell"],
+            "timeout_seconds": 30
+        },
+        "provides": [{"id": "ext_x_cap", "kind": "domain_rule", "visibility": "public"}],
+        "implements": [{"capability_id": "ext_x_cap", "protocol": "command_json_v0"}]
+    });
+    let mut obj = raw.as_object().unwrap().clone();
+    overrides(&mut obj);
+    serde_json::Value::Object(obj)
+}
+
+fn valid_manifest() -> ExtensionManifest {
+    validate_manifest_value(&manifest_json(|_| {}), "test").unwrap()
+}
+
+// ── manifest validation matrix ─────────────────────────────────────────────
+
+#[test]
+fn manifest_top_level_errors() {
+    let _g = LOCK.lock().unwrap();
+    // Not an object.
+    assert!(validate_manifest_value(&serde_json::json!([]), "t").is_err());
+    // Bad / legacy schema.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("schema_version".into(), "nope".into());
+    }), "t")
+    .is_err());
+    validate_manifest_value(&manifest_json(|m| {
+        m.insert("schema_version".into(), "loopx_extension_manifest_v0".into());
+    }), "t")
+    .unwrap();
+    // Missing required strings.
+    for key in ["schema_version", "id", "version", "requires_future_loop_api"] {
+        assert!(validate_manifest_value(&manifest_json(|m| {
+            m.remove(key);
+        }), "t")
+        .is_err(), "{key}");
+    }
+    // permissions not an array / non-string items.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("permissions".into(), "shell".into());
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("permissions".into(), serde_json::json!(["shell", 7]));
+    }), "t")
+    .is_err());
+    // Empty manifest (no runtime/provides/implements) → error.
+    assert!(validate_manifest_value(&serde_json::json!({
+        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+        "id": "e", "version": "1", "requires_future_loop_api": ">=1",
+    }), "t")
+    .is_err());
+}
+
+#[test]
+fn manifest_runtime_errors() {
+    let _g = LOCK.lock().unwrap();
+    // Bad protocol token.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap().insert("protocol".into(), "NOPE".into());
+    }), "t")
+    .is_err());
+    // Both entrypoint and python_module.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap().insert("python_module".into(), "mod".into());
+    }), "t")
+    .is_err());
+    // Neither entrypoint nor python_module.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap().remove("entrypoint");
+    }), "t")
+    .is_err());
+    // python_module-only runtime is valid.
+    validate_manifest_value(&manifest_json(|m| {
+        let rt = m["runtime"].as_object_mut().unwrap();
+        rt.remove("entrypoint");
+        rt.insert("python_module".into(), "ext_mod".into());
+    }), "t")
+    .unwrap();
+    // Undeclared required_permissions.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap()
+            .insert("required_permissions".into(), serde_json::json!(["shell", "net"]));
+    }), "t")
+    .is_err());
+    // timeout out of range.
+    for t in [0, 121] {
+        assert!(validate_manifest_value(&manifest_json(|m| {
+            m["runtime"].as_object_mut().unwrap()
+                .insert("timeout_seconds".into(), serde_json::json!(t));
+        }), "t")
+        .is_err(), "{t}");
+    }
+}
+
+#[test]
+fn manifest_provides_implements_errors() {
+    let _g = LOCK.lock().unwrap();
+    // provides not an array / item not an object / missing fields.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("provides".into(), "x".into());
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("provides".into(), serde_json::json!(["x"]));
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("provides".into(), serde_json::json!([{"kind": "domain_rule"}]));
+    }), "t")
+    .is_err());
+    // implements: not array / item not object / bad protocol / no runtime /
+    // protocol mismatch.
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("implements".into(), "x".into());
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("implements".into(), serde_json::json!(["x"]));
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "BAD"}]));
+    }), "t")
+    .is_err());
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.remove("runtime");
+        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "command_json_v0"}]));
+    }), "t")
+    .is_err(), "implements without runtime");
+    assert!(validate_manifest_value(&manifest_json(|m| {
+        m.insert("implements".into(), serde_json::json!([{"capability_id": "c", "protocol": "other_proto_v1"}]));
+    }), "t")
+    .is_err(), "protocol mismatch");
+    // load_extension_manifest: unreadable + invalid JSON.
+    assert!(load_extension_manifest(std::path::Path::new("/nonexistent.json")).is_err());
+    let dir = tempfile::tempdir().unwrap();
+    let bad = dir.path().join("bad.json");
+    std::fs::write(&bad, "{nope").unwrap();
+    assert!(load_extension_manifest(&bad).is_err());
+}
+
+#[test]
+fn protocol_token_matrix() {
+    let _g = LOCK.lock().unwrap();
+    assert!(validate_protocol_token("command_json_v0"));
+    assert!(validate_protocol_token("a_v1"));
+    assert!(!validate_protocol_token(""));
+    assert!(!validate_protocol_token("UPPER_v1"));
+    assert!(!validate_protocol_token("1starts_digit_v1"));
+    assert!(!validate_protocol_token("no_version"));
+    assert!(!validate_protocol_token("trailing_v"));
+    assert!(!validate_protocol_token("bad_vx"));
+    assert!(!validate_protocol_token("dash-not-allowed_v1"));
+}
+
+#[test]
+fn api_version_clause_matrix() {
+    let _g = LOCK.lock().unwrap();
+    // LOOPX_EXTENSION_API_VERSION == 1.
+    assert!(require_compatible_future_loop_api(">=1").is_ok());
+    assert!(require_compatible_future_loop_api(">=1,<3").is_ok());
+    assert!(require_compatible_future_loop_api("<=1").is_ok());
+    assert!(require_compatible_future_loop_api("==1").is_ok());
+    assert!(require_compatible_future_loop_api("1").is_ok(), "bare number means ==");
+    assert!(require_compatible_future_loop_api(">0").is_ok());
+    assert!(require_compatible_future_loop_api("<2").is_ok());
+    assert!(require_compatible_future_loop_api(">=2").is_err());
+    assert!(require_compatible_future_loop_api("<1").is_err());
+    assert!(require_compatible_future_loop_api("==2").is_err());
+    assert!(require_compatible_future_loop_api("").is_err());
+    assert!(require_compatible_future_loop_api(">=x").is_err());
+}
+
+// ── readiness (doctor) ─────────────────────────────────────────────────────
+
+#[test]
+fn readiness_branches() {
+    let _g = LOCK.lock().unwrap();
+    // Entrypoint resolves on PATH → ready (no doctor args configured).
+    let m = valid_manifest();
+    let report = extension_doctor(&m);
+    // `sh` exists on unix; on Windows it may not — both arms are valid.
+    let expected = if cfg!(unix) {
+        DoctorStatus::Ready.label()
+    } else {
+        DoctorStatus::EntrypointMissing.label()
+    };
+    assert_eq!(report.status, expected);
+    // Missing entrypoint → entrypoint_missing (both doctor-args arms).
+    let missing = validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap()
+            .insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
+    }), "t")
+    .unwrap();
+    assert_eq!(extension_doctor(&missing).status, DoctorStatus::EntrypointMissing.label());
+    let missing_with_doctor_args = validate_manifest_value(&manifest_json(|m| {
+        let rt = m["runtime"].as_object_mut().unwrap();
+        rt.insert("entrypoint".into(), "definitely-not-a-real-cmd-xyz".into());
+        rt.insert("doctor_args".into(), serde_json::json!(["--check"]));
+    }), "t")
+    .unwrap();
+    assert_eq!(
+        extension_doctor(&missing_with_doctor_args).status,
+        DoctorStatus::EntrypointMissing.label()
+    );
+    // resolve_runtime_entrypoint: absolute-path fallback and None arm.
+    let abs = validate_manifest_value(&manifest_json(|m| {
+        m["runtime"].as_object_mut().unwrap().insert(
+            "entrypoint".into(),
+            if cfg!(unix) { "/bin/sh" } else { "sh" }.into(),
+        );
+    }), "t")
+    .unwrap();
+    let resolved = resolve_runtime_entrypoint(abs.runtime.as_ref().unwrap());
+    if cfg!(unix) {
+        assert!(resolved.is_some());
+    }
+    // No runtime at all → None.
+    let no_rt = validate_manifest_value(&serde_json::json!({
+        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+        "id": "e", "version": "1", "requires_future_loop_api": ">=1",
+        "provides": [{"id": "c", "kind": "k"}],
+    }), "t")
+    .unwrap();
+    assert!(no_rt.runtime.is_none());
+    // python_module resolution (needs python3/python on PATH — whatever the
+    // host has; both arms acceptable).
+    let py = validate_manifest_value(&manifest_json(|m| {
+        let rt = m["runtime"].as_object_mut().unwrap();
+        rt.remove("entrypoint");
+        rt.insert("python_module".into(), "ext_mod".into());
+    }), "t")
+    .unwrap();
+    let _ = resolve_runtime_entrypoint(py.runtime.as_ref().unwrap());
+    // PATH removed entirely → which() returns None (process-global: locked).
+    let saved = std::env::var_os("PATH");
+    std::env::remove_var("PATH");
+    assert!(resolve_runtime_entrypoint(abs.runtime.as_ref().unwrap()).is_none());
+    if let Some(p) = saved {
+        std::env::set_var("PATH", p);
+    }
+}
+
+// ── runtime lifecycle validation arms ──────────────────────────────────────
+
+#[test]
+fn runtime_lifecycle_errors() {
+    let _g = LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    let m = valid_manifest();
+    // upgrade before install → not installed.
+    assert!(install_extension(&m, &state_file, "upgrade", false).is_err());
+    // bad operation token.
+    assert!(install_extension(&m, &state_file, "frobnicate", false).is_err());
+    // install (execute) → installed; second install → already installed.
+    install_extension(&m, &state_file, "install", true).unwrap();
+    assert!(install_extension(&m, &state_file, "install", false).is_err());
+    // Same-revision upgrade → already active.
+    assert!(install_extension(&m, &state_file, "upgrade", true).is_err());
+    // enable/disable/rollback on a missing extension.
+    assert!(enable_extension("ghost", &state_file, false).is_err());
+    assert!(disable_extension("ghost", &state_file, false).is_err());
+    assert!(rollback_extension("ghost", &state_file, false).is_err());
+    // rollback with no prior upgrade → no rollback revision.
+    assert!(rollback_extension("ext-x", &state_file, false).is_err());
+    // Upgrade to a new revision, then rollback works (execute + dry-run).
+    let m2 = validate_manifest_value(&manifest_json(|mm| {
+        mm.insert("version".into(), "1.1.0".into());
+    }), "t")
+    .unwrap();
+    install_extension(&m2, &state_file, "upgrade", true).unwrap();
+    rollback_extension("ext-x", &state_file, false).unwrap();
+    rollback_extension("ext-x", &state_file, true).unwrap();
+    // Corrupt state file → read_state error.
+    std::fs::write(&state_file, "{corrupt").unwrap();
+    assert!(extension_status(&state_file, None).is_err());
+    // Bad schema token in state.
+    std::fs::write(&state_file, "{\"schema_version\":\"nope\",\"extensions\":{}}").unwrap();
+    assert!(extension_status(&state_file, None).is_err());
+    // status/catalog on a missing state file → empty.
+    let missing = dir.path().join("absent.json");
+    assert!(extension_status(&missing, None).unwrap().is_empty());
+    assert!(extension_catalog_entries(&missing).unwrap().is_empty());
+}
+
+#[test]
+fn revision_digest_stable() {
+    let _g = LOCK.lock().unwrap();
+    let m = valid_manifest();
+    assert_eq!(manifest_revision(&m), manifest_revision(&m));
+    assert_eq!(manifest_revision(&m).len(), 16);
+}

--- a/orchestration/loop/tests/extensions_drive.rs
+++ b/orchestration/loop/tests/extensions_drive.rs
@@ -48,7 +48,7 @@ fn valid_manifest() -> ExtensionManifest {
 
 #[test]
 fn manifest_top_level_errors() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Not an object.
     assert!(validate_manifest_value(&serde_json::json!([]), "t").is_err());
     // Bad / legacy schema.
@@ -86,7 +86,7 @@ fn manifest_top_level_errors() {
 
 #[test]
 fn manifest_runtime_errors() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Bad protocol token.
     assert!(validate_manifest_value(&manifest_json(|m| {
         m["runtime"].as_object_mut().unwrap().insert("protocol".into(), "NOPE".into());
@@ -127,7 +127,7 @@ fn manifest_runtime_errors() {
 
 #[test]
 fn manifest_provides_implements_errors() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // provides not an array / item not an object / missing fields.
     assert!(validate_manifest_value(&manifest_json(|m| {
         m.insert("provides".into(), "x".into());
@@ -174,7 +174,7 @@ fn manifest_provides_implements_errors() {
 
 #[test]
 fn protocol_token_matrix() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     assert!(validate_protocol_token("command_json_v0"));
     assert!(validate_protocol_token("a_v1"));
     assert!(!validate_protocol_token(""));
@@ -188,7 +188,7 @@ fn protocol_token_matrix() {
 
 #[test]
 fn api_version_clause_matrix() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // LOOPX_EXTENSION_API_VERSION == 1.
     assert!(require_compatible_future_loop_api(">=1").is_ok());
     assert!(require_compatible_future_loop_api(">=1,<3").is_ok());
@@ -208,7 +208,7 @@ fn api_version_clause_matrix() {
 
 #[test]
 fn readiness_branches() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Entrypoint resolves on PATH → ready (no doctor args configured).
     let m = valid_manifest();
     let report = extension_doctor(&m);
@@ -278,7 +278,7 @@ fn readiness_branches() {
 
 #[test]
 fn runtime_lifecycle_errors() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
     let m = valid_manifest();
@@ -319,7 +319,7 @@ fn runtime_lifecycle_errors() {
 
 #[test]
 fn revision_digest_stable() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let m = valid_manifest();
     assert_eq!(manifest_revision(&m), manifest_revision(&m));
     assert_eq!(manifest_revision(&m).len(), 16);

--- a/orchestration/loop/tests/extensions_drive2.rs
+++ b/orchestration/loop/tests/extensions_drive2.rs
@@ -36,7 +36,7 @@ fn manifest_with_entrypoint(id: &str, version: &str, entrypoint: &str) -> future
 
 #[test]
 fn example_manifest_writer() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let path = write_example_manifest(dir.path(), "ext-example");
     assert!(path.exists());
@@ -48,7 +48,7 @@ fn example_manifest_writer() {
 
 #[test]
 fn doctor_status_labels() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     for (s, label) in [
         (DoctorStatus::Ready, "ready"),
         (DoctorStatus::EntrypointMissing, "entrypoint_missing"),
@@ -62,7 +62,7 @@ fn doctor_status_labels() {
 
 #[test]
 fn doctor_gated_lifecycle_errors() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
     // An extension whose entrypoint cannot resolve (doctor not ready).
@@ -94,7 +94,7 @@ fn doctor_gated_lifecycle_errors() {
 
 #[test]
 fn doctor_gated_enable_and_rollback_via_state_surgery() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
     let good = manifest_with_entrypoint("ext-surg", "1.0.0", "sh");
@@ -103,7 +103,7 @@ fn doctor_gated_enable_and_rollback_via_state_surgery() {
     // enable doctor refuses.
     let text = std::fs::read_to_string(&state_file).unwrap();
     let broken = text.replace("\"sh\"", "\"definitely-not-a-real-cmd-xyz\"");
-    assert_ne!(text, broken);
+    assert_ne!(text, broken, "surgery must change the state");
     std::fs::write(&state_file, &broken).unwrap();
     let err = enable_extension("ext-surg", &state_file, true).unwrap_err();
     assert!(err.contains("doctor"), "{err}");
@@ -132,7 +132,7 @@ fn doctor_gated_enable_and_rollback_via_state_surgery() {
 
 #[test]
 fn revision_retention_overflow() {
-    let _g = LOCK.lock().unwrap();
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
     // MAX_REVISIONS is small (bounded history) — exceed it and confirm the
@@ -149,4 +149,54 @@ fn revision_retention_overflow() {
     // catalog entries include the lifecycle row.
     let entries = extension_catalog_entries(&state_file).unwrap();
     assert!(entries.iter().any(|e| e.id == "ext-churn"));
+}
+
+#[test]
+fn extension_api_version_and_catalog_skip_arm() {
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    assert_eq!(future_loop::extensions::runtime::extension_api_version(), 1);
+    // An entry whose ACTIVE revision does not resolve to a stored manifest
+    // is skipped in the catalog projection.
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    install_extension(&manifest_with_entrypoint("ext-skip", "1.0.0", "sh"), &state_file, "install", true).unwrap();
+    let mut value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
+    value["extensions"]["ext-skip"]
+        .as_object_mut()
+        .unwrap()
+        .insert("active_revision".into(), serde_json::json!("nonexistent-revision"));
+    std::fs::write(&state_file, serde_json::to_string(&value).unwrap()).unwrap();
+    let entries = extension_catalog_entries(&state_file).unwrap();
+    assert!(entries.is_empty(), "invalid manifest skipped: {entries:?}");
+    // status still lists it (manifest resolution is not required for rows).
+    assert_eq!(extension_status(&state_file, None).unwrap().len(), 1);
+}
+
+#[test]
+fn retain_revisions_reinserts_required_rollback() {
+    let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Craft a state where the rollback target sits OUTSIDE the retention
+    // window, then upgrade once: retain must re-insert it at the head.
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    install_extension(&manifest_with_entrypoint("ext-deep", "1.0.0", "sh"), &state_file, "install", true).unwrap();
+    for v in 1..6 {
+        install_extension(&manifest_with_entrypoint("ext-deep", &format!("1.0.{v}"), "sh"), &state_file, "upgrade", true).unwrap();
+    }
+    // State surgery: rewrite the rollback pointer to the OLDEST revision and
+    // truncate the revision list to the window, so the required target is
+    // outside it. Simply removing knowledge of the oldest revisions from the
+    // state file achieves this after the next upgrade trims.
+    let mut value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
+    let entry = value["extensions"]["ext-deep"].as_object_mut().unwrap();
+    let revisions = entry["revisions"].as_array().unwrap();
+    let oldest = revisions.first().unwrap()["revision"].as_str().unwrap().to_string();
+    entry.insert("rollback_revision".into(), serde_json::json!(oldest));
+    std::fs::write(&state_file, serde_json::to_string(&value).unwrap()).unwrap();
+    // One more upgrade pushes the window past the oldest; retain re-inserts it.
+    install_extension(&manifest_with_entrypoint("ext-deep", "1.0.9", "sh"), &state_file, "upgrade", true).unwrap();
+    let rows = extension_status(&state_file, Some("ext-deep")).unwrap();
+    assert!(rows[0].rollback_available, "required rollback retained: {rows:?}");
 }

--- a/orchestration/loop/tests/extensions_drive2.rs
+++ b/orchestration/loop/tests/extensions_drive2.rs
@@ -13,7 +13,11 @@ use future_loop::extensions::runtime::{
 
 static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-fn manifest_with_entrypoint(id: &str, version: &str, entrypoint: &str) -> future_loop::extensions::manifest::ExtensionManifest {
+fn manifest_with_entrypoint(
+    id: &str,
+    version: &str,
+    entrypoint: &str,
+) -> future_loop::extensions::manifest::ExtensionManifest {
     let raw = serde_json::json!({
         "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
         "id": id,
@@ -75,16 +79,35 @@ fn doctor_gated_lifecycle_errors() {
     install_extension(&good, &state_file, "install", true).unwrap();
     // Now corrupt the installed entry's manifest by hand so enable's doctor
     // fails: point the stored manifest at a missing entrypoint.
-    install_extension(&manifest_with_entrypoint("ext-good", "1.1.0", "sh"), &state_file, "upgrade", true).unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-good", "1.1.0", "sh"),
+        &state_file,
+        "upgrade",
+        true,
+    )
+    .unwrap();
     // enable on an already-enabled extension → changed=false arm.
     let op = enable_extension("ext-good", &state_file, true).unwrap();
     assert!(!op.changed, "already enabled → unchanged");
     // disable → changed; disable again → unchanged arm.
-    assert!(disable_extension("ext-good", &state_file, true).unwrap().changed);
-    assert!(!disable_extension("ext-good", &state_file, true).unwrap().changed);
+    assert!(
+        disable_extension("ext-good", &state_file, true)
+            .unwrap()
+            .changed
+    );
+    assert!(
+        !disable_extension("ext-good", &state_file, true)
+            .unwrap()
+            .changed
+    );
     // status filter: miss → error; hit → one row.
     assert!(extension_status(&state_file, Some("ghost")).is_err());
-    assert_eq!(extension_status(&state_file, Some("ext-good")).unwrap().len(), 1);
+    assert_eq!(
+        extension_status(&state_file, Some("ext-good"))
+            .unwrap()
+            .len(),
+        1
+    );
     // rollback: the rollback target exists (1.0.0); doctor-gated rollback on
     // a broken target errors — craft by installing a broken rollback target.
     let good2 = manifest_with_entrypoint("ext-good", "1.2.0", "sh");
@@ -112,8 +135,20 @@ fn doctor_gated_enable_and_rollback_via_state_surgery() {
     // directly: v1 broken on disk, v2 good active.
     let dir2 = tempfile::tempdir().unwrap();
     let state_file2 = dir2.path().join("state.json");
-    install_extension(&manifest_with_entrypoint("ext-rb", "1.0.0", "sh"), &state_file2, "install", true).unwrap();
-    install_extension(&manifest_with_entrypoint("ext-rb", "1.1.0", "sh"), &state_file2, "upgrade", true).unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-rb", "1.0.0", "sh"),
+        &state_file2,
+        "install",
+        true,
+    )
+    .unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-rb", "1.1.0", "sh"),
+        &state_file2,
+        "upgrade",
+        true,
+    )
+    .unwrap();
     // Break ONLY the rollback target (the 1.0.0 revision) in the state file.
     let text = std::fs::read_to_string(&state_file2).unwrap();
     // The first "sh" occurrence belongs to the older revision payload.
@@ -144,8 +179,15 @@ fn revision_retention_overflow() {
     }
     let rows = extension_status(&state_file, Some("ext-churn")).unwrap();
     assert_eq!(rows.len(), 1);
-    assert!(rows[0].revision_count <= 10, "bounded: {}", rows[0].revision_count);
-    assert!(rows[0].rollback_available, "required rollback revision retained");
+    assert!(
+        rows[0].revision_count <= 10,
+        "bounded: {}",
+        rows[0].revision_count
+    );
+    assert!(
+        rows[0].rollback_available,
+        "required rollback revision retained"
+    );
     // catalog entries include the lifecycle row.
     let entries = extension_catalog_entries(&state_file).unwrap();
     assert!(entries.iter().any(|e| e.id == "ext-churn"));
@@ -159,13 +201,22 @@ fn extension_api_version_and_catalog_skip_arm() {
     // is skipped in the catalog projection.
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
-    install_extension(&manifest_with_entrypoint("ext-skip", "1.0.0", "sh"), &state_file, "install", true).unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-skip", "1.0.0", "sh"),
+        &state_file,
+        "install",
+        true,
+    )
+    .unwrap();
     let mut value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
     value["extensions"]["ext-skip"]
         .as_object_mut()
         .unwrap()
-        .insert("active_revision".into(), serde_json::json!("nonexistent-revision"));
+        .insert(
+            "active_revision".into(),
+            serde_json::json!("nonexistent-revision"),
+        );
     std::fs::write(&state_file, serde_json::to_string(&value).unwrap()).unwrap();
     let entries = extension_catalog_entries(&state_file).unwrap();
     assert!(entries.is_empty(), "invalid manifest skipped: {entries:?}");
@@ -180,9 +231,21 @@ fn retain_revisions_reinserts_required_rollback() {
     // window, then upgrade once: retain must re-insert it at the head.
     let dir = tempfile::tempdir().unwrap();
     let state_file = dir.path().join("state.json");
-    install_extension(&manifest_with_entrypoint("ext-deep", "1.0.0", "sh"), &state_file, "install", true).unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-deep", "1.0.0", "sh"),
+        &state_file,
+        "install",
+        true,
+    )
+    .unwrap();
     for v in 1..6 {
-        install_extension(&manifest_with_entrypoint("ext-deep", &format!("1.0.{v}"), "sh"), &state_file, "upgrade", true).unwrap();
+        install_extension(
+            &manifest_with_entrypoint("ext-deep", &format!("1.0.{v}"), "sh"),
+            &state_file,
+            "upgrade",
+            true,
+        )
+        .unwrap();
     }
     // State surgery: rewrite the rollback pointer to the OLDEST revision and
     // truncate the revision list to the window, so the required target is
@@ -192,11 +255,23 @@ fn retain_revisions_reinserts_required_rollback() {
         serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
     let entry = value["extensions"]["ext-deep"].as_object_mut().unwrap();
     let revisions = entry["revisions"].as_array().unwrap();
-    let oldest = revisions.first().unwrap()["revision"].as_str().unwrap().to_string();
+    let oldest = revisions.first().unwrap()["revision"]
+        .as_str()
+        .unwrap()
+        .to_string();
     entry.insert("rollback_revision".into(), serde_json::json!(oldest));
     std::fs::write(&state_file, serde_json::to_string(&value).unwrap()).unwrap();
     // One more upgrade pushes the window past the oldest; retain re-inserts it.
-    install_extension(&manifest_with_entrypoint("ext-deep", "1.0.9", "sh"), &state_file, "upgrade", true).unwrap();
+    install_extension(
+        &manifest_with_entrypoint("ext-deep", "1.0.9", "sh"),
+        &state_file,
+        "upgrade",
+        true,
+    )
+    .unwrap();
     let rows = extension_status(&state_file, Some("ext-deep")).unwrap();
-    assert!(rows[0].rollback_available, "required rollback retained: {rows:?}");
+    assert!(
+        rows[0].rollback_available,
+        "required rollback retained: {rows:?}"
+    );
 }

--- a/orchestration/loop/tests/extensions_drive2.rs
+++ b/orchestration/loop/tests/extensions_drive2.rs
@@ -172,7 +172,7 @@ fn revision_retention_overflow() {
     let state_file = dir.path().join("state.json");
     // MAX_REVISIONS is small (bounded history) — exceed it and confirm the
     // rollback target survives trimming.
-    let mut version = |v: u32| manifest_with_entrypoint("ext-churn", &format!("1.0.{v}"), "sh");
+    let version = |v: u32| manifest_with_entrypoint("ext-churn", &format!("1.0.{v}"), "sh");
     install_extension(&version(0), &state_file, "install", true).unwrap();
     for v in 1..10 {
         install_extension(&version(v), &state_file, "upgrade", true).unwrap();

--- a/orchestration/loop/tests/extensions_drive2.rs
+++ b/orchestration/loop/tests/extensions_drive2.rs
@@ -1,0 +1,114 @@
+//! Coverage drive 2 for `extensions/`: example manifest writer, doctor-status
+//! labels, revision-overflow retention, doctor-gated lifecycle errors, and
+//! the status/catalog filter arms.
+
+use future_loop::extensions::manifest::{
+    validate_manifest_value, write_example_manifest, EXTENSION_MANIFEST_SCHEMA_VERSION,
+};
+use future_loop::extensions::readiness::DoctorStatus;
+use future_loop::extensions::runtime::{
+    disable_extension, enable_extension, extension_catalog_entries, extension_status,
+    install_extension, rollback_extension,
+};
+
+static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn manifest_with_entrypoint(id: &str, version: &str, entrypoint: &str) -> future_loop::extensions::manifest::ExtensionManifest {
+    let raw = serde_json::json!({
+        "schema_version": EXTENSION_MANIFEST_SCHEMA_VERSION,
+        "id": id,
+        "version": version,
+        "requires_future_loop_api": ">=1,<3",
+        "permissions": ["shell"],
+        "runtime": {
+            "protocol": "command_json_v0",
+            "entrypoint": entrypoint,
+            "args": [],
+            "doctor_args": ["--check"],
+            "required_permissions": ["shell"],
+            "timeout_seconds": 30
+        },
+        "provides": [{"id": format!("{id}_cap"), "kind": "domain_rule", "visibility": "public"}],
+        "implements": [{"capability_id": format!("{id}_cap"), "protocol": "command_json_v0"}]
+    });
+    validate_manifest_value(&raw, "test").unwrap()
+}
+
+#[test]
+fn example_manifest_writer() {
+    let _g = LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_example_manifest(dir.path(), "ext-example");
+    assert!(path.exists());
+    // The example manifest is itself valid.
+    let text = std::fs::read_to_string(&path).unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&text).unwrap();
+    validate_manifest_value(&raw, "example").unwrap();
+}
+
+#[test]
+fn doctor_status_labels() {
+    let _g = LOCK.lock().unwrap();
+    for (s, label) in [
+        (DoctorStatus::Ready, "ready"),
+        (DoctorStatus::EntrypointMissing, "entrypoint_missing"),
+        (DoctorStatus::DoctorNotConfigured, "doctor_not_configured"),
+        (DoctorStatus::ProbeRequired, "probe_required"),
+        (DoctorStatus::ProviderUnavailable, "provider_unavailable"),
+    ] {
+        assert_eq!(s.label(), label);
+    }
+}
+
+#[test]
+fn doctor_gated_lifecycle_errors() {
+    let _g = LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    // An extension whose entrypoint cannot resolve (doctor not ready).
+    let bad = manifest_with_entrypoint("ext-bad", "1.0.0", "definitely-not-a-real-cmd-xyz");
+    // Dry-run install skips the doctor; --execute refuses.
+    install_extension(&bad, &state_file, "install", false).unwrap();
+    assert!(install_extension(&bad, &state_file, "install", true).is_err());
+    // The dry-run install did NOT persist; use a good manifest for the rest.
+    let good = manifest_with_entrypoint("ext-good", "1.0.0", "sh");
+    install_extension(&good, &state_file, "install", true).unwrap();
+    // Now corrupt the installed entry's manifest by hand so enable's doctor
+    // fails: point the stored manifest at a missing entrypoint.
+    install_extension(&manifest_with_entrypoint("ext-good", "1.1.0", "sh"), &state_file, "upgrade", true).unwrap();
+    // enable on an already-enabled extension → changed=false arm.
+    let op = enable_extension("ext-good", &state_file, true).unwrap();
+    assert!(!op.changed, "already enabled → unchanged");
+    // disable → changed; disable again → unchanged arm.
+    assert!(disable_extension("ext-good", &state_file, true).unwrap().changed);
+    assert!(!disable_extension("ext-good", &state_file, true).unwrap().changed);
+    // status filter: miss → error; hit → one row.
+    assert!(extension_status(&state_file, Some("ghost")).is_err());
+    assert_eq!(extension_status(&state_file, Some("ext-good")).unwrap().len(), 1);
+    // rollback: the rollback target exists (1.0.0); doctor-gated rollback on
+    // a broken target errors — craft by installing a broken rollback target.
+    let good2 = manifest_with_entrypoint("ext-good", "1.2.0", "sh");
+    install_extension(&good2, &state_file, "upgrade", true).unwrap();
+    rollback_extension("ext-good", &state_file, true).unwrap();
+}
+
+#[test]
+fn revision_retention_overflow() {
+    let _g = LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    // MAX_REVISIONS is small (bounded history) — exceed it and confirm the
+    // rollback target survives trimming.
+    let mut version = |v: u32| manifest_with_entrypoint("ext-churn", &format!("1.0.{v}"), "sh");
+    install_extension(&version(0), &state_file, "install", true).unwrap();
+    for v in 1..10 {
+        install_extension(&version(v), &state_file, "upgrade", true).unwrap();
+    }
+    let rows = extension_status(&state_file, Some("ext-churn")).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].revision_count <= 10, "bounded: {}", rows[0].revision_count);
+    assert!(rows[0].rollback_available, "required rollback revision retained");
+    // catalog entries include the lifecycle row.
+    let entries = extension_catalog_entries(&state_file).unwrap();
+    assert!(entries.iter().any(|e| e.id == "ext-churn"));
+}

--- a/orchestration/loop/tests/extensions_drive2.rs
+++ b/orchestration/loop/tests/extensions_drive2.rs
@@ -93,6 +93,44 @@ fn doctor_gated_lifecycle_errors() {
 }
 
 #[test]
+fn doctor_gated_enable_and_rollback_via_state_surgery() {
+    let _g = LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let state_file = dir.path().join("state.json");
+    let good = manifest_with_entrypoint("ext-surg", "1.0.0", "sh");
+    install_extension(&good, &state_file, "install", true).unwrap();
+    // State surgery: point the stored manifest at a missing entrypoint so the
+    // enable doctor refuses.
+    let text = std::fs::read_to_string(&state_file).unwrap();
+    let broken = text.replace("\"sh\"", "\"definitely-not-a-real-cmd-xyz\"");
+    assert_ne!(text, broken);
+    std::fs::write(&state_file, &broken).unwrap();
+    let err = enable_extension("ext-surg", &state_file, true).unwrap_err();
+    assert!(err.contains("doctor"), "{err}");
+    // And a rollback whose TARGET manifest is broken refuses the same way:
+    // restore a good active manifest, dry-run a broken upgrade… no — craft
+    // directly: v1 broken on disk, v2 good active.
+    let dir2 = tempfile::tempdir().unwrap();
+    let state_file2 = dir2.path().join("state.json");
+    install_extension(&manifest_with_entrypoint("ext-rb", "1.0.0", "sh"), &state_file2, "install", true).unwrap();
+    install_extension(&manifest_with_entrypoint("ext-rb", "1.1.0", "sh"), &state_file2, "upgrade", true).unwrap();
+    // Break ONLY the rollback target (the 1.0.0 revision) in the state file.
+    let text = std::fs::read_to_string(&state_file2).unwrap();
+    // The first "sh" occurrence belongs to the older revision payload.
+    let idx = text.find("\"sh\"").unwrap();
+    let broken = format!(
+        "{}\"definitely-not-a-real-cmd-xyz\"{}",
+        &text[..idx],
+        &text[idx + 4..]
+    );
+    std::fs::write(&state_file2, &broken).unwrap();
+    let err = rollback_extension("ext-rb", &state_file2, true).unwrap_err();
+    assert!(err.contains("doctor"), "{err}");
+    // And the dry-run (no doctor) still works.
+    rollback_extension("ext-rb", &state_file2, false).unwrap();
+}
+
+#[test]
 fn revision_retention_overflow() {
     let _g = LOCK.lock().unwrap();
     let dir = tempfile::tempdir().unwrap();

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -33,7 +33,11 @@ fn scope_frontier_arms() {
     goal.todos.push(lapsed);
     // Unclaimed advancement + a monitor + a blocker (agent-work classes).
     goal.todos.push(Todo::advancement("t3", "free"));
-    goal.todos.push(Todo::monitor("m1", "watch", std::time::Duration::from_secs(60)));
+    goal.todos.push(Todo::monitor(
+        "m1",
+        "watch",
+        std::time::Duration::from_secs(60),
+    ));
     goal.todos.push(Todo::blocker("b1", "blocker", &[]));
     // An open gate for the gates list.
     goal.todos.push(Todo::user_gate("g1", "q?", &[]));
@@ -63,7 +67,10 @@ fn capability_gate_arms() {
     let mut t = Todo::advancement("t1", "x");
     t.required_capability = Some("shell".into());
     assert!(cg::missing_required_capabilities(&t, &avail).is_empty());
-    assert_eq!(cg::missing_required_capabilities(&t, &[]), vec!["shell".to_string()]);
+    assert_eq!(
+        cg::missing_required_capabilities(&t, &[]),
+        vec!["shell".to_string()]
+    );
     let plain = Todo::advancement("t2", "y");
     assert!(cg::missing_required_capabilities(&plain, &[]).is_empty());
     // todo_is_runnable (note: the DEFAULT available set includes shell, so
@@ -81,8 +88,14 @@ fn capability_gate_arms() {
     let todos = vec![needs_shell, needs_custom, Todo::advancement("t3", "free")];
     let gate = cg::build_capability_gate(&todos, &[]).expect("gate with blocked todos");
     assert!(gate.runnable_todo_ids.contains(&"t3".to_string()));
-    assert!(gate.runnable_todo_ids.contains(&"t1".to_string()), "shell is default-available");
-    assert!(gate.blocked_todo_ids.contains(&"t2".to_string()), "custom-xyz missing");
+    assert!(
+        gate.runnable_todo_ids.contains(&"t1".to_string()),
+        "shell is default-available"
+    );
+    assert!(
+        gate.blocked_todo_ids.contains(&"t2".to_string()),
+        "custom-xyz missing"
+    );
     // Everything runnable → None.
     let free = vec![Todo::advancement("t9", "free")];
     assert!(cg::build_capability_gate(&free, &[]).is_none());
@@ -103,7 +116,8 @@ fn lane_recommendation_arms() {
     let rec = compact_agent_lane_recommendation(&goal, "w1").unwrap();
     assert!(rec.recommended_action.is_none());
     // With evidence → truncated action.
-    goal.history.push(run_record("t1", "completed", now_epoch()));
+    goal.history
+        .push(run_record("t1", "completed", now_epoch()));
     let rec = compact_agent_lane_recommendation(&goal, "w1").unwrap();
     assert!(rec.recommended_action.is_some());
 }
@@ -129,7 +143,11 @@ fn loop_protocol_comparison_contract() {
         "r1",
         lp::LOOPX_PRODUCT_MODE_ROUTE,
     );
-    assert_eq!(c3.max_rounds_budget, lp::BLIND_LOOP_DEFAULT_MAX_ROUNDS, "0 → default");
+    assert_eq!(
+        c3.max_rounds_budget,
+        lp::BLIND_LOOP_DEFAULT_MAX_ROUNDS,
+        "0 → default"
+    );
     // Route classifiers.
     assert!(!lp::blind_loop_routes().is_empty());
     assert!(!lp::product_mode_routes().is_empty());
@@ -143,11 +161,17 @@ fn auto_research_parse_arms() {
     let registry = CapabilityRegistry::with_builtin();
     let cap = registry.get("auto_research").unwrap();
     // Structured with all keys.
-    let ps = cap.propose("question: does X beat Y on metric Z?\nhypothesis: X wins\nmethod: ablation");
+    let ps =
+        cap.propose("question: does X beat Y on metric Z?\nhypothesis: X wins\nmethod: ablation");
     assert!(!ps.is_empty());
     // A non-question → clarify successor.
     let ps = cap.propose("question: just a statement");
-    assert!(ps.iter().any(|p| p.reason.contains("not shaped as a research question") || p.reason.contains("Clarify")), "{ps:?}");
+    assert!(
+        ps.iter()
+            .any(|p| p.reason.contains("not shaped as a research question")
+                || p.reason.contains("Clarify")),
+        "{ps:?}"
+    );
     // Empty.
     assert!(!cap.propose("").is_empty());
 }
@@ -164,9 +188,18 @@ fn periodic_report_parse_arms() {
     assert_eq!(p.cadence, "every friday with details");
     // Cadence tokens → (class, seconds).
     use future_loop::capabilities::periodic_report::cadence_due_secs;
-    assert_eq!(cadence_due_secs("hourly"), Some(("hourly".to_string(), 3600)));
-    assert_eq!(cadence_due_secs("every-6h"), Some(("every-6h".to_string(), 21600)));
-    assert_eq!(cadence_due_secs("every-2d"), Some(("every-2d".to_string(), 172800)));
+    assert_eq!(
+        cadence_due_secs("hourly"),
+        Some(("hourly".to_string(), 3600))
+    );
+    assert_eq!(
+        cadence_due_secs("every-6h"),
+        Some(("every-6h".to_string(), 21600))
+    );
+    assert_eq!(
+        cadence_due_secs("every-2d"),
+        Some(("every-2d".to_string(), 172800))
+    );
     assert_eq!(cadence_due_secs("every-0h"), None);
     assert_eq!(cadence_due_secs("fortnightly"), None);
     let _ = &p;
@@ -203,14 +236,20 @@ fn compat_write_run_and_active_state() {
     t.status = TodoStatus::Done;
     t.completed_at = Some(1_700_000_000);
     goal.todos.push(t);
-    goal.todos.push(Todo::monitor("m1", "watch", std::time::Duration::from_secs(60)));
+    goal.todos.push(Todo::monitor(
+        "m1",
+        "watch",
+        std::time::Duration::from_secs(60),
+    ));
     // write_active_state with evidence/completed anchors.
     future_loop::compat::write_active_state(goal_dir, &goal).unwrap();
     let md = std::fs::read_to_string(goal_dir.join("ACTIVE_GOAL_STATE.md")).unwrap();
     assert!(md.contains("t1"), "{md}");
     // write_run twice (json + md artifacts).
-    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch())).unwrap();
-    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch())).unwrap();
+    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch()))
+        .unwrap();
+    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch()))
+        .unwrap();
     let runs = goal_dir.join("runs");
     assert!(runs.exists());
 }
@@ -247,7 +286,8 @@ fn heartbeat_render_arms() {
     gate.gate_question = None;
     goal.todos.push(gate);
     goal.todos.push(Todo::advancement("t1", "fallback work"));
-    goal.history.push(run_record("t0", "completed", now_epoch()));
+    goal.history
+        .push(run_record("t0", "completed", now_epoch()));
     let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
     let out = render_heartbeat_prompt(&goal, &packet);
     assert!(out.contains("USER ACTION REQUIRED"), "{out}");
@@ -289,15 +329,18 @@ fn migration_arms() {
     assert!(report.migrated_lines >= 1);
     // Bridge status: rollback_plan_recorded flips once a backup exists.
     let store = open_store(&cr);
-    let before = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    let before =
+        future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
     assert!(!before.checks.rollback_plan_recorded);
     store.backup_goal(&gid).unwrap();
-    let after = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    let after =
+        future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
     assert!(after.checks.rollback_plan_recorded);
     // dual_read_parity: ACTIVE_GOAL_STATE.md with anchors matching the replay.
     let goal = store.replay(&gid).unwrap().unwrap();
     future_loop::compat::write_active_state(&store.goal_dir(&gid), &goal).unwrap();
-    let with_state = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    let with_state =
+        future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
     let _ = with_state.checks.dual_read_parity_clean;
     // migration_steps registry is non-empty and ordered.
     assert!(!future_loop::migration::migration_steps().is_empty());
@@ -319,7 +362,13 @@ fn quota_slot_accounting_arms() {
     assert_eq!(sa::SlotSpendSource::parse("bogus"), None);
     // stall repair: kind() + is_stalled_mode arms.
     use future_loop::quota::stall_repair::{detect_stall, is_stalled_mode};
-    for kind in ["outcome_floor", "repair_budget_exhausted", "monitor_stalled", "succession_obligation", "acceptance_gap"] {
+    for kind in [
+        "outcome_floor",
+        "repair_budget_exhausted",
+        "monitor_stalled",
+        "succession_obligation",
+        "acceptance_gap",
+    ] {
         assert!(is_stalled_mode(kind), "{kind}");
     }
     assert!(!is_stalled_mode("normal_run"));
@@ -356,9 +405,10 @@ fn runtime_run_history_and_index_arms() {
         ),
     )
     .unwrap();
-    let projection = future_loop::runtime::run_history::build_run_history(&cr.root, &gid, now_epoch())
-        .unwrap()
-        .expect("rows present");
+    let projection =
+        future_loop::runtime::run_history::build_run_history(&cr.root, &gid, now_epoch())
+            .unwrap()
+            .expect("rows present");
     assert!(projection.sample_run_count >= 2);
     // detect_duplicates: duplicate identity rows are repairable.
     let dup_index = runs_dir.join("dup.jsonl");
@@ -378,11 +428,19 @@ fn runtime_run_history_and_index_arms() {
     let report = future_loop::runtime::run_index::detect_duplicates(&missing).unwrap();
     assert_eq!(report.total_rows, 0);
     // rebuild over an EXISTING index → pre-rebuild backup is written.
-    future_loop::compat::write_run(&store.goal_dir(&gid), &gid, &run_record("t", "completed", now_epoch())).unwrap();
+    future_loop::compat::write_run(
+        &store.goal_dir(&gid),
+        &gid,
+        &run_record("t", "completed", now_epoch()),
+    )
+    .unwrap();
     let report = future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
     assert!(report.rows_written >= 1);
     let report2 = future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
-    assert!(!report2.backup_path.is_empty(), "second rebuild backs up the prior index");
+    assert!(
+        !report2.backup_path.is_empty(),
+        "second rebuild backs up the prior index"
+    );
 }
 
 #[test]
@@ -395,19 +453,29 @@ fn run_compaction_arms() {
     // Two run files with real timestamp payloads (rows derive epochs from
     // file content, not filenames).
     let old_file = runs_dir.join("2020-01-01T00-00-00-00-00.json");
-    std::fs::write(&old_file, "{\"timestamp\":\"2020-01-01T00:00:00+00:00\",\"turn\":1,\"terminal_state\":\"completed\"}").unwrap();
+    std::fs::write(
+        &old_file,
+        "{\"timestamp\":\"2020-01-01T00:00:00+00:00\",\"turn\":1,\"terminal_state\":\"completed\"}",
+    )
+    .unwrap();
     let new_file = runs_dir.join("2030-01-01T00-00-00-00-00.json");
-    std::fs::write(&new_file, "{\"timestamp\":\"2030-01-01T00:00:00+00:00\",\"turn\":2,\"terminal_state\":\"completed\"}").unwrap();
+    std::fs::write(
+        &new_file,
+        "{\"timestamp\":\"2030-01-01T00:00:00+00:00\",\"turn\":2,\"terminal_state\":\"completed\"}",
+    )
+    .unwrap();
     future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
     // archive_runs_before: cutoff between the two → old one moves to archive/.
     let cutoff = chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00+00:00")
         .unwrap()
         .timestamp() as u64;
-    let report = future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
+    let report =
+        future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
     assert_eq!(report.archived.len(), 1, "{report:?}");
     assert!(!old_file.exists());
     // Second run: the file is gone (already archived) — row re-pointed only.
-    let report = future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
+    let report =
+        future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
     assert!(report.archived.is_empty());
     // archive_keeping_latest on a fresh goal with 3 runs: keep=1 → the
     // cutoff is the second-newest row → the single oldest run archives.
@@ -417,9 +485,18 @@ fn run_compaction_arms() {
         let runs_dir = store.goal_dir(&gid3).join("runs");
         std::fs::create_dir_all(&runs_dir).unwrap();
         for (name, ts) in [
-            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
-            ("2025-01-01T00-00-00-00-00.json", "2025-01-01T00:00:00+00:00"),
-            ("2030-01-01T00-00-00-00-00.json", "2030-01-01T00:00:00+00:00"),
+            (
+                "2020-01-01T00-00-00-00-00.json",
+                "2020-01-01T00:00:00+00:00",
+            ),
+            (
+                "2025-01-01T00-00-00-00-00.json",
+                "2025-01-01T00:00:00+00:00",
+            ),
+            (
+                "2030-01-01T00-00-00-00-00.json",
+                "2030-01-01T00:00:00+00:00",
+            ),
         ] {
             std::fs::write(
                 runs_dir.join(name),
@@ -429,7 +506,8 @@ fn run_compaction_arms() {
         }
     }
     future_loop::runtime::run_index::rebuild_index(&cr.root, &gid3).unwrap();
-    let report = future_loop::runtime::run_compaction::archive_keeping_latest(&cr.root, &gid3, 1).unwrap();
+    let report =
+        future_loop::runtime::run_compaction::archive_keeping_latest(&cr.root, &gid3, 1).unwrap();
     assert_eq!(report.archived.len(), 1, "{report:?}");
     // No index → error.
     let gid2 = init_goal(&cr, "no index goal");
@@ -474,7 +552,11 @@ fn cli_projection_arms() {
     let mut m = Todo::monitor("m1", "watch", std::time::Duration::from_secs(60));
     m.monitor_target = Some("file:x".into());
     goal.todos.push(m);
-    goal.todos.push(Todo::monitor("m2", "plain", std::time::Duration::from_secs(60)));
+    goal.todos.push(Todo::monitor(
+        "m2",
+        "plain",
+        std::time::Duration::from_secs(60),
+    ));
     let lines = future_loop::cli_projection::monitor_metadata_lines(&goal);
     assert_eq!(lines.len(), 2);
     assert!(lines[0].contains("target=file:x"), "{lines:?}");
@@ -502,12 +584,18 @@ fn task_graph_and_lease_arms() {
     let mut dependent = Todo::advancement("dep", "d");
     dependent.blocked_by_gate = Some("gate1".into());
     goal.todos.push(dependent);
-    assert_eq!(tg::successors_of(&goal, "gate1"), vec!["x".to_string(), "y".to_string()]);
+    assert_eq!(
+        tg::successors_of(&goal, "gate1"),
+        vec!["x".to_string(), "y".to_string()]
+    );
     let mut adv = Todo::advancement("plain", "p");
     adv.blocked_by_gate = None;
     goal.todos.push(adv);
     let succ = tg::successors_of(&goal, "dep");
-    assert!(succ.is_empty(), "nothing lists dep as predecessor: {succ:?}");
+    assert!(
+        succ.is_empty(),
+        "nothing lists dep as predecessor: {succ:?}"
+    );
     assert!(tg::successors_of(&goal, "ghost").is_empty());
 
     // task_lease: claim on a non-open todo bails; release after expiry is a
@@ -534,9 +622,15 @@ fn store_projection_gap_and_guard_arms() {
     goal.next_action = Some("waiting for the host".into());
     assert!(future_loop::store::projection_gap(&goal).is_none());
     goal.next_action = Some("please decide the scope".into());
-    assert!(future_loop::store::projection_gap(&goal).is_some(), "decide without gate");
+    assert!(
+        future_loop::store::projection_gap(&goal).is_some(),
+        "decide without gate"
+    );
     goal.next_action = Some(String::new());
-    assert!(future_loop::store::projection_gap(&goal).is_none(), "empty → no gap");
+    assert!(
+        future_loop::store::projection_gap(&goal).is_none(),
+        "empty → no gap"
+    );
     goal.next_action = None;
     assert!(future_loop::store::projection_gap(&goal).is_none());
 
@@ -596,7 +690,10 @@ fn store_projection_gap_and_guard_arms() {
             })
             .unwrap();
         let g = store.replay(&gid).unwrap().unwrap();
-        assert_eq!(g.todo(&first).unwrap().priority, future_loop::state::Priority::P2);
+        assert_eq!(
+            g.todo(&first).unwrap().priority,
+            future_loop::state::Priority::P2
+        );
     }
 }
 
@@ -612,7 +709,9 @@ fn replan_obligation_cleared_arms() {
     m.updated_at = 1_000;
     goal.todos.push(m);
     let obligations = ro::unfulfilled_obligations(&goal);
-    assert!(obligations.iter().any(|o| o.kind == "monitor_no_change_streak"));
+    assert!(obligations
+        .iter()
+        .any(|o| o.kind == "monitor_no_change_streak"));
     assert!(ro::has_unfulfilled_obligation(&goal));
     // A ReplanAck with a frontier-changing delta recorded AFTER raised_at
     // clears the obligation (has_frontier_delta accepts only these kinds).
@@ -622,7 +721,12 @@ fn replan_obligation_cleared_arms() {
         at: 2_000,
     });
     let obligations = ro::unfulfilled_obligations(&goal);
-    assert!(obligations.iter().all(|o| o.kind != "monitor_no_change_streak"), "{obligations:?}");
+    assert!(
+        obligations
+            .iter()
+            .all(|o| o.kind != "monitor_no_change_streak"),
+        "{obligations:?}"
+    );
 }
 
 // ── operator inbox load arms ───────────────────────────────────────────────
@@ -636,7 +740,11 @@ fn operator_inbox_load_arms() {
     std::fs::create_dir_all(&inbox).unwrap();
     // Events with missing optional fields get defaults; entries without a
     // message_id or content are skipped; non-objects are skipped.
-    std::fs::write(inbox.join("a.json"), "{\"message_id\":\"m1\",\"content\":\"hi\"}").unwrap();
+    std::fs::write(
+        inbox.join("a.json"),
+        "{\"message_id\":\"m1\",\"content\":\"hi\"}",
+    )
+    .unwrap();
     std::fs::write(inbox.join("b.json"), "\"just a string\"").unwrap();
     std::fs::write(inbox.join("c.json"), "[{\"message_id\":\"m2\"}]").unwrap();
     std::fs::write(inbox.join("d.json"), "{\"message_id\":\"m3\"}").unwrap();
@@ -647,5 +755,9 @@ fn operator_inbox_load_arms() {
     assert!(load_pending_inbox_events(&project, "/abs").is_err());
     // Missing inbox dir → empty.
     let empty = tempfile::tempdir().unwrap();
-    assert!(load_pending_inbox_events(&empty.path().to_string_lossy(), "inbox").unwrap().is_empty());
+    assert!(
+        load_pending_inbox_events(&empty.path().to_string_lossy(), "inbox")
+            .unwrap()
+            .is_empty()
+    );
 }

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -1,0 +1,651 @@
+//! Coverage drive — the long tail across agents/, benchmark/loop_protocol,
+//! capabilities parsing, cli/registry, compat, decision/, heartbeat,
+//! migration, quota/, runtime/, work_items/ and cli_projection.
+
+mod common;
+
+use common::{cli_root, init_goal, open_store, run_record};
+use future_loop::state::{now_epoch, Goal, TaskClass, Todo, TodoStatus};
+use future_loop::store::{Event, Store};
+
+// ── agents/scope ───────────────────────────────────────────────────────────
+
+#[test]
+fn scope_frontier_arms() {
+    use future_loop::agents::scope::{identity_scoped_frontier, todo_matches_agent};
+    let now = now_epoch();
+    let mut goal = Goal::new("g", "scope", "/tmp");
+    // A user action bound to ANOTHER agent (diagnostic-only arm).
+    let mut ua = Todo::user_action("ua1", "user action");
+    ua.claimed_by = Some("other-agent".into());
+    goal.todos.push(ua);
+    // A user action bound to THIS agent (not diagnostic).
+    let mut ua2 = Todo::user_action("ua2", "user action two");
+    ua2.claimed_by = Some("w1".into());
+    goal.todos.push(ua2);
+    // Agent work claimed by another agent with a live lease.
+    let mut theirs = Todo::advancement("t1", "theirs");
+    theirs.claim("other-agent", 3600, now);
+    goal.todos.push(theirs);
+    // Agent work claimed by another agent with an EXPIRED lease (free).
+    let mut lapsed = Todo::advancement("t2", "lapsed");
+    lapsed.claim("other-agent", 1, now - 10);
+    goal.todos.push(lapsed);
+    // Unclaimed advancement + a monitor + a blocker (agent-work classes).
+    goal.todos.push(Todo::advancement("t3", "free"));
+    goal.todos.push(Todo::monitor("m1", "watch", std::time::Duration::from_secs(60)));
+    goal.todos.push(Todo::blocker("b1", "blocker", &[]));
+    // An open gate for the gates list.
+    goal.todos.push(Todo::user_gate("g1", "q?", &[]));
+
+    let f = identity_scoped_frontier(&goal, "w1", &[]);
+    assert!(f.visible_agent_todo_ids.contains(&"t3".to_string()));
+    assert!(f.other_agent_claimed_ids.contains(&"t1".to_string()));
+    assert!(f.open_user_gate_ids.contains(&"g1".to_string()));
+    assert!(f.unclaimed_advancement_count >= 1);
+    // todo_matches_agent matrix.
+    let mut claimed = Todo::advancement("x", "x");
+    claimed.claimed_by = Some("other-agent".into());
+    assert!(todo_matches_agent(&Todo::advancement("x", "x"), "w1"));
+    assert!(todo_matches_agent(&claimed, "other-agent"));
+    assert!(!todo_matches_agent(&claimed, "w1"));
+}
+
+// ── agents/capability_gate ─────────────────────────────────────────────────
+
+#[test]
+fn capability_gate_arms() {
+    use future_loop::agents::capability_gate as cg;
+    // available_capabilities_with_defaults merges declared over defaults.
+    let avail = cg::available_capabilities_with_defaults(&["custom-cap".to_string()]);
+    assert!(avail.contains(&"custom-cap".to_string()));
+    // missing_required_capabilities on a todo with/without requirements.
+    let mut t = Todo::advancement("t1", "x");
+    t.required_capability = Some("shell".into());
+    assert!(cg::missing_required_capabilities(&t, &avail).is_empty());
+    assert_eq!(cg::missing_required_capabilities(&t, &[]), vec!["shell".to_string()]);
+    let plain = Todo::advancement("t2", "y");
+    assert!(cg::missing_required_capabilities(&plain, &[]).is_empty());
+    // todo_is_runnable (note: the DEFAULT available set includes shell, so
+    // only a custom capability blocks).
+    assert!(cg::todo_is_runnable(&plain, &[]));
+    assert!(cg::todo_is_runnable(&t, &[]), "shell is in the default set");
+    let mut custom = Todo::advancement("t4", "z");
+    custom.required_capability = Some("custom-xyz".into());
+    assert!(!cg::todo_is_runnable(&custom, &[]));
+    // build_capability_gate with blocked todos across owner classes.
+    let mut needs_shell = Todo::advancement("t1", "needs shell");
+    needs_shell.required_capability = Some("shell".into());
+    let mut needs_custom = Todo::advancement("t2", "needs custom");
+    needs_custom.required_capability = Some("custom-xyz".into());
+    let todos = vec![needs_shell, needs_custom, Todo::advancement("t3", "free")];
+    let gate = cg::build_capability_gate(&todos, &[]).expect("gate with blocked todos");
+    assert!(gate.runnable_todo_ids.contains(&"t3".to_string()));
+    assert!(gate.runnable_todo_ids.contains(&"t1".to_string()), "shell is default-available");
+    assert!(gate.blocked_todo_ids.contains(&"t2".to_string()), "custom-xyz missing");
+    // Everything runnable → None.
+    let free = vec![Todo::advancement("t9", "free")];
+    assert!(cg::build_capability_gate(&free, &[]).is_none());
+    let _ = gate;
+}
+
+// ── agents/lane ────────────────────────────────────────────────────────────
+
+#[test]
+fn lane_recommendation_arms() {
+    use future_loop::agents::lane::compact_agent_lane_recommendation;
+    let mut goal = Goal::new("g", "lane", "/tmp");
+    goal.register_agent("w1", vec![]);
+    // A run with EMPTY evidence → no recommended action.
+    let mut r = run_record("t1", "completed", now_epoch());
+    r.evidence = String::new();
+    goal.history.push(r);
+    let rec = compact_agent_lane_recommendation(&goal, "w1").unwrap();
+    assert!(rec.recommended_action.is_none());
+    // With evidence → truncated action.
+    goal.history.push(run_record("t1", "completed", now_epoch()));
+    let rec = compact_agent_lane_recommendation(&goal, "w1").unwrap();
+    assert!(rec.recommended_action.is_some());
+}
+
+// ── benchmark/loop_protocol ────────────────────────────────────────────────
+
+#[test]
+fn loop_protocol_comparison_contract() {
+    use future_loop::benchmark::loop_protocol as lp;
+    let c = lp::build_product_mode_main_table_comparison_contract(
+        "bench",
+        Some(7),
+        lp::RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
+        lp::LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+    );
+    assert_eq!(c.max_rounds_budget, 7);
+    // Default budget + non-special routes.
+    let c2 = lp::build_product_mode_main_table_comparison_contract("bench", None, "r1", "r2");
+    assert_eq!(c2.max_rounds_budget, lp::BLIND_LOOP_DEFAULT_MAX_ROUNDS);
+    let c3 = lp::build_product_mode_main_table_comparison_contract(
+        "bench",
+        Some(0),
+        "r1",
+        lp::LOOPX_PRODUCT_MODE_ROUTE,
+    );
+    assert_eq!(c3.max_rounds_budget, lp::BLIND_LOOP_DEFAULT_MAX_ROUNDS, "0 → default");
+    // Route classifiers.
+    assert!(!lp::blind_loop_routes().is_empty());
+    assert!(!lp::product_mode_routes().is_empty());
+}
+
+// ── capabilities parsing (auto_research / periodic_report) ─────────────────
+
+#[test]
+fn auto_research_parse_arms() {
+    use future_loop::capabilities::CapabilityRegistry;
+    let registry = CapabilityRegistry::with_builtin();
+    let cap = registry.get("auto_research").unwrap();
+    // Structured with all keys.
+    let ps = cap.propose("question: does X beat Y on metric Z?\nhypothesis: X wins\nmethod: ablation");
+    assert!(!ps.is_empty());
+    // A non-question → clarify successor.
+    let ps = cap.propose("question: just a statement");
+    assert!(ps.iter().any(|p| p.reason.contains("not shaped as a research question") || p.reason.contains("Clarify")), "{ps:?}");
+    // Empty.
+    assert!(!cap.propose("").is_empty());
+}
+
+#[test]
+fn periodic_report_parse_arms() {
+    use future_loop::capabilities::periodic_report::parse_report_profile;
+    let p = parse_report_profile("cadence: daily\nscope: team\naudience: ops\nnotes: n");
+    assert_eq!(p.cadence, "daily");
+    assert_eq!(p.scope, "team");
+    assert_eq!(p.audience, "ops");
+    // Free text becomes the cadence when no key is present.
+    let p = parse_report_profile("every friday\nwith details");
+    assert_eq!(p.cadence, "every friday with details");
+    // Cadence tokens → (class, seconds).
+    use future_loop::capabilities::periodic_report::cadence_due_secs;
+    assert_eq!(cadence_due_secs("hourly"), Some(("hourly".to_string(), 3600)));
+    assert_eq!(cadence_due_secs("every-6h"), Some(("every-6h".to_string(), 21600)));
+    assert_eq!(cadence_due_secs("every-2d"), Some(("every-2d".to_string(), 172800)));
+    assert_eq!(cadence_due_secs("every-0h"), None);
+    assert_eq!(cadence_due_secs("fortnightly"), None);
+    let _ = &p;
+}
+
+// ── cli/registry ───────────────────────────────────────────────────────────
+
+#[test]
+fn registry_idempotent_group_and_render_marks() {
+    use future_loop::cli::registry::CommandRegistry;
+    let mut r = CommandRegistry::new();
+    let a = r.group("g", "first");
+    let b = r.group("g", "second");
+    assert_eq!(a, b, "group() is idempotent by name");
+    // render_help marks experimental commands and skips empty groups (it
+    // prints usage + summary, not the command name).
+    let g = r.group("main", "m");
+    r.command(g, "stable-cmd", "stable summary", "stable-cmd-usage");
+    let _ = r.group("empty-group", "e");
+    let text = r.render_help(false);
+    assert!(text.contains("stable-cmd-usage"), "{text}");
+    assert!(!text.contains("empty-group"), "empty groups skipped");
+}
+
+// ── compat ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn compat_write_run_and_active_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let goal_dir = dir.path();
+    let mut goal = Goal::new("g", "compat", "/tmp");
+    let mut t = Todo::advancement("t1", "task");
+    t.evidence = Some("proof+plus".into());
+    t.status = TodoStatus::Done;
+    t.completed_at = Some(1_700_000_000);
+    goal.todos.push(t);
+    goal.todos.push(Todo::monitor("m1", "watch", std::time::Duration::from_secs(60)));
+    // write_active_state with evidence/completed anchors.
+    future_loop::compat::write_active_state(goal_dir, &goal).unwrap();
+    let md = std::fs::read_to_string(goal_dir.join("ACTIVE_GOAL_STATE.md")).unwrap();
+    assert!(md.contains("t1"), "{md}");
+    // write_run twice (json + md artifacts).
+    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch())).unwrap();
+    future_loop::compat::write_run(goal_dir, "g", &run_record("t1", "completed", now_epoch())).unwrap();
+    let runs = goal_dir.join("runs");
+    assert!(runs.exists());
+}
+
+// ── decision misc ──────────────────────────────────────────────────────────
+
+#[test]
+fn decision_misc_arms() {
+    // truncate: short pass-through + multibyte-safe ellipsis.
+    assert_eq!(future_loop::decision::truncate("abc", 5), "abc");
+    let long = "界".repeat(100);
+    let t = future_loop::decision::truncate(&long, 10);
+    assert!(t.ends_with('…'));
+    // complete_todo on a missing todo is a no-op.
+    let mut goal = Goal::new("g", "o", "/tmp");
+    future_loop::decision::complete_todo(&mut goal, "ghost", true, vec![]);
+    // boundary: a home-path objective leaks into the packet boundary.
+    let home = std::env::var("HOME").unwrap_or_default();
+    if !home.is_empty() {
+        let goal = Goal::new("g", &format!("read {home}/secrets.txt"), "/tmp");
+        let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+        assert!(!packet.boundary.public_safe);
+    }
+}
+
+// ── heartbeat render arms ──────────────────────────────────────────────────
+
+#[test]
+fn heartbeat_render_arms() {
+    use future_loop::heartbeat::render_heartbeat_prompt;
+    // Gate WITHOUT a question → "(see todo)" + gate id list + fallback todo.
+    let mut goal = Goal::new("g", "hb", "/tmp");
+    let mut gate = Todo::user_gate("tg", "gate text", &[]);
+    gate.gate_question = None;
+    goal.todos.push(gate);
+    goal.todos.push(Todo::advancement("t1", "fallback work"));
+    goal.history.push(run_record("t0", "completed", now_epoch()));
+    let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+    let out = render_heartbeat_prompt(&goal, &packet);
+    assert!(out.contains("USER ACTION REQUIRED"), "{out}");
+    assert!(out.contains("gate todos: tg"), "{out}");
+    assert!(out.contains("fallback todo"), "{out}");
+    assert!(out.contains("last evidence"), "{out}");
+    // Boundary leak + terminal stop condition.
+    let home = std::env::var("HOME").unwrap_or_default();
+    let goal2 = Goal::new("g2", &format!("touch {home}/x"), "/tmp");
+    let packet = future_loop::decision::decide_for(&goal2, std::time::SystemTime::now(), None);
+    let out = render_heartbeat_prompt(&goal2, &packet);
+    if !packet.boundary.public_safe {
+        assert!(out.contains("boundary leaks"), "{out}");
+    }
+    // Terminal goal (cancelled) → stop-condition arm + no selected todo.
+    let mut goal3 = Goal::new("g3", "hb", "/tmp");
+    goal3.status = "cancelled".into();
+    let packet = future_loop::decision::decide_for(&goal3, std::time::SystemTime::now(), None);
+    let out = render_heartbeat_prompt(&goal3, &packet);
+    assert!(out.contains("goal validated closed"), "{out}");
+}
+
+// ── migration ──────────────────────────────────────────────────────────────
+
+#[test]
+fn migration_arms() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "migration drive");
+    let store = open_store(&cr);
+    let goal_dir = store.goal_dir(&gid);
+    // apply_migrations with blank lines in the ledger (kept verbatim).
+    {
+        let events = goal_dir.join("events.jsonl");
+        let existing = std::fs::read_to_string(&events).unwrap();
+        std::fs::write(&events, format!("\n{existing}")).unwrap();
+        std::fs::remove_file(goal_dir.join("schema.json")).unwrap();
+    }
+    let report = future_loop::migration::apply_migrations(&goal_dir, &gid).unwrap();
+    assert!(report.migrated_lines >= 1);
+    // Bridge status: rollback_plan_recorded flips once a backup exists.
+    let store = open_store(&cr);
+    let before = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    assert!(!before.checks.rollback_plan_recorded);
+    store.backup_goal(&gid).unwrap();
+    let after = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    assert!(after.checks.rollback_plan_recorded);
+    // dual_read_parity: ACTIVE_GOAL_STATE.md with anchors matching the replay.
+    let goal = store.replay(&gid).unwrap().unwrap();
+    future_loop::compat::write_active_state(&store.goal_dir(&gid), &goal).unwrap();
+    let with_state = future_loop::migration::migration_bridge_status(&store, &gid, &store.goal_dir(&gid));
+    let _ = with_state.checks.dual_read_parity_clean;
+    // migration_steps registry is non-empty and ordered.
+    assert!(!future_loop::migration::migration_steps().is_empty());
+}
+
+// ── quota ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn quota_slot_accounting_arms() {
+    use future_loop::quota::slot_accounting as sa;
+    for (s, expect) in [
+        ("run", sa::SlotSpendSource::Run),
+        ("agent", sa::SlotSpendSource::Agent),
+        ("heartbeat", sa::SlotSpendSource::Heartbeat),
+    ] {
+        assert_eq!(sa::SlotSpendSource::parse(s), Some(expect));
+        assert_eq!(expect.as_str(), s);
+    }
+    assert_eq!(sa::SlotSpendSource::parse("bogus"), None);
+    // stall repair: kind() + is_stalled_mode arms.
+    use future_loop::quota::stall_repair::{detect_stall, is_stalled_mode};
+    for kind in ["outcome_floor", "repair_budget_exhausted", "monitor_stalled", "succession_obligation", "acceptance_gap"] {
+        assert!(is_stalled_mode(kind), "{kind}");
+    }
+    assert!(!is_stalled_mode("normal_run"));
+    // detect_stall on a healthy goal → None; with a stalled monitor → Some.
+    let goal = Goal::new("g", "o", "/tmp");
+    assert!(detect_stall(&goal).is_none());
+    let mut goal = Goal::new("g", "o", "/tmp");
+    let mut m = Todo::monitor("m1", "watch", std::time::Duration::from_secs(60));
+    m.consecutive_no_change = 99;
+    goal.todos.push(m);
+    let hint = detect_stall(&goal).expect("stalled monitor");
+    assert_eq!(hint.kind(), "monitor_stalled");
+}
+
+// ── runtime: run_history / run_index / run_compaction / stale_latest_run ───
+
+#[test]
+fn runtime_run_history_and_index_arms() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "runtime drive");
+    let store = open_store(&cr);
+    let runs_dir = store.goal_dir(&gid).join("runs");
+    std::fs::create_dir_all(&runs_dir).unwrap();
+    // Index rows: malformed line skipped; empty classification → "work";
+    // unparseable timestamp → row_epoch None (skipped in totals).
+    let index = runs_dir.join("index.jsonl");
+    std::fs::write(
+        &index,
+        concat!(
+            "{bad json\n",
+            "{\"goal_id\":\"G\",\"timestamp\":\"not-a-date\",\"path\":\"a.json\",\"classification\":\"\"}\n",
+            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"b.json\",\"classification\":\"\"}\n",
+            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"c.json\",\"classification\":\"monitor\"}\n",
+        ),
+    )
+    .unwrap();
+    let projection = future_loop::runtime::run_history::build_run_history(&cr.root, &gid, now_epoch())
+        .unwrap()
+        .expect("rows present");
+    assert!(projection.sample_run_count >= 2);
+    // detect_duplicates: duplicate identity rows are repairable.
+    let dup_index = runs_dir.join("dup.jsonl");
+    std::fs::write(
+        &dup_index,
+        concat!(
+            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"a.json\",\"classification\":\"work\"}\n",
+            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"a.json\",\"classification\":\"work\"}\n",
+        ),
+    )
+    .unwrap();
+    let report = future_loop::runtime::run_index::detect_duplicates(&dup_index).unwrap();
+    assert_eq!(report.duplicate_groups.len(), 1);
+    assert!(report.repairable);
+    // detect on a missing index → empty report.
+    let missing = runs_dir.join("absent.jsonl");
+    let report = future_loop::runtime::run_index::detect_duplicates(&missing).unwrap();
+    assert_eq!(report.total_rows, 0);
+    // rebuild over an EXISTING index → pre-rebuild backup is written.
+    future_loop::compat::write_run(&store.goal_dir(&gid), &gid, &run_record("t", "completed", now_epoch())).unwrap();
+    let report = future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
+    assert!(report.rows_written >= 1);
+    let report2 = future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
+    assert!(!report2.backup_path.is_empty(), "second rebuild backs up the prior index");
+}
+
+#[test]
+fn run_compaction_arms() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "compaction drive");
+    let store = open_store(&cr);
+    let runs_dir = store.goal_dir(&gid).join("runs");
+    std::fs::create_dir_all(&runs_dir).unwrap();
+    // Two run files with real timestamp payloads (rows derive epochs from
+    // file content, not filenames).
+    let old_file = runs_dir.join("2020-01-01T00-00-00-00-00.json");
+    std::fs::write(&old_file, "{\"timestamp\":\"2020-01-01T00:00:00+00:00\",\"turn\":1,\"terminal_state\":\"completed\"}").unwrap();
+    let new_file = runs_dir.join("2030-01-01T00-00-00-00-00.json");
+    std::fs::write(&new_file, "{\"timestamp\":\"2030-01-01T00:00:00+00:00\",\"turn\":2,\"terminal_state\":\"completed\"}").unwrap();
+    future_loop::runtime::run_index::rebuild_index(&cr.root, &gid).unwrap();
+    // archive_runs_before: cutoff between the two → old one moves to archive/.
+    let cutoff = chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00+00:00")
+        .unwrap()
+        .timestamp() as u64;
+    let report = future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
+    assert_eq!(report.archived.len(), 1, "{report:?}");
+    assert!(!old_file.exists());
+    // Second run: the file is gone (already archived) — row re-pointed only.
+    let report = future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid, cutoff).unwrap();
+    assert!(report.archived.is_empty());
+    // archive_keeping_latest on a fresh goal with 3 runs: keep=1 → the
+    // cutoff is the second-newest row → the single oldest run archives.
+    let gid3 = init_goal(&cr, "keeping latest");
+    {
+        let store = open_store(&cr);
+        let runs_dir = store.goal_dir(&gid3).join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        for (name, ts) in [
+            ("2020-01-01T00-00-00-00-00.json", "2020-01-01T00:00:00+00:00"),
+            ("2025-01-01T00-00-00-00-00.json", "2025-01-01T00:00:00+00:00"),
+            ("2030-01-01T00-00-00-00-00.json", "2030-01-01T00:00:00+00:00"),
+        ] {
+            std::fs::write(
+                runs_dir.join(name),
+                format!("{{\"timestamp\":\"{ts}\",\"turn\":1,\"terminal_state\":\"completed\"}}"),
+            )
+            .unwrap();
+        }
+    }
+    future_loop::runtime::run_index::rebuild_index(&cr.root, &gid3).unwrap();
+    let report = future_loop::runtime::run_compaction::archive_keeping_latest(&cr.root, &gid3, 1).unwrap();
+    assert_eq!(report.archived.len(), 1, "{report:?}");
+    // No index → error.
+    let gid2 = init_goal(&cr, "no index goal");
+    assert!(future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid2, 1).is_err());
+}
+
+// ── cli_projection remaining arms ──────────────────────────────────────────
+
+#[test]
+fn cli_projection_arms() {
+    // render_quota_projection with a stall that carries a blocked scope, an
+    // arbitration, and a terminal closure payload.
+    let mut goal = Goal::new("g", "proj", "/tmp");
+    goal.todos.push(Todo::advancement("t1", "work"));
+    let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+    let stall = future_loop::quota::stall_repair::StallRepairHint {
+        kind: "monitor_no_change_stalled".into(),
+        reason: "r".into(),
+        replan_hint: "h".into(),
+        blocked_action_scope: Some("deploy".into()),
+    };
+    let out = future_loop::cli_projection::render_quota_projection(&packet, None, Some(&stall));
+    assert!(out.contains("blocked action scope: deploy"), "{out}");
+    let out2 = future_loop::cli_projection::render_quota_projection(&packet, None, None);
+    assert!(!out2.contains("stall:"), "{out2}");
+    // render_cadence_plan: multi-interval progressions show the next step;
+    // the last index wraps.
+    let out = future_loop::cli_projection::render_cadence_plan("hourly", &[15, 30], 0);
+    assert!(out.contains("next"), "{out}");
+    let out = future_loop::cli_projection::render_cadence_plan("hourly", &[15, 30], 1);
+    assert!(out.contains("wraps to start"), "{out}");
+    // Unknown class with no progression → single-execution early return.
+    let out = future_loop::cli_projection::render_cadence_plan("once", &[], 0);
+    assert!(out.contains("single execution"), "{out}");
+    // initial_rrule_for arms.
+    assert!(future_loop::cli_projection::initial_rrule_for("hourly").is_some());
+    assert!(future_loop::cli_projection::initial_rrule_for("daily").is_some());
+    assert!(future_loop::cli_projection::initial_rrule_for("weekly").is_some());
+    assert!(future_loop::cli_projection::initial_rrule_for("once").is_none());
+    // monitor_metadata_lines with/without metadata.
+    let mut goal = Goal::new("g", "mon", "/tmp");
+    let mut m = Todo::monitor("m1", "watch", std::time::Duration::from_secs(60));
+    m.monitor_target = Some("file:x".into());
+    goal.todos.push(m);
+    goal.todos.push(Todo::monitor("m2", "plain", std::time::Duration::from_secs(60)));
+    let lines = future_loop::cli_projection::monitor_metadata_lines(&goal);
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("target=file:x"), "{lines:?}");
+    assert!(!lines[1].contains("target="), "{lines:?}");
+}
+
+// ── work_items misc ────────────────────────────────────────────────────────
+
+#[test]
+fn task_graph_and_lease_arms() {
+    use future_loop::work_items::task_graph as tg;
+    // topological_sort skips edges referencing unknown todos.
+    let todos = vec![Todo::advancement("a", "a"), Todo::advancement("b", "b")];
+    let edges = vec![
+        ("a".to_string(), "b".to_string()),
+        ("ghost".to_string(), "b".to_string()),
+    ];
+    let (order, cycle) = tg::topological_sort(&todos, &edges);
+    assert!(cycle.is_empty());
+    assert_eq!(order, vec!["a".to_string(), "b".to_string()]);
+    // successors_of: blocking source names dependents; plain todo → reverse lookup.
+    let mut goal = Goal::new("g", "o", "/tmp");
+    let gate = Todo::user_gate("gate1", "q?", &["x", "y"]);
+    goal.todos.push(gate);
+    let mut dependent = Todo::advancement("dep", "d");
+    dependent.blocked_by_gate = Some("gate1".into());
+    goal.todos.push(dependent);
+    assert_eq!(tg::successors_of(&goal, "gate1"), vec!["x".to_string(), "y".to_string()]);
+    let mut adv = Todo::advancement("plain", "p");
+    adv.blocked_by_gate = None;
+    goal.todos.push(adv);
+    let succ = tg::successors_of(&goal, "dep");
+    assert!(succ.is_empty(), "nothing lists dep as predecessor: {succ:?}");
+    assert!(tg::successors_of(&goal, "ghost").is_empty());
+
+    // task_lease: claim on a non-open todo bails; release after expiry is a
+    // no-op success.
+    use future_loop::work_items::task_lease as lease;
+    let mut t = Todo::advancement("t", "x");
+    t.status = TodoStatus::Done;
+    assert!(lease::claim(&mut t, "a", 60, 100).is_err());
+    let mut t = Todo::advancement("t", "x");
+    lease::claim(&mut t, "a", 1, 100).unwrap();
+    let op = lease::release(&mut t, "a", 10_000).unwrap();
+    assert!(matches!(op, lease::LeaseOp::Released { missing: true }));
+}
+
+// ── store projection-gap + apply guard arms ────────────────────────────────
+
+#[test]
+fn store_projection_gap_and_guard_arms() {
+    // projection_gap: "[P1]" prefix and "waiting" markers suppress the gap;
+    // "decide" without gates fires the user-side gap.
+    let mut goal = Goal::new("g", "o", "/tmp");
+    goal.next_action = Some("[P1] prioritized".into());
+    assert!(future_loop::store::projection_gap(&goal).is_none());
+    goal.next_action = Some("waiting for the host".into());
+    assert!(future_loop::store::projection_gap(&goal).is_none());
+    goal.next_action = Some("please decide the scope".into());
+    assert!(future_loop::store::projection_gap(&goal).is_some(), "decide without gate");
+    goal.next_action = Some(String::new());
+    assert!(future_loop::store::projection_gap(&goal).is_none(), "empty → no gap");
+    goal.next_action = None;
+    assert!(future_loop::store::projection_gap(&goal).is_none());
+
+    // Apply guards: release by a non-owner and expiry without a claim are
+    // no-ops on replay.
+    let cr = cli_root();
+    let gid = init_goal(&cr, "guard arms");
+    {
+        let mut store: Store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let first = g.todos.first().unwrap().id.clone();
+        drop(g);
+        // Renew sets a claim when none existed (claim-fill arm).
+        store
+            .append(Event::TodoRenewed {
+                goal_id: gid.clone(),
+                todo_id: first.clone(),
+                agent_id: "a".into(),
+                lease_expires_at: 42,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        // Release by a DIFFERENT agent must not clear it.
+        store
+            .append(Event::TodoReleased {
+                goal_id: gid.clone(),
+                todo_id: first.clone(),
+                agent_id: "b".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todo(&first).unwrap();
+        assert_eq!(t.claimed_by.as_deref(), Some("a"));
+        assert_eq!(t.lease_expires_at, Some(42));
+        // Expiry on a todo with no claim → no-op arm.
+        store
+            .append(Event::TodoExpired {
+                goal_id: gid.clone(),
+                todo_id: "todo_never_claimed".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        // TodoUpdated priority P2 arm.
+        store
+            .append(Event::TodoUpdated {
+                goal_id: gid.clone(),
+                todo_id: first.clone(),
+                text: None,
+                status: None,
+                evidence: None,
+                note: None,
+                priority: Some("p2".into()),
+                resume_when: None,
+                blocks: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+        let g = store.replay(&gid).unwrap().unwrap();
+        assert_eq!(g.todo(&first).unwrap().priority, future_loop::state::Priority::P2);
+    }
+}
+
+// ── replan obligation arms ─────────────────────────────────────────────────
+
+#[test]
+fn replan_obligation_cleared_arms() {
+    use future_loop::work_items::replan_obligation as ro;
+    let mut goal = Goal::new("g", "o", "/tmp");
+    // Monitor over the no-change threshold → obligation raised (uncleared).
+    let mut m = Todo::monitor("m1", "watch", std::time::Duration::from_secs(60));
+    m.consecutive_no_change = 99;
+    m.updated_at = 1_000;
+    goal.todos.push(m);
+    let obligations = ro::unfulfilled_obligations(&goal);
+    assert!(obligations.iter().any(|o| o.kind == "monitor_no_change_streak"));
+    assert!(ro::has_unfulfilled_obligation(&goal));
+    // A ReplanAck with a frontier-changing delta recorded AFTER raised_at
+    // clears the obligation (has_frontier_delta accepts only these kinds).
+    goal.replan_ack = Some(future_loop::state::ReplanAck {
+        recorded: true,
+        delta_kinds: vec!["vision_patch".into()],
+        at: 2_000,
+    });
+    let obligations = ro::unfulfilled_obligations(&goal);
+    assert!(obligations.iter().all(|o| o.kind != "monitor_no_change_streak"), "{obligations:?}");
+}
+
+// ── operator inbox load arms ───────────────────────────────────────────────
+
+#[test]
+fn operator_inbox_load_arms() {
+    use future_loop::work_items::operator_inbox::load_pending_inbox_events;
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().to_string_lossy().into_owned();
+    let inbox = dir.path().join(".future/loop/inbox");
+    std::fs::create_dir_all(&inbox).unwrap();
+    // Events with missing optional fields get defaults; entries without a
+    // message_id or content are skipped; non-objects are skipped.
+    std::fs::write(inbox.join("a.json"), "{\"message_id\":\"m1\",\"content\":\"hi\"}").unwrap();
+    std::fs::write(inbox.join("b.json"), "\"just a string\"").unwrap();
+    std::fs::write(inbox.join("c.json"), "[{\"message_id\":\"m2\"}]").unwrap();
+    std::fs::write(inbox.join("d.json"), "{\"message_id\":\"m3\"}").unwrap();
+    let events = load_pending_inbox_events(&project, "inbox").unwrap();
+    assert_eq!(events.len(), 1, "{events:?}");
+    assert_eq!(events[0].message_id, "m1");
+    assert!(load_pending_inbox_events(&project, "../escape").is_err());
+    assert!(load_pending_inbox_events(&project, "/abs").is_err());
+    // Missing inbox dir → empty.
+    let empty = tempfile::tempdir().unwrap();
+    assert!(load_pending_inbox_events(&empty.path().to_string_lossy(), "inbox").unwrap().is_empty());
+}

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use common::{cli_root, init_goal, open_store, run_record};
-use future_loop::state::{now_epoch, Goal, TaskClass, Todo, TodoStatus};
+use future_loop::state::{now_epoch, Goal, Todo, TodoStatus};
 use future_loop::store::{Event, Store};
 
 // ── agents/scope ───────────────────────────────────────────────────────────

--- a/orchestration/loop/tests/replay_drive.rs
+++ b/orchestration/loop/tests/replay_drive.rs
@@ -4,12 +4,12 @@
 
 use future_loop::replay::corpus::ModelBehaviorActor;
 use future_loop::replay::corpus::{
-    build_model_behavior_corpus, delete_path, get_path, run_model_behavior_corpus, ModelBehaviorCorpus,
-    PatchCase, RetainedPacket, StubActor,
+    build_model_behavior_corpus, delete_path, get_path, run_model_behavior_corpus,
+    ModelBehaviorCorpus, PatchCase, RetainedPacket, StubActor,
 };
 use future_loop::replay::decision_replay::{
-    reduce_public_safe_decision, replay_public_safe_decision_case, validate_public_safe_decision_case,
-    walk_public_safe_violations, DecisionReplay,
+    reduce_public_safe_decision, replay_public_safe_decision_case,
+    validate_public_safe_decision_case, walk_public_safe_violations, DecisionReplay,
 };
 use future_loop::state::{Goal, TaskClass, Todo, TodoStatus};
 
@@ -37,9 +37,20 @@ fn corpus_load_errors() {
     // Empty case list.
     let goal = base_goal();
     let packet = packet_for(&goal);
-    let corpus = build_model_behavior_corpus(&packet, &[PatchCase::new("p", serde_json::json!({}))], &[], &[], &[]).unwrap();
+    let corpus = build_model_behavior_corpus(
+        &packet,
+        &[PatchCase::new("p", serde_json::json!({}))],
+        &[],
+        &[],
+        &[],
+    )
+    .unwrap();
     let empty = dir.path().join("empty.json");
-    std::fs::write(&empty, "{\"schema_version\":\"model_behavior_corpus_v0\",\"cases\":[]}").unwrap();
+    std::fs::write(
+        &empty,
+        "{\"schema_version\":\"model_behavior_corpus_v0\",\"cases\":[]}",
+    )
+    .unwrap();
     assert!(ModelBehaviorCorpus::load(&empty).is_err());
     // Case schema mismatch.
     let mut value = serde_json::to_value(&corpus).unwrap();
@@ -94,7 +105,10 @@ fn corpus_build_matrix() {
             PatchCase::new("a", serde_json::json!({"quota": {"extra": 1}})),
             PatchCase::new("b", serde_json::json!({"decision": "replaced"})),
         ],
-        &[PatchCase::new("cf", serde_json::json!({"should_run": false}))],
+        &[PatchCase::new(
+            "cf",
+            serde_json::json!({"should_run": false}),
+        )],
         &["decision".to_string()],
         &[retained],
     )
@@ -102,20 +116,39 @@ fn corpus_build_matrix() {
     assert_eq!(corpus.cases.len(), 5);
     // Ablation of a hard-invariant path → candidate invalid → fail_closed ✓.
     let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
-    assert!(result.all_cases_passed, "{:#?}", result.cases.iter().map(|c| (&c.case_id, c.passed)).collect::<Vec<_>>());
+    assert!(
+        result.all_cases_passed,
+        "{:#?}",
+        result
+            .cases
+            .iter()
+            .map(|c| (&c.case_id, c.passed))
+            .collect::<Vec<_>>()
+    );
     assert!(result.corpus_gate_passed);
     assert!(result.promotion_eligible);
     // Ablation of a nonexistent path → build error.
-    assert!(build_model_behavior_corpus(&packet, &[], &[], &["nope.nope".to_string()], &[]).is_err());
+    assert!(
+        build_model_behavior_corpus(&packet, &[], &[], &["nope.nope".to_string()], &[]).is_err()
+    );
     // Duplicate ablation paths → duplicate case ids → error.
-    assert!(build_model_behavior_corpus(&packet, &[], &[], &["decision".to_string(), "decision".to_string()], &[]).is_err());
+    assert!(build_model_behavior_corpus(
+        &packet,
+        &[],
+        &[],
+        &["decision".to_string(), "decision".to_string()],
+        &[]
+    )
+    .is_err());
     // No cases at all → error.
     assert!(build_model_behavior_corpus(&packet, &[], &[], &[], &[]).is_err());
     // Oversized case id (patch name > 120 chars) → case gate error.
     assert!(build_model_behavior_corpus(
         &packet,
         &[PatchCase::new(&"x".repeat(130), serde_json::json!({}))],
-        &[], &[], &[],
+        &[],
+        &[],
+        &[],
     )
     .is_err());
     // StubActor identity.
@@ -136,7 +169,11 @@ fn decision_replay_load_errors() {
     std::fs::write(&schema, "{\"schema_version\":\"nope\",\"cases\":[]}").unwrap();
     assert!(DecisionReplay::load(&schema).is_err());
     let empty = dir.path().join("empty.json");
-    std::fs::write(&empty, "{\"schema_version\":\"public_safe_decision_replay_v0\",\"cases\":[]}").unwrap();
+    std::fs::write(
+        &empty,
+        "{\"schema_version\":\"public_safe_decision_replay_v0\",\"cases\":[]}",
+    )
+    .unwrap();
     assert!(DecisionReplay::load(&empty).is_err());
     // A case whose case_id is an absolute path fails the public-safety walk.
     let goal = base_goal();
@@ -148,7 +185,10 @@ fn decision_replay_load_errors() {
     replay.add(case);
     let p = dir.path().join("violating.json");
     replay.save(&p).unwrap();
-    assert!(DecisionReplay::load(&p).is_err(), "load validates each case");
+    assert!(
+        DecisionReplay::load(&p).is_err(),
+        "load validates each case"
+    );
     // Bad case schema inside the file.
     let mut value = serde_json::to_value(&replay).unwrap();
     value["cases"][0]
@@ -172,9 +212,20 @@ fn walk_violations_matrix() {
         "items": [{"path": "/abs/file"}, {"ref": "file://x"}, {"ok": "fine"}],
     });
     let violations = walk_public_safe_violations(&v);
-    assert!(violations.iter().any(|s| s.contains("banned key: credential")), "{violations:?}");
-    assert!(violations.iter().any(|s| s.contains("nested.trajectory")), "{violations:?}");
-    assert!(violations.iter().any(|s| s.contains("local path")), "{violations:?}");
+    assert!(
+        violations
+            .iter()
+            .any(|s| s.contains("banned key: credential")),
+        "{violations:?}"
+    );
+    assert!(
+        violations.iter().any(|s| s.contains("nested.trajectory")),
+        "{violations:?}"
+    );
+    assert!(
+        violations.iter().any(|s| s.contains("local path")),
+        "{violations:?}"
+    );
     assert!(walk_public_safe_violations(&serde_json::json!({"clean": "yes"})).is_empty());
 }
 
@@ -214,7 +265,10 @@ fn reduce_covers_todo_matrix() {
     // Gate-open packet → AskUser interaction arms.
     let packet = packet_for(&goal);
     let case = reduce_public_safe_decision(&packet, &goal, "rich-case", None);
-    assert!(!case.user_todos.is_empty(), "gate/action populate user todos");
+    assert!(
+        !case.user_todos.is_empty(),
+        "gate/action populate user todos"
+    );
     validate_public_safe_decision_case(&case).unwrap();
     // Replay it (kernel should reproduce the ask_user decision).
     let comparison = replay_public_safe_decision_case(&case).unwrap();
@@ -232,7 +286,10 @@ fn replay_mismatch_diff_arms() {
     tampered.decision.should_run = !case.decision.should_run;
     let comparison = replay_public_safe_decision_case(&tampered).unwrap();
     assert!(!comparison.matched);
-    assert!(comparison.mismatches.iter().any(|m| m.contains("should_run")));
+    assert!(comparison
+        .mismatches
+        .iter()
+        .any(|m| m.contains("should_run")));
     // Save/load roundtrip through DecisionReplay::add.
     let mut replay = DecisionReplay::default();
     replay.add(case);

--- a/orchestration/loop/tests/replay_drive.rs
+++ b/orchestration/loop/tests/replay_drive.rs
@@ -11,7 +11,7 @@ use future_loop::replay::decision_replay::{
     reduce_public_safe_decision, replay_public_safe_decision_case,
     validate_public_safe_decision_case, walk_public_safe_violations, DecisionReplay,
 };
-use future_loop::state::{Goal, TaskClass, Todo, TodoStatus};
+use future_loop::state::{Goal, Todo, TodoStatus};
 
 fn packet_for(goal: &Goal) -> future_loop::contract::ShouldRunPacket {
     future_loop::decision::decide_for(goal, std::time::SystemTime::now(), None)

--- a/orchestration/loop/tests/replay_drive.rs
+++ b/orchestration/loop/tests/replay_drive.rs
@@ -1,0 +1,244 @@
+//! Coverage drive for `replay/`: corpus load/validation errors, deep_merge /
+//! get_path / delete_path, case-construction gates, the fail-closed ablation
+//! path, and decision-replay load/reduce/walk/replay branch matrices.
+
+use future_loop::replay::corpus::ModelBehaviorActor;
+use future_loop::replay::corpus::{
+    build_model_behavior_corpus, delete_path, get_path, run_model_behavior_corpus, ModelBehaviorCorpus,
+    PatchCase, RetainedPacket, StubActor,
+};
+use future_loop::replay::decision_replay::{
+    reduce_public_safe_decision, replay_public_safe_decision_case, validate_public_safe_decision_case,
+    walk_public_safe_violations, DecisionReplay,
+};
+use future_loop::state::{Goal, TaskClass, Todo, TodoStatus};
+
+fn packet_for(goal: &Goal) -> future_loop::contract::ShouldRunPacket {
+    future_loop::decision::decide_for(goal, std::time::SystemTime::now(), None)
+}
+
+fn base_goal() -> Goal {
+    Goal::new("g1", "replay drive", "/tmp")
+}
+
+// ── corpus: load / validation ──────────────────────────────────────────────
+
+#[test]
+fn corpus_load_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("nope.json");
+    assert!(ModelBehaviorCorpus::load(&missing).is_err());
+    let bad_json = dir.path().join("bad.json");
+    std::fs::write(&bad_json, "{nope").unwrap();
+    assert!(ModelBehaviorCorpus::load(&bad_json).is_err());
+    let bad_schema = dir.path().join("schema.json");
+    std::fs::write(&bad_schema, "{\"schema_version\":\"nope\",\"cases\":[]}").unwrap();
+    assert!(ModelBehaviorCorpus::load(&bad_schema).is_err());
+    // Empty case list.
+    let goal = base_goal();
+    let packet = packet_for(&goal);
+    let corpus = build_model_behavior_corpus(&packet, &[PatchCase::new("p", serde_json::json!({}))], &[], &[], &[]).unwrap();
+    let empty = dir.path().join("empty.json");
+    std::fs::write(&empty, "{\"schema_version\":\"model_behavior_corpus_v0\",\"cases\":[]}").unwrap();
+    assert!(ModelBehaviorCorpus::load(&empty).is_err());
+    // Case schema mismatch.
+    let mut value = serde_json::to_value(&corpus).unwrap();
+    value["cases"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("schema_version".into(), "nope".into());
+    let p = dir.path().join("case-schema.json");
+    std::fs::write(&p, serde_json::to_string(&value).unwrap()).unwrap();
+    assert!(ModelBehaviorCorpus::load(&p).is_err());
+    // Duplicate case ids.
+    let mut value = serde_json::to_value(&corpus).unwrap();
+    let dup = value["cases"][0].clone();
+    value["cases"].as_array_mut().unwrap().push(dup);
+    let p = dir.path().join("dup.json");
+    std::fs::write(&p, serde_json::to_string(&value).unwrap()).unwrap();
+    assert!(ModelBehaviorCorpus::load(&p).is_err());
+}
+
+// ── corpus: path helpers + build matrix ────────────────────────────────────
+
+#[test]
+fn corpus_path_helpers() {
+    let v = serde_json::json!({"a": {"b": {"c": 1}}, "list": [1]});
+    assert_eq!(get_path(&v, "a.b.c"), Some(&serde_json::json!(1)));
+    assert_eq!(get_path(&v, "a.b.missing"), None);
+    assert_eq!(get_path(&v, "a.b.c.deeper"), None, "non-object mid-path");
+    assert_eq!(get_path(&v, "list.x"), None);
+    // delete_path.
+    let mut v = serde_json::json!({"a": {"b": 1}, "c": 2});
+    assert!(delete_path(&mut v, "").is_err());
+    assert!(delete_path(&mut v, "a.missing.deep").is_err());
+    assert!(delete_path(&mut v, "a.nope").is_err());
+    assert!(delete_path(&mut v, "c.x").is_err(), "non-object cursor");
+    delete_path(&mut v, "a.b").unwrap();
+    assert_eq!(v["a"], serde_json::json!({}));
+}
+
+#[test]
+fn corpus_build_matrix() {
+    let goal = base_goal();
+    let packet = packet_for(&goal);
+    // state_matrix + counterfactuals + retained + ablation (fail-closed on
+    // a hard-invariant path passes the gate).
+    let retained = RetainedPacket {
+        case_id: "retained-1".into(),
+        packet: serde_json::to_value(&packet).unwrap(),
+    };
+    let corpus = build_model_behavior_corpus(
+        &packet,
+        &[
+            PatchCase::new("a", serde_json::json!({"quota": {"extra": 1}})),
+            PatchCase::new("b", serde_json::json!({"decision": "replaced"})),
+        ],
+        &[PatchCase::new("cf", serde_json::json!({"should_run": false}))],
+        &["decision".to_string()],
+        &[retained],
+    )
+    .unwrap();
+    assert_eq!(corpus.cases.len(), 5);
+    // Ablation of a hard-invariant path → candidate invalid → fail_closed ✓.
+    let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
+    assert!(result.all_cases_passed, "{:#?}", result.cases.iter().map(|c| (&c.case_id, c.passed)).collect::<Vec<_>>());
+    assert!(result.corpus_gate_passed);
+    assert!(result.promotion_eligible);
+    // Ablation of a nonexistent path → build error.
+    assert!(build_model_behavior_corpus(&packet, &[], &[], &["nope.nope".to_string()], &[]).is_err());
+    // Duplicate ablation paths → duplicate case ids → error.
+    assert!(build_model_behavior_corpus(&packet, &[], &[], &["decision".to_string(), "decision".to_string()], &[]).is_err());
+    // No cases at all → error.
+    assert!(build_model_behavior_corpus(&packet, &[], &[], &[], &[]).is_err());
+    // Oversized case id (patch name > 120 chars) → case gate error.
+    assert!(build_model_behavior_corpus(
+        &packet,
+        &[PatchCase::new(&"x".repeat(130), serde_json::json!({}))],
+        &[], &[], &[],
+    )
+    .is_err());
+    // StubActor identity.
+    assert_eq!(StubActor.id(), "stub");
+    assert!(StubActor.respond("arm", "req").unwrap().contains("req"));
+}
+
+// ── decision replay: load / walk / validate ────────────────────────────────
+
+#[test]
+fn decision_replay_load_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(DecisionReplay::load(&dir.path().join("nope.json")).is_err());
+    let bad = dir.path().join("bad.json");
+    std::fs::write(&bad, "{nope").unwrap();
+    assert!(DecisionReplay::load(&bad).is_err());
+    let schema = dir.path().join("schema.json");
+    std::fs::write(&schema, "{\"schema_version\":\"nope\",\"cases\":[]}").unwrap();
+    assert!(DecisionReplay::load(&schema).is_err());
+    let empty = dir.path().join("empty.json");
+    std::fs::write(&empty, "{\"schema_version\":\"public_safe_decision_replay_v0\",\"cases\":[]}").unwrap();
+    assert!(DecisionReplay::load(&empty).is_err());
+    // A case whose case_id is an absolute path fails the public-safety walk.
+    let goal = base_goal();
+    let packet = packet_for(&goal);
+    let mut case = reduce_public_safe_decision(&packet, &goal, "c1", None);
+    case.case_id = "/abs/path".to_string();
+    assert!(validate_public_safe_decision_case(&case).is_err());
+    let mut replay = DecisionReplay::new();
+    replay.add(case);
+    let p = dir.path().join("violating.json");
+    replay.save(&p).unwrap();
+    assert!(DecisionReplay::load(&p).is_err(), "load validates each case");
+    // Bad case schema inside the file.
+    let mut value = serde_json::to_value(&replay).unwrap();
+    value["cases"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("case_id".into(), "fine".into());
+    value["cases"][0]
+        .as_object_mut()
+        .unwrap()
+        .insert("schema_version".into(), "nope".into());
+    let p2 = dir.path().join("badcase.json");
+    std::fs::write(&p2, serde_json::to_string(&value).unwrap()).unwrap();
+    assert!(DecisionReplay::load(&p2).is_err());
+}
+
+#[test]
+fn walk_violations_matrix() {
+    let v = serde_json::json!({
+        "credential": "x",
+        "nested": {"trajectory": []},
+        "items": [{"path": "/abs/file"}, {"ref": "file://x"}, {"ok": "fine"}],
+    });
+    let violations = walk_public_safe_violations(&v);
+    assert!(violations.iter().any(|s| s.contains("banned key: credential")), "{violations:?}");
+    assert!(violations.iter().any(|s| s.contains("nested.trajectory")), "{violations:?}");
+    assert!(violations.iter().any(|s| s.contains("local path")), "{violations:?}");
+    assert!(walk_public_safe_violations(&serde_json::json!({"clean": "yes"})).is_empty());
+}
+
+// ── decision replay: reduce / replay matrices ──────────────────────────────
+
+#[test]
+fn reduce_covers_todo_matrix() {
+    let mut goal = base_goal();
+    // Every class + status + optional-field arm.
+    let mut gate = Todo::user_gate("tg", "approve?", &[]);
+    gate.decision = Some("yes".into());
+    gate.goal_bound = true;
+    gate.global_gate = true;
+    goal.todos.push(gate);
+    let mut action = Todo::user_action("ta", "user acts");
+    action.status = TodoStatus::Blocked;
+    goal.todos.push(action);
+    let mut mon = Todo::monitor("tm", "watch", std::time::Duration::from_secs(60));
+    mon.resume_when_text = Some("15m".into());
+    goal.todos.push(mon);
+    let blocker = Todo::blocker("tb", "external", &[]);
+    goal.todos.push(blocker);
+    let mut done = Todo::advancement("td", "done");
+    done.status = TodoStatus::Done;
+    goal.todos.push(done);
+    let mut sup = Todo::advancement("ts", "old");
+    sup.status = TodoStatus::Superseded;
+    goal.todos.push(sup);
+    let mut def = Todo::advancement("tdef", "later");
+    def.status = TodoStatus::Deferred;
+    def.resume_when = Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600));
+    goal.todos.push(def);
+    let mut claimed = Todo::advancement("tc", "claimed");
+    claimed.claimed_by = Some("agent-1".into());
+    goal.todos.push(claimed);
+
+    // Gate-open packet → AskUser interaction arms.
+    let packet = packet_for(&goal);
+    let case = reduce_public_safe_decision(&packet, &goal, "rich-case", None);
+    assert!(!case.user_todos.is_empty(), "gate/action populate user todos");
+    validate_public_safe_decision_case(&case).unwrap();
+    // Replay it (kernel should reproduce the ask_user decision).
+    let comparison = replay_public_safe_decision_case(&case).unwrap();
+    assert!(comparison.matched, "{:?}", comparison.mismatches);
+}
+
+#[test]
+fn replay_mismatch_diff_arms() {
+    let mut goal = base_goal();
+    goal.todos.push(Todo::advancement("t1", "work"));
+    let packet = packet_for(&goal);
+    let case = reduce_public_safe_decision(&packet, &goal, "c-diff", None);
+    // Tamper: flip recorded should_run → replay diverges → mismatch list.
+    let mut tampered = case.clone();
+    tampered.decision.should_run = !case.decision.should_run;
+    let comparison = replay_public_safe_decision_case(&tampered).unwrap();
+    assert!(!comparison.matched);
+    assert!(comparison.mismatches.iter().any(|m| m.contains("should_run")));
+    // Save/load roundtrip through DecisionReplay::add.
+    let mut replay = DecisionReplay::default();
+    replay.add(case);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sub/dir/replay.json");
+    replay.save(&path).unwrap();
+    let loaded = DecisionReplay::load(&path).unwrap();
+    assert_eq!(loaded.cases.len(), 1);
+}

--- a/orchestration/loop/tests/replay_drive2.rs
+++ b/orchestration/loop/tests/replay_drive2.rs
@@ -133,3 +133,27 @@ fn decision_replay_mismatch_groups() {
     let cmp = replay_public_safe_decision_case(&t5).unwrap();
     assert!(cmp.mismatches.iter().any(|m| m.contains("must_attempt")), "{:?}", cmp.mismatches);
 }
+
+#[test]
+fn corpus_run_actor_error_propagates() {
+    // NOTE: the semantic-drift else-branch in the pair evaluator is
+    // unreachable — render_actor_request always emits the schema header,
+    // "TODO " and the completion-contract lines, so the contract is complete
+    // for every packet (documented in the coverage report).
+    struct ErrActor;
+    impl future_loop::replay::corpus::ModelBehaviorActor for ErrActor {
+        fn id(&self) -> &str {
+            "err"
+        }
+        fn respond(&self, _arm: &str, _request: &str) -> anyhow::Result<String> {
+            anyhow::bail!("actor exploded")
+        }
+    }
+    let full = base_packet_json();
+    let case = case_json("c-err", "equivalent", full, None);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("corpus.json");
+    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    let corpus = ModelBehaviorCorpus::load(&path).unwrap();
+    assert!(run_model_behavior_corpus(&corpus, &ErrActor, 2, 0).is_err());
+}

--- a/orchestration/loop/tests/replay_drive2.rs
+++ b/orchestration/loop/tests/replay_drive2.rs
@@ -1,0 +1,131 @@
+//! Coverage drive 2 for `replay/`: hand-crafted corpus JSON reaching the
+//! fail-closed full-packet arm and the semantic-drift gate, plus the
+//! decision-replay per-group mismatch arms.
+
+use future_loop::replay::corpus::{
+    build_model_behavior_corpus, run_model_behavior_corpus, ModelBehaviorCorpus, PatchCase, StubActor,
+};
+use future_loop::replay::decision_replay::{
+    reduce_public_safe_decision, replay_public_safe_decision_case,
+};
+use future_loop::state::{Goal, Todo};
+
+fn base_packet_json() -> serde_json::Value {
+    let mut goal = Goal::new("g1", "replay drive 2", "/tmp");
+    goal.todos.push(Todo::advancement("t1", "work"));
+    let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+    serde_json::to_value(&packet).unwrap()
+}
+
+fn corpus_json_with(cases: Vec<serde_json::Value>) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": "model_behavior_corpus_v0",
+        "persistence_boundary": {"note": "in-memory test corpus"},
+        "cases": cases,
+    })
+}
+
+fn case_json(id: &str, expected: &str, full: serde_json::Value, candidate: Option<serde_json::Value>) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": "model_behavior_corpus_case_v0",
+        "case_id": id,
+        "source_kind": "state_matrix",
+        "expected_outcome": expected,
+        "full_packet": full,
+        "candidate_packet": candidate,
+    })
+}
+
+#[test]
+fn corpus_run_full_packet_fail_closed() {
+    // full_packet missing hard invariants → the pair fails closed before the
+    // actor runs; expected fail_closed → the case passes the gate.
+    let case = case_json("c-fail", "fail_closed", serde_json::json!({}), None);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("corpus.json");
+    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    let corpus = ModelBehaviorCorpus::load(&path).unwrap();
+    let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
+    assert!(result.all_cases_passed, "{:?}", result.cases.iter().map(|c| (&c.case_id, c.passed)).collect::<Vec<_>>());
+}
+
+#[test]
+fn corpus_run_semantic_drift_fails_gate() {
+    // candidate = full minus the selected todo → the rendered request loses
+    // the "TODO " section → semantic contract incomplete → equivalent case
+    // fails → corpus gate bails.
+    let full = base_packet_json();
+    let mut candidate = full.clone();
+    candidate.as_object_mut().unwrap().remove("selected_todo");
+    let case = case_json("c-drift", "equivalent", full, Some(candidate));
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("corpus.json");
+    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    let corpus = ModelBehaviorCorpus::load(&path).unwrap();
+    let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
+    assert!(!result.all_cases_passed);
+    assert!(!result.corpus_gate_passed);
+    assert!(!result.promotion_eligible);
+    // And the case reports the failed arm detail.
+    let c = &result.cases[0];
+    assert!(!c.passed);
+    assert!(!c.runs.is_empty());
+}
+
+#[test]
+fn corpus_build_patch_merge_arms() {
+    // deep_merge: object-into-object merges, scalar replaces, array replaces.
+    let mut goal = Goal::new("g", "merge", "/tmp");
+    goal.todos.push(Todo::advancement("t1", "w"));
+    let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+    let corpus = build_model_behavior_corpus(
+        &packet,
+        &[
+            PatchCase::new("nested", serde_json::json!({"quota": {"spent_slots": 3}})),
+            PatchCase::new("scalar", serde_json::json!({"should_run": false})),
+            PatchCase::new("array", serde_json::json!({"boundary": {"leaks": ["x"]}})),
+        ],
+        &[],
+        &[],
+        &[],
+    )
+    .unwrap();
+    assert_eq!(corpus.cases.len(), 3);
+    let merged: serde_json::Value = corpus.cases[0].full_packet.clone();
+    assert_eq!(merged["quota"]["spent_slots"], serde_json::json!(3));
+}
+
+#[test]
+fn decision_replay_mismatch_groups() {
+    let mut goal = Goal::new("g", "tamper", "/tmp");
+    goal.todos.push(Todo::advancement("t1", "work"));
+    let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
+    let case = reduce_public_safe_decision(&packet, &goal, "c1", None);
+    assert_eq!(case.case_id(), "c1");
+    // Tamper one field per comparison group: decision / expected /
+    // interaction (string + Option + bool closure).
+    let mut t1 = case.clone();
+    t1.decision.effective_action = "tampered".to_string();
+    let cmp = replay_public_safe_decision_case(&t1).unwrap();
+    assert!(cmp.mismatches.iter().any(|m| m.contains("decision.effective_action")));
+
+    let mut t2 = case.clone();
+    t2.expected.scheduler_action = "tampered".to_string();
+    let cmp = replay_public_safe_decision_case(&t2).unwrap();
+    assert!(cmp.mismatches.iter().any(|m| m.contains("expected.scheduler_action")));
+
+    let mut t3 = case.clone();
+    t3.interaction_contract.mode = "terminal".to_string();
+    let cmp = replay_public_safe_decision_case(&t3).unwrap();
+    assert!(cmp.mismatches.iter().any(|m| m.contains("interaction.mode")));
+
+    let mut t4 = case.clone();
+    t4.interaction_contract.user_channel.notify = Some("tampered".to_string());
+    let cmp = replay_public_safe_decision_case(&t4).unwrap();
+    assert!(cmp.mismatches.iter().any(|m| m.contains("user_channel.notify")));
+
+    let mut t5 = case.clone();
+    t5.interaction_contract.agent_channel.must_attempt = Some(!case.interaction_contract.agent_channel.must_attempt.unwrap_or(false));
+    let cmp = replay_public_safe_decision_case(&t5).unwrap();
+    assert!(cmp.mismatches.iter().any(|m| m.contains("must_attempt")), "{:?}", cmp.mismatches);
+}

--- a/orchestration/loop/tests/replay_drive2.rs
+++ b/orchestration/loop/tests/replay_drive2.rs
@@ -51,12 +51,16 @@ fn corpus_run_full_packet_fail_closed() {
 
 #[test]
 fn corpus_run_semantic_drift_fails_gate() {
-    // candidate = full minus the selected todo → the rendered request loses
-    // the "TODO " section → semantic contract incomplete → equivalent case
-    // fails → corpus gate bails.
+    // candidate = full minus the selected todo fields → the rendered request
+    // loses the "TODO " section → semantic contract incomplete → equivalent
+    // case fails → corpus gate bails.
     let full = base_packet_json();
     let mut candidate = full.clone();
-    candidate.as_object_mut().unwrap().remove("selected_todo");
+    {
+        let obj = candidate.as_object_mut().unwrap();
+        obj.remove("selected_todo");
+        obj.remove("selected_todo_id");
+    }
     let case = case_json("c-drift", "equivalent", full, Some(candidate));
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("corpus.json");

--- a/orchestration/loop/tests/replay_drive2.rs
+++ b/orchestration/loop/tests/replay_drive2.rs
@@ -3,7 +3,8 @@
 //! decision-replay per-group mismatch arms.
 
 use future_loop::replay::corpus::{
-    build_model_behavior_corpus, run_model_behavior_corpus, ModelBehaviorCorpus, PatchCase, StubActor,
+    build_model_behavior_corpus, run_model_behavior_corpus, ModelBehaviorCorpus, PatchCase,
+    StubActor,
 };
 use future_loop::replay::decision_replay::{
     reduce_public_safe_decision, replay_public_safe_decision_case,
@@ -25,7 +26,12 @@ fn corpus_json_with(cases: Vec<serde_json::Value>) -> serde_json::Value {
     })
 }
 
-fn case_json(id: &str, expected: &str, full: serde_json::Value, candidate: Option<serde_json::Value>) -> serde_json::Value {
+fn case_json(
+    id: &str,
+    expected: &str,
+    full: serde_json::Value,
+    candidate: Option<serde_json::Value>,
+) -> serde_json::Value {
     serde_json::json!({
         "schema_version": "model_behavior_corpus_case_v0",
         "case_id": id,
@@ -43,10 +49,22 @@ fn corpus_run_full_packet_fail_closed() {
     let case = case_json("c-fail", "fail_closed", serde_json::json!({}), None);
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("corpus.json");
-    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        serde_json::to_string(&corpus_json_with(vec![case])).unwrap(),
+    )
+    .unwrap();
     let corpus = ModelBehaviorCorpus::load(&path).unwrap();
     let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
-    assert!(result.all_cases_passed, "{:?}", result.cases.iter().map(|c| (&c.case_id, c.passed)).collect::<Vec<_>>());
+    assert!(
+        result.all_cases_passed,
+        "{:?}",
+        result
+            .cases
+            .iter()
+            .map(|c| (&c.case_id, c.passed))
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -64,7 +82,11 @@ fn corpus_run_semantic_drift_fails_gate() {
     let case = case_json("c-drift", "equivalent", full, Some(candidate));
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("corpus.json");
-    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        serde_json::to_string(&corpus_json_with(vec![case])).unwrap(),
+    )
+    .unwrap();
     let corpus = ModelBehaviorCorpus::load(&path).unwrap();
     let result = run_model_behavior_corpus(&corpus, &StubActor, 2, 0).unwrap();
     assert!(!result.all_cases_passed);
@@ -111,27 +133,49 @@ fn decision_replay_mismatch_groups() {
     let mut t1 = case.clone();
     t1.decision.effective_action = "tampered".to_string();
     let cmp = replay_public_safe_decision_case(&t1).unwrap();
-    assert!(cmp.mismatches.iter().any(|m| m.contains("decision.effective_action")));
+    assert!(cmp
+        .mismatches
+        .iter()
+        .any(|m| m.contains("decision.effective_action")));
 
     let mut t2 = case.clone();
     t2.expected.scheduler_action = "tampered".to_string();
     let cmp = replay_public_safe_decision_case(&t2).unwrap();
-    assert!(cmp.mismatches.iter().any(|m| m.contains("expected.scheduler_action")));
+    assert!(cmp
+        .mismatches
+        .iter()
+        .any(|m| m.contains("expected.scheduler_action")));
 
     let mut t3 = case.clone();
     t3.interaction_contract.mode = "terminal".to_string();
     let cmp = replay_public_safe_decision_case(&t3).unwrap();
-    assert!(cmp.mismatches.iter().any(|m| m.contains("interaction.mode")));
+    assert!(cmp
+        .mismatches
+        .iter()
+        .any(|m| m.contains("interaction.mode")));
 
     let mut t4 = case.clone();
     t4.interaction_contract.user_channel.notify = Some("tampered".to_string());
     let cmp = replay_public_safe_decision_case(&t4).unwrap();
-    assert!(cmp.mismatches.iter().any(|m| m.contains("user_channel.notify")));
+    assert!(cmp
+        .mismatches
+        .iter()
+        .any(|m| m.contains("user_channel.notify")));
 
     let mut t5 = case.clone();
-    t5.interaction_contract.agent_channel.must_attempt = Some(!case.interaction_contract.agent_channel.must_attempt.unwrap_or(false));
+    t5.interaction_contract.agent_channel.must_attempt = Some(
+        !case
+            .interaction_contract
+            .agent_channel
+            .must_attempt
+            .unwrap_or(false),
+    );
     let cmp = replay_public_safe_decision_case(&t5).unwrap();
-    assert!(cmp.mismatches.iter().any(|m| m.contains("must_attempt")), "{:?}", cmp.mismatches);
+    assert!(
+        cmp.mismatches.iter().any(|m| m.contains("must_attempt")),
+        "{:?}",
+        cmp.mismatches
+    );
 }
 
 #[test]
@@ -153,7 +197,11 @@ fn corpus_run_actor_error_propagates() {
     let case = case_json("c-err", "equivalent", full, None);
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("corpus.json");
-    std::fs::write(&path, serde_json::to_string(&corpus_json_with(vec![case])).unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        serde_json::to_string(&corpus_json_with(vec![case])).unwrap(),
+    )
+    .unwrap();
     let corpus = ModelBehaviorCorpus::load(&path).unwrap();
     assert!(run_model_behavior_corpus(&corpus, &ErrActor, 2, 0).is_err());
 }

--- a/orchestration/loop/tests/scheduler_drive.rs
+++ b/orchestration/loop/tests/scheduler_drive.rs
@@ -263,10 +263,10 @@ fn progression_cursor_behaviors() {
     // advance → 30m (index 1); next advance wraps to 15m (returns true).
     assert_eq!(st::apply_next_progression(&mut state, 2).as_deref(), Some("FREQ=MINUTELY;INTERVAL=30"));
     assert!(st::advance_progression(&mut state), "wraps to start");
-    assert!(!st::advance_progression(&mut state), "index 1, no wrap");
-    // current_rrule / current_progression_minutes.
     assert_eq!(st::current_progression_minutes(&state), Some(15));
     assert_eq!(st::current_rrule(&state).as_deref(), Some("FREQ=MINUTELY;INTERVAL=15"));
+    assert!(!st::advance_progression(&mut state), "index 1, no wrap");
+    assert_eq!(st::current_progression_minutes(&state), Some(30));
     // Empty progression: no-op advance, None rrules.
     state.progression_minutes = vec![];
     assert!(!st::advance_progression(&mut state));

--- a/orchestration/loop/tests/scheduler_drive.rs
+++ b/orchestration/loop/tests/scheduler_drive.rs
@@ -115,17 +115,33 @@ fn host_update_failure_normalization() {
     // Non-object → None.
     assert!(st::normalize_host_update_failure(&serde_json::json!("x")).is_none());
     // Wrong schema → None.
-    assert!(st::normalize_host_update_failure(&serde_json::json!({"schema_version": "nope"}))
-        .is_none());
+    assert!(
+        st::normalize_host_update_failure(&serde_json::json!({"schema_version": "nope"})).is_none()
+    );
     // Missing fields → None.
-    let mut v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 1);
+    let mut v = failure_json(
+        "FREQ=MINUTELY;INTERVAL=15",
+        "",
+        "2026-08-10T00:00:00+00:00",
+        1,
+    );
     v.as_object_mut().unwrap().remove("failure_kind");
     assert!(st::normalize_host_update_failure(&v).is_none());
     // Zero count → None.
-    let v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 0);
+    let v = failure_json(
+        "FREQ=MINUTELY;INTERVAL=15",
+        "",
+        "2026-08-10T00:00:00+00:00",
+        0,
+    );
     assert!(st::normalize_host_update_failure(&v).is_none());
     // Valid; missing observed_rrule defaults to "".
-    let v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 2);
+    let v = failure_json(
+        "FREQ=MINUTELY;INTERVAL=15",
+        "",
+        "2026-08-10T00:00:00+00:00",
+        2,
+    );
     let f = st::normalize_host_update_failure(&v).unwrap();
     assert_eq!(f.failure_count, 2);
     // Dedup by pair keeps the latest; cache limit caps the list.
@@ -155,8 +171,8 @@ fn retained_failures_ttl_and_observed_filter() {
         .to_rfc3339();
     let failures = vec![
         failure("T", "OBS", &fresh, 1),
-        failure("T2", "OBS2", &stale, 1),   // TTL-expired
-        failure("T3", "OTHER", &fresh, 1),  // different observed rrule
+        failure("T2", "OBS2", &stale, 1),  // TTL-expired
+        failure("T3", "OTHER", &fresh, 1), // different observed rrule
     ];
     // No observed filter: TTL only.
     let kept = st::retained_host_update_failures(&failures, now, None);
@@ -173,7 +189,9 @@ fn retained_failures_ttl_and_observed_filter() {
 #[test]
 fn merge_host_update_failure_replaces_pair() {
     let now = 1_800_000_000u64;
-    let ts = chrono::DateTime::from_timestamp(now as i64, 0).unwrap().to_rfc3339();
+    let ts = chrono::DateTime::from_timestamp(now as i64, 0)
+        .unwrap()
+        .to_rfc3339();
     let existing = vec![failure("T", "OBS", &ts, 1)];
     let merged = st::merge_host_update_failure(&existing, failure("T", "OBS", &ts, 5), now);
     assert_eq!(merged.len(), 1);
@@ -210,39 +228,120 @@ fn scheduler_state_validation_matrix() {
     )
     .unwrap();
     // Scope mismatches → None.
-    assert!(st::normalize_scheduler_state(&good, "OTHER", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
-    assert!(st::normalize_scheduler_state(&good, "g1", "OTHER", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
-    assert!(st::normalize_scheduler_state(&good, "g1", "a1", "OTHER", st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
-    assert!(st::normalize_scheduler_state(&good, "g1", "a1", st::CODEX_APP_SURFACE, "OTHER").is_none());
+    assert!(st::normalize_scheduler_state(
+        &good,
+        "OTHER",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
+    assert!(st::normalize_scheduler_state(
+        &good,
+        "g1",
+        "OTHER",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
+    assert!(st::normalize_scheduler_state(
+        &good,
+        "g1",
+        "a1",
+        "OTHER",
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
+    assert!(
+        st::normalize_scheduler_state(&good, "g1", "a1", st::CODEX_APP_SURFACE, "OTHER").is_none()
+    );
     // Bad schema → None; legacy schema token accepted.
     let mut s = good.clone();
     s.schema_version = "nope".into();
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     let mut s = good.clone();
     s.schema_version = "loopx_scheduler_state_v0".into();
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_some());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_some());
     // Empty required fields → None.
     let mut s = good.clone();
     s.reset_token = "  ".into();
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     let mut s = good.clone();
     s.identity_signature = String::new();
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     // Empty rrule with no failures → None; with failures → Some.
     let mut s = good.clone();
     s.last_applied_rrule = String::new();
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     let mut s = good.clone();
     s.last_applied_rrule = String::new();
     s.host_update_failures = vec![failure("T", "O", "2026-08-10T00:00:00+00:00", 1)];
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_some());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_some());
     // Non-positive progression entry → None (and the build error path).
     let mut s = good.clone();
     s.progression_minutes = vec![15, 0];
-    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(
+        &s,
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     assert!(st::build_scheduler_state(
-        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
-        "tok", "id", 0, vec![0], "R", 1, vec![],
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "tok",
+        "id",
+        0,
+        vec![0],
+        "R",
+        1,
+        vec![],
     )
     .is_err());
 }
@@ -250,8 +349,15 @@ fn scheduler_state_validation_matrix() {
 #[test]
 fn progression_cursor_behaviors() {
     let mut state = st::build_scheduler_state(
-        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
-        &st::reset_token("tick_next", &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE), "FREQ=MINUTELY;INTERVAL=15"),
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        &st::reset_token(
+            "tick_next",
+            &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE),
+            "FREQ=MINUTELY;INTERVAL=15",
+        ),
         &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE),
         0,
         vec![15, 30],
@@ -261,10 +367,16 @@ fn progression_cursor_behaviors() {
     )
     .unwrap();
     // advance → 30m (index 1); next advance wraps to 15m (returns true).
-    assert_eq!(st::apply_next_progression(&mut state, 2).as_deref(), Some("FREQ=MINUTELY;INTERVAL=30"));
+    assert_eq!(
+        st::apply_next_progression(&mut state, 2).as_deref(),
+        Some("FREQ=MINUTELY;INTERVAL=30")
+    );
     assert!(st::advance_progression(&mut state), "wraps to start");
     assert_eq!(st::current_progression_minutes(&state), Some(15));
-    assert_eq!(st::current_rrule(&state).as_deref(), Some("FREQ=MINUTELY;INTERVAL=15"));
+    assert_eq!(
+        st::current_rrule(&state).as_deref(),
+        Some("FREQ=MINUTELY;INTERVAL=15")
+    );
     assert!(!st::advance_progression(&mut state), "index 1, no wrap");
     assert_eq!(st::current_progression_minutes(&state), Some(30));
     // Empty progression: no-op advance, None rrules.
@@ -280,9 +392,17 @@ fn persistence_roundtrip_and_scope_guard() {
     let dir = tempfile::tempdir().unwrap();
     let goal_dir = dir.path();
     let state = st::build_scheduler_state(
-        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
-        "tok", &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE), 0, vec![15],
-        "FREQ=MINUTELY;INTERVAL=15", 1, vec![],
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "tok",
+        &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE),
+        0,
+        vec![15],
+        "FREQ=MINUTELY;INTERVAL=15",
+        1,
+        vec![],
     )
     .unwrap();
     st::write_scheduler_state(goal_dir, &state).unwrap();
@@ -294,11 +414,28 @@ fn persistence_roundtrip_and_scope_guard() {
     );
     assert_eq!(loaded, Some(state));
     // Wrong scope → None; missing file → None; corrupt file → None.
-    assert!(st::load_scheduler_state(goal_dir, "other", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::load_scheduler_state(
+        goal_dir,
+        "other",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     assert!(st::load_scheduler_state(goal_dir, "a1", st::CODEX_APP_SURFACE, "other-key").is_none());
-    let path = st::scheduler_state_path(goal_dir, "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY);
+    let path = st::scheduler_state_path(
+        goal_dir,
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    );
     std::fs::write(&path, "{corrupt").unwrap();
-    assert!(st::load_scheduler_state(goal_dir, "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::load_scheduler_state(
+        goal_dir,
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY
+    )
+    .is_none());
     // safe_segment: path-hostile characters are stripped (agent ids with
     // separators cannot escape the scheduler-state dir).
     let p = st::scheduler_state_path(goal_dir, "../evil/agent", "surf ace", "key");
@@ -313,7 +450,10 @@ fn misc_helpers() {
         st::identity_signature("g", "a", "s"),
         st::identity_signature("g", "a", "s")
     );
-    assert_ne!(st::identity_signature("g", "a", "s"), st::identity_signature("g", "a", "x"));
+    assert_ne!(
+        st::identity_signature("g", "a", "s"),
+        st::identity_signature("g", "a", "x")
+    );
     let tok = st::reset_token("tick_next", "identity", "RRULE");
     assert!(!tok.is_empty());
     // stable_digest length cap.

--- a/orchestration/loop/tests/scheduler_drive.rs
+++ b/orchestration/loop/tests/scheduler_drive.rs
@@ -1,0 +1,321 @@
+//! Coverage drive for `scheduler/state.rs` — pure-function branch matrix
+//! (rrule parsing, cadence classes, host-update-failure normalization /
+//! retention / merge, scheduler-state validation, persistence).
+
+use future_loop::scheduler::state as st;
+use future_loop::scheduler::state::HostUpdateFailure;
+
+fn failure(target: &str, observed: &str, failed_at: &str, count: u64) -> HostUpdateFailure {
+    HostUpdateFailure {
+        schema_version: st::SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION.to_string(),
+        target_rrule: target.to_string(),
+        observed_host_rrule: observed.to_string(),
+        failure_kind: "host_stale_rrule".to_string(),
+        failed_at: failed_at.to_string(),
+        failure_count: count as u32,
+    }
+}
+
+fn failure_json(target: &str, observed: &str, failed_at: &str, count: u64) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": st::SCHEDULER_HOST_UPDATE_FAILURE_SCHEMA_VERSION,
+        "target_rrule": target,
+        "observed_host_rrule": observed,
+        "failure_kind": "host_stale_rrule",
+        "failed_at": failed_at,
+        "failure_count": count,
+    })
+}
+
+#[test]
+fn rrule_parsing_matrix() {
+    // normalize_scheduler_rrule: collapses whitespace runs and strips an
+    // RRULE: prefix (it does NOT reorder parts or change case).
+    assert_eq!(
+        st::normalize_scheduler_rrule("  FREQ=MINUTELY;INTERVAL=15  "),
+        "FREQ=MINUTELY;INTERVAL=15"
+    );
+    assert_eq!(
+        st::normalize_scheduler_rrule("RRULE:FREQ=MINUTELY;INTERVAL=15"),
+        "FREQ=MINUTELY;INTERVAL=15"
+    );
+    // interval extraction.
+    assert_eq!(
+        st::scheduler_rrule_interval_minutes("FREQ=MINUTELY;INTERVAL=15"),
+        Some(15)
+    );
+    assert_eq!(
+        st::scheduler_rrule_interval_minutes("FREQ=HOURLY;INTERVAL=15"),
+        None,
+        "non-MINUTELY"
+    );
+    assert_eq!(
+        st::scheduler_rrule_interval_minutes("FREQ=MINUTELY;INTERVAL=0"),
+        None,
+        "zero interval"
+    );
+    assert_eq!(
+        st::scheduler_rrule_interval_minutes("FREQ=MINUTELY;INTERVAL=x"),
+        None,
+        "unparseable interval"
+    );
+    assert_eq!(st::scheduler_rrule_interval_minutes("no-separator"), None);
+    // rrule_for_minutes / cadence_label.
+    assert_eq!(st::rrule_for_minutes(90), "FREQ=MINUTELY;INTERVAL=90");
+    assert_eq!(st::cadence_label(7 * 24 * 60), "1w");
+    assert_eq!(st::cadence_label(48 * 60), "2d");
+    assert_eq!(st::cadence_label(120), "2h");
+    assert_eq!(st::cadence_label(45), "45m");
+}
+
+#[test]
+fn cadence_class_matrix() {
+    for (input, minutes) in [
+        ("hourly", 60),
+        ("hour", 60),
+        ("1h", 60),
+        ("daily", 24 * 60),
+        ("day", 24 * 60),
+        ("1d", 24 * 60),
+        ("weekly", 7 * 24 * 60),
+        ("week", 7 * 24 * 60),
+    ] {
+        let rrule = st::rrule_for_cadence_class(input).unwrap();
+        assert_eq!(
+            st::scheduler_rrule_interval_minutes(&rrule),
+            Some(minutes),
+            "{input}"
+        );
+    }
+    for none in ["once", "", "none", "biweekly"] {
+        assert!(st::rrule_for_cadence_class(none).is_none(), "{none}");
+    }
+    // A raw rrule passes through.
+    assert_eq!(
+        st::rrule_for_cadence_class("FREQ=MINUTELY;INTERVAL=7").as_deref(),
+        Some("FREQ=MINUTELY;INTERVAL=7")
+    );
+}
+
+#[test]
+fn monitor_cadence_secs_matrix() {
+    assert_eq!(st::monitor_cadence_secs(""), None);
+    assert_eq!(st::monitor_cadence_secs("15m"), Some(900));
+    assert_eq!(st::monitor_cadence_secs("30s"), Some(30));
+    assert_eq!(st::monitor_cadence_secs("2h"), Some(7200));
+    assert_eq!(st::monitor_cadence_secs("1d"), Some(86400));
+    assert_eq!(st::monitor_cadence_secs("0m"), None);
+    assert_eq!(st::monitor_cadence_secs("123"), None, "no unit separator");
+    assert_eq!(st::monitor_cadence_secs("xm"), None, "bad count");
+    assert_eq!(st::monitor_cadence_secs("5w"), None, "unknown unit");
+}
+
+#[test]
+fn host_update_failure_normalization() {
+    // Non-object → None.
+    assert!(st::normalize_host_update_failure(&serde_json::json!("x")).is_none());
+    // Wrong schema → None.
+    assert!(st::normalize_host_update_failure(&serde_json::json!({"schema_version": "nope"}))
+        .is_none());
+    // Missing fields → None.
+    let mut v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 1);
+    v.as_object_mut().unwrap().remove("failure_kind");
+    assert!(st::normalize_host_update_failure(&v).is_none());
+    // Zero count → None.
+    let v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 0);
+    assert!(st::normalize_host_update_failure(&v).is_none());
+    // Valid; missing observed_rrule defaults to "".
+    let v = failure_json("FREQ=MINUTELY;INTERVAL=15", "", "2026-08-10T00:00:00+00:00", 2);
+    let f = st::normalize_host_update_failure(&v).unwrap();
+    assert_eq!(f.failure_count, 2);
+    // Dedup by pair keeps the latest; cache limit caps the list.
+    let now = "2026-08-10T00:00:00+00:00";
+    let mut list: Vec<serde_json::Value> = vec![];
+    for i in 0..10 {
+        list.push(failure_json("FREQ=MINUTELY;INTERVAL=15", "A", now, i + 1));
+    }
+    list.push(failure_json("FREQ=MINUTELY;INTERVAL=30", "B", now, 1));
+    let normalized = st::normalize_host_update_failures(&list);
+    assert_eq!(normalized.len(), 2, "same-pair dedup");
+    let a = normalized
+        .iter()
+        .find(|f| f.observed_host_rrule == "A")
+        .unwrap();
+    assert_eq!(a.failure_count, 10, "latest wins");
+}
+
+#[test]
+fn retained_failures_ttl_and_observed_filter() {
+    let now = 1_800_000_000u64;
+    let fresh = chrono::DateTime::from_timestamp((now - 60) as i64, 0)
+        .unwrap()
+        .to_rfc3339();
+    let stale = chrono::DateTime::from_timestamp(1_000_000, 0)
+        .unwrap()
+        .to_rfc3339();
+    let failures = vec![
+        failure("T", "OBS", &fresh, 1),
+        failure("T2", "OBS2", &stale, 1),   // TTL-expired
+        failure("T3", "OTHER", &fresh, 1),  // different observed rrule
+    ];
+    // No observed filter: TTL only.
+    let kept = st::retained_host_update_failures(&failures, now, None);
+    assert_eq!(kept.len(), 2);
+    // With observed filter: only the matching fresh one.
+    let kept = st::retained_host_update_failures(&failures, now, Some("OBS"));
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].target_rrule, "T");
+    // Unparseable failed_at parses as 0 → TTL-expired.
+    let weird = vec![failure("T", "OBS", "not-a-date", 1)];
+    assert!(st::retained_host_update_failures(&weird, now, None).is_empty());
+}
+
+#[test]
+fn merge_host_update_failure_replaces_pair() {
+    let now = 1_800_000_000u64;
+    let ts = chrono::DateTime::from_timestamp(now as i64, 0).unwrap().to_rfc3339();
+    let existing = vec![failure("T", "OBS", &ts, 1)];
+    let merged = st::merge_host_update_failure(&existing, failure("T", "OBS", &ts, 5), now);
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].failure_count, 5, "latest replaces the pair");
+    // Merging retains only failures matching the NEW failure's observed
+    // rrule (the retained-set filter), so a new observed rrule drops others.
+    let merged = st::merge_host_update_failure(&existing, failure("T", "NEW", &ts, 1), now);
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].observed_host_rrule, "NEW");
+}
+
+#[test]
+fn parse_epoch_variants() {
+    assert!(st::parse_epoch("2026-08-10T00:00:00+00:00").unwrap() > 0);
+    assert!(st::parse_epoch("garbage").is_none());
+    // Pre-epoch timestamps clamp to 0.
+    assert_eq!(st::parse_epoch("1900-01-01T00:00:00+00:00"), Some(0));
+}
+
+#[test]
+fn scheduler_state_validation_matrix() {
+    let good = st::build_scheduler_state(
+        "g1",
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "reset-token",
+        "identity",
+        0,
+        vec![15, 30],
+        "FREQ=MINUTELY;INTERVAL=15",
+        1_800_000_000,
+        vec![],
+    )
+    .unwrap();
+    // Scope mismatches → None.
+    assert!(st::normalize_scheduler_state(&good, "OTHER", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(&good, "g1", "OTHER", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(&good, "g1", "a1", "OTHER", st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::normalize_scheduler_state(&good, "g1", "a1", st::CODEX_APP_SURFACE, "OTHER").is_none());
+    // Bad schema → None; legacy schema token accepted.
+    let mut s = good.clone();
+    s.schema_version = "nope".into();
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    let mut s = good.clone();
+    s.schema_version = "loopx_scheduler_state_v0".into();
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_some());
+    // Empty required fields → None.
+    let mut s = good.clone();
+    s.reset_token = "  ".into();
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    let mut s = good.clone();
+    s.identity_signature = String::new();
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    // Empty rrule with no failures → None; with failures → Some.
+    let mut s = good.clone();
+    s.last_applied_rrule = String::new();
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    let mut s = good.clone();
+    s.last_applied_rrule = String::new();
+    s.host_update_failures = vec![failure("T", "O", "2026-08-10T00:00:00+00:00", 1)];
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_some());
+    // Non-positive progression entry → None (and the build error path).
+    let mut s = good.clone();
+    s.progression_minutes = vec![15, 0];
+    assert!(st::normalize_scheduler_state(&s, "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::build_scheduler_state(
+        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "tok", "id", 0, vec![0], "R", 1, vec![],
+    )
+    .is_err());
+}
+
+#[test]
+fn progression_cursor_behaviors() {
+    let mut state = st::build_scheduler_state(
+        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        &st::reset_token("tick_next", &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE), "FREQ=MINUTELY;INTERVAL=15"),
+        &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE),
+        0,
+        vec![15, 30],
+        "FREQ=MINUTELY;INTERVAL=15",
+        1,
+        vec![],
+    )
+    .unwrap();
+    // advance → 30m (index 1); next advance wraps to 15m (returns true).
+    assert_eq!(st::apply_next_progression(&mut state, 2).as_deref(), Some("FREQ=MINUTELY;INTERVAL=30"));
+    assert!(st::advance_progression(&mut state), "wraps to start");
+    assert!(!st::advance_progression(&mut state), "index 1, no wrap");
+    // current_rrule / current_progression_minutes.
+    assert_eq!(st::current_progression_minutes(&state), Some(15));
+    assert_eq!(st::current_rrule(&state).as_deref(), Some("FREQ=MINUTELY;INTERVAL=15"));
+    // Empty progression: no-op advance, None rrules.
+    state.progression_minutes = vec![];
+    assert!(!st::advance_progression(&mut state));
+    assert_eq!(st::apply_next_progression(&mut state, 3), None);
+    assert_eq!(st::current_progression_minutes(&state), None);
+    assert_eq!(st::current_rrule(&state), None);
+}
+
+#[test]
+fn persistence_roundtrip_and_scope_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let goal_dir = dir.path();
+    let state = st::build_scheduler_state(
+        "g1", "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+        "tok", &st::identity_signature("g1", "a1", st::CODEX_APP_SURFACE), 0, vec![15],
+        "FREQ=MINUTELY;INTERVAL=15", 1, vec![],
+    )
+    .unwrap();
+    st::write_scheduler_state(goal_dir, &state).unwrap();
+    let loaded = st::load_scheduler_state(
+        goal_dir,
+        "a1",
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    );
+    assert_eq!(loaded, Some(state));
+    // Wrong scope → None; missing file → None; corrupt file → None.
+    assert!(st::load_scheduler_state(goal_dir, "other", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    assert!(st::load_scheduler_state(goal_dir, "a1", st::CODEX_APP_SURFACE, "other-key").is_none());
+    let path = st::scheduler_state_path(goal_dir, "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY);
+    std::fs::write(&path, "{corrupt").unwrap();
+    assert!(st::load_scheduler_state(goal_dir, "a1", st::CODEX_APP_SURFACE, st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).is_none());
+    // safe_segment: path-hostile characters are stripped (agent ids with
+    // separators cannot escape the scheduler-state dir).
+    let p = st::scheduler_state_path(goal_dir, "../evil/agent", "surf ace", "key");
+    assert!(p.starts_with(goal_dir), "{p:?}");
+    assert!(!p.to_string_lossy().contains(".."), "{p:?}");
+}
+
+#[test]
+fn misc_helpers() {
+    // identity_signature / reset_token are deterministic.
+    assert_eq!(
+        st::identity_signature("g", "a", "s"),
+        st::identity_signature("g", "a", "s")
+    );
+    assert_ne!(st::identity_signature("g", "a", "s"), st::identity_signature("g", "a", "x"));
+    let tok = st::reset_token("tick_next", "identity", "RRULE");
+    assert!(!tok.is_empty());
+    // stable_digest length cap.
+    assert_eq!(st::stable_digest(&["a", "b"], 8).len(), 8);
+}

--- a/orchestration/loop/tests/server_drive.rs
+++ b/orchestration/loop/tests/server_drive.rs
@@ -1,0 +1,109 @@
+//! In-process coverage for `status_server.rs` (the blocking HTTP dashboard).
+//! The server loops forever, so it runs on a leaked background thread — the
+//! test process exits reaps it, and in-process execution means the coverage
+//! is actually recorded (a killed subprocess writes no profraw).
+
+use std::io::{Read, Write};
+
+use future_loop::state::{now_epoch, Goal, Todo};
+use future_loop::status_server::serve;
+use future_loop::store::{Event, Store};
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn http_get(port: u16, request: &str) -> String {
+    let mut last_err = None;
+    for _ in 0..100 {
+        match std::net::TcpStream::connect(("127.0.0.1", port)) {
+            Ok(mut stream) => {
+                stream.write_all(request.as_bytes()).unwrap();
+                let mut buf = String::new();
+                stream.read_to_string(&mut buf).unwrap();
+                return buf;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        }
+    }
+    panic!("server never accepted connections: {last_err:?}");
+}
+
+#[test]
+fn status_server_serves_dashboard_and_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("loop-root");
+    std::fs::create_dir_all(&root).unwrap();
+    let root = root.to_string_lossy().into_owned();
+
+    let port = free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let root_for_thread = root.clone();
+    std::thread::spawn(move || {
+        let store = Store::open(&root_for_thread).unwrap();
+        // Blocks forever on accept; the thread is abandoned at test end.
+        let _ = serve(&store, &addr);
+    });
+
+    // Empty registry → the "no goals" dashboard (store reopened per request).
+    let dash = http_get(port, "GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    assert!(dash.contains("no goals"), "{dash}");
+
+    // Register a goal with one todo; the next request sees it (per-request
+    // store reopen).
+    {
+        let mut store = Store::open(&root).unwrap();
+        let goal = Goal::new("goal_srv", "serve the dashboard", "/tmp");
+        store.register(&goal).unwrap();
+        store
+            .append(Event::GoalStarted {
+                goal_id: "goal_srv".to_string(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        let mut done = Todo::advancement("todo_done", "finished task");
+        done.status = future_loop::state::TodoStatus::Done;
+        let mut superseded = Todo::advancement("todo_sup", "old task");
+        superseded.status = future_loop::state::TodoStatus::Superseded;
+        let mut deferred = Todo::advancement("todo_def", "later task");
+        deferred.status = future_loop::state::TodoStatus::Deferred;
+        let mut blocked = Todo::advancement("todo_blk", "blocked task");
+        blocked.status = future_loop::state::TodoStatus::Blocked;
+        for t in [done, superseded, deferred, blocked, Todo::advancement("todo_open", "open task")] {
+            store
+                .append(Event::TodoAdded {
+                    goal_id: "goal_srv".to_string(),
+                    todo: t,
+                    ts: now_epoch(),
+                })
+                .unwrap();
+        }
+    }
+    let dash = http_get(port, "GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    assert!(dash.contains("goal_srv"), "{dash}");
+    assert!(dash.contains("todo_open=open"), "{dash}");
+    assert!(dash.contains("todo_done=done"), "{dash}");
+    assert!(dash.contains("todo_sup=superseded"), "{dash}");
+    assert!(dash.contains("todo_def=deferred"), "{dash}");
+    assert!(dash.contains("todo_blk=blocked"), "{dash}");
+
+    let json = http_get(port, "GET /goals.json HTTP/1.1\r\nHost: x\r\n\r\n");
+    assert!(json.contains("goal_srv"), "{json}");
+
+    // A garbage request line falls back to the dashboard.
+    let garbage = http_get(port, "GARBAGE\r\n\r\n");
+    assert!(garbage.contains("200 OK"), "{garbage}");
+
+    // serve() on an already-bound address errors immediately (deterministic
+    // bind failure — the first server holds the port).
+    let store = Store::open(&root).unwrap();
+    let busy = format!("127.0.0.1:{port}");
+    assert!(serve(&store, &busy).is_err());
+}

--- a/orchestration/loop/tests/server_drive.rs
+++ b/orchestration/loop/tests/server_drive.rs
@@ -76,7 +76,13 @@ fn status_server_serves_dashboard_and_json() {
         deferred.status = future_loop::state::TodoStatus::Deferred;
         let mut blocked = Todo::advancement("todo_blk", "blocked task");
         blocked.status = future_loop::state::TodoStatus::Blocked;
-        for t in [done, superseded, deferred, blocked, Todo::advancement("todo_open", "open task")] {
+        for t in [
+            done,
+            superseded,
+            deferred,
+            blocked,
+            Todo::advancement("todo_open", "open task"),
+        ] {
             store
                 .append(Event::TodoAdded {
                     goal_id: "goal_srv".to_string(),

--- a/orchestration/loop/tests/state_drive.rs
+++ b/orchestration/loop/tests/state_drive.rs
@@ -1,9 +1,7 @@
 //! Coverage drive for `state.rs` — Todo builders, claim/lease primitives,
 //! Goal query/mutation arms that no command path exercises directly.
 
-use future_loop::state::{
-    default_goal_status, Goal, Priority, TaskClass, Todo, TodoStatus,
-};
+use future_loop::state::{default_goal_status, Goal, Priority, TaskClass, Todo, TodoStatus};
 
 #[test]
 fn todo_builders() {
@@ -29,12 +27,33 @@ fn todo_builders() {
 
     // monitor_with derives the first due time from a cadence (or keeps the
     // explicit delay for `once`/unknown cadences).
-    let m = Todo::monitor_with("m1", "watch", Some("file:x"), Some("exists"), Some("15m"), std::time::Duration::from_secs(5));
+    let m = Todo::monitor_with(
+        "m1",
+        "watch",
+        Some("file:x"),
+        Some("exists"),
+        Some("15m"),
+        std::time::Duration::from_secs(5),
+    );
     assert!(m.resume_when.is_some());
     assert_eq!(m.monitor_target.as_deref(), Some("file:x"));
-    let m2 = Todo::monitor_with("m2", "watch", None, None, Some("bogus"), std::time::Duration::from_secs(5));
+    let m2 = Todo::monitor_with(
+        "m2",
+        "watch",
+        None,
+        None,
+        Some("bogus"),
+        std::time::Duration::from_secs(5),
+    );
     assert!(m2.resume_when.is_some(), "explicit delay kept");
-    let m3 = Todo::monitor_with("m3", "watch", None, None, None, std::time::Duration::from_secs(5));
+    let m3 = Todo::monitor_with(
+        "m3",
+        "watch",
+        None,
+        None,
+        None,
+        std::time::Duration::from_secs(5),
+    );
     assert!(m3.resume_when.is_some());
 
     // user_gate default question / blocks; blocker; user_action.
@@ -69,8 +88,8 @@ fn todo_claim_and_complete_primitives() {
 #[test]
 fn goal_query_and_mutation_arms() {
     assert_eq!(default_goal_status(), "active");
-    let mut goal = Goal::new("g", "obj", "/tmp")
-        .with_acceptance(vec![("gap1", "d1"), ("gap2", "d2")]);
+    let mut goal =
+        Goal::new("g", "obj", "/tmp").with_acceptance(vec![("gap1", "d1"), ("gap2", "d2")]);
     // register_agent dedup + profile replacement.
     goal.register_agent("a1", vec!["shell".into()]);
     goal.register_agent("a1", vec!["web".into()]);

--- a/orchestration/loop/tests/state_drive.rs
+++ b/orchestration/loop/tests/state_drive.rs
@@ -1,0 +1,174 @@
+//! Coverage drive for `state.rs` — Todo builders, claim/lease primitives,
+//! Goal query/mutation arms that no command path exercises directly.
+
+use future_loop::state::{
+    default_goal_status, Goal, Priority, TaskClass, Todo, TodoStatus,
+};
+
+#[test]
+fn todo_builders() {
+    let t = Todo::advancement("t1", "base")
+        .at_index(3)
+        .with_title("Title")
+        .with_note("a note")
+        .with_gate_scope(true, true)
+        .with_monitor_target("file:x")
+        .with_monitor_policy("exists")
+        .with_monitor_cadence("15m")
+        .at_priority(Priority::P0)
+        .with_action_kind("deploy");
+    assert_eq!(t.index, 3);
+    assert_eq!(t.title, "Title");
+    assert_eq!(t.note.as_deref(), Some("a note"));
+    assert!(t.goal_bound && t.global_gate);
+    assert_eq!(t.monitor_target.as_deref(), Some("file:x"));
+    assert_eq!(t.monitor_policy.as_deref(), Some("exists"));
+    assert_eq!(t.monitor_cadence.as_deref(), Some("15m"));
+    assert_eq!(t.priority, Priority::P0);
+    assert_eq!(t.action_kind.as_deref(), Some("deploy"));
+
+    // monitor_with derives the first due time from a cadence (or keeps the
+    // explicit delay for `once`/unknown cadences).
+    let m = Todo::monitor_with("m1", "watch", Some("file:x"), Some("exists"), Some("15m"), std::time::Duration::from_secs(5));
+    assert!(m.resume_when.is_some());
+    assert_eq!(m.monitor_target.as_deref(), Some("file:x"));
+    let m2 = Todo::monitor_with("m2", "watch", None, None, Some("bogus"), std::time::Duration::from_secs(5));
+    assert!(m2.resume_when.is_some(), "explicit delay kept");
+    let m3 = Todo::monitor_with("m3", "watch", None, None, None, std::time::Duration::from_secs(5));
+    assert!(m3.resume_when.is_some());
+
+    // user_gate default question / blocks; blocker; user_action.
+    let g = Todo::user_gate("g1", "question?", &["a", "b"]);
+    assert_eq!(g.class, TaskClass::UserGate);
+    assert_eq!(g.blocked_by_gate.as_deref(), Some("a,b"));
+    let b = Todo::blocker("b1", "blocked", &["x"]);
+    assert_eq!(b.class, TaskClass::Blocker);
+    let ua = Todo::user_action("u1", "user does it");
+    assert_eq!(ua.class, TaskClass::UserAction);
+}
+
+#[test]
+fn todo_claim_and_complete_primitives() {
+    let mut t = Todo::advancement("t1", "x");
+    // Claim on a non-open todo → false.
+    t.status = TodoStatus::Done;
+    assert!(!t.claim("a", 60, 100));
+    // Live lease held by someone else → false.
+    let mut t = Todo::advancement("t1", "x");
+    assert!(t.claim("a", 60, 100));
+    assert!(!t.claim("b", 60, 100));
+    // Same agent re-claims (renew) → true.
+    assert!(t.claim("a", 60, 100));
+    // Expired lease → another agent claims.
+    assert!(t.claim("b", 60, 10_000), "lease expired at 160");
+    // set_evidence stamps the todo.
+    t.set_evidence("proof");
+    assert_eq!(t.evidence.as_deref(), Some("proof"));
+}
+
+#[test]
+fn goal_query_and_mutation_arms() {
+    assert_eq!(default_goal_status(), "active");
+    let mut goal = Goal::new("g", "obj", "/tmp")
+        .with_acceptance(vec![("gap1", "d1"), ("gap2", "d2")]);
+    // register_agent dedup + profile replacement.
+    goal.register_agent("a1", vec!["shell".into()]);
+    goal.register_agent("a1", vec!["web".into()]);
+    assert_eq!(goal.registered_agents, vec!["a1".to_string()]);
+    let p = goal.agent_profiles.iter().find(|p| p.id == "a1").unwrap();
+    assert!(p.has("web"));
+    assert!(!p.has("shell"));
+    // is_registered_agent.
+    assert!(goal.is_registered_agent(Some("a1")));
+    assert!(!goal.is_registered_agent(Some("ghost")));
+    assert!(goal.is_registered_agent(None), "anonymous path is allowed");
+
+    // Todos for the blocking matrix.
+    goal.todos.push(Todo::advancement("pred", "predecessor"));
+    goal.todos.push(Todo::user_gate("gate1", "q?", &[]));
+    let mut dependent = Todo::advancement("dep", "dependent");
+    dependent.blocked_by_gate = Some("pred".into());
+    goal.todos.push(dependent.clone());
+    let mut gated = Todo::advancement("gated", "gated");
+    gated.blocked_by_gate = Some("gate1".into());
+    goal.todos.push(gated);
+    let mut unknown = Todo::advancement("unk", "unknown pred");
+    unknown.blocked_by_gate = Some("todo_ghost".into());
+    goal.todos.push(unknown);
+    let mut blank = Todo::advancement("blank", "blank pred");
+    blank.blocked_by_gate = Some("".into());
+    goal.todos.push(blank);
+
+    // Plain-todo predecessor still open → blocked; done → unblocked.
+    assert!(goal.is_blocked(&dependent));
+    goal.todo_mut("pred").unwrap().status = TodoStatus::Done;
+    assert!(!goal.is_blocked(&dependent));
+    // Open gate predecessor → blocked; resolved → unblocked.
+    assert!(goal.is_blocked(&goal.todo("gated").unwrap().clone()));
+    goal.todo_mut("gate1").unwrap().status = TodoStatus::Done;
+    assert!(!goal.is_blocked(&goal.todo("gated").unwrap().clone()));
+    // Superseded predecessor does not block.
+    goal.todo_mut("pred").unwrap().status = TodoStatus::Superseded;
+    assert!(!goal.is_blocked(&dependent));
+    // Unknown / empty predecessor ids never block.
+    assert!(!goal.is_blocked(&goal.todo("unk").unwrap().clone()));
+    assert!(!goal.is_blocked(&goal.todo("blank").unwrap().clone()));
+    // No blocked_by_gate at all → false.
+    assert!(!goal.is_blocked(&Todo::advancement("free", "free")));
+
+    // open_blocking_sources: gates + blockers that are open.
+    goal.todos.push(Todo::blocker("blk", "ext", &[]));
+    let sources: Vec<_> = goal.open_blocking_sources().collect();
+    assert!(sources.iter().any(|t| t.id == "blk"));
+
+    // completed_without_closure_intent.
+    let mut done_open = Todo::advancement("d1", "done silently");
+    done_open.status = TodoStatus::Done;
+    goal.todos.push(done_open);
+    let mut done_closed = Todo::advancement("d2", "done with intent");
+    done_closed.status = TodoStatus::Done;
+    done_closed.no_follow_up = true;
+    goal.todos.push(done_closed);
+    let unclosed: Vec<_> = goal.completed_without_closure_intent();
+    assert_eq!(unclosed.len(), 1);
+    assert_eq!(unclosed[0].id, "d1");
+
+    // Gaps.
+    assert_eq!(goal.unsatisfied_gaps().len(), 2);
+    goal.satisfy_gap("gap1");
+    goal.satisfy_gap("gap_ghost");
+    assert_eq!(goal.unsatisfied_gaps().len(), 1);
+
+    // supersede / archive on present + missing todos.
+    goal.supersede("d1");
+    goal.supersede("todo_ghost");
+    assert_eq!(goal.todo("d1").unwrap().status, TodoStatus::Superseded);
+    goal.archive_todo("d2");
+    goal.archive_todo("todo_ghost");
+    assert_eq!(goal.todo("d2").unwrap().archive_state, "archived");
+
+    // runnable_advancement_for: an agent's frontier excludes todos claimed by
+    // others (live lease) but includes its own.
+    let mut goal2 = Goal::new("g2", "obj", "/tmp");
+    let mut mine = Todo::advancement("t1", "mine");
+    mine.claim("alice", 3600, now_for_test());
+    let mut theirs = Todo::advancement("t2", "theirs");
+    theirs.claim("bob", 3600, now_for_test());
+    goal2.todos.push(theirs);
+    goal2.todos.push(mine);
+    goal2.todos.push(Todo::advancement("t3", "free"));
+    let alice_frontier: Vec<_> = goal2
+        .runnable_advancement_for(Some("alice"))
+        .map(|t| t.id.clone())
+        .collect();
+    assert!(alice_frontier.contains(&"t1".to_string()));
+    assert!(alice_frontier.contains(&"t3".to_string()));
+    assert!(!alice_frontier.contains(&"t2".to_string()));
+    // Anonymous frontier excludes all claimed todos.
+    let anon: Vec<_> = goal2.runnable_advancement().map(|t| t.id.clone()).collect();
+    assert_eq!(anon, vec!["t3".to_string()]);
+}
+
+fn now_for_test() -> u64 {
+    future_loop::state::now_epoch()
+}

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -1,0 +1,571 @@
+//! Coverage drive for `store.rs`: ledger read/write edge paths, the
+//! registry dual-format loader, backup/restore/delete arms, schema-version
+//! normalization, try_claim_todo lease reconstruction, and the event-apply
+//! matrix (via append + replay assertions).
+
+mod common;
+
+use common::run_record;
+use std::io::Write;
+use future_loop::state::{now_epoch, Goal, Todo, TodoStatus};
+use future_loop::store::{Event, Store};
+
+fn fresh_store(tag: &str) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join(tag);
+    std::fs::create_dir_all(&root).unwrap();
+    (dir, root.to_string_lossy().into_owned())
+}
+
+fn registered_goal(store: &mut Store, gid: &str) {
+    let goal = Goal::new(gid, "store drive", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: gid.to_string(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+}
+
+fn add(store: &mut Store, gid: &str, id: &str) {
+    store
+        .append(Event::TodoAdded {
+            goal_id: gid.to_string(),
+            todo: Todo::advancement(id, &format!("task {id}")),
+            ts: now_epoch(),
+        })
+        .unwrap();
+}
+
+// ── append / dedupe / conflicts ────────────────────────────────────────────
+
+#[test]
+fn append_requires_registration_and_dedupes() {
+    let (_d, root) = fresh_store("s1");
+    let mut store = Store::open(&root).unwrap();
+    // Unregistered goal → bail.
+    assert!(store
+        .append(Event::GoalStarted {
+            goal_id: "goal_ghost".into(),
+            ts: 1,
+        })
+        .is_err());
+    registered_goal(&mut store, "g1");
+    // Explicit event id appended twice with identical content → idempotent.
+    let mk = || Event::TodoAdded {
+        goal_id: "g1".into(),
+        todo: Todo::advancement("t1", "x"),
+        ts: 1,
+    };
+    store
+        .append_with_meta(mk(), Some("evt-fixed".into()), None, None, None, None, None)
+        .unwrap();
+    store
+        .append_with_meta(mk(), Some("evt-fixed".into()), None, None, None, None, None)
+        .unwrap();
+    let lines = store.raw_ledger_lines("g1").unwrap();
+    assert_eq!(lines.len(), 2, "identical duplicate is not re-appended");
+    // Same id, different content → conflict error.
+    let conflicting = Event::TodoAdded {
+        goal_id: "g1".into(),
+        todo: Todo::advancement("t1", "DIFFERENT"),
+        ts: 2,
+    };
+    assert!(store
+        .append_with_meta(conflicting, Some("evt-fixed".into()), None, None, None, None, None)
+        .is_err());
+    // raw_ledger_lines on a goal with no ledger file → empty.
+    let store2 = Store::open(&root).unwrap();
+    assert!(store2.raw_ledger_lines("goal_nofile").unwrap().is_empty());
+}
+
+// ── try_claim_todo ─────────────────────────────────────────────────────────
+
+#[test]
+fn try_claim_todo_lease_reconstruction() {
+    let (_d, root) = fresh_store("s2");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    add(&mut store, "g1", "t1");
+    // Free todo → claim succeeds.
+    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    // Live lease held by alice → bob loses the race (Ok(false)).
+    assert!(!store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    // Alice re-claims (same holder) → succeeds.
+    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    // Release → free → bob claims.
+    store
+        .append(Event::TodoReleased {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "alice".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    assert!(store.try_claim_todo("g1", "t1", "bob", 1).unwrap());
+    // Let bob's 1s lease lapse → carol steals (expired arm).
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+    assert!(store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+    // Expire event clears the lease → free.
+    store
+        .append(Event::TodoExpired {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    assert!(store.try_claim_todo("g1", "t1", "dave", 3600).unwrap());
+    // A garbage line in the ledger is skipped during reconstruction.
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap()
+        .write_all(b"{not json\n")
+        .unwrap();
+    assert!(store.try_claim_todo("g1", "t1", "dave", 3600).is_ok());
+}
+
+// ── schema version normalization ───────────────────────────────────────────
+
+#[test]
+fn goal_schema_version_variants() {
+    let (_d, root) = fresh_store("s3");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    // The stamp written at first append is the current schema.
+    assert!(store.goal_schema_version("g1").is_some());
+    let dir = store.goal_dir("g1");
+    // Missing file → None.
+    std::fs::remove_file(dir.join("schema.json")).unwrap();
+    assert!(store.goal_schema_version("g1").is_none());
+    // Invalid JSON → None.
+    std::fs::write(dir.join("schema.json"), "{nope").unwrap();
+    assert!(store.goal_schema_version("g1").is_none());
+    // Missing field → None.
+    std::fs::write(dir.join("schema.json"), "{}").unwrap();
+    assert!(store.goal_schema_version("g1").is_none());
+    // Legacy tokens normalize.
+    std::fs::write(
+        dir.join("schema.json"),
+        "{\"event_store_schema_version\":\"loopx_event_store_v1\"}",
+    )
+    .unwrap();
+    assert_ne!(store.goal_schema_version("g1").as_deref(), Some("loopx_event_store_v1"));
+    std::fs::write(
+        dir.join("schema.json"),
+        "{\"event_store_schema_version\":\"loopx_event_store_v0\"}",
+    )
+    .unwrap();
+    let v0 = store.goal_schema_version("g1").unwrap();
+    assert!(v0.contains("legacy") || v0.contains("v0"), "{v0}");
+}
+
+// ── replay edge paths ──────────────────────────────────────────────────────
+
+#[test]
+fn replay_edge_paths() {
+    let (_d, root) = fresh_store("s4");
+    let mut store = Store::open(&root).unwrap();
+    // Registry entry without an events file → replay None.
+    store.register(&Goal::new("g_empty", "x", "/tmp")).unwrap();
+    assert!(store.replay("g_empty").unwrap().is_none());
+    // Not in the registry at all → None.
+    assert!(store.replay("goal_nope").unwrap().is_none());
+    // Malformed event line → read_ledger errors with line context.
+    registered_goal(&mut store, "g1");
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap()
+        .write_all(b"{broken\n")
+        .unwrap();
+    assert!(store.replay("g1").is_err());
+    // Identical duplicate lines collapse on read; conflicting ids fail closed.
+    std::fs::write(&events_path, "").unwrap();
+    let line = {
+        let se = serde_json::json!({
+            "event_id": "evt-dup",
+            "kind": "goal_started",
+            "goal_id": "g1",
+            "ts": 1,
+        });
+        format!("{}\n", se.to_string())
+    };
+    std::fs::write(&events_path, format!("{line}{line}")).unwrap();
+    let goal = store.replay("g1").unwrap();
+    assert!(goal.is_some(), "identical dups collapse");
+    // Conflicting: same id, different payload.
+    let a = serde_json::json!({"event_id":"evt-c","kind":"goal_started","goal_id":"g1","ts":1});
+    let b = serde_json::json!({"event_id":"evt-c","kind":"goal_started","goal_id":"g1","ts":2});
+    std::fs::write(
+        &events_path,
+        format!("{}\n{}\n", a.to_string(), b.to_string()),
+    )
+    .unwrap();
+    assert!(store.replay("g1").is_err(), "conflicting ids fail closed");
+}
+
+#[test]
+fn replay_skips_malformed_run_lines() {
+    let (_d, root) = fresh_store("s5");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    let runs = store.goal_dir("g1").join("runs.jsonl");
+    std::fs::write(&runs, "{broken\n").unwrap();
+    store.append_run("g1", &run_record("t1", "completed", now_epoch())).unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert_eq!(goal.history.len(), 1, "malformed line skipped");
+}
+
+// ── registry dual-format loader ────────────────────────────────────────────
+
+#[test]
+fn registry_loader_formats() {
+    // Map form with id/repo aliasing.
+    let (_d, root) = fresh_store("s6");
+    std::fs::write(
+        std::path::Path::new(&root).join("registry.json"),
+        serde_json::to_string(&serde_json::json!({
+            "goals": [{"id": "g_legacy", "objective": "obj", "repo": "/tmp/repo", "status": "active", "created_at": 1}]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let store = Store::open(&root).unwrap();
+    assert!(store.registered("g_legacy"), "id→goal_id, repo→cwd aliasing");
+    // Neither array nor {goals} → bail.
+    let (_d2, root2) = fresh_store("s7");
+    std::fs::write(
+        std::path::Path::new(&root2).join("registry.json"),
+        "\"just a string\"",
+    )
+    .unwrap();
+    assert!(Store::open(&root2).is_err());
+    // Non-object entry → error.
+    let (_d3, root3) = fresh_store("s8");
+    std::fs::write(
+        std::path::Path::new(&root3).join("registry.json"),
+        "[\"nope\"]",
+    )
+    .unwrap();
+    assert!(Store::open(&root3).is_err());
+    // Invalid JSON → error.
+    let (_d4, root4) = fresh_store("s9");
+    std::fs::write(std::path::Path::new(&root4).join("registry.json"), "{bad").unwrap();
+    assert!(Store::open(&root4).is_err());
+}
+
+// ── backup / restore / delete arms ─────────────────────────────────────────
+
+#[test]
+fn backup_restore_delete_arms() {
+    let (_d, root) = fresh_store("s10");
+    let mut store = Store::open(&root).unwrap();
+    // Backup a goal with no state → bail.
+    store.register(&Goal::new("g_nostate", "x", "/tmp")).unwrap();
+    assert!(store.backup_goal("g_nostate").is_err());
+    // Full backup including scheduler-state + registry entry.
+    registered_goal(&mut store, "g1");
+    let sched = store.goal_dir("g1").join("scheduler-state");
+    std::fs::create_dir_all(&sched).unwrap();
+    std::fs::write(sched.join("state.json"), "{}").unwrap();
+    let dest = store.backup_goal("g1").unwrap();
+    assert!(std::path::Path::new(&dest).join("scheduler-state/state.json").exists());
+    assert!(std::path::Path::new(&dest).join("registry-entry.json").exists());
+    // Restore from a dir without events.jsonl → bail; from the real backup → ok.
+    assert!(store.restore_goal("g1", "/nonexistent-backup").is_err());
+    store.restore_goal("g1", &dest).unwrap();
+    // Delete: unknown goal bails; registered goal disappears (registry + dir).
+    assert!(store.delete_goal("goal_nope").is_err());
+    store.delete_goal("g1").unwrap();
+    assert!(!store.registered("g1"));
+    assert!(!store.goal_dir("g1").exists());
+}
+
+// ── verify ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn verify_ledger_reports() {
+    let (_d, root) = fresh_store("s11");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    let report = store.verify("g1").unwrap();
+    assert!(report.ok);
+    // Legacy line without event_id counts; duplicates and conflicts show up.
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    let legacy = serde_json::json!({"kind":"goal_started","goal_id":"g1","ts":1});
+    let dup = serde_json::json!({"event_id":"e1","kind":"goal_started","goal_id":"g1","ts":1});
+    let conflict_a = serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":1});
+    let conflict_b = serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":9});
+    std::fs::write(
+        &events_path,
+        format!(
+            "{}\n{}\n{}\n{}\n{}\n",
+            legacy.to_string(),
+            dup.to_string(),
+            dup.to_string(),
+            conflict_a.to_string(),
+            conflict_b.to_string(),
+        ),
+    )
+    .unwrap();
+    let report = store.verify("g1").unwrap();
+    assert_eq!(report.legacy_lines_without_id, 1);
+    assert_eq!(report.idempotent_duplicates, 1);
+    assert!(report.conflicts.contains(&"e2".to_string()));
+    assert!(!report.ok);
+    // No ledger file → empty report.
+    let report = store.verify("goal_nofile").unwrap();
+    assert_eq!(report.total_events, 0);
+}
+
+// ── apply matrix (append + replay state assertions) ────────────────────────
+
+#[test]
+fn apply_matrix() {
+    let (_d, root) = fresh_store("s12");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    add(&mut store, "g1", "t1");
+    // TodoAdded with a preset index skips the index assignment.
+    let mut preset = Todo::advancement("t_preset", "preset index");
+    preset.index = 7;
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: preset,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // TodoUpdated: every status arm + bogus status + missing todo.
+    for status in ["open", "blocked", "deferred", "superseded", "bogus"] {
+        store
+            .append(Event::TodoUpdated {
+                goal_id: "g1".into(),
+                todo_id: "t1".into(),
+                text: None,
+                status: Some(status.into()),
+                evidence: None,
+                note: None,
+                priority: None,
+                resume_when: None,
+                blocks: None,
+                ts: now_epoch(),
+            })
+            .unwrap();
+    }
+    store
+        .append(Event::TodoUpdated {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            text: Some("x".into()),
+            status: None,
+            evidence: None,
+            note: None,
+            priority: Some("P2".into()),
+            resume_when: Some("defer:5".into()),
+            blocks: Some(vec!["a".into()]),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // GateResolved with note on a real todo; on a missing todo.
+    store
+        .append(Event::GateResolved {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            decision: "d".into(),
+            note: Some("n".into()),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::GateResolved {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            decision: "d".into(),
+            note: None,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // Claim on missing todo (skip arm); renew with/without prior claim.
+    store
+        .append(Event::TodoClaimed {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            agent_id: "a".into(),
+            lease_expires_at: 9,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoRenewed {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "a".into(),
+            lease_expires_at: 42,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // AgentRegistered twice (dedup arm), re-onboard replaces the profile.
+    for _ in 0..2 {
+        store
+            .append(Event::AgentRegistered {
+                goal_id: "g1".into(),
+                agent_id: "a".into(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+    }
+    store
+        .append(Event::AgentOnboarded {
+            goal_id: "g1".into(),
+            agent_id: "a".into(),
+            capabilities: vec!["shell".into()],
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::AgentOnboarded {
+            goal_id: "g1".into(),
+            agent_id: "a".into(),
+            capabilities: vec!["web".into()],
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // EvidenceAttached on live + missing todos.
+    store
+        .append(Event::EvidenceAttached {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            evidence: "e".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::EvidenceAttached {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            evidence: "e".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // MonitorPolled changed + no_change; QuotaSpent.
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::monitor("m1", "watch", std::time::Duration::from_secs(60)),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::MonitorPolled {
+            goal_id: "g1".into(),
+            todo_id: "m1".into(),
+            result: "changed".into(),
+            no_change_count: 0,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::MonitorPolled {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            result: "no_change".into(),
+            no_change_count: 3,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::QuotaSpent {
+            goal_id: "g1".into(),
+            run_id: "r".into(),
+            todo_id: "t1".into(),
+            source: "run".into(),
+            slots: 2,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // TodoCompleted on a missing todo (skip arm); supersede; release; expire.
+    store
+        .append(Event::TodoCompleted {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            no_follow_up: true,
+            successor_ids: vec![],
+            evidence: Some("e".into()),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoSuperseded {
+            goal_id: "g1".into(),
+            todo_id: "t_preset".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoReleased {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "a".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoExpired {
+            goal_id: "g1".into(),
+            todo_id: "todo_ghost".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // Supervisor events (apply arms).
+    store
+        .append(Event::SupervisorProposed {
+            goal_id: "g1".into(),
+            supervisor_agent_id: "sup".into(),
+            decision_id: "d1".into(),
+            decision_kind: "observe".into(),
+            target_agent_id: "a".into(),
+            required_host_capabilities: vec![],
+            decision: "watch".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::SupervisorReceiptRecorded {
+            goal_id: "g1".into(),
+            decision_id: "d1".into(),
+            receipt_id: "r1".into(),
+            adapter_id: "ad".into(),
+            outcome: "rejected".into(),
+            authority_ref: None,
+            rollback_ref: None,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // GoalCancelled + GapSatisfied.
+    store
+        .append(Event::GapSatisfied {
+            goal_id: "g1".into(),
+            gap_id: "gap1".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+
+    let goal = store.replay("g1").unwrap().unwrap();
+    let t1 = goal.todo("t1").unwrap();
+    assert_eq!(t1.evidence.as_deref(), Some("e"));
+    // The TodoReleased apply cleared the earlier claim/renew.
+    assert_eq!(t1.claimed_by, None);
+    assert_eq!(t1.lease_expires_at, None);
+    assert_eq!(goal.registered_agents, vec!["a".to_string()]);
+    let profile = goal.agent_profiles.iter().find(|p| p.id == "a").unwrap();
+    assert_eq!(profile.capabilities, vec!["web".to_string()]);
+    assert_eq!(goal.quota_spent_slots, 2);
+    assert_eq!(goal.todo("t_preset").unwrap().status, TodoStatus::Superseded);
+    assert_eq!(goal.todo("t_preset").unwrap().index, 7);
+    assert_eq!(goal.todo("m1").unwrap().status, TodoStatus::Done);
+}

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -6,9 +6,9 @@
 mod common;
 
 use common::run_record;
-use std::io::Write;
 use future_loop::state::{now_epoch, Goal, Todo, TodoStatus};
 use future_loop::store::{Event, Store};
+use std::io::Write;
 
 fn fresh_store(tag: &str) -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().unwrap();
@@ -73,7 +73,15 @@ fn append_requires_registration_and_dedupes() {
         ts: 2,
     };
     assert!(store
-        .append_with_meta(conflicting, Some("evt-fixed".into()), None, None, None, None, None)
+        .append_with_meta(
+            conflicting,
+            Some("evt-fixed".into()),
+            None,
+            None,
+            None,
+            None,
+            None
+        )
         .is_err());
     // raw_ledger_lines on a goal with no ledger file → empty.
     let store2 = Store::open(&root).unwrap();
@@ -152,7 +160,10 @@ fn goal_schema_version_variants() {
         "{\"event_store_schema_version\":\"loopx_event_store_v1\"}",
     )
     .unwrap();
-    assert_ne!(store.goal_schema_version("g1").as_deref(), Some("loopx_event_store_v1"));
+    assert_ne!(
+        store.goal_schema_version("g1").as_deref(),
+        Some("loopx_event_store_v1")
+    );
     std::fs::write(
         dir.join("schema.json"),
         "{\"event_store_schema_version\":\"loopx_event_store_v0\"}",
@@ -215,7 +226,9 @@ fn replay_skips_malformed_run_lines() {
     registered_goal(&mut store, "g1");
     let runs = store.goal_dir("g1").join("runs.jsonl");
     std::fs::write(&runs, "{broken\n").unwrap();
-    store.append_run("g1", &run_record("t1", "completed", now_epoch())).unwrap();
+    store
+        .append_run("g1", &run_record("t1", "completed", now_epoch()))
+        .unwrap();
     let goal = store.replay("g1").unwrap().unwrap();
     assert_eq!(goal.history.len(), 1, "malformed line skipped");
 }
@@ -235,7 +248,10 @@ fn registry_loader_formats() {
     )
     .unwrap();
     let store = Store::open(&root).unwrap();
-    assert!(store.registered("g_legacy"), "id→goal_id, repo→cwd aliasing");
+    assert!(
+        store.registered("g_legacy"),
+        "id→goal_id, repo→cwd aliasing"
+    );
     // Neither array nor {goals} → bail.
     let (_d2, root2) = fresh_store("s7");
     std::fs::write(
@@ -265,7 +281,9 @@ fn backup_restore_delete_arms() {
     let (_d, root) = fresh_store("s10");
     let mut store = Store::open(&root).unwrap();
     // Backup a goal with no state → bail.
-    store.register(&Goal::new("g_nostate", "x", "/tmp")).unwrap();
+    store
+        .register(&Goal::new("g_nostate", "x", "/tmp"))
+        .unwrap();
     assert!(store.backup_goal("g_nostate").is_err());
     // Full backup including scheduler-state + registry entry.
     registered_goal(&mut store, "g1");
@@ -273,8 +291,12 @@ fn backup_restore_delete_arms() {
     std::fs::create_dir_all(&sched).unwrap();
     std::fs::write(sched.join("state.json"), "{}").unwrap();
     let dest = store.backup_goal("g1").unwrap();
-    assert!(std::path::Path::new(&dest).join("scheduler-state/state.json").exists());
-    assert!(std::path::Path::new(&dest).join("registry-entry.json").exists());
+    assert!(std::path::Path::new(&dest)
+        .join("scheduler-state/state.json")
+        .exists());
+    assert!(std::path::Path::new(&dest)
+        .join("registry-entry.json")
+        .exists());
     // Restore from a dir without events.jsonl → bail; from the real backup → ok.
     assert!(store.restore_goal("g1", "/nonexistent-backup").is_err());
     store.restore_goal("g1", &dest).unwrap();
@@ -298,8 +320,10 @@ fn verify_ledger_reports() {
     let events_path = store.goal_dir("g1").join("events.jsonl");
     let legacy = serde_json::json!({"kind":"goal_started","goal_id":"g1","ts":1});
     let dup = serde_json::json!({"event_id":"e1","kind":"goal_started","goal_id":"g1","ts":1});
-    let conflict_a = serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":1});
-    let conflict_b = serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":9});
+    let conflict_a =
+        serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":1});
+    let conflict_b =
+        serde_json::json!({"event_id":"e2","kind":"goal_started","goal_id":"g1","ts":9});
     std::fs::write(
         &events_path,
         format!(
@@ -327,7 +351,9 @@ fn delete_dirless_goal_and_append_skip_arms() {
     let (_d, root) = fresh_store("s13");
     let mut store = Store::open(&root).unwrap();
     // Registered but no goal dir on disk → delete skips the remove.
-    store.register(&Goal::new("g_dirless", "x", "/tmp")).unwrap();
+    store
+        .register(&Goal::new("g_dirless", "x", "/tmp"))
+        .unwrap();
     store.delete_goal("g_dirless").unwrap();
     assert!(!store.registered("g_dirless"));
     // A garbage ledger line is skipped by the append dedup scan.
@@ -359,11 +385,7 @@ fn verify_conflict_dedup_arm() {
     let a = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":1});
     let b = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":2});
     let c = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":3});
-    std::fs::write(
-        &events_path,
-        format!("{}\n{}\n{}\n", a, b, c),
-    )
-    .unwrap();
+    std::fs::write(&events_path, format!("{}\n{}\n{}\n", a, b, c)).unwrap();
     let report = store.verify("g1").unwrap();
     assert_eq!(report.conflicts.len(), 1, "{report:?}");
 }
@@ -685,7 +707,10 @@ fn apply_matrix() {
     let profile = goal.agent_profiles.iter().find(|p| p.id == "a").unwrap();
     assert_eq!(profile.capabilities, vec!["web".to_string()]);
     assert_eq!(goal.quota_spent_slots, 2);
-    assert_eq!(goal.todo("t_preset").unwrap().status, TodoStatus::Superseded);
+    assert_eq!(
+        goal.todo("t_preset").unwrap().status,
+        TodoStatus::Superseded
+    );
     assert_eq!(goal.todo("t_preset").unwrap().index, 7);
     assert_eq!(goal.todo("m1").unwrap().status, TodoStatus::Done);
 }

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -203,7 +203,7 @@ fn replay_edge_paths() {
             "goal_id": "g1",
             "ts": 1,
         });
-        format!("{}\n", se.to_string())
+        format!("{}\n", se)
     };
     std::fs::write(&events_path, format!("{line}{line}")).unwrap();
     let goal = store.replay("g1").unwrap();
@@ -211,11 +211,7 @@ fn replay_edge_paths() {
     // Conflicting: same id, different payload.
     let a = serde_json::json!({"event_id":"evt-c","kind":"goal_started","goal_id":"g1","ts":1});
     let b = serde_json::json!({"event_id":"evt-c","kind":"goal_started","goal_id":"g1","ts":2});
-    std::fs::write(
-        &events_path,
-        format!("{}\n{}\n", a.to_string(), b.to_string()),
-    )
-    .unwrap();
+    std::fs::write(&events_path, format!("{}\n{}\n", a, b)).unwrap();
     assert!(store.replay("g1").is_err(), "conflicting ids fail closed");
 }
 
@@ -328,11 +324,7 @@ fn verify_ledger_reports() {
         &events_path,
         format!(
             "{}\n{}\n{}\n{}\n{}\n",
-            legacy.to_string(),
-            dup.to_string(),
-            dup.to_string(),
-            conflict_a.to_string(),
-            conflict_b.to_string(),
+            legacy, dup, dup, conflict_a, conflict_b,
         ),
     )
     .unwrap();

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -322,6 +322,52 @@ fn verify_ledger_reports() {
     assert_eq!(report.total_events, 0);
 }
 
+#[test]
+fn delete_dirless_goal_and_append_skip_arms() {
+    let (_d, root) = fresh_store("s13");
+    let mut store = Store::open(&root).unwrap();
+    // Registered but no goal dir on disk → delete skips the remove.
+    store.register(&Goal::new("g_dirless", "x", "/tmp")).unwrap();
+    store.delete_goal("g_dirless").unwrap();
+    assert!(!store.registered("g_dirless"));
+    // A garbage ledger line is skipped by the append dedup scan.
+    registered_goal(&mut store, "g1");
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap()
+        .write_all(b"{broken\n")
+        .unwrap();
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::advancement("t1", "x"),
+            ts: now_epoch(),
+        })
+        .unwrap();
+}
+
+#[test]
+fn verify_conflict_dedup_arm() {
+    let (_d, root) = fresh_store("s14");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    // Three lines sharing an id with TWO distinct payloads: the conflict is
+    // recorded once even though the mismatch is seen twice.
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    let a = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":1});
+    let b = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":2});
+    let c = serde_json::json!({"event_id":"e3","kind":"goal_started","goal_id":"g1","ts":3});
+    std::fs::write(
+        &events_path,
+        format!("{}\n{}\n{}\n", a, b, c),
+    )
+    .unwrap();
+    let report = store.verify("g1").unwrap();
+    assert_eq!(report.conflicts.len(), 1, "{report:?}");
+}
+
 // ── apply matrix (append + replay state assertions) ────────────────────────
 
 #[test]

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -368,6 +368,80 @@ fn verify_conflict_dedup_arm() {
     assert_eq!(report.conflicts.len(), 1, "{report:?}");
 }
 
+#[test]
+fn apply_renew_and_priority_arms() {
+    let (_d, root) = fresh_store("s15");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    add(&mut store, "g1", "t1");
+    // Claim, then renew: the claim-fill arm is skipped (already claimed) but
+    // the lease updates.
+    store
+        .append(Event::TodoClaimed {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "a".into(),
+            lease_expires_at: 100,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoRenewed {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "a".into(),
+            lease_expires_at: 200,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // Release by the owner clears both fields.
+    store
+        .append(Event::TodoReleased {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "a".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // Expiry on a CLAIMED todo clears it (the had-claim arm).
+    store
+        .append(Event::TodoClaimed {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "b".into(),
+            lease_expires_at: 50,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::TodoExpired {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    // TodoUpdated priority P0 arm (P2 covered elsewhere).
+    store
+        .append(Event::TodoUpdated {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            text: None,
+            status: None,
+            evidence: None,
+            note: None,
+            priority: Some("P0".into()),
+            resume_when: None,
+            blocks: None,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    let t = goal.todo("t1").unwrap();
+    assert_eq!(t.claimed_by, None, "expired claim cleared");
+    assert_eq!(t.lease_expires_at, None);
+    assert_eq!(t.priority, future_loop::state::Priority::P0);
+}
+
 // ── apply matrix (append + replay state assertions) ────────────────────────
 
 #[test]

--- a/orchestration/loop/tests/work_items_drive.rs
+++ b/orchestration/loop/tests/work_items_drive.rs
@@ -179,7 +179,7 @@ fn delivery_labels_and_classifiers() {
     assert!(!outcome_floor_configured(&[], &[]));
 
     // Streaks over run history.
-    let mut gap_run = || {
+    let gap_run = || {
         let mut r = run_record("t", "completed", 1);
         r.evidence = "nothing relevant".to_string();
         r

--- a/orchestration/loop/tests/work_items_drive.rs
+++ b/orchestration/loop/tests/work_items_drive.rs
@@ -1,0 +1,289 @@
+//! Coverage drive for `work_items/`: attention queue branches, delivery
+//! outcome/scale classifiers, and the operator-inbox attention kinds.
+
+use future_loop::state::{Goal, Todo};
+use future_loop::work_items::attention::{
+    build_attention_queue, goal_attention_item, AttentionItem, AttentionWaitingOn,
+};
+use future_loop::work_items::delivery::{
+    delivery_batch_scale_for_run, delivery_outcome_for_run, is_progress_outcome,
+    outcome_floor_configured, outcome_gap_streak, small_delivery_batch_scale_streak,
+    DeliveryBatchScale, DeliveryOutcome,
+};
+use future_loop::work_items::operator_inbox::{
+    operator_inbox_attention_kind, project_operator_inbox_urgency, OperatorAttentionKind,
+    OperatorInboxConfig, OperatorInboxEvent,
+};
+
+use common::run_record;
+mod common;
+
+// ── attention ──────────────────────────────────────────────────────────────
+
+#[test]
+fn attention_labels_and_queue() {
+    for (w, label) in [
+        (AttentionWaitingOn::Codex, "codex"),
+        (AttentionWaitingOn::UserOrController, "user_or_controller"),
+        (AttentionWaitingOn::Controller, "controller"),
+        (AttentionWaitingOn::ExternalEvidence, "external_evidence"),
+        (AttentionWaitingOn::Monitor, "monitor_signal"),
+    ] {
+        assert_eq!(w.label(), label);
+    }
+    let item = |waiting_on: &str| AttentionItem {
+        goal_id: "g".into(),
+        status: "s".into(),
+        waiting_on: waiting_on.into(),
+        severity: "info".into(),
+        recommended_action: "act".into(),
+        source: "test".into(),
+    };
+    let queue = build_attention_queue(vec![
+        item("user_or_controller"),
+        item("controller"),
+        item("codex"),
+        item("monitor_signal"),
+        item("something_else"),
+    ]);
+    assert_eq!(queue.item_count, 5);
+    assert_eq!(queue.needs_user_or_controller, 1);
+    assert_eq!(queue.needs_controller, 1);
+    assert_eq!(queue.needs_codex, 1);
+    assert_eq!(queue.watching_monitor, 1);
+}
+
+#[test]
+fn goal_attention_item_branches() {
+    // Gate with a question → high-severity gate item.
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    goal.todos.push(Todo::user_gate("tg", "approve the plan?", &[]));
+    let item = goal_attention_item(&goal).unwrap();
+    assert_eq!(item.status, "operator_gate");
+    assert!(item.recommended_action.contains("approve the plan?"));
+    // Gate without a question → default text arm.
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    let mut g = Todo::user_gate("tg", "q?", &[]);
+    g.gate_question = None;
+    goal.todos.push(g);
+    let item = goal_attention_item(&goal).unwrap();
+    assert!(item.recommended_action.contains("resolve the open user gate"));
+    // Projection gap → codex self-repair item (goal must be non-terminal:
+    // an open user_action keeps it open while leaving agent_open == 0).
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    goal.todos.push(Todo::user_action("ua", "pending user action"));
+    goal.next_action = Some("totally stale action".into());
+    let item = goal_attention_item(&goal).unwrap();
+    assert_eq!(item.status, "projection_gap");
+    // Open advancement → codex advancement item.
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    goal.todos.push(Todo::advancement("t1", "do work"));
+    goal.next_action = Some("do work".into());
+    let item = goal_attention_item(&goal).unwrap();
+    assert_eq!(item.status, "advancement_open");
+    // Due monitor → monitor item (a user_action keeps the goal non-terminal
+    // without an open advancement, and a "waiting" next-action avoids a
+    // projection gap).
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    goal.todos.push(Todo::user_action("ua", "pending user action"));
+    goal.todos.push(Todo::monitor("m1", "watch it", std::time::Duration::from_secs(0)));
+    goal.next_action = Some("waiting on the user".into());
+    let item = goal_attention_item(&goal).unwrap();
+    assert_eq!(item.status, "monitor_due");
+    // Nothing actionable → None.
+    let mut goal = Goal::new("g1", "attn", "/tmp");
+    goal.next_action = Some("all todos complete; no further action".into());
+    assert!(goal_attention_item(&goal).is_none());
+}
+
+// ── delivery ───────────────────────────────────────────────────────────────
+
+#[test]
+fn delivery_labels_and_classifiers() {
+    for (s, label) in [
+        (DeliveryBatchScale::TestOnly, "test_only"),
+        (DeliveryBatchScale::SingleSurface, "single_surface"),
+        (DeliveryBatchScale::MultiSurface, "multi_surface"),
+        (DeliveryBatchScale::Implementation, "implementation"),
+        (DeliveryBatchScale::Unknown, "unknown"),
+    ] {
+        assert_eq!(s.label(), label);
+    }
+    for (o, label) in [
+        (DeliveryOutcome::OutcomeProgress, "outcome_progress"),
+        (DeliveryOutcome::SurfaceOnly, "surface_only"),
+        (DeliveryOutcome::OutcomeGap, "outcome_gap"),
+        (DeliveryOutcome::NotConfigured, "not_configured"),
+        (DeliveryOutcome::Unknown, "unknown"),
+    ] {
+        assert_eq!(o.label(), label);
+    }
+    assert!(is_progress_outcome(DeliveryOutcome::OutcomeProgress));
+    assert!(!is_progress_outcome(DeliveryOutcome::SurfaceOnly));
+
+    // Batch scale from evidence text.
+    let scale = |evidence: &str| {
+        let mut r = run_record("t", "completed", 1);
+        r.evidence = evidence.to_string();
+        delivery_batch_scale_for_run(&r)
+    };
+    assert_eq!(scale("unit test passed"), DeliveryBatchScale::TestOnly);
+    assert_eq!(scale("changes across surfaces"), DeliveryBatchScale::MultiSurface);
+    assert_eq!(scale("implementation landed"), DeliveryBatchScale::Implementation);
+    // NOTE: the Unknown arm is unreachable through delivery_batch_scale_for_run
+    // (evidence_text always contains the "<state> " separator); a non-empty
+    // non-matching text is a single surface.
+    assert_eq!(scale(""), DeliveryBatchScale::SingleSurface);
+    assert_eq!(scale("one file edited"), DeliveryBatchScale::SingleSurface);
+
+    // Outcome classification against markers.
+    let markers = vec!["shipped".to_string()];
+    let surface = vec!["docs only".to_string()];
+    let outcome = |evidence: &str, m: &[String], s: &[String]| {
+        let mut r = run_record("t", "completed", 1);
+        r.evidence = evidence.to_string();
+        delivery_outcome_for_run(&r, m, s)
+    };
+    assert_eq!(outcome("anything", &[], &[]), DeliveryOutcome::NotConfigured);
+    assert_eq!(outcome("docs only tweak", &markers, &surface), DeliveryOutcome::SurfaceOnly);
+    assert_eq!(outcome("shipped it", &markers, &surface), DeliveryOutcome::OutcomeProgress);
+    assert_eq!(outcome("nothing relevant", &markers, &surface), DeliveryOutcome::OutcomeGap);
+    assert!(outcome_floor_configured(&markers, &[]));
+    assert!(!outcome_floor_configured(&[], &[]));
+
+    // Streaks over run history.
+    let mut gap_run = || {
+        let mut r = run_record("t", "completed", 1);
+        r.evidence = "nothing relevant".to_string();
+        r
+    };
+    let mut good = run_record("t", "completed", 1);
+    good.evidence = "shipped it".to_string();
+    let runs = vec![gap_run(), gap_run(), good.clone(), gap_run()];
+    // Leading streak (callers pass newest-first runs): stops at the first
+    // progress run.
+    assert_eq!(outcome_gap_streak(&runs, &markers, &surface), 2);
+    let all_gaps = vec![gap_run(), gap_run()];
+    assert_eq!(outcome_gap_streak(&all_gaps, &markers, &surface), 2);
+    // Not-configured floor → gap streak treats runs as gaps? probe both.
+    let _ = outcome_gap_streak(&runs, &[], &[]);
+    // Small-batch streak (SingleSurface/TestOnly count; larger scales break).
+    let mut small = run_record("t", "completed", 1);
+    small.evidence = "unit test ok".to_string();
+    let mut big = run_record("t", "completed", 1);
+    big.evidence = "changes across surfaces".to_string();
+    assert_eq!(small_delivery_batch_scale_streak(&[small.clone(), small.clone()]), 2);
+    assert_eq!(small_delivery_batch_scale_streak(&[small, big]), 1);
+}
+
+// ── operator inbox ─────────────────────────────────────────────────────────
+
+fn inbox_event(content: &str, verified: bool, reply: bool) -> OperatorInboxEvent {
+    OperatorInboxEvent {
+        message_id: "m".into(),
+        create_time: "2026-08-10T00:00:00Z".into(),
+        content: content.to_string(),
+        reply_context_verified: verified,
+        reply_to_operator: reply,
+    }
+}
+
+#[test]
+fn operator_inbox_kinds() {
+    for (k, label) in [
+        (OperatorAttentionKind::DirectQuestion, "direct_question"),
+        (OperatorAttentionKind::DirectMention, "direct_mention"),
+        (OperatorAttentionKind::ReplyToOperator, "reply_to_operator"),
+    ] {
+        assert_eq!(k.label(), label);
+    }
+    // Verified reply always counts (any scope).
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("ok", true, true), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::ReplyToOperator)
+    );
+    // Question mark (ASCII + full-width).
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("@operator ready?", false, false), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::DirectQuestion)
+    );
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("@operator ready？", false, false), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::DirectQuestion)
+    );
+    // Mention without question.
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("@operator FYI", false, false), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::DirectMention)
+    );
+    // future-loop mention.
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("@future-loop ping", false, false), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::DirectMention)
+    );
+    // Scope semantics (as implemented, mirroring the reference): in
+    // configured_chat_all a message WITHOUT any mention is dropped; in
+    // addressed_only a bare question still counts (the '?' heuristic).
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("random chatter", false, false), "operator", "addressed_only"),
+        None
+    );
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("random chatter", false, false), "operator", "configured_chat_all"),
+        None
+    );
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("is this on?", false, false), "operator", "configured_chat_all"),
+        None
+    );
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("is this on?", false, false), "operator", "addressed_only"),
+        Some(OperatorAttentionKind::DirectQuestion)
+    );
+    // Unverified reply flag without verification → not a reply.
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("no marks", false, true), "operator", "addressed_only"),
+        None
+    );
+    // Empty operator name: no explicit mention arm.
+    assert_eq!(
+        operator_inbox_attention_kind(&inbox_event("@someone hi", false, false), "", "addressed_only"),
+        None
+    );
+}
+
+#[test]
+fn operator_inbox_urgency_projection() {
+    let config = |enabled: bool, scope: &str| OperatorInboxConfig {
+        enabled,
+        capture_scope: scope.to_string(),
+        inbox_dir: "inbox".to_string(),
+        operator_display_name: "operator".to_string(),
+        reply_enabled: true,
+    };
+    // Disabled → zeroed projection.
+    let u = project_operator_inbox_urgency(&config(false, "addressed_only"), &[inbox_event("@operator q?", false, false)]);
+    assert!(!u.enabled);
+    assert_eq!(u.pending_count, 0);
+    // Enabled with a mix.
+    let pending = vec![
+        inbox_event("@operator ready?", false, false),
+        inbox_event("@operator note", false, false),
+        inbox_event("replied", true, true),
+        inbox_event("noise", false, false),
+    ];
+    let u = project_operator_inbox_urgency(&config(true, "addressed_only"), &pending);
+    assert_eq!(u.pending_count, 4);
+    assert_eq!(u.direct_question_count, 1);
+    assert_eq!(u.direct_mention_count, 1);
+    assert_eq!(u.reply_to_operator_count, 1);
+    assert!(u.attention_required_count >= 3);
+    assert!(u.reply_due);
+    // reply_due = any attention required + replies enabled.
+    let u = project_operator_inbox_urgency(&config(true, "addressed_only"), &[]);
+    assert!(!u.reply_due, "no pending events");
+    let mut no_reply = config(true, "addressed_only");
+    no_reply.reply_enabled = false;
+    let u = project_operator_inbox_urgency(&no_reply, &[inbox_event("@operator q?", false, false)]);
+    assert!(!u.reply_due, "replies disabled");
+}

--- a/orchestration/loop/tests/work_items_drive.rs
+++ b/orchestration/loop/tests/work_items_drive.rs
@@ -57,7 +57,8 @@ fn attention_labels_and_queue() {
 fn goal_attention_item_branches() {
     // Gate with a question → high-severity gate item.
     let mut goal = Goal::new("g1", "attn", "/tmp");
-    goal.todos.push(Todo::user_gate("tg", "approve the plan?", &[]));
+    goal.todos
+        .push(Todo::user_gate("tg", "approve the plan?", &[]));
     let item = goal_attention_item(&goal).unwrap();
     assert_eq!(item.status, "operator_gate");
     assert!(item.recommended_action.contains("approve the plan?"));
@@ -67,11 +68,14 @@ fn goal_attention_item_branches() {
     g.gate_question = None;
     goal.todos.push(g);
     let item = goal_attention_item(&goal).unwrap();
-    assert!(item.recommended_action.contains("resolve the open user gate"));
+    assert!(item
+        .recommended_action
+        .contains("resolve the open user gate"));
     // Projection gap → codex self-repair item (goal must be non-terminal:
     // an open user_action keeps it open while leaving agent_open == 0).
     let mut goal = Goal::new("g1", "attn", "/tmp");
-    goal.todos.push(Todo::user_action("ua", "pending user action"));
+    goal.todos
+        .push(Todo::user_action("ua", "pending user action"));
     goal.next_action = Some("totally stale action".into());
     let item = goal_attention_item(&goal).unwrap();
     assert_eq!(item.status, "projection_gap");
@@ -85,8 +89,13 @@ fn goal_attention_item_branches() {
     // without an open advancement, and a "waiting" next-action avoids a
     // projection gap).
     let mut goal = Goal::new("g1", "attn", "/tmp");
-    goal.todos.push(Todo::user_action("ua", "pending user action"));
-    goal.todos.push(Todo::monitor("m1", "watch it", std::time::Duration::from_secs(0)));
+    goal.todos
+        .push(Todo::user_action("ua", "pending user action"));
+    goal.todos.push(Todo::monitor(
+        "m1",
+        "watch it",
+        std::time::Duration::from_secs(0),
+    ));
     goal.next_action = Some("waiting on the user".into());
     let item = goal_attention_item(&goal).unwrap();
     assert_eq!(item.status, "monitor_due");
@@ -128,8 +137,14 @@ fn delivery_labels_and_classifiers() {
         delivery_batch_scale_for_run(&r)
     };
     assert_eq!(scale("unit test passed"), DeliveryBatchScale::TestOnly);
-    assert_eq!(scale("changes across surfaces"), DeliveryBatchScale::MultiSurface);
-    assert_eq!(scale("implementation landed"), DeliveryBatchScale::Implementation);
+    assert_eq!(
+        scale("changes across surfaces"),
+        DeliveryBatchScale::MultiSurface
+    );
+    assert_eq!(
+        scale("implementation landed"),
+        DeliveryBatchScale::Implementation
+    );
     // NOTE: the Unknown arm is unreachable through delivery_batch_scale_for_run
     // (evidence_text always contains the "<state> " separator); a non-empty
     // non-matching text is a single surface.
@@ -144,10 +159,22 @@ fn delivery_labels_and_classifiers() {
         r.evidence = evidence.to_string();
         delivery_outcome_for_run(&r, m, s)
     };
-    assert_eq!(outcome("anything", &[], &[]), DeliveryOutcome::NotConfigured);
-    assert_eq!(outcome("docs only tweak", &markers, &surface), DeliveryOutcome::SurfaceOnly);
-    assert_eq!(outcome("shipped it", &markers, &surface), DeliveryOutcome::OutcomeProgress);
-    assert_eq!(outcome("nothing relevant", &markers, &surface), DeliveryOutcome::OutcomeGap);
+    assert_eq!(
+        outcome("anything", &[], &[]),
+        DeliveryOutcome::NotConfigured
+    );
+    assert_eq!(
+        outcome("docs only tweak", &markers, &surface),
+        DeliveryOutcome::SurfaceOnly
+    );
+    assert_eq!(
+        outcome("shipped it", &markers, &surface),
+        DeliveryOutcome::OutcomeProgress
+    );
+    assert_eq!(
+        outcome("nothing relevant", &markers, &surface),
+        DeliveryOutcome::OutcomeGap
+    );
     assert!(outcome_floor_configured(&markers, &[]));
     assert!(!outcome_floor_configured(&[], &[]));
 
@@ -172,7 +199,10 @@ fn delivery_labels_and_classifiers() {
     small.evidence = "unit test ok".to_string();
     let mut big = run_record("t", "completed", 1);
     big.evidence = "changes across surfaces".to_string();
-    assert_eq!(small_delivery_batch_scale_streak(&[small.clone(), small.clone()]), 2);
+    assert_eq!(
+        small_delivery_batch_scale_streak(&[small.clone(), small.clone()]),
+        2
+    );
     assert_eq!(small_delivery_batch_scale_streak(&[small, big]), 1);
 }
 
@@ -204,50 +234,90 @@ fn operator_inbox_kinds() {
     );
     // Question mark (ASCII + full-width).
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("@operator ready?", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("@operator ready?", false, false),
+            "operator",
+            "addressed_only"
+        ),
         Some(OperatorAttentionKind::DirectQuestion)
     );
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("@operator ready？", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("@operator ready？", false, false),
+            "operator",
+            "addressed_only"
+        ),
         Some(OperatorAttentionKind::DirectQuestion)
     );
     // Mention without question.
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("@operator FYI", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("@operator FYI", false, false),
+            "operator",
+            "addressed_only"
+        ),
         Some(OperatorAttentionKind::DirectMention)
     );
     // future-loop mention.
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("@future-loop ping", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("@future-loop ping", false, false),
+            "operator",
+            "addressed_only"
+        ),
         Some(OperatorAttentionKind::DirectMention)
     );
     // Scope semantics (as implemented, mirroring the reference): in
     // configured_chat_all a message WITHOUT any mention is dropped; in
     // addressed_only a bare question still counts (the '?' heuristic).
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("random chatter", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("random chatter", false, false),
+            "operator",
+            "addressed_only"
+        ),
         None
     );
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("random chatter", false, false), "operator", "configured_chat_all"),
+        operator_inbox_attention_kind(
+            &inbox_event("random chatter", false, false),
+            "operator",
+            "configured_chat_all"
+        ),
         None
     );
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("is this on?", false, false), "operator", "configured_chat_all"),
+        operator_inbox_attention_kind(
+            &inbox_event("is this on?", false, false),
+            "operator",
+            "configured_chat_all"
+        ),
         None
     );
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("is this on?", false, false), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("is this on?", false, false),
+            "operator",
+            "addressed_only"
+        ),
         Some(OperatorAttentionKind::DirectQuestion)
     );
     // Unverified reply flag without verification → not a reply.
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("no marks", false, true), "operator", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("no marks", false, true),
+            "operator",
+            "addressed_only"
+        ),
         None
     );
     // Empty operator name: no explicit mention arm.
     assert_eq!(
-        operator_inbox_attention_kind(&inbox_event("@someone hi", false, false), "", "addressed_only"),
+        operator_inbox_attention_kind(
+            &inbox_event("@someone hi", false, false),
+            "",
+            "addressed_only"
+        ),
         None
     );
 }
@@ -262,7 +332,10 @@ fn operator_inbox_urgency_projection() {
         reply_enabled: true,
     };
     // Disabled → zeroed projection.
-    let u = project_operator_inbox_urgency(&config(false, "addressed_only"), &[inbox_event("@operator q?", false, false)]);
+    let u = project_operator_inbox_urgency(
+        &config(false, "addressed_only"),
+        &[inbox_event("@operator q?", false, false)],
+    );
     assert!(!u.enabled);
     assert_eq!(u.pending_count, 0);
     // Enabled with a mix.


### PR DESCRIPTION
## Summary

Coverage drive for the `future-loop` crate (goal_4a742a954e3c slice). Baseline → final (cargo llvm-cov, `-p future-loop`):

| metric | baseline | final |
|---|---|---|
| **lines** | 77.72% (13,553/17,439) | **98.43%** (17,542/17,821) |
| regions | 77.31% | 97.31% |
| functions | 71.98% | 95.87% |

756 tests pass (lib + 63 integration binaries; was ~460 before). 24 new/extended test files, incl. a scripted in-process **mock FutureAgent gRPC server** (`tests/common/mock_agent.rs`) that drives `agent_client`, `executor`, the full `run` turn loop, `doctor --agent-addr`, and the benchmark gRPC adapter without a real agent.

## Real bugs found & fixed (all via test failures)

1. **`doctor --agent-addr` panicked 100% of the time** — nested `block_on` inside `console::run`'s runtime. `cmd_doctor` is now async and awaits the probe.
2. **No-change monitor poll marked the monitor Done on replay** — `run_turns` appended a spurious `TodoCompleted` for successful MonitorPoll turns; the event projection closed the monitor while the in-memory writeback kept it open. The append is now skipped for MonitorPoll (the `MonitorPolled` event carries the state).
3. **`benchmark run --agent-addr` panicked 100% of the time** — `GrpcLoopxAdapter::block_on` used `Handle::current().block_on` inside the console runtime; now `block_in_place` + `Handle::block_on`.
4. **`try_claim_todo` lease reconstruction ignored `todo_expired`** — the atomic claim path could disagree with the replay projection after an expiry record; added the missing arm.

Also: `FUTURE_LOOP_AGENT_ADDR` env override for the agent address (test hook, mirrors cli's `BROWSER_LAUNCHER_OVERRIDE` precedent), and the steer watcher body extracted to a testable `steer_poll_once` seam (behavior-preserving).

## Behavior notes (NOT changed — flagged for maintainers)

- `failed_attempts` / `outcome_streak` are mutated by `writeback` only in memory — **no event carries them**, so they reset on replay. Consequences observed in tests: the run loop's repair-budget break (`failed_attempts > MAX_REPAIR_ATTEMPTS`) never engages from ledger state alone (a failing todo retries until `--max-turns`); `replan obligations` can never show `surface_only_progress_streak` (needs `outcome_streak`). Recommend event-sourcing these (e.g. a field on `RunRecorded` apply) — needs a schema decision.
- `canary smoke --json` exits 0 even when checks FAIL (the JSON arm returns before the `all_passed` bail). Text mode fails closed. Intentional or oversight?
- `lease claim --lease-secs 0` silently means 45 minutes (`normalize_ttl` default), not "expire immediately".

## Residual coverage (279 lines)

The remainder is dominated by: defensive error arms with no fault-injection seam (IO failures mid-append, goal-deleted-mid-run races), unreachable-by-construction arms (`_ => unreachable!()` in lease claim, the double-guarded unknown-command bail, the doctor "ledger conflicts" push which replay errors preempt), dead producer arms (`ProposalKind::Repair/Monitor` have no builtin producer; validation `Progress/Unavailable/NotRequired` print variants; corpus semantic-drift else-branch — `render_actor_request` always emits the marker strings), the 10s-sleep steer watcher loop, and a handful of region-boundary brace lines. Getting to a literal 100% requires either deleting dead arms or `cfg(test)` fault-injection hooks — a product decision, tracked as a follow-up todo in the loop goal.

## Test plan

- `cargo test -p future-loop` — 756 tests, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo clippy -p future-loop --target x86_64-pc-windows-msvc --all-targets -- -D warnings` clean (caught two cfg(unix)-gated imports)
- `cargo fmt --all --check` clean