### PR TITLE
fix(remote): self-heal bridge loops; fix iOS script + mobile progress bar

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -167,22 +167,38 @@ pub(super) async fn command_loop(
 ) {
     let subject = format!("p.{pair_id}.cmd.>");
     let queue = format!("bridge.{pair_id}");
-    let mut sub = match client.queue_subscribe(subject.clone(), queue).await {
-        Ok(sub) => sub,
-        Err(e) => {
-            eprintln!("remote: failed to subscribe to commands {subject}: {e}");
-            return;
+    // Self-heal: a failed subscribe or an ended subscription stream (server-side
+    // close, permission error) must not kill the loop — a dead loop leaves the
+    // queue group without a live member and every command then times out until
+    // the next credential-refresh swap. Retry with backoff; the task is only
+    // terminated by the caller (generation swap / stop), which aborts it.
+    let mut backoff = Duration::from_secs(1);
+    loop {
+        let mut sub = match client.queue_subscribe(subject.clone(), queue.clone()).await {
+            Ok(sub) => sub,
+            Err(e) => {
+                eprintln!(
+                    "remote: failed to subscribe to commands {subject}: {e}; retrying in {backoff:?}"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2).min(Duration::from_secs(30));
+                continue;
+            }
+        };
+        backoff = Duration::from_secs(1);
+        eprintln!("remote: subscribed to commands {subject}");
+        while let Some(msg) = sub.next().await {
+            let client = client.clone();
+            let reply_slots = reply_slots.clone();
+            let handshake = handshake.clone();
+            // Spawn per command: prevent a slow command from blocking others.
+            tokio::spawn(async move {
+                handle_command_singleflight(&client, msg, reply_slots, handshake).await;
+            });
         }
-    };
-    eprintln!("remote: subscribed to commands {subject}");
-    while let Some(msg) = sub.next().await {
-        let client = client.clone();
-        let reply_slots = reply_slots.clone();
-        let handshake = handshake.clone();
-        // Spawn per command: prevent a slow command from blocking others.
-        tokio::spawn(async move {
-            handle_command_singleflight(&client, msg, reply_slots, handshake).await;
-        });
+        eprintln!("remote: command subscription ended unexpectedly; resubscribing in {backoff:?}");
+        tokio::time::sleep(backoff).await;
+        backoff = backoff.saturating_mul(2).min(Duration::from_secs(30));
     }
 }
 

--- a/desktop/src-tauri/src/remote/mod.rs
+++ b/desktop/src-tauri/src/remote/mod.rs
@@ -769,7 +769,32 @@ fn spawn_credential_refresh(
             let Some(creds) = pairing::load_creds().filter(|creds| creds.pair_id == pair_id) else {
                 return;
             };
-            tokio::time::sleep(pairing::refresh_delay(&creds)).await;
+            // Tick instead of sleeping until the refresh deadline: the same
+            // generation swap that rotates the JWT also heals a dead
+            // command/transfer loop or a wedged connection (status() derives
+            // real health), so the bridge recovers without a manual
+            // stop/start. Two consecutive unhealthy ticks (30s) debounce
+            // transient NATS reconnects.
+            let mut unhealthy_ticks = 0u8;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+                if status().connected {
+                    unhealthy_ticks = 0;
+                } else {
+                    unhealthy_ticks += 1;
+                }
+                let refresh_due =
+                    pairing::refresh_delay(&creds) < std::time::Duration::from_secs(15);
+                if refresh_due || unhealthy_ticks >= 2 {
+                    if unhealthy_ticks >= 2 {
+                        eprintln!(
+                            "remote: bridge unhealthy for {}s; swapping connection",
+                            unhealthy_ticks as u64 * 15
+                        );
+                    }
+                    break;
+                }
+            }
             let refreshed = match pairing::refresh_bridge_jwt(creds).await {
                 Ok(creds) => creds,
                 Err(error) if pairing::is_invalid_or_revoked_error(&error) => {

--- a/desktop/src-tauri/src/remote/transfer.rs
+++ b/desktop/src-tauri/src/remote/transfer.rs
@@ -633,53 +633,66 @@ pub fn spawn_transfer_loop(
     tokio::spawn(async move {
         let subject = format!("p.{pair_id}.xfer.up.>");
         let queue = format!("bridge-transfer.{pair_id}");
-        let mut sub = match client.queue_subscribe(subject.clone(), queue).await {
-            Ok(sub) => sub,
-            Err(error) => {
-                eprintln!("remote: failed to subscribe to transfers {subject}: {error}");
-                return;
-            }
-        };
-        let mut cleanup = tokio::time::interval(Duration::from_secs(60));
+        // Self-heal like command_loop: a dead transfer loop times out every
+        // chunk pull until the next generation swap.
+        let mut backoff = Duration::from_secs(1);
         loop {
-            tokio::select! {
-                _ = cleanup.tick() => prune_expired(),
-                next = sub.next() => {
-                    let Some(message) = next else { break };
-                    if !active.load(std::sync::atomic::Ordering::Acquire) {
-                        continue;
-                    }
-                    let suffix = message
-                        .subject
-                        .strip_prefix(&format!("p.{pair_id}.xfer.up."))
-                        .unwrap_or_default();
-                    let parts: Vec<&str> = suffix.split('.').collect();
-                    let response = match parts.as_slice() {
-                        [transfer_id, "chunk", index] => index
-                            .parse::<u64>()
-                            .map_err(|_| "Invalid chunk index.".to_string())
-                            .and_then(|index| write_upload_chunk(transfer_id, index, &message.payload)),
-                        [transfer_id, "pull", index] => index
-                            .parse::<u64>()
-                            .map_err(|_| "Invalid chunk index.".to_string())
-                            .and_then(|index| {
-                                publish_download_chunk(&client, &pair_id, transfer_id, index)
-                                    .map(|_| json!({ "published": true, "index": index }))
-                                    .map_err(|error| error.to_string())
-                            }),
-                        _ => Err("Unsupported transfer operation.".to_string()),
-                    };
-                    if let Some(reply) = message.reply {
-                        let body = match response {
-                            Ok(data) => json!({ "success": true, "data": data }),
-                            Err(error) => json!({ "success": false, "error": error }),
+            let mut sub = match client.queue_subscribe(subject.clone(), queue.clone()).await {
+                Ok(sub) => sub,
+                Err(error) => {
+                    eprintln!("remote: failed to subscribe to transfers {subject}: {error}; retrying in {backoff:?}");
+                    tokio::time::sleep(backoff).await;
+                    backoff = backoff.saturating_mul(2).min(Duration::from_secs(30));
+                    continue;
+                }
+            };
+            backoff = Duration::from_secs(1);
+            let mut cleanup = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tokio::select! {
+                    _ = cleanup.tick() => prune_expired(),
+                    next = sub.next() => {
+                        let Some(message) = next else { break };
+                        if !active.load(std::sync::atomic::Ordering::Acquire) {
+                            continue;
+                        }
+                        let suffix = message
+                            .subject
+                            .strip_prefix(&format!("p.{pair_id}.xfer.up."))
+                            .unwrap_or_default();
+                        let parts: Vec<&str> = suffix.split('.').collect();
+                        let response = match parts.as_slice() {
+                            [transfer_id, "chunk", index] => index
+                                .parse::<u64>()
+                                .map_err(|_| "Invalid chunk index.".to_string())
+                                .and_then(|index| write_upload_chunk(transfer_id, index, &message.payload)),
+                            [transfer_id, "pull", index] => index
+                                .parse::<u64>()
+                                .map_err(|_| "Invalid chunk index.".to_string())
+                                .and_then(|index| {
+                                    publish_download_chunk(&client, &pair_id, transfer_id, index)
+                                        .map(|_| json!({ "published": true, "index": index }))
+                                        .map_err(|error| error.to_string())
+                                }),
+                            _ => Err("Unsupported transfer operation.".to_string()),
                         };
-                        if let Ok(bytes) = serde_json::to_vec(&body) {
-                            let _ = client.publish(reply, bytes.into()).await;
+                        if let Some(reply) = message.reply {
+                            let body = match response {
+                                Ok(data) => json!({ "success": true, "data": data }),
+                                Err(error) => json!({ "success": false, "error": error }),
+                            };
+                            if let Ok(bytes) = serde_json::to_vec(&body) {
+                                let _ = client.publish(reply, bytes.into()).await;
+                            }
                         }
                     }
                 }
             }
+            eprintln!(
+                "remote: transfer subscription ended unexpectedly; resubscribing in {backoff:?}"
+            );
+            tokio::time::sleep(backoff).await;
+            backoff = backoff.saturating_mul(2).min(Duration::from_secs(30));
         }
     })
 }


### PR DESCRIPTION
## Summary

Three fixes bundled in this PR:

1. **`fix(remote)`: desktop bridge auto-recovery.** A dead command/transfer loop previously left the pair's NATS queue group without a live member (or a stale member kept stealing deliveries), so mobile commands like `download_prepare` timed out until a manual stop/start. Now:
   - `command_loop` / `spawn_transfer_loop` retry a failed subscribe or an ended subscription stream with exponential backoff, exiting only when aborted by the caller (generation swap / stop).
   - The credential-refresh task ticks every 15s and triggers the same generation swap when the JWT is due **or** `status()` reports the bridge unhealthy for two consecutive ticks (30s, debouncing transient NATS reconnects).
2. **`fix(mobile)`: move the transfer progress bar below the header.** The bar was floating above the composer (uncommon placement); it's now a full-width 2px bar under the header divider.
3. **`fix(scripts)`: `start-mobile-ios.sh` under macOS Bash 3.2.** `set -u` treats an empty, never-assigned array as unbound, so dev mode died with `run_args[@]: unbound variable`. Guarded the args expansion with an array-length check.

## Test plan

- [ ] Desktop: reproduce the "preview download times out" scenario; confirm the bridge self-heals within ~30-45s (look for `remote: ... unhealthy ... swapping connection` in the tauri dev terminal) without a manual stop/start
- [ ] Desktop: normal chat + attachment upload/download still work
- [ ] Mobile: attachment preview opens; progress bar renders under the header during transfer
- [ ] iOS: `./scripts/start-mobile-ios.sh` boots the app and starts Metro without the unbound-variable error

Verified locally: workspace + desktop `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, desktop `cargo test --lib` (198 passed). The 5 pre-existing `future-channel` SIGINT test failures reproduce on `origin/main` unchanged (unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)