### PR TITLE
feat(loop): oscillation detection — A→V→A→V signature-pair guard (LoopX 改进项③)

### DIFF
--- a/orchestration/loop/skill/future-loop/SKILL.md
+++ b/orchestration/loop/skill/future-loop/SKILL.md
@@ -271,7 +271,9 @@ waits (unresolved `--blocks`), or max-turns/max-turn-secs is reached.
 ### 7. Handle replan gates — resolve routine ones yourself
 
 **PLAN_REVIEW gates** (kernel-injected when validation budget is exhausted,
-outcome floor hit, or acceptance gaps remain) are the agent's to resolve:
+outcome floor hit, acceptance gaps remain, or the oscillation guard fires —
+delivery outcomes flip-flopping accept/reject A→V→A→V across the post-ACK
+run history) are the agent's to resolve:
 review (`status` / `diagnose --goal G`) → adjust todos via CLI → resolve and
 resume:
 

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -15,6 +15,7 @@
 //!   - [`self`]    pipeline orchestration (`decide` / `decide_for` / `packet`)
 //!   - [`arbitration`] G-2/G-11 scheduler arbitration: 9 dispositions + consistency repair
 //!   - [`identity`]     fail-closed identity gate (registered peers only)
+//!   - [`oscillation`]  A→V→A→V signature-pair detection over run history (③)
 //!   - [`stall`]        stall semantics: outcome floor, repair budget, monitor stall
 //!   - [`monitor`]      monitor evaluation (stalled / due / quiet-wait backoff)
 //!   - [`frontier`]     runnable sort, work lane, frontier projection
@@ -30,6 +31,7 @@ mod goal_boundary;
 mod heartbeat_recommendation;
 mod identity;
 pub(crate) mod monitor;
+pub(crate) mod oscillation;
 mod primary_action;
 pub(crate) mod stall;
 
@@ -49,6 +51,7 @@ use self::goal_boundary::goal_boundary_json;
 use self::heartbeat_recommendation::recommendation;
 use self::identity::identity_gate;
 use self::monitor::{monitor_outcome, MonitorOutcome};
+use self::oscillation::oscillation_replan_reason;
 use self::primary_action::agent_channel;
 use self::stall::{is_monitor_stalled, outcome_floor_breach, repair_exhausted};
 
@@ -58,6 +61,7 @@ pub use self::arbitration::{
 };
 pub use self::goal_boundary::compose_goal_boundary;
 pub use self::monitor::{monitor_poll_classification, MONITOR_NO_CHANGE_BACKOFF_SECS};
+pub use self::oscillation::OSCILLATION_PATTERN_LEN;
 pub use self::stall::{MAX_REPAIR_ATTEMPTS, MONITOR_NO_CHANGE_REPLAN_THRESHOLD};
 pub use crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS;
 pub use crate::state::now_epoch;
@@ -162,6 +166,13 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     // ── 2b. Outcome floor (LoopX: surface-only progress loop). ──────────
     if let Some(todo) = retryable.first() {
         if let Some(reason) = outcome_floor_breach(goal) {
+            return replan_packet(goal, &reason);
+        }
+        // Oscillation guard (LoopX 对比改进项 ③): the goal's recent delivery
+        // outcomes strictly alternate accept/reject (A→V→A→V) — the
+        // action/verify flip-flop that burns spend without converging.
+        // Force a frontier-changing replan instead of the next delivery.
+        if let Some(reason) = oscillation_replan_reason(goal) {
             return replan_packet(goal, &reason);
         }
         let attempt = todo.failed_attempts + 1;

--- a/orchestration/loop/src/decision/oscillation.rs
+++ b/orchestration/loop/src/decision/oscillation.rs
@@ -1,0 +1,330 @@
+//! Oscillation detection (LoopX 对比改进项 ③) — the projection-layer
+//! sliding-window signature-pair guard against the A→V→A→V incident
+//! pattern (action/verify flip-flopping: each delivery is rejected, the
+//! retry is accepted, the next delivery is rejected again — spend burns
+//! without the frontier ever converging).
+//!
+//! The read model is the goal's run-history projection (`Goal::history`,
+//! folded from `RunRecorded` events): every delivery-class record projects
+//! to one outcome signature — `Accepted` (A) or `Rejected` (V). Over the
+//! post-ack signature stream the detector slides a window of
+//! [`OSCILLATION_PATTERN_LEN`] and fires when the newest window strictly
+//! alternates (A→V→A→V or V→A→V→A): two consecutive repetitions of the
+//! same accept/reject pair.
+//!
+//! Why per-todo guards don't catch it: the repair budget
+//! (`MAX_REPAIR_ATTEMPTS`) trips on *consecutive* failures of one todo, and
+//! the outcome floor trips on *surface-only* turns. The oscillation pattern
+//! completes every todo on retry — no budget exhausts, outcomes are
+//! material — yet every first-pass delivery is rejected, doubling cost per
+//! unit of progress (the $47K-class runaway this guard exists to stop).
+//!
+//! Response: the decision kernel converts the next delivery into a replan
+//! (same family as outcome-floor / monitor-stall / repair-budget triggers),
+//! forcing a frontier-changing delta instead of the next rejected cycle.
+//! LoopX alignment: this is the actuation behind the seven-predicate
+//! contract's delivery lanes — while oscillating, `normal_delivery_allowed`
+//! reads false and only the repair lane (`self_repair_allowed`) stays open.
+//!
+//! Liveness: the detector only observes records *after* the last replan
+//! ACK (`Goal::replan_ack.at`). Without that reset the alternating tail
+//! would re-fire immediately after every ACK while delivery stays blocked,
+//! deadlocking the goal. Post-ACK the pattern must re-emerge across four
+//! fresh delivery outcomes before the guard fires again — a single ACK
+//! buys exactly one chance to break the loop, not a permanent exemption.
+
+use crate::quota::slot_accounting::{classify_record, SlotSpendSource};
+use crate::state::{Goal, RunRecord};
+
+/// Sliding-window size: two full A→V pairs (A→V→A→V) establish the
+/// alternation. Tight enough to intervene before the burn compounds,
+/// loose enough that a lone flaky validation (A→V→A) never trips it.
+pub const OSCILLATION_PATTERN_LEN: usize = 4;
+
+/// The outcome signature of one delivery turn: the projection symbol the
+/// sliding window runs over. (`A` / `V` in the incident vocabulary.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum RunSignature {
+    /// A — an accepted delivery action: the turn completed and, when an
+    /// independent validator ran, passed.
+    Accepted,
+    /// V — the verify phase rejected the delivery: the turn completed but
+    /// the independent validator failed (`--verify` exit != 0).
+    Rejected,
+}
+
+impl RunSignature {
+    fn symbol(self) -> &'static str {
+        match self {
+            RunSignature::Accepted => "A",
+            RunSignature::Rejected => "V",
+        }
+    }
+}
+
+/// What the detector found: the strictly-alternating suffix of the
+/// post-ACK signature stream.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct OscillationReport {
+    /// Length of the alternating suffix (>= [`OSCILLATION_PATTERN_LEN`]).
+    pub alternating_len: usize,
+    /// The suffix rendered in A/V symbols, oldest first (e.g. "A→V→A→V").
+    pub pattern: String,
+    /// `recorded_at` of the newest record in the suffix (diagnostics).
+    pub newest_recorded_at: u64,
+}
+
+/// Project one run record into its outcome signature. Returns `None` for
+/// records that carry no delivery verdict:
+///
+/// - quota-neutral records (monitor polls, replan slices, heartbeats —
+///   [`SlotSpendSource::Heartbeat`]) never enter the stream, so background
+///   activity neither fabricates nor breaks an alternation;
+/// - turns that did not complete produced no verify verdict (a crashed
+///   turn is the repair budget's concern, not an action/verify flip-flop).
+pub fn signature_of(record: &RunRecord) -> Option<RunSignature> {
+    if classify_record(record) == SlotSpendSource::Heartbeat {
+        return None;
+    }
+    if record.terminal_state != "completed" {
+        return None;
+    }
+    Some(match &record.validation {
+        Some(v) if !v.ok => RunSignature::Rejected,
+        _ => RunSignature::Accepted,
+    })
+}
+
+/// Length of the strictly-alternating suffix: 1 + the number of backward
+/// steps from the tail in which adjacent signatures differ.
+fn alternating_suffix_len(signatures: &[RunSignature]) -> usize {
+    let mut len = signatures.len().min(1);
+    for pair in signatures.windows(2).rev() {
+        if pair[0] == pair[1] {
+            break;
+        }
+        len += 1;
+    }
+    len
+}
+
+/// Detect the A→V→A→V oscillation over the goal's run-history projection,
+/// observing only delivery records with `recorded_at > since` (`since` is
+/// the last replan-ACK timestamp, 0 when the goal never ACKed).
+pub fn detect(history: &[RunRecord], since: u64) -> Option<OscillationReport> {
+    let signatures: Vec<(u64, RunSignature)> = history
+        .iter()
+        .filter(|r| r.recorded_at > since)
+        .filter_map(|r| signature_of(r).map(|s| (r.recorded_at, s)))
+        .collect();
+    let len = alternating_suffix_len(&signatures.iter().map(|(_, s)| *s).collect::<Vec<_>>());
+    if len < OSCILLATION_PATTERN_LEN {
+        return None;
+    }
+    let suffix = &signatures[signatures.len() - len..];
+    Some(OscillationReport {
+        alternating_len: len,
+        pattern: suffix
+            .iter()
+            .map(|(_, s)| s.symbol())
+            .collect::<Vec<_>>()
+            .join("→"),
+        newest_recorded_at: suffix.last().map(|(ts, _)| *ts).unwrap_or(0),
+    })
+}
+
+/// Decision-facing predicate (stall family): the replan reason when the
+/// goal oscillates, `None` while delivery may proceed. `pub(crate)` — the
+/// kernel is the only caller; tests go through [`crate::decision::decide`].
+pub(crate) fn oscillation_replan_reason(goal: &Goal) -> Option<String> {
+    let since = goal.replan_ack.as_ref().map(|a| a.at).unwrap_or(0);
+    detect(&goal.history, since).map(|report| {
+        format!(
+            "oscillation detected: delivery outcomes flip-flop {} ({} consecutive alternating turns) — record a frontier-changing replan delta to break the action/verify loop",
+            report.pattern, report.alternating_len
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{task_validation_receipt, RunRecord, ValidationStatus};
+
+    fn record(ts: u64, terminal_state: &str, validation_ok: Option<bool>) -> RunRecord {
+        RunRecord {
+            turn: ts as u32,
+            todo_id: "t".to_string(),
+            run_id: format!("run-{ts}"),
+            terminal_state: terminal_state.to_string(),
+            error: None,
+            tokens_in_delta: 0,
+            tokens_out_delta: 0,
+            cost_delta: 0.0,
+            tools: vec![],
+            evidence: String::new(),
+            recorded_at: ts,
+            spend_source: Some("run".to_string()),
+            validation: validation_ok.map(|ok| {
+                if ok {
+                    task_validation_receipt(ValidationStatus::Passed, "v", "ok", None, Some(0))
+                } else {
+                    task_validation_receipt(
+                        ValidationStatus::Failed,
+                        "v",
+                        "rejected",
+                        Some(crate::state::RecoveryKind::RepairRequired),
+                        Some(1),
+                    )
+                }
+            }),
+        }
+    }
+
+    fn accepted(ts: u64) -> RunRecord {
+        record(ts, "completed", None)
+    }
+
+    fn accepted_validated(ts: u64) -> RunRecord {
+        record(ts, "completed", Some(true))
+    }
+
+    fn rejected(ts: u64) -> RunRecord {
+        record(ts, "completed", Some(false))
+    }
+
+    #[test]
+    fn signature_classification() {
+        assert_eq!(signature_of(&accepted(1)), Some(RunSignature::Accepted));
+        assert_eq!(
+            signature_of(&accepted_validated(1)),
+            Some(RunSignature::Accepted)
+        );
+        assert_eq!(signature_of(&rejected(1)), Some(RunSignature::Rejected));
+        // A failed turn carries no verify verdict.
+        assert_eq!(signature_of(&record(1, "failed", None)), None);
+        // Quota-neutral records never enter the stream — even completed ones.
+        let mut poll = accepted(1);
+        poll.spend_source = Some("heartbeat".to_string());
+        assert_eq!(signature_of(&poll), None);
+        // Legacy unstamped completed records classify as delivery turns.
+        let mut legacy = accepted(1);
+        legacy.spend_source = None;
+        assert_eq!(signature_of(&legacy), Some(RunSignature::Accepted));
+        // Legacy unstamped non-completed records are heartbeat-classified
+        // and stay out of the stream either way.
+        let mut legacy_failed = record(1, "failed", None);
+        legacy_failed.spend_source = None;
+        assert_eq!(signature_of(&legacy_failed), None);
+    }
+
+    #[test]
+    fn alternating_suffix_lengths() {
+        use RunSignature::{Accepted as A, Rejected as V};
+        assert_eq!(alternating_suffix_len(&[]), 0);
+        assert_eq!(alternating_suffix_len(&[A]), 1);
+        assert_eq!(alternating_suffix_len(&[A, A]), 1);
+        assert_eq!(alternating_suffix_len(&[A, V]), 2);
+        assert_eq!(alternating_suffix_len(&[A, V, A]), 3);
+        assert_eq!(alternating_suffix_len(&[A, V, A, V]), 4);
+        // A same-symbol pair resets the suffix regardless of what led it.
+        assert_eq!(alternating_suffix_len(&[A, V, A, V, V]), 1);
+        assert_eq!(alternating_suffix_len(&[V, V, A, V, A]), 4);
+    }
+
+    #[test]
+    fn detect_fires_on_two_full_pairs() {
+        let history = vec![accepted(1), rejected(2), accepted(3), rejected(4)];
+        let report = detect(&history, 0).expect("A→V→A→V must fire");
+        assert_eq!(report.alternating_len, 4);
+        assert_eq!(report.pattern, "A→V→A→V");
+        assert_eq!(report.newest_recorded_at, 4);
+    }
+
+    #[test]
+    fn detect_fires_on_v_first_pattern() {
+        let history = vec![rejected(1), accepted(2), rejected(3), accepted(4)];
+        let report = detect(&history, 0).expect("V→A→V→A must fire");
+        assert_eq!(report.pattern, "V→A→V→A");
+    }
+
+    #[test]
+    fn detect_ignores_shorter_than_two_pairs() {
+        assert!(detect(&[], 0).is_none());
+        assert!(detect(&[accepted(1)], 0).is_none());
+        assert!(detect(&[accepted(1), rejected(2)], 0).is_none());
+        assert!(detect(&[accepted(1), rejected(2), accepted(3)], 0).is_none());
+        // Consecutive rejects break the alternation (repair-budget domain).
+        let history = vec![
+            accepted(1),
+            rejected(2),
+            rejected(3),
+            accepted(4),
+            rejected(5),
+        ];
+        assert!(detect(&history, 0).is_none());
+    }
+
+    #[test]
+    fn detect_reports_the_suffix_not_the_prefix() {
+        // Stabilized start, oscillating tail → fires on the tail.
+        let history = vec![
+            accepted(1),
+            accepted(2),
+            rejected(3),
+            accepted(4),
+            rejected(5),
+            accepted(6),
+        ];
+        let report = detect(&history, 0).expect("oscillating tail must fire");
+        assert_eq!(report.alternating_len, 5);
+        assert_eq!(report.pattern, "A→V→A→V→A");
+        // Oscillating start, stabilized tail → no fire.
+        let history = vec![
+            accepted(1),
+            rejected(2),
+            accepted(3),
+            rejected(4),
+            accepted(5),
+            accepted(6),
+        ];
+        assert!(detect(&history, 0).is_none());
+    }
+
+    #[test]
+    fn non_delivery_records_neither_fabricate_nor_break_the_pattern() {
+        let mut poll = accepted(2);
+        poll.spend_source = Some("heartbeat".to_string());
+        let failed_turn = record(3, "failed", None);
+        let history = vec![
+            accepted(1),
+            poll,
+            failed_turn,
+            rejected(4),
+            accepted(5),
+            rejected(6),
+        ];
+        let report = detect(&history, 0).expect("heartbeat/failed records must be transparent");
+        assert_eq!(report.pattern, "A→V→A→V");
+    }
+
+    #[test]
+    fn since_filter_scopes_observation_to_post_ack_records() {
+        let history = vec![accepted(1), rejected(2), accepted(3), rejected(4)];
+        // All four records predate the ACK → the pattern is consumed.
+        assert!(detect(&history, 4).is_none());
+        assert!(detect(&history, 10).is_none());
+        // A partial post-ACK pattern does not fire.
+        assert!(detect(&history, 2).is_none());
+        let mut fresh = history.clone();
+        fresh.push(accepted(5));
+        // Only one fresh record post-ACK at 4 → no re-fire yet.
+        assert!(detect(&fresh, 4).is_none());
+        // The full pattern re-emerging post-ACK re-fires.
+        let mut fresh = history.clone();
+        fresh.extend([accepted(5), rejected(6), accepted(7), rejected(8)]);
+        let report = detect(&fresh, 4).expect("fresh post-ACK alternation must re-fire");
+        assert_eq!(report.alternating_len, 4);
+        assert_eq!(report.newest_recorded_at, 8);
+    }
+}

--- a/orchestration/loop/tests/oscillation_contract.rs
+++ b/orchestration/loop/tests/oscillation_contract.rs
@@ -1,0 +1,234 @@
+//! P0 contract tests: oscillation detection (LoopX 对比改进项 ③) — the
+//! projection-layer sliding-window signature-pair guard. A goal whose
+//! delivery outcomes strictly alternate accept/reject (A→V→A→V) is burning
+//! spend without converging; the kernel must convert the next delivery
+//! into a replan (frontier delta), then let delivery resume once the agent
+//! ACKs. Deterministic: signatures derive from the run-history projection.
+
+use std::time::SystemTime;
+
+use future_loop::contract::TurnMode;
+use future_loop::decision::decide;
+use future_loop::state::{
+    task_validation_receipt, Goal, RecoveryKind, ReplanAck, RunRecord, Todo, ValidationStatus,
+};
+
+/// A completed delivery turn; `validation_ok = Some(false)` carries a failed
+/// independent-validator receipt (V), otherwise the outcome is accepted (A).
+fn delivery(turn: u32, ts: u64, validation_ok: Option<bool>) -> RunRecord {
+    RunRecord {
+        turn,
+        todo_id: format!("t{turn}"),
+        run_id: format!("run-{turn}"),
+        terminal_state: "completed".to_string(),
+        error: None,
+        tokens_in_delta: 0,
+        tokens_out_delta: 0,
+        cost_delta: 0.0,
+        tools: vec!["edit".to_string()],
+        evidence: "artifact".to_string(),
+        recorded_at: ts,
+        spend_source: Some("run".to_string()),
+        validation: validation_ok.map(|ok| {
+            if ok {
+                task_validation_receipt(ValidationStatus::Passed, "make test", "ok", None, Some(0))
+            } else {
+                task_validation_receipt(
+                    ValidationStatus::Failed,
+                    "make test",
+                    "validator exited 1 — repair required",
+                    Some(RecoveryKind::RepairRequired),
+                    Some(1),
+                )
+            }
+        }),
+    }
+}
+
+fn accepted(turn: u32, ts: u64) -> RunRecord {
+    delivery(turn, ts, None)
+}
+
+fn rejected(turn: u32, ts: u64) -> RunRecord {
+    delivery(turn, ts, Some(false))
+}
+
+fn goal_with_history(history: Vec<RunRecord>) -> Goal {
+    let mut goal = Goal::new("g", "objective", "/tmp");
+    goal.add(Todo::advancement("t-open", "Keep delivering"));
+    goal.history = history;
+    goal
+}
+
+// ── Detection fires on the A→V→A→V pattern ────────────────────────────────
+#[test]
+fn oscillation_forces_replan_instead_of_delivery() {
+    let goal = goal_with_history(vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+    ]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(
+        p.interaction_contract.mode,
+        TurnMode::Replan,
+        "A→V→A→V must convert the next delivery into a replan"
+    );
+    assert!(p.reason.contains("oscillation detected"));
+    assert!(p.reason.contains("A→V→A→V"));
+    assert!(!p.normal_delivery_allowed);
+    assert!(p.self_repair_allowed, "the repair lane stays open");
+}
+
+#[test]
+fn v_first_alternation_also_fires() {
+    let goal = goal_with_history(vec![
+        rejected(1, 1),
+        accepted(2, 2),
+        rejected(3, 3),
+        accepted(4, 4),
+    ]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(p.interaction_contract.mode, TurnMode::Replan);
+    assert!(p.reason.contains("V→A→V→A"));
+}
+
+// ── Below the pattern length the guard stays silent ───────────────────────
+#[test]
+fn shorter_alternation_still_delivers() {
+    // One pair plus a lead-in (len 3 < OSCILLATION_PATTERN_LEN): no fire.
+    let goal = goal_with_history(vec![accepted(1, 1), rejected(2, 2), accepted(3, 3)]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+}
+
+#[test]
+fn consecutive_rejects_break_the_pattern() {
+    // A,V,A,V,V — the same-symbol pair at the tail ends the alternation
+    // (consecutive rejects are the repair budget's domain, not this guard's).
+    let goal = goal_with_history(vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+        rejected(5, 5),
+    ]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+}
+
+#[test]
+fn stabilized_tail_clears_an_earlier_pattern() {
+    // A,V,A,V,A,A — oscillated, then two consecutive accepts stabilized.
+    let goal = goal_with_history(vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+        accepted(5, 5),
+        accepted(6, 6),
+    ]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+}
+
+// ── Non-delivery records are transparent to the detector ──────────────────
+#[test]
+fn monitor_polls_and_failed_turns_neither_fabricate_nor_break() {
+    let mut poll = accepted(2, 2);
+    poll.spend_source = Some("heartbeat".to_string());
+    let mut crashed = accepted(4, 4);
+    crashed.terminal_state = "failed".to_string();
+    crashed.spend_source = Some("run".to_string());
+    let goal = goal_with_history(vec![
+        accepted(1, 1),
+        poll,
+        rejected(3, 3),
+        crashed,
+        accepted(5, 5),
+        rejected(6, 6),
+    ]);
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(
+        p.interaction_contract.mode,
+        TurnMode::Replan,
+        "heartbeat polls and crashed turns must be transparent: A,_,V,_,A,V still alternates"
+    );
+}
+
+// ── The replan ACK consumes the pattern (liveness) ─────────────────────────
+#[test]
+fn replan_ack_consumes_the_pattern_and_delivery_resumes() {
+    let mut goal = goal_with_history(vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+    ]);
+    assert_eq!(
+        decide(&goal, SystemTime::now()).interaction_contract.mode,
+        TurnMode::Replan
+    );
+    // The agent records a frontier-changing delta (ACK at ts=10); every
+    // alternating record predates the ACK, so the pattern is consumed.
+    goal.replan_ack = Some(ReplanAck {
+        recorded: true,
+        delta_kinds: vec!["vision_patch".to_string()],
+        at: 10,
+    });
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(
+        p.interaction_contract.mode,
+        TurnMode::BoundedDelivery,
+        "post-ACK the goal must be allowed to deliver again"
+    );
+}
+
+#[test]
+fn fresh_post_ack_alternation_refires_the_guard() {
+    let mut goal = goal_with_history(vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+    ]);
+    goal.replan_ack = Some(ReplanAck {
+        recorded: true,
+        delta_kinds: vec!["vision_patch".to_string()],
+        at: 10,
+    });
+    // One fresh pair post-ACK: not enough.
+    goal.history.push(accepted(5, 11));
+    goal.history.push(rejected(6, 12));
+    assert_eq!(
+        decide(&goal, SystemTime::now()).interaction_contract.mode,
+        TurnMode::BoundedDelivery
+    );
+    // Two full fresh pairs: the loop survived the replan — fire again.
+    goal.history.push(accepted(7, 13));
+    goal.history.push(rejected(8, 14));
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(p.interaction_contract.mode, TurnMode::Replan);
+    assert!(p.reason.contains("oscillation detected"));
+}
+
+// ── The guard only blocks delivery, never other modes ─────────────────────
+#[test]
+fn oscillation_does_not_block_validated_closure() {
+    let mut goal = Goal::new("g", "objective", "/tmp");
+    goal.add(Todo::advancement("t1", "Work"));
+    goal.todo_mut("t1").unwrap().complete(true, vec![]);
+    goal.history = vec![
+        accepted(1, 1),
+        rejected(2, 2),
+        accepted(3, 3),
+        rejected(4, 4),
+    ];
+    let p = decide(&goal, SystemTime::now());
+    assert_eq!(
+        p.interaction_contract.mode,
+        TurnMode::Terminal,
+        "no runnable work → nothing to defend; closure must proceed"
+    );
+}


### PR DESCRIPTION
## What

LoopX 对比改进项 ③（P0，goal_9942e096abd7 / todo_121ba6d32b74）：投影层滑窗签名对检测，防御 action/verify 反复横跳的 \$47K 级事故模式。

**检测**（新增 `decision/oscillation.rs`，纯函数读模型）：
- 签名投影：`Goal::history`（RunRecorded 投影）中每个**交付类**记录映射为一个结果签名——`Accepted`（A：turn 完成且校验通过/无校验）/ `Rejected`（V：turn 完成但独立 validator 拒绝）。quota-neutral 记录（monitor poll、replan slice、heartbeat）与未完成的 turn 对检测透明（既不伪造也不打断交替）。
- 滑窗判定：对 replan-ACK 之后的签名流取**严格交替后缀**，长度 ≥ 4（两个完整 A→V 对，A→V→A→V 或 V→A→V→A）即判定振荡。
- 与既有防护的分工：repair budget 管**同一 todo 连续失败**；outcome floor 管**无实质产出**；本守卫管**跨 todo 的接受/拒绝交替**——每个 todo 都能在重试后完成（budget 不触发）、产出也都是实质的（floor 不触发），但每个首次交付都被拒绝，单位进度成本翻倍。

**响应**（stall 语义家族，与 outcome floor / monitor stall / repair budget 一致）：下一次交付被转换为 replan（强制 frontier-changing delta）。检测时 packet 谓词：`normal_delivery_allowed=false`、`self_repair_allowed=true`——对齐七谓词契约的修复通道语义。

**活性**（防 replan 死锁）：检测只观察最后一次 replan ACK 之后的记录。ACK 消费掉既有模式 → 交付恢复；只有 ACK 之后重新出现两个完整交替对才再次触发。契约测试覆盖：触发/阈值/稳定化解除/透明性/ACK 复位/ACK 后重现再触发/不阻塞 terminal closure。

## Parity / 回归

无需 decision_split_regression intended-delta 登记：全部 pre-split fixture 的 history 为空，守卫在遗留语料上从不触发（66/66 loop 测试二进制全绿，含 parity 测试）。行为变更只作用于「存在交替交付史 + 可运行 todo」的 goal——这正是该守卫的意图。

## Tests

- 8 unit（签名分类、后缀长度、阈值、后缀 vs 前缀、透明性、since 过滤）
- 9 contract（`tests/oscillation_contract.rs`，全走 `decide()` 端到端）
- workspace clippy `-D warnings` + fmt 干净

## Notes

- 阈值为常量 `OSCILLATION_PATTERN_LEN = 4`（对标 MONITOR_NO_CHANGE_REPLAN_THRESHOLD=3 / MAX_REPAIR_ATTEMPTS=1 的紧预算风格）；如需可配化（ExecutionProfile）留作后续。
- 「降速」响应未实现——replan 已是该语义家族的既定响应且带 ACK 复位；若后续观测到误报可再加 backoff 升级路径。