### PR TITLE
fix: iOS 启动脚本 Bash 3.2 数组修复 + 附件传输进度条位置

### DIFF
--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -576,16 +576,6 @@ export function ChatScreen() {
                   </ScrollView>
                 )}
                 {!!attachmentError && <Text style={styles.attachmentError}>{attachmentError}</Text>}
-                {transferProgress != null && (
-                  <View pointerEvents="none" style={styles.transferTrack}>
-                    <View
-                      style={[
-                        styles.transferFill,
-                        { width: `${Math.max(2, transferProgress * 100)}%` },
-                      ]}
-                    />
-                  </View>
-                )}
                 <TextInput
                   accessibilityLabel={t("chat.placeholder")}
                   editable={remote.desktopOnline && !remote.timeline.streaming && !remote.busy}
@@ -683,6 +673,14 @@ export function ChatScreen() {
               </View>
             </View>
           </View>
+
+          {transferProgress != null && (
+            <View pointerEvents="none" style={styles.transferTrack}>
+              <View
+                style={[styles.transferFill, { width: `${Math.max(2, transferProgress * 100)}%` }]}
+              />
+            </View>
+          )}
         </View>
 
         <Modal
@@ -934,12 +932,10 @@ const styles = StyleSheet.create({
   transferTrack: {
     position: "absolute",
     top: 0,
-    left: spacing.md,
-    right: spacing.md,
+    left: 0,
+    right: 0,
     height: 2,
     overflow: "hidden",
-    borderRadius: radius.pill,
-    backgroundColor: colors.lineSoft,
   },
   transferFill: { height: 2, borderRadius: radius.pill, backgroundColor: colors.accent },
   attachmentButton: {

--- a/scripts/start-mobile-ios.sh
+++ b/scripts/start-mobile-ios.sh
@@ -192,5 +192,10 @@ else
     echo "CLEAN_NATIVE_BUILD=1 — clearing Xcode DerivedData before building."
     run_args+=(--no-build-cache)
   fi
-  cd "$MOBILE_DIR" && exec npx expo run:ios "${run_args[@]}"
+  cd "$MOBILE_DIR"
+  if [[ "${#run_args[@]}" -gt 0 ]]; then
+    exec npx expo run:ios "${run_args[@]}"
+  else
+    exec npx expo run:ios
+  fi
 fi


### PR DESCRIPTION
## Summary

两个独立的小修复，从 dev 备份分支 cherry-pick 过来单独发布：

- **scripts/start-mobile-ios.sh**：`set -u`（源自 `-euo pipefail`）在 macOS 默认 Bash 3.2 下把空数组 `run_args` 当作未绑定变量，dev 模式 `exec expo run:ios "${run_args[@]}"` 报 `run_args[@]: unbound variable`。展开前先检查数组长度。
- **mobile ChatScreen**：附件传输进度条从 composer 卡片内移到 header 下方的 2px 顶部加载条，去掉轨道背景只留 accent 填充。

## Test plan

- `scripts/start-mobile-ios.sh` 在 macOS Bash 3.2 dev 模式可正常启动（含 CLEAN_NATIVE_BUILD=0/1 两条路径）。
- `cd mobile && npx tsc --noEmit` 干净。
- mobile 测试套件通过（progress bar 改动已随 dev 全量 108 测试验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)