### PR TITLE
feat(desktop): auto-grow new-conversation composer; first-run language follows OS

### DIFF
--- a/desktop/src/features/agent/NewConversation.tsx
+++ b/desktop/src/features/agent/NewConversation.tsx
@@ -210,7 +210,6 @@ export function NewConversation({
               onSend={handleSend}
               disabled={catalogLoading}
               placeholder={t("newConversation.placeholder")}
-              textareaClassName="h-16 text-sm leading-5"
               workspaceId={mode === "workspace" ? activeWorkspace?.id : null}
               draftKey="new"
             />

--- a/desktop/src/i18n/i18n.test.ts
+++ b/desktop/src/i18n/i18n.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.removeItem("future.language");
+});
 
 describe("i18n language helpers", () => {
   it("reads a stored language at init", async () => {
@@ -9,11 +14,26 @@ describe("i18n language helpers", () => {
     expect(mod.getLanguage()).toBe("en");
   });
 
-  it("falls back to the default for an unrecognized stored value", async () => {
+  it("follows the OS language when no preference is stored (first run)", async () => {
+    vi.resetModules();
+    // jsdom's navigator.language defaults to "en-US" → the English bundle.
+    expect(navigator.language).toBe("en-US");
+    const mod = await import("./index");
+    expect(mod.getLanguage()).toBe("en");
+  });
+
+  it("detects a Chinese OS and picks zh on first run", async () => {
+    vi.resetModules();
+    vi.stubGlobal("navigator", { language: "zh-CN" });
+    const mod = await import("./index");
+    expect(mod.getLanguage()).toBe("zh");
+  });
+
+  it("falls back to the system language for an unrecognized stored value", async () => {
     vi.resetModules();
     localStorage.setItem("future.language", "fr");
     const mod = await import("./index");
-    expect(mod.getLanguage()).toBe("zh");
+    expect(mod.getLanguage()).toBe("en");
   });
 
   it("setLanguage persists the choice and switches the active language", async () => {

--- a/desktop/src/i18n/index.ts
+++ b/desktop/src/i18n/index.ts
@@ -32,6 +32,20 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 const STORAGE_KEY = "future.language";
 export const DEFAULT_LANGUAGE: Language = "zh";
 
+/**
+ * First-run default follows the OS: the webview mirrors the system locale, and
+ * we only ship zh/en bundles, so a Chinese system picks "zh" and any other
+ * language falls back to English. `navigator` is guarded for non-DOM contexts.
+ */
+function systemLanguage(): Language {
+  try {
+    return navigator.language.toLowerCase().startsWith("zh") ? "zh" : "en";
+  }
+  catch {
+    return DEFAULT_LANGUAGE;
+  }
+}
+
 function readStoredLanguage(): Language {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -39,9 +53,9 @@ function readStoredLanguage(): Language {
       return stored;
   }
   catch {
-    // localStorage may be unavailable; fall through to the default.
+    // localStorage may be unavailable; fall through to the system language.
   }
-  return DEFAULT_LANGUAGE;
+  return systemLanguage();
 }
 
 const namespaces = Object.keys(resources[DEFAULT_LANGUAGE] ?? {});


### PR DESCRIPTION
## Summary
- **New-conversation composer auto-grows**: remove the fixed `h-16` textarea height in [NewConversation.tsx](desktop/src/features/agent/NewConversation.tsx) so the input box grows with content exactly like the conversation-flow composer (`min-h-14` → `max-h-[40vh]`, then scrolls).
- **First-run language follows the OS**: [i18n/index.ts](desktop/src/i18n/index.ts) now detects the system language via `navigator.language` when no preference is stored — Chinese system → `zh`, any other → `en`. The onboarding gate's default language (and the whole app on first launch) follows the system. A manual choice in the gate / settings still persists and wins.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint "src/**/*.{ts,tsx}"`
- [x] `npx vitest run` — 52 files / 552 tests pass; updated `i18n.test.ts` covers system-language detection (jsdom `en-US` → `en`, stubbed `zh-CN` → `zh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)