### PR TITLE
feat(loop): enforce scheduler arbitration — CONSISTENCY_REPAIR fails closed

### DIFF
--- a/orchestration/loop/src/contract.rs
+++ b/orchestration/loop/src/contract.rs
@@ -257,9 +257,9 @@ pub struct ShouldRunPacket {
     pub promotion_readiness_warning: Option<String>,
     pub autonomous_backlog_candidates: Option<serde_json::Value>,
     pub protocol_action_packet: Option<serde_json::Value>,
-    /// G-2/G-11 scheduler arbitration record — observe-only by default
-    /// (records the 9-disposition classification without blocking); flip
-    /// `ARBITRATION_ENFORCEMENT` to fail closed on CONSISTENCY_REPAIR.
+    /// G-2/G-11 scheduler arbitration record — recorded on every packet;
+    /// with `ARBITRATION_ENFORCEMENT` on, a `CONSISTENCY_REPAIR` verdict
+    /// fails closed (rewrites the packet to the repair cadence).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scheduler_arbitration: Option<SchedulerArbitration>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/orchestration/loop/src/decision/arbitration.rs
+++ b/orchestration/loop/src/decision/arbitration.rs
@@ -7,11 +7,11 @@
 //! branch selection (reference rule): only the final interaction contract's
 //! schema / mode / channels decide.
 //!
-//! Rollout (refactor plan §5.1 trade-off): **observe-only first** — every
-//! packet carries its [`SchedulerArbitration`] record but behavior is
-//! unchanged; flip [`ARBITRATION_ENFORCEMENT`] to `true` to fail closed on
-//! `CONSISTENCY_REPAIR` (`repair_action`: rebuild the contract, then rerun
-//! quota before applying scheduler cadence).
+//! Rollout (refactor plan §5.1 trade-off): observe-only shipped first — every
+//! packet carried its [`SchedulerArbitration`] record with behavior
+//! unchanged. [`ARBITRATION_ENFORCEMENT`] is now `true`: `CONSISTENCY_REPAIR`
+//! fails closed (`repair_action`: rebuild the contract, then rerun quota
+//! before applying scheduler cadence).
 //!
 //! Mode vocabulary: our typed [`TurnMode`] is mapped onto the LoopX
 //! interaction-contract mode strings the classifier branches on, so
@@ -33,9 +33,10 @@ pub const CONSISTENCY_REPAIR_ACTION: &str =
     "rebuild interaction_contract from the current quota decision, then rerun \
      quota before applying scheduler cadence";
 
-/// Rollout switch: observe-only (default) records dispositions on every
-/// packet without blocking; `true` makes `CONSISTENCY_REPAIR` fail closed.
-pub const ARBITRATION_ENFORCEMENT: bool = false;
+/// Rollout switch: `true` (enforced) makes `CONSISTENCY_REPAIR` fail closed —
+/// an inconsistent final interaction contract rewrites the packet to the
+/// `consistency_repair` decision with the `control_plane_repair` cadence.
+pub const ARBITRATION_ENFORCEMENT: bool = true;
 
 /// The 9 scheduler dispositions, aligned value-for-value with LoopX
 /// `SchedulerDisposition`.


### PR DESCRIPTION
## What

Flips `ARBITRATION_ENFORCEMENT` (`orchestration/loop/src/decision/arbitration.rs`) from `false` → `true`, completing the refactor-plan §5.1 rollout: the observe-only phase shipped the 9-disposition `SchedulerArbitration` record on every should-run packet; with enforcement on, a structurally inconsistent final interaction contract now **fails closed** — the packet is rewritten to the `consistency_repair` decision with the `control_plane_repair` scheduler cadence (`repair_action`: rebuild the interaction contract from the current quota decision, then rerun quota before applying scheduler cadence).

Also refreshes the two stale doc comments that still described the observe-only default. No other code changes.

## Why

LoopX parity item (goal_9942e096abd7, improvement ①): an inconsistent interaction-contract projection must stop delivery instead of letting a corrupt contract drive scheduler cadence. The fail-closed path and repair cadence were already implemented and unit-tested; only the flag was held off for a canary-first rollout.

## Verification — no latent inconsistency exposed

- **`cargo test -p future-loop` with enforcement on: 756 passed / 0 failed** across 64 suites. Every `decide()` pipeline branch (terminal, replan, monitor due/stalled/waiting, user gates, blockers, deferred, cancelled, identity-blocked) asserts packet fields; any inconsistent contract would have been rewritten to `consistency_repair` and failed those assertions. None were.
- **`future loop canary smoke --profile core-control-plane`: ALL PASSED** (7/7 checks, substantive — live store, 1 goal with ledger/history): root_writable, ledger_integrity, decision_determinism, quota_should_run, scheduler_state, todo_frontier, status_projection.
- **Live CLI probes** (isolated loop root): bounded_delivery → `active_work`, gate open w/ fallback → `ask_user` + `active_work`, post-closure quiet state → `monitor_wait` — all with arbitration `errors: []`.
- Pre-existing unit coverage of the enforcement semantics itself: `enforcement_fails_closed_on_inconsistent_contract` / `enforcement_never_blocks_a_consistent_packet` (tests/arbitration_contract.rs).

## Rollback

Single-commit revert of the flag restores observe-only mode; the arbitration record continues to be emitted either way.

## Checks

- `cargo fmt --check` ✔ · `cargo clippy --workspace --all-targets -- -D warnings` ✔ · `cargo test -p future-loop` 756/756 ✔
- Loop-crate-only diff; desktop untouched.