### PR TITLE
feat(loop): P0-1 workspace_guard — multi-agent shared-workspace write-conflict protection

### DIFF
--- a/orchestration/loop/src/agents/mod.rs
+++ b/orchestration/loop/src/agents/mod.rs
@@ -1,10 +1,12 @@
 //! agents subdomain (G-16/G-24) — single-process multi-agent reservation:
 //! identity-scoped frontiers (scope), lane recommendations (lane), the
-//! supervisor proposal/receipt event surface (supervisor), and the
-//! capability gate binding agent capabilities to todo runnability
-//! (capability_gate). Cross-process A2A stays a contract-schema concern.
+//! supervisor proposal/receipt event surface (supervisor), the capability
+//! gate binding agent capabilities to todo runnability (capability_gate),
+//! and the workspace guard against shared-workspace write conflicts
+//! (workspace_guard). Cross-process A2A stays a contract-schema concern.
 
 pub mod capability_gate;
 pub mod lane;
 pub mod scope;
 pub mod supervisor;
+pub mod workspace_guard;

--- a/orchestration/loop/src/agents/workspace_guard.rs
+++ b/orchestration/loop/src/agents/workspace_guard.rs
@@ -1,0 +1,339 @@
+//! Agent workspace guard (P0-1) — LoopX
+//! `control_plane/agents/workspace_guard.py`, natively. Multi-agent
+//! shared-workspace write-conflict protection: registered agents declare
+//! the workspace path set they write into; claiming a todo while a peer
+//! holds a live lease in an overlapping workspace is a conflict — the
+//! claim degrades to serial (refused with a retry hint) unless the caller
+//! passes an explicit `--force`.
+//!
+//! The guard is ADVISORY and fail-open: an agent that declares no
+//! workspaces cannot be assessed and never blocks (legacy peers keep
+//! working). Every successful claim by a workspace-declaring agent also
+//! appends a `WorkspaceLockAcquired` ledger event so `agent list` can show
+//! who occupies which paths.
+
+use crate::state::Goal;
+
+pub const WORKSPACE_GUARD_SCHEMA_VERSION: &str = "agent_workspace_guard_v1";
+
+/// Expand a leading `~` to the user's home directory (HOME, else
+/// USERPROFILE on Windows). Anything else is returned unchanged.
+fn expand_home(raw: &str) -> String {
+    if raw == "~" || raw.starts_with("~/") || raw.starts_with("~\\") {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_default();
+        if !home.is_empty() {
+            return format!("{}{}", home, &raw[1..]);
+        }
+    }
+    raw.to_string()
+}
+
+/// Lexically normalize a path (resolve `.`/`..` components, drop trailing
+/// separators) WITHOUT touching the filesystem — the fallback for
+/// workspace paths that do not exist yet.
+fn lexical_normalize(path: &std::path::Path) -> String {
+    use std::path::Component;
+    let mut out = std::path::PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Keep leading `..` on relative paths; otherwise pop.
+                if !out.pop() {
+                    out.push(comp.as_os_str());
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
+
+/// Normalize a declared workspace path for storage: expand `~`, absolutize
+/// against the process cwd, canonicalize when the path exists (resolves
+/// symlinks such as /tmp → /private/tmp on macOS), otherwise fall back to
+/// lexical normalization. Storage stays a plain string so replay is
+/// platform-agnostic.
+pub fn normalize_workspace_path(raw: &str) -> String {
+    let expanded = expand_home(raw.trim());
+    let path = std::path::PathBuf::from(expanded);
+    let abs = if path.is_absolute() {
+        path
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(path),
+            Err(_) => path,
+        }
+    };
+    if let Ok(canon) = abs.canonicalize() {
+        return canon.to_string_lossy().into_owned();
+    }
+    lexical_normalize(&abs)
+}
+
+/// True when two workspace paths overlap: equal, or one is an ancestor of
+/// the other. Component-aware, so `/repo/a` never overlaps `/repo/ab`
+/// while `/repo/a` and `/repo/a/sub` do.
+pub fn paths_overlap(a: &str, b: &str) -> bool {
+    let pa = std::path::Path::new(a);
+    let pb = std::path::Path::new(b);
+    pa == pb || pa.starts_with(pb) || pb.starts_with(pa)
+}
+
+/// One live workspace conflict: another registered agent holds a live
+/// lease while its declared workspace set overlaps the claimer's.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WorkspaceConflict {
+    pub schema_version: String,
+    /// The OTHER agent currently occupying the overlapping workspace.
+    pub holder_agent_id: String,
+    /// Todos the holder owns under a live lease right now.
+    pub holder_todo_ids: Vec<String>,
+    /// Holder workspace paths that overlap the claimer's set.
+    pub overlapping_paths: Vec<String>,
+    /// Earliest live-lease expiry of the holder — the serial retry hint
+    /// ("rerun after this epoch, or pass --force").
+    pub holder_lease_expires_at: u64,
+}
+
+/// The declared workspace set of an agent (empty = undeclared → guard is
+/// fail-open for that agent).
+pub fn agent_workspaces(goal: &Goal, agent_id: &str) -> Vec<String> {
+    goal.agent_profiles
+        .iter()
+        .find(|p| p.id == agent_id)
+        .map(|p| p.workspaces.clone())
+        .unwrap_or_default()
+}
+
+/// Compute the live workspace conflicts for `agent_id` claiming work at
+/// `now`: every OTHER registered agent that (a) declares workspaces,
+/// (b) holds at least one live lease, and (c) whose declared set overlaps
+/// the claimer's. Empty = safe to claim. Fail-open: an empty claimer set
+/// yields no conflicts (nothing to compare against).
+pub fn live_workspace_conflicts(goal: &Goal, agent_id: &str, now: u64) -> Vec<WorkspaceConflict> {
+    let mine = agent_workspaces(goal, agent_id);
+    if mine.is_empty() {
+        return vec![];
+    }
+    let mut conflicts = vec![];
+    for profile in &goal.agent_profiles {
+        if profile.id == agent_id || profile.workspaces.is_empty() {
+            continue;
+        }
+        let mut held: Vec<&crate::state::Todo> = goal
+            .todos
+            .iter()
+            .filter(|t| {
+                t.claimed_by.as_deref() == Some(profile.id.as_str())
+                    && t.lease_expires_at.map(|e| e > now).unwrap_or(false)
+            })
+            .collect();
+        if held.is_empty() {
+            continue;
+        }
+        let overlapping: Vec<String> = profile
+            .workspaces
+            .iter()
+            .filter(|w| mine.iter().any(|m| paths_overlap(m, w)))
+            .cloned()
+            .collect();
+        if overlapping.is_empty() {
+            continue;
+        }
+        held.sort_by(|a, b| a.id.cmp(&b.id));
+        let earliest = held
+            .iter()
+            .filter_map(|t| t.lease_expires_at)
+            .min()
+            .unwrap_or(now);
+        conflicts.push(WorkspaceConflict {
+            schema_version: WORKSPACE_GUARD_SCHEMA_VERSION.to_string(),
+            holder_agent_id: profile.id.clone(),
+            holder_todo_ids: held.iter().map(|t| t.id.clone()).collect(),
+            overlapping_paths: overlapping,
+            holder_lease_expires_at: earliest,
+        });
+    }
+    conflicts.sort_by(|a, b| a.holder_agent_id.cmp(&b.holder_agent_id));
+    conflicts
+}
+
+/// Render conflicts as a human report for CLI refusal messages (the
+/// serial-degradation hint: wait for the holder's lease, or force).
+pub fn render_conflicts(conflicts: &[WorkspaceConflict], now: u64) -> String {
+    let mut out = String::new();
+    for c in conflicts {
+        let wait = c.holder_lease_expires_at.saturating_sub(now);
+        out.push_str(&format!(
+            "  ⚠ agent `{}` is writing {} (todos: {}; lease expires in {}s)\n",
+            c.holder_agent_id,
+            c.overlapping_paths.join(", "),
+            c.holder_todo_ids.join(", "),
+            wait
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{AgentProfile, Goal, Todo};
+
+    fn goal_with(agents: &[(&str, Vec<&str>)], todos: Vec<Todo>) -> Goal {
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        for (id, ws) in agents {
+            goal.registered_agents.push(id.to_string());
+            goal.agent_profiles.push(AgentProfile {
+                id: id.to_string(),
+                capabilities: vec![],
+                workspaces: ws.iter().map(|s| s.to_string()).collect(),
+            });
+        }
+        goal.todos = todos;
+        goal
+    }
+
+    fn claimed(todo_id: &str, holder: &str, expires_at: u64) -> Todo {
+        let mut t = Todo::advancement(todo_id, "work");
+        t.claimed_by = Some(holder.to_string());
+        t.lease_expires_at = Some(expires_at);
+        t
+    }
+
+    // ── path normalization ───────────────────────────────────────────────
+
+    #[test]
+    fn normalize_absolutizes_relative_paths_against_cwd() {
+        let cwd = std::env::current_dir().unwrap();
+        let got = normalize_workspace_path("sub/dir");
+        let canon = cwd.canonicalize().unwrap_or(cwd.clone());
+        assert_eq!(got, format!("{}/sub/dir", canon.to_string_lossy()));
+    }
+
+    #[test]
+    fn normalize_resolves_dot_components_lexically() {
+        // Path that cannot exist → lexical fallback resolves `a/./b` and `..`.
+        let got = normalize_workspace_path("/definitely/not/here/./x/../y");
+        assert_eq!(got, "/definitely/not/here/y");
+    }
+
+    #[test]
+    fn normalize_expands_home_tilde() {
+        let home = std::env::var("HOME").unwrap_or_default();
+        if home.is_empty() {
+            return; // no HOME on this host (CI Windows) — nothing to assert
+        }
+        let got = normalize_workspace_path("~/some-workspace");
+        assert!(!got.contains('~'), "tilde must expand: {got}");
+        assert!(got.ends_with("/some-workspace"), "got: {got}");
+    }
+
+    // ── overlap semantics ────────────────────────────────────────────────
+
+    #[test]
+    fn overlap_is_component_boundary_aware() {
+        assert!(paths_overlap("/repo/wt1", "/repo/wt1"));
+        assert!(paths_overlap("/repo/wt1", "/repo/wt1/src"));
+        assert!(paths_overlap("/repo/wt1/src", "/repo/wt1"));
+        assert!(!paths_overlap("/repo/wt1", "/repo/wt12"));
+        assert!(!paths_overlap("/repo/wt1", "/repo/wt2"));
+    }
+
+    // ── conflict computation ─────────────────────────────────────────────
+
+    #[test]
+    fn conflict_when_peer_holds_live_lease_in_overlapping_workspace() {
+        let goal = goal_with(
+            &[
+                ("agent-a", vec!["/repo/wt1"]),
+                ("agent-b", vec!["/repo/wt1"]),
+            ],
+            vec![claimed("t1", "agent-b", 2000)],
+        );
+        let conflicts = live_workspace_conflicts(&goal, "agent-a", 1000);
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        assert_eq!(c.holder_agent_id, "agent-b");
+        assert_eq!(c.holder_todo_ids, vec!["t1"]);
+        assert_eq!(c.overlapping_paths, vec!["/repo/wt1"]);
+        assert_eq!(c.holder_lease_expires_at, 2000);
+        assert_eq!(c.schema_version, WORKSPACE_GUARD_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn no_conflict_when_peer_lease_expired_or_peer_idle() {
+        // Expired lease → free again.
+        let goal = goal_with(
+            &[
+                ("agent-a", vec!["/repo/wt1"]),
+                ("agent-b", vec!["/repo/wt1"]),
+            ],
+            vec![claimed("t1", "agent-b", 500)],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+        // Registered but holding nothing → no occupancy.
+        let goal = goal_with(
+            &[
+                ("agent-a", vec!["/repo/wt1"]),
+                ("agent-b", vec!["/repo/wt1"]),
+            ],
+            vec![],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+    }
+
+    #[test]
+    fn no_conflict_for_disjoint_workspaces_or_self_claim() {
+        // Disjoint sets never conflict.
+        let goal = goal_with(
+            &[
+                ("agent-a", vec!["/repo/wt1"]),
+                ("agent-b", vec!["/repo/wt2"]),
+            ],
+            vec![claimed("t1", "agent-b", 2000)],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+        // The claimer's own live todos never conflict with itself.
+        let goal = goal_with(
+            &[("agent-a", vec!["/repo/wt1"])],
+            vec![claimed("t1", "agent-a", 2000)],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+    }
+
+    #[test]
+    fn undeclared_workspace_is_fail_open() {
+        // Claimer declares nothing → cannot assess → no conflict.
+        let goal = goal_with(
+            &[("agent-a", vec![]), ("agent-b", vec!["/repo/wt1"])],
+            vec![claimed("t1", "agent-b", 2000)],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+        // Holder declares nothing → advisory guard stays silent.
+        let goal = goal_with(
+            &[("agent-a", vec!["/repo/wt1"]), ("agent-b", vec![])],
+            vec![claimed("t1", "agent-b", 2000)],
+        );
+        assert!(live_workspace_conflicts(&goal, "agent-a", 1000).is_empty());
+    }
+
+    #[test]
+    fn render_lists_holder_paths_and_serial_hint() {
+        let goal = goal_with(
+            &[
+                ("agent-a", vec!["/repo/wt1"]),
+                ("agent-b", vec!["/repo/wt1"]),
+            ],
+            vec![claimed("t1", "agent-b", 2000)],
+        );
+        let conflicts = live_workspace_conflicts(&goal, "agent-a", 1000);
+        let text = render_conflicts(&conflicts, 1000);
+        assert!(text.contains("agent-b"), "got: {text}");
+        assert!(text.contains("/repo/wt1"), "got: {text}");
+        assert!(text.contains("1000s"), "wait hint missing: {text}");
+    }
+}

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -289,7 +289,7 @@ fn build_cli_registry() -> CommandRegistry {
         todo,
         "lease",
         "task lease lifecycle (claim/renew/release/expire/status)",
-        "lease claim|renew|release|expire|status --goal G --todo-id T [--agent-id A] [--format json (status)]",
+        "lease claim|renew|release|expire|status --goal G --todo-id T [--agent-id A] [--force (claim)] [--format json (status)]",
     );
     r.command(
         todo,
@@ -302,8 +302,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         agent,
         "agent",
-        "register/onboard agents",
-        "agent onboard --goal G --agent-id A [--capabilities c1,c2]",
+        "register/onboard agents (declare capabilities + workspaces)",
+        "agent onboard --goal G --agent-id A [--capabilities c1,c2] [--workspace p1,p2]",
     );
     r.command(
         agent,
@@ -468,7 +468,7 @@ fn build_cli_registry() -> CommandRegistry {
         ops,
         "run",
         "drive one bounded gRPC turn (requires --agent-id; auto-registers)",
-        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N]",
+        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N] [--force-workspace]",
     );
 
     let work_items = r.group("work-items", "attention / operator inbox (G-15)");
@@ -1045,12 +1045,23 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
     let mut todo_id = None;
     let mut agent_id = None;
     let mut lease_secs = 3600u64;
-    reject_unknown_flags(args, &["--agent-id", "--goal", "--lease-secs", "--todo-id"])?;
+    let mut force = false;
+    reject_unknown_flags(
+        args,
+        &[
+            "--agent-id",
+            "--force",
+            "--goal",
+            "--lease-secs",
+            "--todo-id",
+        ],
+    )?;
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
         "--todo-id" => todo_id = Some(v),
         "--agent-id" => agent_id = Some(v),
         "--lease-secs" => lease_secs = v.parse().unwrap_or(3600),
+        "--force" => force = true,
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -1063,6 +1074,16 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
         bail!("agent `{agent}` is not registered for goal {goal_id} — `{} agent register --goal {goal_id} --agent-id {agent}` first", prog());
     }
     let now = crate::state::now_epoch();
+    // P0-1 workspace guard: refuse (degrade to serial) when a peer holds a
+    // live lease in an overlapping declared workspace, unless --force.
+    let conflicts = crate::agents::workspace_guard::live_workspace_conflicts(&goal, &agent, now);
+    if !conflicts.is_empty() && !force {
+        bail!(
+            "workspace conflict — claiming would race a peer writing the same workspace:\n{}\
+             degrade to serial: retry after the holder's lease expires, or pass --force",
+            crate::agents::workspace_guard::render_conflicts(&conflicts, now)
+        );
+    }
     let claimed = goal
         .todo_mut(&todo_id)
         .map(|t| t.claim(&agent, lease_secs, now))
@@ -1078,14 +1099,53 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
         lease_expires_at: expires,
         ts: now,
     })?;
+    append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
     refresh_next_action(store, &goal_id)?;
     sync_compat(store, &goal_id)?;
     println!("todo {todo_id} claimed by {agent} until epoch {expires} ✔");
     Ok(())
 }
 
-/// `loopx agent register --goal G --agent-id A` — register a peer (LoopX:
-/// coordination.registered_agents; precondition for quota --agent-id).
+/// P0-1: append the advisory write-lock record after a successful claim by
+/// a workspace-declaring agent (empty declared set → no record, the guard
+/// is fail-open). `goal` must be the pre-claim replay carrying the
+/// claimer's profile; `forced` marks a claim that overrode a conflict.
+fn append_workspace_lock(
+    store: &mut Store,
+    goal_id: &str,
+    agent_id: &str,
+    todo_id: &str,
+    goal: &Goal,
+    forced: bool,
+) -> Result<()> {
+    let paths = crate::agents::workspace_guard::agent_workspaces(goal, agent_id);
+    if paths.is_empty() {
+        return Ok(());
+    }
+    store.append(Event::WorkspaceLockAcquired {
+        goal_id: goal_id.to_string(),
+        agent_id: agent_id.to_string(),
+        todo_id: todo_id.to_string(),
+        paths,
+        forced,
+        ts: crate::state::now_epoch(),
+    })?;
+    Ok(())
+}
+
+/// Parse a `--workspace` flag value into normalized absolute paths
+/// (comma-separated, like `--capabilities`; empty entries dropped).
+fn parse_workspaces(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(crate::agents::workspace_guard::normalize_workspace_path)
+        .collect()
+}
+
+/// `loopx agent register --goal G --agent-id A [--workspace p1,p2]` —
+/// register a peer (LoopX: coordination.registered_agents; precondition for
+/// quota --agent-id). `--workspace` declares the P0-1 guard write set.
 fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
     if args.first().map(|s| s.as_str()) == Some("onboard") {
         return cmd_agent_onboard(store, &args[1..]);
@@ -1095,10 +1155,12 @@ fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
     }
     let mut goal_id = None;
     let mut agent_id = None;
-    reject_unknown_flags(args, &["--agent-id", "--goal"])?;
+    let mut workspaces = vec![];
+    reject_unknown_flags(args, &["--agent-id", "--goal", "--workspace"])?;
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
         "--agent-id" => agent_id = Some(v),
+        "--workspace" => workspaces = parse_workspaces(&v),
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -1109,22 +1171,35 @@ fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
     store.append(Event::AgentRegistered {
         goal_id: goal_id.clone(),
         agent_id: agent_id.clone(),
+        workspaces: workspaces.clone(),
         ts: crate::state::now_epoch(),
     })?;
-    println!("agent `{agent_id}` registered for {goal_id} ✔");
+    if workspaces.is_empty() {
+        println!("agent `{agent_id}` registered for {goal_id} ✔");
+    } else {
+        println!("agent `{agent_id}` registered for {goal_id} (workspaces={workspaces:?}) ✔");
+    }
     Ok(())
 }
 
-/// `loopx agent onboard --goal G --agent-id A [--capability shell,github]`
-/// — register a peer AND declare its capabilities (LoopX: agent_profiles;
-/// input to the capability gate).
+/// `loopx agent onboard --goal G --agent-id A [--capability shell,github]
+/// [--workspace p1,p2]` — register a peer AND declare its capabilities
+/// (LoopX: agent_profiles; input to the capability gate) plus the P0-1
+/// workspace-guard write set.
 fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut agent_id = None;
     let mut capabilities = vec![];
+    let mut workspaces = vec![];
     reject_unknown_flags(
         args,
-        &["--agent-id", "--capabilities", "--capability", "--goal"],
+        &[
+            "--agent-id",
+            "--capabilities",
+            "--capability",
+            "--goal",
+            "--workspace",
+        ],
     )?;
     parse_pairs(args, |k, v| match k {
         "--goal" => goal_id = Some(v),
@@ -1132,6 +1207,7 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
         "--capability" | "--capabilities" => {
             capabilities = v.split(',').map(|s| s.trim().to_string()).collect()
         }
+        "--workspace" => workspaces = parse_workspaces(&v),
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -1143,9 +1219,12 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
         goal_id: goal_id.clone(),
         agent_id: agent_id.clone(),
         capabilities: capabilities.clone(),
+        workspaces: workspaces.clone(),
         ts: crate::state::now_epoch(),
     })?;
-    println!("agent `{agent_id}` onboarded (capabilities={capabilities:?}) ✔");
+    println!(
+        "agent `{agent_id}` onboarded (capabilities={capabilities:?} workspaces={workspaces:?}) ✔"
+    );
     Ok(())
 }
 
@@ -1203,14 +1282,19 @@ fn cmd_agent_list(store: &Store, args: &[String]) -> Result<()> {
         goal.registered_agents.len()
     );
     println!(
-        "  {:<12} {:<8} {:<32} {:<14} {:<12}",
-        "agent_id", "status", "work-on", "capabilities", "last-active"
+        "  {:<12} {:<8} {:<28} {:<24} {:<14} {:<12}",
+        "agent_id", "status", "work-on", "workspaces", "capabilities", "last-active"
     );
     for row in &rows {
         let work_label = if row.work_on.is_empty() {
             "-".to_string()
         } else {
             row.work_on.join("; ")
+        };
+        let ws_label = if row.workspaces.is_empty() {
+            "-".to_string()
+        } else {
+            row.workspaces.join(",")
         };
         let caps = if row.capabilities.is_empty() {
             "-".to_string()
@@ -1222,9 +1306,28 @@ fn cmd_agent_list(store: &Store, args: &[String]) -> Result<()> {
             .map(|ts| format!("{} ago", human_dur(now.saturating_sub(ts))))
             .unwrap_or_else(|| "-".to_string());
         println!(
-            "  {:<12} {:<8} {:<32} {:<14} {:<12}",
-            row.agent_id, row.status, work_label, caps, last
+            "  {:<12} {:<8} {:<28} {:<24} {:<14} {:<12}",
+            row.agent_id, row.status, work_label, ws_label, caps, last
         );
+    }
+    // P0-1: live workspace conflicts — who occupies the paths you declared.
+    let mut any_conflict = false;
+    for row in &rows {
+        let conflicts =
+            crate::agents::workspace_guard::live_workspace_conflicts(&goal, &row.agent_id, now);
+        for c in &conflicts {
+            any_conflict = true;
+            println!(
+                "⚠ workspace conflict: {} ↔ {} share {} (holder lease expires in {})",
+                row.agent_id,
+                c.holder_agent_id,
+                c.overlapping_paths.join(", "),
+                human_dur(c.holder_lease_expires_at.saturating_sub(now))
+            );
+        }
+    }
+    if any_conflict {
+        println!("hint: conflicting claims need `--force` — or wait for the holder's lease");
     }
     println!(
         "hint: agent ids are goal-scoped; check this list before `agent register`/`onboard` \
@@ -1242,8 +1345,20 @@ struct AgentListRow {
     status: String,
     /// Human-readable live lease labels (todo id + remaining time).
     work_on: Vec<String>,
+    /// P0-1 declared workspace write set (display-shortened; a `✍` suffix
+    /// marks paths the agent currently occupies under a live lease).
+    workspaces: Vec<String>,
     capabilities: Vec<String>,
     last_active_ts: Option<u64>,
+}
+
+/// Shorten a workspace path for the agent-list table: `$HOME` → `~`.
+fn shorten_home(path: &str) -> String {
+    let home = std::env::var("HOME").unwrap_or_default();
+    if !home.is_empty() && path.starts_with(&home) {
+        return format!("~{}", &path[home.len()..]);
+    }
+    path.to_string()
 }
 
 /// Build the agent-list projection rows (event-derived last-active map +
@@ -1262,16 +1377,29 @@ fn agent_list_rows(goal: &Goal, last_active: &HashMap<String, u64>, now: u64) ->
                 }
             }
             let status = if work.is_empty() { "idle" } else { "running" };
-            let caps = goal
-                .agent_profiles
-                .iter()
-                .find(|p| p.id == *aid)
-                .map(|p| p.capabilities.clone())
+            let occupying = !work.is_empty();
+            let profile = goal.agent_profiles.iter().find(|p| p.id == *aid);
+            let caps = profile.map(|p| p.capabilities.clone()).unwrap_or_default();
+            let workspaces = profile
+                .map(|p| {
+                    p.workspaces
+                        .iter()
+                        .map(|w| {
+                            let short = shorten_home(w);
+                            if occupying {
+                                format!("{short} ✍")
+                            } else {
+                                short
+                            }
+                        })
+                        .collect()
+                })
                 .unwrap_or_default();
             AgentListRow {
                 agent_id: aid.clone(),
                 status: status.to_string(),
                 work_on: work,
+                workspaces,
                 capabilities: caps,
                 last_active_ts: last_active.get(aid).copied(),
             }
@@ -2226,7 +2354,10 @@ const DEFAULT_RUN_LEASE_SECS: u64 = 4 * 3600;
 /// nothing, so two agentless runs deterministically race on the same todo.
 /// An id that is not yet registered is auto-registered on first use (replay
 /// is idempotent, so `run` never needs a separate `agent register` step).
-/// `--anonymous` opts back into the legacy uncoordinated one-shot path.
+/// Auto-registration declares the process cwd as the agent's P0-1 workspace
+/// (parallel runs launched from the same checkout then trip the workspace
+/// guard instead of silently overwriting each other). `--anonymous` opts
+/// back into the legacy uncoordinated one-shot path.
 /// Returns the resolved agent id (None for `--anonymous`).
 pub fn ensure_run_identity(
     store: &mut Store,
@@ -2240,9 +2371,20 @@ pub fn ensure_run_identity(
                 .replay(goal_id)?
                 .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
             if !goal.is_registered_agent(Some(aid)) {
+                let cwd = std::env::current_dir()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                let workspaces = if cwd.is_empty() {
+                    vec![]
+                } else {
+                    vec![crate::agents::workspace_guard::normalize_workspace_path(
+                        &cwd,
+                    )]
+                };
                 store.append(Event::AgentRegistered {
                     goal_id: goal_id.to_string(),
                     agent_id: aid.to_string(),
+                    workspaces,
                     ts: now_epoch(),
                 })?;
                 println!("agent `{aid}` auto-registered for {goal_id} ✔");
@@ -2272,11 +2414,13 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut agent_id = None;
     let mut anonymous = false;
     let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
+    let mut force_workspace = false;
     reject_unknown_flags(
         args,
         &[
             "--agent-id",
             "--anonymous",
+            "--force-workspace",
             "--goal",
             "--lease-secs",
             "--max-turn-secs",
@@ -2294,6 +2438,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         "--agent-id" => agent_id = Some(v),
         "--lease-secs" => lease_secs = v.parse().unwrap_or(DEFAULT_RUN_LEASE_SECS),
         "--anonymous" => anonymous = true,
+        "--force-workspace" => force_workspace = true,
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -2329,6 +2474,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         lease_secs,
         agent_id.as_deref(),
         max_turn_secs,
+        force_workspace,
     )
     .await;
     if let Err(e) = client.delete_session(&session_id).await {
@@ -2509,6 +2655,7 @@ async fn run_turns(
     lease_secs: u64,
     agent_id: Option<&str>,
     max_turn_secs: u64,
+    force_workspace: bool,
 ) -> Result<()> {
     let mut turn = 0u32;
     loop {
@@ -2556,6 +2703,30 @@ async fn run_turns(
         }
 
         // bounded_delivery / monitor_poll: execute one turn.
+        // Claim with a lease BEFORE executing — atomically (check+append under
+        // one lock) so two concurrent `run --agent-id` workers can never both
+        // win the same todo; on contention, re-decide against the fresh
+        // ledger and pick the next runnable todo (up to 3 re-decides).
+        //
+        // P0-1 workspace guard: if a PEER agent holds a live lease in an
+        // overlapping declared workspace, degrade to serial — stop the run
+        // with a retry hint (the scheduler will relaunch later) unless the
+        // operator passed --force-workspace.
+        let mut workspace_conflict_forced = false;
+        if let Some(aid) = agent_id {
+            let now = crate::state::now_epoch();
+            let conflicts =
+                crate::agents::workspace_guard::live_workspace_conflicts(&goal, aid, now);
+            if !conflicts.is_empty() && !force_workspace {
+                bail!(
+                    "workspace conflict — running would race a peer writing the same workspace:\n{}\
+                     degrade to serial: rerun after the holder's lease expires, \
+                     or pass --force-workspace",
+                    crate::agents::workspace_guard::render_conflicts(&conflicts, now)
+                );
+            }
+            workspace_conflict_forced = !conflicts.is_empty() && force_workspace;
+        }
         let mut packet = packet;
         let Some(todo_id) =
             claim_selected_with_lease(store, goal_id, &mut packet, agent_id, lease_secs)?
@@ -2563,6 +2734,22 @@ async fn run_turns(
             println!("   no selected todo; stopping");
             break;
         };
+        // P0-1: record the advisory write lock for the claimed todo (audit
+        // trail for agent list / history). Best-effort against the
+        // turn-start replay — profiles rarely change mid-turn.
+        if let Some(aid) = agent_id {
+            let goal = store.replay(goal_id)?.ok_or_else(|| {
+                anyhow::anyhow!("goal {goal_id} not found (deleted while running?)")
+            })?;
+            append_workspace_lock(
+                store,
+                goal_id,
+                aid,
+                &todo_id,
+                &goal,
+                workspace_conflict_forced,
+            )?;
+        }
         let goal = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
@@ -2993,10 +3180,12 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
     let mut todo_id = None;
     let mut agent_id = None;
     let mut lease_secs = 0u64;
+    let mut force = false;
     reject_unknown_flags(
         &args[1..],
         &[
             "--agent-id",
+            "--force",
             "--format",
             "--goal",
             "--json",
@@ -3009,6 +3198,7 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
         "--todo-id" => todo_id = Some(v),
         "--agent-id" => agent_id = Some(v),
         "--lease-secs" => lease_secs = v.parse().unwrap_or(0),
+        "--force" => force = true,
         _ => {}
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -3044,6 +3234,20 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
         return Ok(());
     }
 
+    // P0-1 workspace guard (claim only): checked before the mutable todo
+    // borrow below; same conflict semantics as `todo claim`.
+    if sub == "claim" {
+        let conflicts =
+            crate::agents::workspace_guard::live_workspace_conflicts(&goal, &agent, now);
+        if !conflicts.is_empty() && !force {
+            bail!(
+                "workspace conflict — claiming would race a peer writing the same workspace:\n{}\
+                 degrade to serial: retry after the holder's lease expires, or pass --force",
+                crate::agents::workspace_guard::render_conflicts(&conflicts, now)
+            );
+        }
+    }
+
     let todo = goal
         .todo_mut(&todo_id)
         .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
@@ -3066,6 +3270,8 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
                     lease_expires_at: expires,
                     ts: now,
                 })?;
+                // P0-1: advisory workspace write lock (audit for agent list).
+                append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
             }
             let _ = sync_compat(store, &goal_id);
             println!(
@@ -5105,6 +5311,7 @@ fn event_touches_todo(event: &crate::store::Event, todo_id: &str) -> bool {
         | Event::TodoRenewed { todo_id: id, .. }
         | Event::TodoReleased { todo_id: id, .. }
         | Event::TodoExpired { todo_id: id, .. }
+        | Event::WorkspaceLockAcquired { todo_id: id, .. }
         | Event::GateResolved { todo_id: id, .. } => id == todo_id,
         Event::RunRecorded { record, .. } => record.todo_id == todo_id,
         _ => false,
@@ -5170,6 +5377,19 @@ fn describe_event(event: &crate::store::Event) -> String {
             return format!(
                 "agent_onboarded agent={agent_id} capabilities={}",
                 capabilities.join(",")
+            );
+        }
+        Event::WorkspaceLockAcquired {
+            agent_id,
+            todo_id,
+            paths,
+            forced,
+            ..
+        } => {
+            return format!(
+                "workspace_lock agent={agent_id} todo={todo_id} paths={}{}",
+                paths.join(","),
+                if *forced { " (forced)" } else { "" }
             );
         }
         Event::ReplanAcked { delta_kinds, .. } => {
@@ -6353,6 +6573,7 @@ mod cli_quirks_tests {
         goal.agent_profiles = vec![crate::state::AgentProfile {
             id: "alice".to_string(),
             capabilities: vec!["code".to_string()],
+            workspaces: vec![],
         }];
         let mut todo = Todo::advancement("t1", "work");
         todo.claimed_by = Some("alice".to_string());
@@ -6593,5 +6814,266 @@ mod cli_quirks_tests {
         assert_eq!(todo.status, crate::state::TodoStatus::Deferred);
         let deadline = todo.resume_when.expect("numeric sets a deadline");
         assert!(deadline >= before + std::time::Duration::from_secs(120));
+    }
+}
+
+// ── P0-1 workspace guard CLI contract tests ───────────────────────────────
+
+#[cfg(test)]
+mod workspace_guard_cli_tests {
+    use super::*;
+
+    fn tmp_store(tag: &str) -> Store {
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-p01-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        Store::open(dir.to_string_lossy().as_ref()).unwrap()
+    }
+
+    fn open_goal(store: &mut Store, goal_id: &str, todo_ids: &[&str]) {
+        let goal = Goal::new(goal_id, "objective", "/tmp");
+        store.register(&goal).unwrap();
+        let ts = goal.created_at;
+        store
+            .append(Event::GoalStarted {
+                goal_id: goal_id.into(),
+                ts,
+            })
+            .unwrap();
+        for id in todo_ids {
+            store
+                .append(Event::TodoAdded {
+                    goal_id: goal_id.into(),
+                    todo: Todo::advancement(id, "work"),
+                    ts,
+                })
+                .unwrap();
+        }
+    }
+
+    fn onboard(store: &mut Store, goal: &str, agent: &str, workspace: &str) {
+        cmd_agent_onboard(
+            store,
+            &[
+                "--goal".to_string(),
+                goal.to_string(),
+                "--agent-id".to_string(),
+                agent.to_string(),
+                "--workspace".to_string(),
+                workspace.to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    fn claim_args(goal: &str, todo: &str, agent: &str, extra: &[&str]) -> Vec<String> {
+        let mut v = vec![
+            "--goal".to_string(),
+            goal.to_string(),
+            "--todo-id".to_string(),
+            todo.to_string(),
+            "--agent-id".to_string(),
+            agent.to_string(),
+        ];
+        v.extend(extra.iter().map(|s| s.to_string()));
+        v
+    }
+
+    fn lock_events(store: &Store, goal: &str) -> Vec<(String, String, bool)> {
+        store
+            .events(goal)
+            .unwrap()
+            .iter()
+            .filter_map(|se| match &se.event {
+                Event::WorkspaceLockAcquired {
+                    agent_id,
+                    todo_id,
+                    forced,
+                    ..
+                } => Some((agent_id.clone(), todo_id.clone(), *forced)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn register_and_onboard_workspace_roundtrip_through_replay() {
+        let mut store = tmp_store("declare");
+        open_goal(&mut store, "g1", &[]);
+        cmd_agent(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--agent-id".to_string(),
+                "a1".to_string(),
+                "--workspace".to_string(),
+                "/definitely/not/here/wt1".to_string(),
+            ],
+        )
+        .unwrap();
+        onboard(&mut store, "g1", "a2", "/definitely/not/here/wt2");
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert_eq!(
+            crate::agents::workspace_guard::agent_workspaces(&goal, "a1"),
+            vec!["/definitely/not/here/wt1".to_string()]
+        );
+        assert_eq!(
+            crate::agents::workspace_guard::agent_workspaces(&goal, "a2"),
+            vec!["/definitely/not/here/wt2".to_string()]
+        );
+    }
+
+    #[test]
+    fn legacy_agent_registered_event_without_workspaces_replays_empty() {
+        // Old ledger line (pre-P0-1) — no `workspaces` field.
+        let json = r#"{"kind":"agent_registered","goal_id":"g1","agent_id":"old","ts":1}"#;
+        let event: Event = serde_json::from_str(json).unwrap();
+        match event {
+            Event::AgentRegistered { workspaces, .. } => assert!(workspaces.is_empty()),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claim_refuses_on_live_workspace_conflict_and_stays_serial() {
+        let mut store = tmp_store("conflict");
+        open_goal(&mut store, "g1", &["t1", "t2"]);
+        onboard(&mut store, "g1", "agent-a", "/definitely/not/here/wt1");
+        onboard(&mut store, "g1", "agent-b", "/definitely/not/here/wt1");
+        // agent-b claims t1 first (a is idle → no conflict).
+        todo_claim(&mut store, &claim_args("g1", "t1", "agent-b", &[])).unwrap();
+        // agent-a claiming t2 in the same workspace must be refused.
+        let err = todo_claim(&mut store, &claim_args("g1", "t2", "agent-a", &[])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("workspace conflict"), "got: {msg}");
+        assert!(msg.contains("agent-b"), "holder missing: {msg}");
+        assert!(msg.contains("--force"), "force hint missing: {msg}");
+        // No claim for t2 landed in the ledger.
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert!(goal.todo("t2").unwrap().claimed_by.is_none());
+    }
+
+    #[test]
+    fn claim_force_overrides_conflict_and_records_forced_lock() {
+        let mut store = tmp_store("force");
+        open_goal(&mut store, "g1", &["t1", "t2"]);
+        onboard(&mut store, "g1", "agent-a", "/definitely/not/here/wt1");
+        onboard(&mut store, "g1", "agent-b", "/definitely/not/here/wt1");
+        todo_claim(&mut store, &claim_args("g1", "t1", "agent-b", &[])).unwrap();
+        todo_claim(&mut store, &claim_args("g1", "t2", "agent-a", &["--force"])).unwrap();
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert_eq!(
+            goal.todo("t2").unwrap().claimed_by.as_deref(),
+            Some("agent-a")
+        );
+        let locks = lock_events(&store, "g1");
+        assert_eq!(locks.len(), 2, "one lock per workspace-declaring claim");
+        assert_eq!(locks[0], ("agent-b".to_string(), "t1".to_string(), false));
+        assert_eq!(locks[1], ("agent-a".to_string(), "t2".to_string(), true));
+    }
+
+    #[test]
+    fn claim_without_conflict_records_unforced_lock_only_for_declaring_agents() {
+        let mut store = tmp_store("lock");
+        open_goal(&mut store, "g1", &["t1", "t2"]);
+        onboard(&mut store, "g1", "agent-a", "/definitely/not/here/wt1");
+        // agent-b registers WITHOUT a workspace declaration.
+        cmd_agent(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--agent-id".to_string(),
+                "agent-b".to_string(),
+            ],
+        )
+        .unwrap();
+        todo_claim(&mut store, &claim_args("g1", "t1", "agent-a", &[])).unwrap();
+        todo_claim(&mut store, &claim_args("g1", "t2", "agent-b", &[])).unwrap();
+        let locks = lock_events(&store, "g1");
+        assert_eq!(
+            locks,
+            vec![("agent-a".to_string(), "t1".to_string(), false)],
+            "undeclared agents leave no lock record (fail-open)"
+        );
+    }
+
+    #[test]
+    fn disjoint_workspaces_claim_freely() {
+        let mut store = tmp_store("disjoint");
+        open_goal(&mut store, "g1", &["t1", "t2"]);
+        onboard(&mut store, "g1", "agent-a", "/definitely/not/here/wt1");
+        onboard(&mut store, "g1", "agent-b", "/definitely/not/here/wt2");
+        todo_claim(&mut store, &claim_args("g1", "t1", "agent-b", &[])).unwrap();
+        todo_claim(&mut store, &claim_args("g1", "t2", "agent-a", &[])).unwrap();
+    }
+
+    #[test]
+    fn lease_claim_applies_the_same_guard() {
+        let mut store = tmp_store("lease-guard");
+        open_goal(&mut store, "g1", &["t1", "t2"]);
+        onboard(&mut store, "g1", "agent-a", "/definitely/not/here/wt1");
+        onboard(&mut store, "g1", "agent-b", "/definitely/not/here/wt1");
+        let lease_args = |todo: &str, agent: &str, extra: &[&str]| {
+            let mut v = vec!["claim".to_string()];
+            v.extend(claim_args("g1", todo, agent, &["--lease-secs", "3600"]));
+            v.extend(extra.iter().map(|s| s.to_string()));
+            v
+        };
+        cmd_lease(&mut store, &lease_args("t1", "agent-b", &[])).unwrap();
+        let err = cmd_lease(&mut store, &lease_args("t2", "agent-a", &[])).unwrap_err();
+        assert!(format!("{err}").contains("workspace conflict"));
+        cmd_lease(&mut store, &lease_args("t2", "agent-a", &["--force"])).unwrap();
+        let locks = lock_events(&store, "g1");
+        assert_eq!(locks.len(), 2);
+        assert!(locks[1].2, "forced lease claim must record forced=true");
+    }
+
+    #[test]
+    fn agent_list_rows_show_declared_workspaces_and_occupancy() {
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.registered_agents = vec!["alice".to_string()];
+        goal.agent_profiles = vec![crate::state::AgentProfile {
+            id: "alice".to_string(),
+            capabilities: vec![],
+            workspaces: vec!["/repo/wt1".to_string()],
+        }];
+        // idle: declared, not occupied.
+        let rows = agent_list_rows(&goal, &HashMap::new(), 1_000);
+        assert_eq!(rows[0].workspaces, vec!["/repo/wt1".to_string()]);
+        // running: occupancy marker on the declared path.
+        let mut todo = Todo::advancement("t1", "work");
+        todo.claimed_by = Some("alice".to_string());
+        todo.lease_expires_at = Some(2_000);
+        goal.todos.push(todo);
+        let rows = agent_list_rows(&goal, &HashMap::new(), 1_000);
+        assert_eq!(rows[0].workspaces, vec!["/repo/wt1 ✍".to_string()]);
+        let json = serde_json::to_string(&rows).unwrap();
+        assert!(json.contains("workspaces"));
+    }
+
+    #[test]
+    fn describe_event_renders_workspace_lock() {
+        let event = Event::WorkspaceLockAcquired {
+            goal_id: "g1".to_string(),
+            agent_id: "a1".to_string(),
+            todo_id: "t1".to_string(),
+            paths: vec!["/repo/wt1".to_string()],
+            forced: true,
+            ts: 1,
+        };
+        let text = describe_event(&event);
+        assert!(text.contains("workspace_lock"), "got: {text}");
+        assert!(text.contains("a1"), "got: {text}");
+        assert!(text.contains("(forced)"), "got: {text}");
+        // todo-event filtering picks the lock event up for its todo.
+        assert!(event_touches_todo(&event, "t1"));
+        assert!(!event_touches_todo(&event, "t2"));
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -5854,12 +5854,14 @@ mod coverage_tests {
             Event::AgentRegistered {
                 goal_id: "g".into(),
                 agent_id: "a".into(),
+                workspaces: vec![],
                 ts: 1,
             },
             Event::AgentOnboarded {
                 goal_id: "g".into(),
                 agent_id: "a".into(),
                 capabilities: vec!["shell".into()],
+                workspaces: vec![],
                 ts: 1,
             },
             Event::ReplanAcked {

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -624,11 +624,15 @@ pub fn delta_kind_changes_frontier(kind: &str) -> bool {
 
 /// Agent peer profile (LoopX: coordination.agent_profiles — a registered
 /// peer plus the capabilities it declares; the capability gate uses these to
-/// decide which todos an agent may run).
+/// decide which todos an agent may run). `workspaces` is the P0-1 workspace
+/// guard declaration: the normalized absolute path set this agent writes
+/// into (empty = undeclared → the guard is fail-open for this agent).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AgentProfile {
     pub id: String,
     pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub workspaces: Vec<String>,
 }
 
 impl AgentProfile {
@@ -913,6 +917,7 @@ impl Goal {
         self.agent_profiles.push(AgentProfile {
             id: agent_id.to_string(),
             capabilities,
+            workspaces: vec![],
         });
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -221,9 +221,14 @@ pub enum Event {
         ts: u64,
     },
     /// Register an agent peer for the goal (LoopX: coordination.registered_agents).
+    /// `workspaces` is the P0-1 workspace-guard declaration (normalized
+    /// absolute paths the agent writes into; empty = undeclared/fail-open).
+    /// Old events without the field deserialize as empty.
     AgentRegistered {
         goal_id: String,
         agent_id: String,
+        #[serde(default)]
+        workspaces: Vec<String>,
         ts: u64,
     },
     /// Onboard an agent with declared capabilities (LoopX: agent_profiles).
@@ -231,6 +236,21 @@ pub enum Event {
         goal_id: String,
         agent_id: String,
         capabilities: Vec<String>,
+        #[serde(default)]
+        workspaces: Vec<String>,
+        ts: u64,
+    },
+    /// P0-1: advisory write-lock record — an agent with declared workspaces
+    /// claimed a todo and now occupies its workspace set. `forced` marks a
+    /// claim that overrode a live workspace conflict via `--force`.
+    /// Projection-only: occupancy is derived from profiles + live leases;
+    /// this event is the audit trail (agent list / history / todo-event).
+    WorkspaceLockAcquired {
+        goal_id: String,
+        agent_id: String,
+        todo_id: String,
+        paths: Vec<String>,
+        forced: bool,
         ts: u64,
     },
     /// Replan acknowledgment with frontier-delta kinds (vision patch /
@@ -374,6 +394,7 @@ impl Event {
             | Event::TodoClaimed { goal_id, .. }
             | Event::AgentRegistered { goal_id, .. }
             | Event::AgentOnboarded { goal_id, .. }
+            | Event::WorkspaceLockAcquired { goal_id, .. }
             | Event::ReplanAcked { goal_id, .. }
             | Event::ProfileSet { goal_id, .. }
             | Event::AuthoritySet { goal_id, .. }
@@ -1166,7 +1187,11 @@ fn apply(goal: &mut Goal, event: Event) {
                 t.lease_expires_at = Some(lease_expires_at);
             }
         }
-        Event::AgentRegistered { agent_id, .. } => {
+        Event::AgentRegistered {
+            agent_id,
+            workspaces,
+            ..
+        } => {
             if !goal.registered_agents.iter().any(|a| a == &agent_id) {
                 goal.registered_agents.push(agent_id.clone());
             }
@@ -1174,11 +1199,13 @@ fn apply(goal: &mut Goal, event: Event) {
             goal.agent_profiles.push(crate::state::AgentProfile {
                 id: agent_id,
                 capabilities: vec![],
+                workspaces,
             });
         }
         Event::AgentOnboarded {
             agent_id,
             capabilities,
+            workspaces,
             ..
         } => {
             if !goal.registered_agents.iter().any(|a| a == &agent_id) {
@@ -1188,8 +1215,13 @@ fn apply(goal: &mut Goal, event: Event) {
             goal.agent_profiles.push(crate::state::AgentProfile {
                 id: agent_id,
                 capabilities,
+                workspaces,
             });
         }
+        // P0-1: advisory write-lock records are projection-only — occupancy
+        // is derived from profiles + live leases; the event is the audit
+        // trail (like the supervisor events below).
+        Event::WorkspaceLockAcquired { .. } => {}
         Event::ReplanAcked {
             delta_kinds, ts, ..
         } => {

--- a/orchestration/loop/tests/capability_contract.rs
+++ b/orchestration/loop/tests/capability_contract.rs
@@ -117,6 +117,7 @@ fn agent_profiles_survive_replay() {
             goal_id: "g1".into(),
             agent_id: "alice".into(),
             capabilities: vec!["shell".into(), "github".into()],
+            workspaces: vec![],
             ts,
         })
         .unwrap();

--- a/orchestration/loop/tests/claim_lease_contract.rs
+++ b/orchestration/loop/tests/claim_lease_contract.rs
@@ -98,6 +98,85 @@ fn claim_rejects_live_lease_from_other_agent() {
     assert_eq!(g.todo("t1").unwrap().claimed_by.as_deref(), Some("alice"));
 }
 
+// ── Contract (P0-1): workspace declarations survive replay and drive the
+//    guard — a peer holding a live lease in an overlapping workspace
+//    conflicts; idle or disjoint peers do not. ─────────────────────────────
+#[test]
+fn workspace_guard_survives_replay_and_detects_conflicts() {
+    use future_loop::agents::workspace_guard as wsg;
+    let root = tmp_root("wsguard");
+    let mut store = Store::open(&root).unwrap();
+    let g = Goal::new("g1", "objective", "/tmp");
+    store.register(&g).unwrap();
+    let now = now_epoch();
+    store
+        .append(Event::GoalStarted {
+            goal_id: "g1".into(),
+            ts: now,
+        })
+        .unwrap();
+    store
+        .append(Event::AgentOnboarded {
+            goal_id: "g1".into(),
+            agent_id: "alice".into(),
+            capabilities: vec![],
+            workspaces: vec!["/definitely/not/here/wt1".into()],
+            ts: now,
+        })
+        .unwrap();
+    store
+        .append(Event::AgentOnboarded {
+            goal_id: "g1".into(),
+            agent_id: "bob".into(),
+            capabilities: vec![],
+            workspaces: vec!["/definitely/not/here/wt1".into()],
+            ts: now,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::advancement("t1", "shared work"),
+            ts: now,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoClaimed {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: "alice".into(),
+            lease_expires_at: now + 3600,
+            ts: now,
+        })
+        .unwrap();
+    store
+        .append(Event::WorkspaceLockAcquired {
+            goal_id: "g1".into(),
+            agent_id: "alice".into(),
+            todo_id: "t1".into(),
+            paths: vec!["/definitely/not/here/wt1".into()],
+            forced: false,
+            ts: now,
+        })
+        .unwrap();
+
+    // Fresh store → replay: declarations, lease and the lock audit event
+    // all survive.
+    let rebuilt = Store::open(&root).unwrap().replay("g1").unwrap().unwrap();
+    assert_eq!(
+        wsg::agent_workspaces(&rebuilt, "alice"),
+        vec!["/definitely/not/here/wt1".to_string()]
+    );
+    let conflicts = wsg::live_workspace_conflicts(&rebuilt, "bob", now + 10);
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].holder_agent_id, "alice");
+    assert_eq!(conflicts[0].holder_todo_ids, vec!["t1".to_string()]);
+    // Alice never conflicts with herself; after the lease lapses the
+    // workspace is free again.
+    assert!(wsg::live_workspace_conflicts(&rebuilt, "alice", now + 10).is_empty());
+    assert!(wsg::live_workspace_conflicts(&rebuilt, "bob", now + 7200).is_empty());
+}
+
 // ── Contract: claim/lease persists through the event ledger ────────────────
 #[test]
 fn claim_survives_replay() {
@@ -116,6 +195,7 @@ fn claim_survives_replay() {
         .append(Event::AgentRegistered {
             goal_id: "g1".into(),
             agent_id: "alice".into(),
+            workspaces: vec![],
             ts,
         })
         .unwrap();

--- a/orchestration/loop/tests/run_identity_contract.rs
+++ b/orchestration/loop/tests/run_identity_contract.rs
@@ -95,6 +95,7 @@ fn existing_registered_id_passes_through() {
         .append(future_loop::store::Event::AgentRegistered {
             goal_id: "g1".to_string(),
             agent_id: "alice".to_string(),
+            workspaces: vec![],
             ts: future_loop::state::now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -624,6 +624,7 @@ fn apply_matrix() {
             .append(Event::AgentRegistered {
                 goal_id: "g1".into(),
                 agent_id: "a".into(),
+                workspaces: vec![],
                 ts: now_epoch(),
             })
             .unwrap();
@@ -633,6 +634,7 @@ fn apply_matrix() {
             goal_id: "g1".into(),
             agent_id: "a".into(),
             capabilities: vec!["shell".into()],
+            workspaces: vec![],
             ts: now_epoch(),
         })
         .unwrap();
@@ -641,6 +643,7 @@ fn apply_matrix() {
             goal_id: "g1".into(),
             agent_id: "a".into(),
             capabilities: vec!["web".into()],
+            workspaces: vec![],
             ts: now_epoch(),
         })
         .unwrap();


### PR DESCRIPTION
loopx-improvement-report.md **P0-1**（wave1 拆分 PR 3/11）。

- agent 注册/onboard 声明工作区路径集合（`--workspace p1,p2`）
- todo claim/run 时路径交集冲突检测：默认降级串行（bail + 重试提示），`--force-workspace` 显式强制
- advisory 写锁事件入 ledger，`agent list` 展示占用者
- 参照 ~/loopx control_plane/agents/workspace_guard.py

解决与 main 的结构性冲突：保留 `claim_selected_with_lease` helper 与 ClaimOutcome struct API，guard 逻辑融合之。
本地：fmt ✅ clippy ✅ future-loop 全绿 ✅。源：claude/loop-wave1 b753c9c7