### PR TITLE
test(cli): eliminate spawn_mock port-steal/startup races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tonic",
 ]

--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -725,8 +725,11 @@ mod tests {
 
     #[test]
     fn resolve_future_base_url_returns_default() {
-        // When auth.json doesn't have future.base_url or future.platform_base_url,
-        // should return the default. (In test env, may or may not have auth.json.)
+        // Hermetic: an empty isolated $HOME (no auth.json) always resolves the
+        // default. TestHome also holds the process-global HOME lock for the
+        // test's duration, so a parallel fixture's auth.json (e.g. an http://
+        // mock base_url) cannot leak in and flip the scheme assertion.
+        let _home = crate::test_support::TestHome::new();
         let url = resolve_future_base_url();
         assert!(!url.is_empty());
         assert!(url.starts_with("https://"));

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,3 +42,4 @@ indexmap = "2"
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }

--- a/cli/src/test_server.rs
+++ b/cli/src/test_server.rs
@@ -125,17 +125,22 @@ impl FutureAgent for MockAgent {
 }
 
 /// Spawn the mock on an ephemeral port; returns "127.0.0.1:<port>".
+///
+/// The socket stays bound and listening across the handover to the tonic
+/// server (`serve_with_incoming`), so there is no drop/re-bind window in
+/// which a parallel test can steal the port, and clients can connect the
+/// moment this returns (the OS backlog holds the handshake until the server
+/// task first polls accept) — no fixed startup sleep to race under load.
 pub async fn spawn_mock(agent: MockAgent) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local_addr");
-    drop(listener);
+    listener.set_nonblocking(true).expect("nonblocking");
+    let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener from std");
     tokio::spawn(
         Server::builder()
             .add_service(FutureAgentServer::new(agent))
-            .serve(addr),
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
     );
-    // Give the listener a moment to come up before clients dial.
-    tokio::time::sleep(Duration::from_millis(50)).await;
     format!("127.0.0.1:{}", addr.port())
 }
 


### PR DESCRIPTION
## Summary

Blocks the goal-acceptance full-workspace coverage run (goal_4a742a954e3c, todo_5ec593a7e412): `cli rpc::tests::run_applies_full_configuration` failed with `transport error` during the single `cargo llvm-cov --workspace` measurement.

Root cause in `cli/src/test_server.rs::spawn_mock`: bind ephemeral port → **drop listener** → re-bind inside the spawned tonic server after a **fixed 50ms sleep**. Two races under instrumented parallel load:
1. a parallel test steals the port in the drop/re-bind window,
2. the client dials before the server binds (connection refused).

Fix: hand the still-bound listener to `serve_with_incoming(TcpListenerStream)` — no drop window, and the OS backlog holds client handshakes until the server task first polls accept, so the startup sleep is deleted. Same pattern already used by `channels/src/test_support.rs` and `orchestration/loop/tests/common/mock_agent.rs`.

## Test plan

- `cargo test -p future-cli --lib`: 690/690 green (the failing test passes standalone; race eliminated by construction)
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean
- Full-workspace `cargo llvm-cov --workspace` re-run in progress on this branch (the run that previously failed)