### PR TITLE
fix(mobile): use github.run_number for store build numbers; pin dev version at 0.0.2

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -25,8 +25,12 @@ jobs:
         run: |
           node scripts/version.mjs --github-output
           # versionCode must be a monotonic integer if this ever goes to Play
-          # Store; the repo-wide run counter never resets on workflow renames.
-          echo "build_number=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          # Store. github.run_id is a GitHub-wide counter that has already
+          # exceeded Android's int32 limit, so use github.run_number — this
+          # workflow's own per-repo counter, starting at 1. It resets if the
+          # workflow is renamed, but that only matters for Play (not currently
+          # used); versionCode monotonicity within a single workflow is enough.
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
 
   build-apk:
     name: Build APK

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -9,9 +9,10 @@ permissions: read-all
 #
 # TestFlight requires a plain numeric marketing version, so this workflow pins it
 # at `0.0.1` (constant across builds; bumped only for real releases). The store
-# build number (CFBundleVersion / Android versionCode) comes from `github.run_id`
-# via FUTURE_BUILD_NUMBER — a monotonic per-repo counter that never resets on
-# workflow renames and is immune to shallow-checkout commit counts.
+# build number (CFBundleVersion / Android versionCode) comes from
+# `github.run_number` via FUTURE_BUILD_NUMBER — this workflow's per-repo counter
+# starting at 1. It must stay small: Android versionCode is an int32, and
+# `github.run_id` (a GitHub-wide counter) already exceeds its limit.
 #
 # Keep this workflow restricted to trusted triggers: it imports signing
 # credentials and submits software to Apple's TestFlight service. Do not add
@@ -35,11 +36,11 @@ jobs:
         id: v
         run: |
           # Marketing version stays pinned at 0.0.1 for dev/TestFlight; bump it
-          # here only when cutting a real release. The store build number is the
-          # repo-wide run counter (monotonic, never resets, not git-dependent).
+          # here only when cutting a real release. The store build number is this
+          # workflow's per-repo run counter (starts at 1; stays within int32).
           echo "version=0.0.1" >> "$GITHUB_OUTPUT"
-          echo "build_number=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
-          echo "TestFlight version: 0.0.1 (build ${{ github.run_id }})"
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "TestFlight version: 0.0.1 (build ${{ github.run_number }})"
 
   build:
     name: Build and upload TestFlight

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -7,12 +7,17 @@ permissions: read-all
 # Expo prebuild + xcodebuild, uploads it to TestFlight via altool, and mirrors
 # the .ipa to OSS.
 #
-# TestFlight requires a plain numeric marketing version, so this workflow pins it
-# at `0.0.1` (constant across builds; bumped only for real releases). The store
-# build number (CFBundleVersion / Android versionCode) comes from
-# `github.run_number` via FUTURE_BUILD_NUMBER — this workflow's per-repo counter
-# starting at 1. It must stay small: Android versionCode is an int32, and
-# `github.run_id` (a GitHub-wide counter) already exceeds its limit.
+# TestFlight requires a plain numeric marketing version. It was pinned at `0.0.1`
+# until 0.0.1's build number hit 31479016198 (the old github.run_id counter).
+# TestFlight enforces a monotonically increasing build number per marketing
+# version, so switching back to small run_number build numbers under 0.0.1 would
+# be rejected. Bumping the marketing version to `0.0.2` resets the build-number
+# sequence, letting it restart at 1. The store build number (CFBundleVersion /
+# Android versionCode) comes from `github.run_number` via FUTURE_BUILD_NUMBER —
+# this workflow's per-repo counter starting at 1. It must stay small: Android
+# versionCode is an int32, and `github.run_id` (a GitHub-wide counter) already
+# exceeds its limit. Bump the marketing version here only when cutting a real
+# release or resetting the TestFlight build-number sequence again.
 #
 # Keep this workflow restricted to trusted triggers: it imports signing
 # credentials and submits software to Apple's TestFlight service. Do not add
@@ -35,12 +40,14 @@ jobs:
       - name: Resolve build number
         id: v
         run: |
-          # Marketing version stays pinned at 0.0.1 for dev/TestFlight; bump it
-          # here only when cutting a real release. The store build number is this
-          # workflow's per-repo run counter (starts at 1; stays within int32).
-          echo "version=0.0.1" >> "$GITHUB_OUTPUT"
+          # Marketing version bumped to 0.0.2: TestFlight already accepted
+          # 0.0.1 with build number 31479016198, so 0.0.1's sequence can only
+          # increase; small run_number values must start fresh under 0.0.2.
+          # The store build number is this workflow's per-repo run counter
+          # (starts at 1; stays within int32).
+          echo "version=0.0.2" >> "$GITHUB_OUTPUT"
           echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
-          echo "TestFlight version: 0.0.1 (build ${{ github.run_number }})"
+          echo "TestFlight version: 0.0.2 (build ${{ github.run_number }})"
 
   build:
     name: Build and upload TestFlight

--- a/.github/workflows/build-windows-signed.yml
+++ b/.github/workflows/build-windows-signed.yml
@@ -104,7 +104,7 @@ jobs:
           "$env:USERPROFILE\.cargo\bin" | Add-Content -Path $env:GITHUB_PATH
 
       # Single source of truth: scripts/version.mjs. A `vX.Y.Z` tag → release
-      # ("X.Y.Z"); anything else → dev ("0.0.0-<hash>").
+      # ("X.Y.Z"); anything else → dev ("0.0.2-<hash>").
       - name: Resolve version
         id: v
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   # Compute the build version once (single source of truth: scripts/version.mjs).
-  # Manual builds resolve to a development version (`0.0.0-dev.<hash>`).
+  # Manual builds resolve to a development version (`0.0.2-<hash>`).
   version:
     name: Resolve version
     runs-on: ubuntu-latest

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -29,8 +29,8 @@ fn emit_build_version() {
 /// Port of scripts/version.mjs `resolveVersion()`:
 ///   - FUTURE_VERSION env override wins (trimmed, empty treated as unset)
 ///   - release tag `refs/tags/vX.Y.Z` → `X.Y.Z`
-///   - dev build `0.0.<commit-count>-<hash>`; `+local` (and `.dirty`) appended
-///     for local builds (no GITHUB_ACTIONS/CI), matching the TS CLI exactly.
+///   - dev build `0.0.2-<hash>`; `+local` (and `.dirty`) appended for local
+///     builds (no GITHUB_ACTIONS/CI), matching the TS CLI exactly.
 fn resolve_version() -> String {
     if let Ok(v) = std::env::var("FUTURE_VERSION") {
         let v = v.trim();
@@ -46,21 +46,18 @@ fn resolve_version() -> String {
             }
         }
     }
-    let count = git(&["rev-list", "--count", "HEAD"])
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "0".to_string());
+    // Dev minor is pinned at 0.0.2 (mirroring DEV_VERSION in version.mjs). A
+    // commit-count scheme is useless in CI (shallow checkout → always 1), so
+    // the version never derives from the git history length.
     let hash = git(&["rev-parse", "--short", "HEAD"])
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
     let ci = std::env::var("GITHUB_ACTIONS").is_ok() || std::env::var("CI").is_ok();
     if ci {
-        return format!("0.0.{count}-{hash}");
+        return format!("0.0.2-{hash}");
     }
     let dirty = git_status_porcelain_nonempty();
-    format!(
-        "0.0.{count}-{hash}+local{}",
-        if dirty { ".dirty" } else { "" }
-    )
+    format!("0.0.2-{hash}+local{}", if dirty { ".dirty" } else { "" })
 }
 
 fn is_semver_core(s: &str) -> bool {

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,5 +1,5 @@
 //! Build-time version for `future --version` — injected by build.rs, mirroring
 //! scripts/version.mjs so the Rust CLI prints exactly what the TS CLI prints.
 
-/// Display version string (e.g. `0.0.1568-479c8fee+local`).
+/// Display version string (e.g. `0.0.2-479c8fee+local`).
 pub const VERSION: &str = env!("FUTURE_CLI_VERSION");

--- a/desktop/src-tauri/src/build_info.rs
+++ b/desktop/src-tauri/src/build_info.rs
@@ -2,10 +2,10 @@
 //!
 //! `FUTURE_VERSION` is set by `build.rs` from the `FUTURE_VERSION` env
 //! (see `scripts/version.mjs`). Release builds carry a plain `1.X.Y`; dev builds
-//! carry `0.0.<commit-count>[-<hash>]` (the iOS TestFlight variant drops the
-//! suffix). The channel is derived from the first version component — `0` means
-//! dev, `1`+ means release — so there is a single injected value. See the note
-//! in `scripts/version.mjs` for the one assumption this makes (release versions
+//! carry `0.0.2[-<hash>]` (the iOS TestFlight variant drops the suffix). The
+//! channel is derived from the first version component — `0` means dev, `1`+
+//! means release — so there is a single injected value. See the note in
+//! `scripts/version.mjs` for the one assumption this makes (release versions
 //! must never start with `0`).
 
 /// Display version string for this build.

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -11,9 +11,10 @@ function futureVersion(): string {
 const version = futureVersion();
 const bundleVersion = version.split(/[-+]/)[0];
 // Store build numbers (CFBundleVersion / Android versionCode) must be monotonic
-// integers. CI injects FUTURE_BUILD_NUMBER (a repo-wide counter that never
-// resets); local dev builds just use a constant — TestFlight/Play enforce
-// monotonicity only, not that the number corresponds to any git commit.
+// integers. CI injects FUTURE_BUILD_NUMBER (this workflow's own per-repo
+// counter, starting at 1 — kept small because Android versionCode is an int32);
+// local dev builds just use a constant — TestFlight/Play enforce monotonicity
+// only, not that the number corresponds to any git commit.
 const buildNumber = process.env.FUTURE_BUILD_NUMBER || "1";
 
 const config: ExpoConfig = {

--- a/mobile/src/config/environment.ts
+++ b/mobile/src/config/environment.ts
@@ -5,7 +5,7 @@ export const PRODUCTION_PLATFORM_URL = "https://future-os.cn";
 
 // Channel policy mirrors the desktop (desktop/src-tauri/src/build_info.rs +
 // future_platform.rs): a release build (plain `X.Y.Z`) is production-locked,
-// every other build (`0.0.0-<hash>…`) targets the test environment. The flag is
+// every other build (`0.0.2-<hash>…`) targets the test environment. The flag is
 // derived from the version string by scripts/version.mjs — NOT from `__DEV__` —
 // so a local Gradle release build is still a dev-channel package and must reach
 // the test host (the production host has remote control disabled).

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -3,20 +3,26 @@
 //
 // Three cases, all keyed off "is this a release tag":
 //   - on a `vX.Y.Z` tag    → release, version = "X.Y.Z"   (X must be ≥ 1)
-//   - other online build   → dev,    version = "0.0.<commit-count>-<hash>"
-//   - local build          → dev,    version = "0.0.<commit-count>-<hash>+local"
+//   - other online build   → dev,    version = "0.0.2-<hash>"
+//   - local build          → dev,    version = "0.0.2-<hash>+local"
 //                                      (…+local.dirty when the tree is dirty)
-//   - iOS TestFlight       → dev,    version = "0.0.<commit-count>"
+//   - iOS TestFlight       → dev,    version = "0.0.2"
 //                                      (plain number: TestFlight rejects suffixes;
 //                                      injected via FUTURE_VERSION by the workflow)
 //
-// The commit count (git rev-list --count HEAD) makes the version monotonic
-// across builds; the short hash pinpoints the exact code (`git show <hash>`) and
-// keeps distinct branches from colliding on the same 0.0.<count>. Local builds
-// add `+local` build metadata so they're never mistaken for the matching online
-// build, and `.dirty` when the working tree has uncommitted changes — a dirty
-// local build does NOT correspond to that commit, so the hash must not be
-// trusted verbatim.
+// The dev minor is pinned at `0.0.2` (DEV_VERSION below), NOT derived from git.
+// CI uses a shallow checkout (fetch-depth: 1), so `git rev-list --count HEAD`
+// always returns 1 there and a commit-count version would be frozen at 0.0.1.
+// The short hash still identifies the exact code; local builds add `+local` (and
+// `.dirty` when the tree is dirty) so a tester's laptop build is never mistaken
+// for the matching online build, and a dirty local build's hash must not be
+// trusted verbatim. Store build numbers (Android versionCode / iOS
+// CFBundleVersion) are injected separately by the workflows via github.run_number,
+// so the display version does not need to be monotonic.
+//
+// Bump DEV_VERSION (0.0.2 → 0.0.3) whenever the test-build version should
+// advance — e.g. TestFlight already accepted a larger build number under the
+// current marketing version, so a new marketing version must reset the sequence.
 //
 // The release/dev channel is DERIVED from the version string, not injected
 // separately: a version whose FIRST component is `0` is a dev build; anything
@@ -37,6 +43,9 @@ import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+/** Dev-build display version (semver core; the short hash is appended later). */
+const DEV_VERSION = "0.0.2";
+
 /** Resolve the display version string for this build. */
 export function resolveVersion() {
   // Explicit override (set by CI job env / Makefile) wins.
@@ -49,18 +58,18 @@ export function resolveVersion() {
   if (tag) {
     return tag[1];
   }
-  // Dev build: 0.0.<commit-count>-<hash>. The commit count is monotonic (build
-  // number for stores); the short hash locates the exact code and keeps branches
-  // from colliding on the same count.
-  const count = gitCommitCount();
+  // Dev build: pinned 0.0.2 + short hash. The hash locates the exact code and
+  // keeps distinct branches from colliding on the same display version. A
+  // commit-count scheme is useless in CI (shallow checkout → always 1), so the
+  // minor is fixed and advanced manually via DEV_VERSION.
   const hash = gitShortHash();
   // Online (CI) builds are reproducible from the pushed commit, so the hash
   // stands alone. Local builds add `+local` (and `.dirty` for an uncommitted
   // tree) so a tester's laptop build is never confused with the online one.
   if (process.env.GITHUB_ACTIONS || process.env.CI) {
-    return `0.0.${count}-${hash}`;
+    return `${DEV_VERSION}-${hash}`;
   }
-  return `0.0.${count}-${hash}+local${gitDirty() ? ".dirty" : ""}`;
+  return `${DEV_VERSION}-${hash}+local${gitDirty() ? ".dirty" : ""}`;
 }
 
 /** Short git hash, or "unknown" outside a git checkout (tarball build). */
@@ -72,18 +81,6 @@ function gitShortHash() {
   }
   catch {
     return "unknown";
-  }
-}
-
-/** Total commit count on HEAD, or 0 outside a git checkout. */
-function gitCommitCount() {
-  try {
-    return execSync("git rev-list --count HEAD", { stdio: ["ignore", "pipe", "ignore"] })
-      .toString()
-      .trim() || "0";
-  }
-  catch {
-    return "0";
   }
 }
 

--- a/tui/build.rs
+++ b/tui/build.rs
@@ -33,8 +33,8 @@ fn emit_build_version() {
 /// Port of scripts/version.mjs `resolveVersion()`:
 ///   - FUTURE_VERSION env override wins (trimmed, empty treated as unset)
 ///   - release tag `refs/tags/vX.Y.Z` → `X.Y.Z`
-///   - dev build `0.0.<commit-count>-<hash>`; `+local` (and `.dirty`) appended
-///     for local builds (no GITHUB_ACTIONS/CI), matching the TS TUI exactly.
+///   - dev build `0.0.2-<hash>`; `+local` (and `.dirty`) appended for local
+///     builds (no GITHUB_ACTIONS/CI), matching the TS TUI exactly.
 fn resolve_version() -> String {
     if let Ok(v) = std::env::var("FUTURE_VERSION") {
         let v = v.trim();
@@ -50,21 +50,18 @@ fn resolve_version() -> String {
             }
         }
     }
-    let count = git(&["rev-list", "--count", "HEAD"])
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "0".to_string());
+    // Dev minor is pinned at 0.0.2 (mirroring DEV_VERSION in version.mjs). A
+    // commit-count scheme is useless in CI (shallow checkout → always 1), so
+    // the version never derives from the git history length.
     let hash = git(&["rev-parse", "--short", "HEAD"])
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
     let ci = std::env::var("GITHUB_ACTIONS").is_ok() || std::env::var("CI").is_ok();
     if ci {
-        return format!("0.0.{count}-{hash}");
+        return format!("0.0.2-{hash}");
     }
     let dirty = git_status_porcelain_nonempty();
-    format!(
-        "0.0.{count}-{hash}+local{}",
-        if dirty { ".dirty" } else { "" }
-    )
+    format!("0.0.2-{hash}+local{}", if dirty { ".dirty" } else { "" })
 }
 
 fn is_semver_core(s: &str) -> bool {


### PR DESCRIPTION
## Summary

APK 在线打包失败（`Value is null` at `build.gradle:95`）。根因有两层：

1. **`github.run_id` 溢出 int32**：`run_id` 是 GitHub 全站共享计数器，已涨到 314 亿，超过 Android `versionCode` 的 32 位上限（2147483647）。`expo prebuild` 把 `versionCode 31479016198` 写进 `build.gradle` 第 95 行，Gradle 配置期崩溃。
2. **commit-count 版本在 CI 失效**：version.mjs 用 `git rev-list --count HEAD` 生成 `0.0.<count>-<hash>`，但 CI 浅拷贝（fetch-depth: 1）下 count 恒为 1，所有 dev 包实际一直是 `0.0.1-<hash>`。

## Changes

- **store build number**：Android/iOS workflow 改用 `github.run_number`（workflow 内自增、从 1 开始），替换超限的 `github.run_id`
- **iOS marketing version**：bump 到 `0.0.2`（TestFlight 已接受 0.0.1 的大 build number，同一 marketing version 下换小 build number 会被拒）
- **dev 显示版本**：version.mjs 固定为 `0.0.2-<hash>`（`DEV_VERSION` 常量），手动 bump；同步 `cli/build.rs`、`tui/build.rs`、`desktop/src-tauri/src/build_info.rs`、注释

## Verification

- 本地 prebuild 复现：`versionCode 10` + `versionName "0.0.2-<hash>"`，合法
- `cargo fmt --check` / `cargo clippy -- -D warnings` 通过
- `future --version` 测试 3 个全过

## Notes

- workflow 为 `workflow_dispatch` 手动触发，PR 合并后需在 Actions 手动跑 `Build Android APK` 验证
- `github.run_number` 在 workflow 重命名时重置，仅影响将来上 Play Store 时的 versionCode 单调性，当前内部测试不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)