### PR TITLE
docs(loop): long-run evidence ledger + coverage goal entry (LoopX 对比改进项 ⑥)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 |---|---|
 | [Build & Install](build-and-install.md) ([中文](build-and-install.zh-CN.md)) | Prerequisites, per-platform toolchains (macOS / Linux / Windows), `make` targets, GUI packaging, `future-loop` install, skills install |
 | [Loop Control Plane](loop-control-plane.md) ([中文](loop-control-plane.zh-CN.md)) | `future-loop` — goals/todos/gates/monitors, should-run kernel, quota, event sourcing, extensions & multi-agent, handoff |
+| [Long-Run Evidence Ledger](long-run-evidence-ledger.md) ([中文](long-run-evidence-ledger.zh-CN.md)) | Accountability record for long-range loop goals — wall clock, spend, validation results, explicit boundaries per closed goal |
 | [TUI](tui.md) ([中文](tui.zh-CN.md)) | The terminal UI (`future-tui`): slash commands, keyboard shortcuts, settings |
 | [Directory layout](directory-layout.md) ([中文](directory-layout.zh-CN.md)) | What lives where under `~/.future/` (agent, channels, TUI, GUI, loop) |
 | [Channels configuration](channels-config.md) ([中文](channels-config.zh-CN.md)) | Unified reference for `~/.future/channels/config.json` (agent / Feishu / DingTalk blocks, defaults) |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -9,6 +9,7 @@
 |---|---|
 | [构建与安装](build-and-install.zh-CN.md)（[English](build-and-install.md)） | 前置要求、各平台工具链（macOS / Linux / Windows）、`make` 目标、GUI 打包、`future-loop` 安装、技能安装 |
 | [Loop 控制面](loop-control-plane.zh-CN.md)（[English](loop-control-plane.md)） | `future-loop`——目标/todos/门禁/监控、should-run 内核、额度、事件溯源、扩展与多 agent、交接 |
+| [长程运行证据台账](long-run-evidence-ledger.zh-CN.md)（[English](long-run-evidence-ledger.md)） | 长程 loop 目标的问责记录——每个已关闭目标的墙钟、花费、验证结果与显式边界 |
 | [TUI](tui.zh-CN.md)（[English](tui.md)） | 终端界面（`future-tui`）：斜杠命令、键盘快捷键、设置 |
 | [目录布局](directory-layout.zh-CN.md)（[English](directory-layout.md)） | `~/.future/` 下各目录的职责（agent、channels、TUI、GUI、loop） |
 | [渠道配置](channels-config.zh-CN.md)（[English](channels-config.md)） | `~/.future/channels/config.json` 统一参考（agent / 飞书 / 钉钉 各块与默认值） |

--- a/docs/long-run-evidence-ledger.md
+++ b/docs/long-run-evidence-ledger.md
@@ -1,0 +1,157 @@
+# Long-Run Evidence Ledger
+
+> ([中文](long-run-evidence-ledger.zh-CN.md)) Accountability record for
+> long-range goals — multi-day, multi-turn efforts driven through the
+> [loop control plane](loop-control-plane.md). One entry per closed
+> long-range goal.
+
+A long-range goal spends real wall-clock time, tokens, and money across many
+bounded turns. This ledger exists so that each such effort leaves behind a
+factual, verifiable record: **how long it took, what it cost, what was
+validated, and — just as important — what was explicitly NOT done** (accepted
+residuals, waivers, scope exclusions). Entries are written at goal closure
+from primary sources, not from memory.
+
+## How to append an entry
+
+Data sources (all local, all verifiable):
+
+- **Turns / wall clock / spend** — the goal's run-history files under
+  `.future/loop/goals/<goal-id>/runs/*.json` (per-run `terminal_state`,
+  `tokens_in`, `tokens_out`, `cost`, tool-call count) and the compact
+  projection from `future loop runs history --goal <id> --format json` /
+  `future loop quota usage --goal <id>`.
+- **Validation** — the goal's official measurement (name the tool, command,
+  commit, and date), plus `future loop evidence-log --goal <id>`.
+- **PRs** — `git log --grep` over the goal's working window.
+- **Boundaries** — the goal's waiver / sign-off records (user gates,
+  acceptance todos) and anything a reader could otherwise mistake for an
+  omission.
+
+Entry schema:
+
+1. **Goal** — id, objective, closure date.
+2. **Wall clock & turns** — first-run → last-run timestamps, span, run
+   classifications (completed / error / incomplete).
+3. **Spend** — tokens in/out and cost as recorded by the run-history ledger,
+   with a per-turn breakdown.
+4. **Validation results** — the acceptance metric, baseline → final, how it
+   was verified.
+5. **Explicit boundaries** — scope exclusions, accepted residuals with their
+   sign-off, attribution limits of the data.
+6. **Lessons** — only durable, reusable ones (details live in FUTURE.md).
+
+---
+
+## Entry 2026-08-12 — Workspace test-coverage goal
+
+**Goal** `goal_4a742a954e3c` — drive the Rust workspace to ~100% line
+coverage (official metric: `cargo llvm-cov` summary **Lines**, per crate +
+TOTAL) via per-crate test pushes, then reconcile and accept the residual.
+Closed 2026-08-12 with user sign-off on the waiver inventory.
+
+### Wall clock & turns
+
+- First run: 2026-08-09 23:05 (+08:00) — last run: 2026-08-12 10:21 (+08:00).
+- **Span: ~59.3 hours (2 days 11 h 16 m).**
+- **10 bounded runs**: 7 completed, 2 error, 1 incomplete. Every errored /
+  incomplete push was retried to completion within the goal.
+- 14 ledger todos (6 crate pushes, tooling + baseline, cli residual,
+  acceptance, user gate, deliverables, onboarding; 2 superseded).
+
+### Spend (as recorded by the run-history ledger)
+
+Totals: **1,777,043,598 tokens in / 3,562,578 tokens out / ≈ $1,946.84**,
+5,979 tool calls.
+
+| # | Started (+08:00) | State | Focus | Tokens in | Tokens out | Cost (USD) | Tools |
+|---|---|---|---|---|---|---|---|
+| 1 | 08-09 23:05 | completed | `scripts/coverage.sh` tooling + workspace baseline (PR #138) | 2,076,302 | 31,272 | 4.39 | 94 |
+| 2 | 08-10 00:06 | completed | future-rpc → 100% (PR #139) | 20,874,338 | 192,220 | 32.56 | 214 |
+| 3 | 08-10 07:21 | error | future-tui push, attempt (redone in turn 4) | 837,524,085 | 1,121,310 | 880.04 | 1,824 |
+| 4 | 08-10 13:03 | completed | future-tui → 100% (PRs #140, #141) | 33,663,407 | 152,044 | 44.66 | 270 |
+| 5 | 08-10 14:30 | error | future-cli push (dual-executor collision; landed via the concurrent session, PRs #146, #147) | 71,805,042 | 322,458 | 89.42 | 493 |
+| 6 | 08-11 03:12 | completed | future-agent → 96.75% (PR #149) | 547,793,935 | 769,548 | 577.46 | 1,450 |
+| 7 | 08-11 06:09 | incomplete | future-channels push (continued in turn 8) | 167,851,903 | 549,848 | 193.99 | 842 |
+| 8 | 08-11 07:34 | completed | future-channels → 100% lcov DA (PR #150) | 81,609,442 | 310,002 | 101.68 | 546 |
+| 9 | 08-11 08:27 | completed | final acceptance measurement + waiver reconciliation | 13,305,340 | 95,796 | 20.62 | 220 |
+| 10 | 08-12 10:21 | completed | deliverables (`coverage/`) + gate method (FUTURE.md) | 539,804 | 18,080 | 2.03 | 26 |
+
+### Validation results
+
+Official measurement: single workspace run of `scripts/coverage.sh` on
+`main@b24d5501` (2026-08-12) — **regions 98.26% / functions 98.03% /
+lines 98.80%**, **3,864 tests, 0 failures**.
+
+| Crate | Baseline @4d3dd2fc (lines) | Final (summary Lines; missed) | PRs |
+|---|---|---|---|
+| future-rpc | 91.77% | 99.79% (7 summary / 0 per-line) | #139 |
+| future-tui | 67.80% | 100.00% (0) | #140, #141 |
+| future-cli | 42.46% | 99.83% (40 summary / 15 per-line) | #146, #147 |
+| future-loop | 77.72% | 98.43% (279 summary / 191 per-line) | #148 |
+| future-agent | 84.44% | 96.75% (987 summary / 700 per-line) | #149 |
+| future-channels | 31.50% | 99.84% (17 summary / 0 per-line; lcov DA 100%) | #150 |
+| **TOTAL** | **70.15%** (54,559/77,775) | **98.80%** | — |
+
+Tests: 2,173 → 3,864 (+1,691). Merged PRs: 10 — #138 (tooling), six crate
+pushes (#139; #140+#141; #146+#147; #148; #149; #150), #151 (flake
+hardening).
+
+Residual reconciliation: summary-missed 1,330 lines = **906 real + 424
+phantom** (the summary counts per function record; per-line tools max-merge
+across generic instantiations). The 906 real missed lines = 446
+non-executable attribution artifacts (365 closing braces, 74 line-1 anchors,
+7 comments) + ~460 defensive / dead-arm lines, cross-validated as lcov DA
+zero-hit = HTML uncovered-line.
+
+Defects found by the push: **6 real bugs** — 4 in future-loop (#148:
+`doctor --agent-addr` and `benchmark run --agent-addr` nested-`block_on`
+panics, monitor no-change poll appending spurious `TodoCompleted`,
+`try_claim_todo` reconstruction missing the expiry arm), 1 in
+future-channels (#150: gRPC client `entry_id` shadowing), 1 in future-cli
+(CDP dispatch-loop subscribe race) — plus **2 flake root causes** fixed in
+#151 (spawn_mock port-steal race, `resolve_future_base_url` env leak).
+
+### Explicit boundaries
+
+- **Scope was the Rust workspace only.** `desktop/src-tauri` (~9,753
+  baseline uncovered lines), the desktop frontend, and mobile were never in
+  scope for this goal.
+- **The gated metric is summary Lines**; regions (98.26%) and functions
+  (98.03%) are reported but not gated at 100%.
+- **The 906 real residual lines are accepted, not forgotten**: waiver
+  categories W1–W8 (platform `cfg(windows)` / defensive-dead arms /
+  OS-failure injection / race windows / attribution artifacts / summary
+  phantoms / test-mock closures / dead producers) signed off by the user via
+  gate todo_01368ac862e2 on 2026-08-11; full inventory in
+  `coverage/acceptance-waivers.md`. Forcing them covered would mean deleting
+  defensive code, adding prod `cfg(test)` hooks, or nightly-only
+  `#[no_coverage]` — explicitly rejected.
+- **424 phantom summary lines cannot be printed by any per-line tool**
+  (verified immovable by tests); per-line truth = lcov DA zero-hit / HTML
+  uncovered-line.
+- **Deliverables are local-only**: `coverage/` (lcov.info, html/,
+  summary.txt, missed-lines.txt, acceptance-waivers.md) is gitignored by
+  design per `scripts/coverage.sh`.
+- **Attribution limits**: run-history spend covers only the 10 loop runs.
+  The future-loop push (PR #148) and the future-cli residual (PRs #146/#147)
+  were executed partly by a concurrent interactive session sharing the
+  worktrees (dual-executor collision), so their spend is not metered above.
+  Token counts are cumulative-context tokens as recorded per run, not unique
+  tokens; errored/incomplete runs' partial spend is included in totals.
+
+### Lessons
+
+- Sanitize the environment before any official measurement (unset `CARGO*`,
+  rustup toolchain bin first in PATH, isolated `HOME`) — unit-hash desync
+  and auth-file leaks otherwise corrupt counts.
+- A summary "missed line" is real iff ALL regions on it are zero; always
+  cross-check with per-line tools before chasing lines.
+- Two executors on one goal need disjoint file sets + early/often commits;
+  an untracked `COORDINATION-NOTE.md` in the shared worktree worked.
+- Full-suite-only flakes: re-run the failed test standalone under the same
+  sanitized env — both occurrences here were real defects, not noise.
+
+---
+
+*Next entry: append below this line when the next long-range goal closes.*

--- a/docs/long-run-evidence-ledger.zh-CN.md
+++ b/docs/long-run-evidence-ledger.zh-CN.md
@@ -1,0 +1,146 @@
+# 长程运行证据台账
+
+> （[English](long-run-evidence-ledger.md)）长程目标的问责记录——经
+> [Loop 控制面](loop-control-plane.zh-CN.md)驱动的多日、多 turn
+> 工作。每个关闭的长程目标在此留一条记录。
+
+长程目标会在多个有界 turn 中消耗真实的墙钟时间、token 和费用。本台账
+的意义在于：每个这样的工作都留下一份**事实性、可核验**的记录——
+**花了多久、花了多少、验证了什么，以及同样重要的——明确没有做什么**
+（已接受的残差、豁免、范围排除）。条目在目标关闭时依据一手数据源
+填写，而非凭记忆。
+
+## 如何追加条目
+
+数据源（全部本地、全部可核验）：
+
+- **turn / 墙钟 / 花费**——目标运行历史文件
+  `.future/loop/goals/<goal-id>/runs/*.json`（每次运行的
+  `terminal_state`、`tokens_in`、`tokens_out`、`cost`、工具调用数），
+  以及 `future loop runs history --goal <id> --format json` /
+  `future loop quota usage --goal <id>` 的紧凑投影。
+- **验证**——目标的官方测量（写明工具、命令、commit、日期），以及
+  `future loop evidence-log --goal <id>`。
+- **PR**——在目标工作窗口内 `git log --grep`。
+- **边界**——目标的豁免/签收记录（用户门禁、验收 todo），以及任何
+  读者可能误认为是遗漏的事项。
+
+条目结构：
+
+1. **目标**——id、目标内容、关闭日期。
+2. **墙钟与 turn**——首跑→末跑时间戳、跨度、运行分类
+   （completed / error / incomplete）。
+3. **花费**——运行历史台账记录的 token 入/出与费用，含逐 turn 明细。
+4. **验证结果**——验收指标、基线→最终、验证方式。
+5. **显式边界**——范围排除、已签收的残差、数据本身的归因限制。
+6. **教训**——只记耐久可复用的（细节在 FUTURE.md）。
+
+---
+
+## 条目 2026-08-12 —— workspace 测试覆盖率目标
+
+**目标** `goal_4a742a954e3c`——通过逐 crate 补测试把 Rust workspace
+推到约 100% 行覆盖（官方指标：`cargo llvm-cov` summary 的 **Lines**
+列，分 crate + 总计），然后对账残差并验收。2026-08-12 关闭，豁免清单
+经用户签收。
+
+### 墙钟与 turn
+
+- 首跑：2026-08-09 23:05（+08:00）——末跑：2026-08-12 10:21（+08:00）。
+- **跨度：约 59.3 小时（2 天 11 小时 16 分）。**
+- **10 次有界运行**：7 completed、2 error、1 incomplete。每个
+  error/incomplete 的推进都在目标内重试至完成。
+- 台账共 14 个 todo（6 个 crate 推进、工具+基线、cli 收尾、验收、
+  用户门禁、交付物、onboarding；2 个被 supersede）。
+
+### 花费（按运行历史台账记录）
+
+合计：**输入 1,777,043,598 token / 输出 3,562,578 token /
+约 $1,946.84**，5,979 次工具调用。
+
+| # | 开始（+08:00） | 状态 | 内容 | 输入 token | 输出 token | 费用（USD） | 工具 |
+|---|---|---|---|---|---|---|---|
+| 1 | 08-09 23:05 | completed | `scripts/coverage.sh` 工具 + workspace 基线（PR #138） | 2,076,302 | 31,272 | 4.39 | 94 |
+| 2 | 08-10 00:06 | completed | future-rpc → 100%（PR #139） | 20,874,338 | 192,220 | 32.56 | 214 |
+| 3 | 08-10 07:21 | error | future-tui 推进，未遂（turn 4 重做） | 837,524,085 | 1,121,310 | 880.04 | 1,824 |
+| 4 | 08-10 13:03 | completed | future-tui → 100%（PR #140、#141） | 33,663,407 | 152,044 | 44.66 | 270 |
+| 5 | 08-10 14:30 | error | future-cli 推进（双执行器冲突；由并发会话落地，PR #146、#147） | 71,805,042 | 322,458 | 89.42 | 493 |
+| 6 | 08-11 03:12 | completed | future-agent → 96.75%（PR #149） | 547,793,935 | 769,548 | 577.46 | 1,450 |
+| 7 | 08-11 06:09 | incomplete | future-channels 推进（turn 8 继续） | 167,851,903 | 549,848 | 193.99 | 842 |
+| 8 | 08-11 07:34 | completed | future-channels → lcov DA 100%（PR #150） | 81,609,442 | 310,002 | 101.68 | 546 |
+| 9 | 08-11 08:27 | completed | 最终验收测量 + 豁免对账 | 13,305,340 | 95,796 | 20.62 | 220 |
+| 10 | 08-12 10:21 | completed | 交付物（`coverage/`）+ 门禁方法（FUTURE.md） | 539,804 | 18,080 | 2.03 | 26 |
+
+### 验证结果
+
+官方测量：2026-08-12 在 `main@b24d5501` 上单次全量运行
+`scripts/coverage.sh`——**regions 98.26% / functions 98.03% /
+lines 98.80%**，**3,864 个测试，0 失败**。
+
+| Crate | 基线 @4d3dd2fc（lines） | 最终（summary Lines； missed 数） | PR |
+|---|---|---|---|
+| future-rpc | 91.77% | 99.79%（summary 7 / per-line 0） | #139 |
+| future-tui | 67.80% | 100.00%（0） | #140、#141 |
+| future-cli | 42.46% | 99.83%（summary 40 / per-line 15） | #146、#147 |
+| future-loop | 77.72% | 98.43%（summary 279 / per-line 191） | #148 |
+| future-agent | 84.44% | 96.75%（summary 987 / per-line 700） | #149 |
+| future-channels | 31.50% | 99.84%（summary 17 / per-line 0；lcov DA 100%） | #150 |
+| **总计** | **70.15%**（54,559/77,775） | **98.80%** | — |
+
+测试数：2,173 → 3,864（+1,691）。合并 PR 共 10 个：#138（工具）、
+六个 crate 推进（#139；#140+#141；#146+#147；#148；#149；#150）、
+#151（flake 加固）。
+
+残差对账：summary missed 1,330 行 = **真实 906 + 幻影 424**（summary
+按函数记录计数；per-line 工具对泛型实例做 max 合并）。906 真实 missed
+= 446 行不可执行的归因伪影（365 个闭括号、74 个行首锚点、7 个注释）
++ ~460 行防御性/死 arm 代码，并经 lcov DA 零命中 = HTML uncovered-line
+交叉验证。
+
+推进中发现的真实缺陷：**6 个真 bug**——future-loop 4 个（#148：
+`doctor --agent-addr` 与 `benchmark run --agent-addr` 嵌套 `block_on`
+panic、monitor 无变化轮询追加伪 `TodoCompleted`、`try_claim_todo`
+重建漏掉过期 arm）、future-channels 1 个（#150：gRPC client
+`entry_id` 遮蔽）、future-cli 1 个（CDP 分发循环订阅竞态）——另有
+**2 个 flake 根因**在 #151 修复（spawn_mock 抢端口竞态、
+`resolve_future_base_url` 环境泄漏）。
+
+### 显式边界
+
+- **范围仅限 Rust workspace。** `desktop/src-tauri`（基线约 9,753 行
+  未覆盖）、desktop 前端、mobile 均不在本目标范围内。
+- **门禁指标是 summary Lines**；regions（98.26%）与 functions
+  （98.03%）如实报告但不按 100% 门禁。
+- **906 行真实残差是"经签收接受"，不是遗忘**：豁免类别 W1–W8
+  （平台 `cfg(windows)` / 防御性死 arm / OS 故障注入 / 竞态窗口 /
+  归因伪影 / summary 幻影 / 测试 mock 闭包 / 死生产者）已于
+  2026-08-11 经用户门禁 todo_01368ac862e2 签收；完整清单见
+  `coverage/acceptance-waivers.md`。强行覆盖意味着删除防御性代码、
+  在生产代码加 `cfg(test)` 钩子、或使用仅限 nightly 的
+  `#[no_coverage]`——已明确否决。
+- **424 行幻影 summary 行无法被任何 per-line 工具打印**（已验证测试
+  无法移动）；per-line 真相 = lcov DA 零命中 / HTML uncovered-line。
+- **交付物仅本地**：`coverage/`（lcov.info、html/、summary.txt、
+  missed-lines.txt、acceptance-waivers.md）按 `scripts/coverage.sh`
+  的设计被 gitignore。
+- **归因限制**：运行历史花费只覆盖 10 次 loop 运行。future-loop 推进
+  （PR #148）与 future-cli 收尾（PR #146/#147）部分由共享 worktree
+  的并发交互会话执行（双执行器冲突），其花费未计入上表。token 数为
+  台账按次记录的累计上下文 token，非去重 token；error/incomplete
+  运行的部分花费已计入合计。
+
+### 教训
+
+- 任何官方测量前先净化环境（unset 所有 `CARGO*` 变量、rustup
+  工具链 bin 置于 PATH 最前、隔离 `HOME`）——否则 unit-hash 错位
+  与 auth 文件泄漏会污染计数。
+- summary 的 "missed line" 为真当且仅当该行所有 region 均为零；
+  追行之前务必用 per-line 工具交叉核对。
+- 一个目标上的两个执行器需要不相交的文件集 + 早提交/勤提交；共享
+  worktree 里放一份未跟踪的 `COORDINATION-NOTE.md` 有效。
+- 只在全量运行时出现的 flake：在相同净化环境下单独重跑该测试——
+  本次两例都是真实缺陷，不是噪声。
+
+---
+
+*下一条目：下一个长程目标关闭时追加在此行之下。*


### PR DESCRIPTION
## What

LoopX 对比改进项 ⑥（长程证据台账）: add `docs/long-run-evidence-ledger.md` (zh-CN synced) — an accountability record for long-range loop goals, plus the first entry with the coverage goal's measured data. Indexed from `docs/README.md` / `README.zh-CN.md`.

## Ledger page

- **Purpose**: every long-range (multi-day, multi-turn) goal leaves a factual, verifiable record at closure — wall clock, spend, validation results, and **explicit boundaries** (accepted residuals, waivers, scope exclusions).
- **Data sources documented**: run-history JSON files, `runs history`/`quota usage` projections, `evidence-log`, `git log`, waiver/gate records.
- **Entry schema** for future appends.

## First entry: coverage goal `goal_4a742a954e3c` (closed 2026-08-12)

- **Wall clock**: 2026-08-09 23:05 → 2026-08-12 10:21 (+08:00) ≈ **59.3 h**; **10 runs** (7 completed / 2 error / 1 incomplete), every failure retried to completion.
- **Spend** (ledger-recorded): **1,777,043,598 tok in / 3,562,578 tok out / ≈ $1,946.84**, 5,979 tool calls — with a per-turn breakdown table.
- **Validation**: official `scripts/coverage.sh` run on `main@b24d5501` — regions 98.26% / functions 98.03% / **lines 98.80%**, 3,864 tests 0 failures; per-crate baseline→final table (TOTAL lines 70.15% → 98.80%, tests 2,173 → 3,864); 10 merged PRs (#138–#151).
- **Reconciliation**: summary-missed 1,330 = 906 real + 424 phantom; 906 = 446 attribution artifacts + ~460 defensive/dead-arm lines.
- **Found by the push**: 6 real bugs + 2 flake root causes.
- **Explicit boundaries**: Rust workspace only (desktop/mobile out of scope); summary-Lines is the gated metric; 906 real residual lines accepted under user-signed W1–W8 waivers; `coverage/` deliverables local-only by design; spend attribution excludes the concurrent interactive session (dual-executor collision).

## Checks

Docs-only change (2 new pages + 2 index rows) — no Rust/TS code touched, so fmt/clippy/tsc are unaffected and CI's change filters skip those jobs. All intra-doc links verified to resolve.