### PR TITLE
feat(loop): P0-2 post-delivery outcome closure — delivery_outcome + outcome_followthrough

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -152,6 +152,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "task-graph" => cmd_task_graph(&store, &args[1..]),
         "attention" => cmd_attention(&store, &args[1..]),
         "inbox" => cmd_inbox(&store, &args[1..]),
+        "delivery" => cmd_delivery(&mut store, &args[1..]),
         "registry" => cmd_registry(&registry, &args[1..]),
         "commands" => cmd_commands(&registry, &args[1..]),
         // ── P4 commands (G-18 / G-19 / G-20 / G-27) ───────────────────────
@@ -198,6 +199,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("scheduler", Journey::Daily),
     ("attention", Journey::Daily),
     ("inbox", Journey::Daily),
+    ("delivery", Journey::Daily),
     ("diagnose", Journey::Daily),
     ("evidence-log", Journey::Daily),
     ("todo-event", Journey::Daily),
@@ -471,7 +473,10 @@ fn build_cli_registry() -> CommandRegistry {
         "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N] [--force-workspace]",
     );
 
-    let work_items = r.group("work-items", "attention / operator inbox (G-15)");
+    let work_items = r.group(
+        "work-items",
+        "attention / operator inbox (G-15) / delivery outcome closure (P0-2)",
+    );
     r.command(
         work_items,
         "attention",
@@ -483,6 +488,12 @@ fn build_cli_registry() -> CommandRegistry {
         "inbox",
         "project the operator inbox urgency",
         "inbox --project DIR [--scope addressed_only|configured_chat_all] [--name NAME] [--format json]",
+    );
+    r.command(
+        work_items,
+        "delivery",
+        "post-delivery outcome closure (P0-2): delivered → verified/failed/rework + follow-through",
+        "delivery status --goal G [--format json] | record --goal G --todo-id T --outcome verified|failed|rework [--note N] | followthrough --goal G [--turns N]",
     );
 
     let handoff = r.group("handoff", "project handoff (G-17)");
@@ -1493,6 +1504,7 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
             );
         }
     }
+    let is_advancement = t.class == TaskClass::Advancement;
     let successors = successor.clone().into_iter().collect::<Vec<_>>();
     store.append(Event::TodoCompleted {
         goal_id: goal_id.clone(),
@@ -1502,6 +1514,25 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
         evidence: evidence.clone(),
         ts: now_epoch(),
     })?;
+    // P0-2①: a completed advancement todo is a delivery pending verification
+    // ("delivered ≠ succeeded") — record the outcome signal so it can be
+    // resolved (verified/failed/rework) and aged by the follow-through scan.
+    if is_advancement {
+        let delivered_turn = goal.history.iter().map(|r| r.turn).max().unwrap_or(0);
+        let seq = goal
+            .delivery_state(&todo_id)
+            .map(|d| d.seq + 1)
+            .unwrap_or(1);
+        store.append(Event::DeliveryOutcomeRecorded {
+            goal_id: goal_id.clone(),
+            todo_id: todo_id.clone(),
+            outcome: crate::work_items::delivery_outcome::OUTCOME_DELIVERED.to_string(),
+            note: None,
+            delivered_turn,
+            seq,
+            ts: now_epoch(),
+        })?;
+    }
     complete_todo(&mut goal, &todo_id, no_follow_up, successors);
     if let Some(ev) = &evidence {
         if let Some(t) = goal.todo_mut(&todo_id) {
@@ -2910,6 +2941,23 @@ async fn run_turns(
                 evidence: Some(record.evidence.clone()),
                 ts: now_epoch(),
             })?;
+            // P0-2①: a completed advancement todo is a delivery pending
+            // verification — record the outcome signal at this turn.
+            if g.todo(&todo_id)
+                .map(|t| t.class == crate::state::TaskClass::Advancement)
+                .unwrap_or(false)
+            {
+                let seq = g.delivery_state(&todo_id).map(|d| d.seq + 1).unwrap_or(1);
+                store.append(Event::DeliveryOutcomeRecorded {
+                    goal_id: goal_id.to_string(),
+                    todo_id: todo_id.clone(),
+                    outcome: crate::work_items::delivery_outcome::OUTCOME_DELIVERED.to_string(),
+                    note: None,
+                    delivered_turn: record.turn,
+                    seq,
+                    ts: now_epoch(),
+                })?;
+            }
         } else {
             // A missing todo (deleted mid-turn) carries no budget signal.
             let stop = g
@@ -2935,6 +2983,23 @@ async fn run_turns(
             if stop {
                 break;
             }
+        }
+        // P0-2②: outcome_followthrough — auto-derive a follow-up todo for any
+        // delivery left unverified past the threshold (fires once per cycle).
+        let followups = run_followthrough_check(
+            store,
+            goal_id,
+            crate::work_items::delivery_outcome::DEFAULT_FOLLOWTHROUGH_TURNS,
+        )?;
+        for followup in &followups {
+            println!("   ↻ follow-through: todo {followup} auto-created (unverified delivery)");
+        }
+        if !followups.is_empty() {
+            // The follow-up todo(s) joined the frontier — refresh the read
+            // model so the Next Action sync below cannot project a gap.
+            g = store.replay(goal_id)?.ok_or_else(|| {
+                anyhow::anyhow!("goal {goal_id} not found (deleted while running?)")
+            })?;
         }
         // Sync Next Action to the frontier (avoid projection gap).
         let next_text = g
@@ -4389,6 +4454,211 @@ fn cmd_inbox(store: &Store, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+// ── delivery (P0-2: post-delivery outcome closure) ────────────────────────
+
+/// `delivery <status|record|followthrough>` — the P0-2 signal chain:
+/// delivered → verified/failed/rework, plus the manual follow-through scan
+/// (the run path also scans automatically after every turn).
+fn cmd_delivery(store: &mut Store, args: &[String]) -> Result<()> {
+    match args.first().map(|s| s.as_str()) {
+        Some("status") => delivery_status(store, &args[1..]),
+        Some("record") => delivery_record(store, &args[1..]),
+        Some("followthrough") => delivery_followthrough(store, &args[1..]),
+        _ => bail!("delivery subcommand must be `status`, `record`, or `followthrough`"),
+    }
+}
+
+/// `delivery status --goal G [--format json]` — the per-work-item delivery
+/// outcome read model (state, age in turns, follow-through linkage).
+fn delivery_status(store: &Store, args: &[String]) -> Result<()> {
+    reject_unknown_flags(args, &["--format", "--goal", "--json"])?;
+    let mut goal_id = None;
+    parse_pairs(args, |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v)
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let current_turn = goal.history.iter().map(|r| r.turn).max().unwrap_or(0);
+    if wants_json(args) {
+        let items: Vec<serde_json::Value> = goal
+            .delivery_states
+            .iter()
+            .map(|d| {
+                serde_json::json!({
+                    "todo_id": d.todo_id,
+                    "todo_text": goal.todo(&d.todo_id).map(|t| t.text.clone()),
+                    "outcome": d.outcome,
+                    "delivered_turn": d.delivered_turn,
+                    "turns_since_delivery": current_turn.saturating_sub(d.delivered_turn),
+                    "pending_verification": d.outcome
+                        == crate::work_items::delivery_outcome::OUTCOME_DELIVERED,
+                    "followthrough_todo_id": d.followthrough_todo_id,
+                    "note": d.note,
+                    "updated_at": d.updated_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+    if goal.delivery_states.is_empty() {
+        println!(
+            "no deliveries recorded for goal {goal_id} (a delivery is recorded when an advancement todo completes)"
+        );
+        return Ok(());
+    }
+    println!(
+        "deliveries for {goal_id} (current turn {current_turn}, follow-through threshold {} turns):",
+        crate::work_items::delivery_outcome::DEFAULT_FOLLOWTHROUGH_TURNS
+    );
+    for d in &goal.delivery_states {
+        let age = current_turn.saturating_sub(d.delivered_turn);
+        let pending = d.outcome == crate::work_items::delivery_outcome::OUTCOME_DELIVERED;
+        let follow = d
+            .followthrough_todo_id
+            .as_deref()
+            .map(|f| format!(" follow-through={f}"))
+            .unwrap_or_default();
+        let age = if pending {
+            format!(" age={age}turns")
+        } else {
+            String::new()
+        };
+        let note = d
+            .note
+            .as_deref()
+            .map(|n| format!(" note={n}"))
+            .unwrap_or_default();
+        println!(
+            "  {} [{}] delivered_turn={}{}{}{}",
+            d.todo_id, d.outcome, d.delivered_turn, age, follow, note
+        );
+    }
+    Ok(())
+}
+
+/// `delivery record --goal G --todo-id T --outcome <delivered|verified|
+/// failed|rework> [--note ...]` — manual outcome writeback (the operator /
+/// validator verification signal). Transitions are validated against the
+/// current state before the event lands.
+fn delivery_record(store: &mut Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut todo_id = None;
+    let mut outcome_raw = None;
+    let mut note = None;
+    reject_unknown_flags(args, &["--goal", "--note", "--outcome", "--todo-id"])?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--todo-id" => todo_id = Some(v),
+        "--outcome" => outcome_raw = Some(v),
+        "--note" => note = Some(v),
+        _ => {}
+    });
+    use crate::work_items::delivery_outcome as dov;
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let todo_id = todo_id.ok_or_else(|| anyhow::anyhow!("--todo-id required"))?;
+    let outcome_raw = outcome_raw.ok_or_else(|| anyhow::anyhow!("--outcome required"))?;
+    let outcome = dov::normalize_outcome(&outcome_raw).ok_or_else(|| {
+        anyhow::anyhow!(
+            "--outcome must be one of: {}",
+            dov::DELIVERY_OUTCOME_CHOICES.join(", ")
+        )
+    })?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    if goal.todo(&todo_id).is_none() {
+        bail!("todo {todo_id} not found in goal {goal_id}");
+    }
+    dov::validate_transition(goal.delivery_state(&todo_id), outcome)
+        .map_err(|e| anyhow::anyhow!("delivery {todo_id}: {e}"))?;
+    let current_turn = goal.history.iter().map(|r| r.turn).max().unwrap_or(0);
+    let seq = goal
+        .delivery_state(&todo_id)
+        .map(|d| d.seq + 1)
+        .unwrap_or(1);
+    store.append(Event::DeliveryOutcomeRecorded {
+        goal_id: goal_id.clone(),
+        todo_id: todo_id.clone(),
+        outcome: outcome.to_string(),
+        note,
+        delivered_turn: current_turn,
+        seq,
+        ts: now_epoch(),
+    })?;
+    println!("delivery {todo_id} → {outcome} ✔");
+    Ok(())
+}
+
+/// `delivery followthrough --goal G [--turns N]` — manually run the
+/// outcome_followthrough scan (P0-2②); the run path calls the same driver
+/// automatically after every turn.
+fn delivery_followthrough(store: &mut Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut turns = crate::work_items::delivery_outcome::DEFAULT_FOLLOWTHROUGH_TURNS;
+    reject_unknown_flags(args, &["--goal", "--turns"])?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--turns" => turns = v.parse().unwrap_or(turns),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let created = run_followthrough_check(store, &goal_id, turns)?;
+    if created.is_empty() {
+        println!("no overdue deliveries (all deliveries resolved or under {turns} turns old)");
+    } else {
+        for id in created {
+            println!("follow-through todo {id} auto-created ✔ (unverified delivery aged past {turns} turns)");
+        }
+    }
+    Ok(())
+}
+
+/// P0-2② outcome_followthrough driver: scan delivered-but-unverified work
+/// items and auto-derive a follow-up todo for each one overdue by at least
+/// `threshold` turns. Fires exactly once per delivery cycle — the
+/// `FollowthroughCreated` event stamps the source delivery. Returns the ids
+/// of the follow-up todos created.
+fn run_followthrough_check(
+    store: &mut Store,
+    goal_id: &str,
+    threshold: u32,
+) -> Result<Vec<String>> {
+    use crate::work_items::delivery_outcome as dov;
+    let goal = store
+        .replay(goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let current_turn = goal.history.iter().map(|r| r.turn).max().unwrap_or(0);
+    let overdue = dov::overdue_deliveries(&goal, current_turn, threshold);
+    let mut created = Vec::new();
+    for od in overdue {
+        let followup_id = gen_id("todo");
+        let mut todo = Todo::advancement(&followup_id, &dov::followthrough_todo_text(&od));
+        todo.note = Some(format!(
+            "auto-created by outcome_followthrough (source {}, turn {current_turn}, threshold {threshold})",
+            od.todo_id
+        ));
+        store.append(Event::TodoAdded {
+            goal_id: goal_id.to_string(),
+            todo,
+            ts: now_epoch(),
+        })?;
+        store.append(Event::FollowthroughCreated {
+            goal_id: goal_id.to_string(),
+            source_todo_id: od.todo_id.clone(),
+            followup_todo_id: followup_id.clone(),
+            turns_overdue: od.turns_overdue,
+            ts: now_epoch(),
+        })?;
+        created.push(followup_id);
+    }
+    Ok(created)
+}
+
 // ── registry (G-26) ────────────────────────────────────────────────────────
 
 /// `loopx registry [--format json|--json] [--include-experimental]` — inspect
@@ -5461,6 +5731,20 @@ fn describe_event(event: &crate::store::Event) -> String {
         }
         Event::TodoExpired { todo_id, .. } => {
             return format!("todo_expired todo={todo_id}");
+        }
+        Event::DeliveryOutcomeRecorded {
+            todo_id, outcome, ..
+        } => {
+            return format!("delivery_outcome todo={todo_id} outcome={outcome}");
+        }
+        Event::FollowthroughCreated {
+            source_todo_id,
+            followup_todo_id,
+            ..
+        } => {
+            return format!(
+                "followthrough_created source={source_todo_id} followup={followup_todo_id}"
+            );
         }
         Event::SupervisorProposed {
             decision_id,

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -622,6 +622,28 @@ pub fn delta_kind_changes_frontier(kind: &str) -> bool {
     )
 }
 
+/// P0-2: latest delivery-outcome state per work item — rebuilt by replay
+/// from `DeliveryOutcomeRecorded` / `FollowthroughCreated` events. The
+/// signal chain: `delivered` (pending verification) → `verified` / `failed`
+/// / `rework` (terminal resolutions). Domain rules live in
+/// [`crate::work_items::delivery_outcome`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeliveryState {
+    pub todo_id: String,
+    /// `delivered` (pending) | `verified` | `failed` | `rework`.
+    pub outcome: String,
+    pub note: Option<String>,
+    /// Run-turn counter at delivery time (0 = recorded without run context).
+    pub delivered_turn: u32,
+    /// Follow-up todo auto-created by outcome_followthrough (P0-2②) — the
+    /// dedupe stamp so the follow-through fires exactly once per cycle.
+    pub followthrough_todo_id: Option<String>,
+    /// Per-todo outcome sequence number of the latest event (audit ordering;
+    /// also what makes each cycle's events content-distinct).
+    pub seq: u32,
+    pub updated_at: u64,
+}
+
 /// Agent peer profile (LoopX: coordination.agent_profiles — a registered
 /// peer plus the capabilities it declares; the capability gate uses these to
 /// decide which todos an agent may run). `workspaces` is the P0-1 workspace
@@ -721,6 +743,9 @@ pub struct Goal {
     /// G-3: quota slots spent as recorded by QuotaSpent events (replay
     /// projection — the authoritative spend ledger stays runs.jsonl).
     pub quota_spent_slots: u32,
+    /// P0-2: per-work-item delivery outcome states (latest event wins —
+    /// folded from DeliveryOutcomeRecorded / FollowthroughCreated).
+    pub delivery_states: Vec<DeliveryState>,
     /// Per-tool quota read model (LoopX 对比改进项 ②): (ts, tool) pairs
     /// folded from accepted `CapabilityInvoked` events — the invocation
     /// count behind [`crate::quota::tool_quota`]. Rejected invocations are
@@ -761,6 +786,7 @@ impl Goal {
             created_at: now_epoch(),
             next_index: 0,
             quota_spent_slots: 0,
+            delivery_states: vec![],
             capability_invocations: vec![],
         }
     }
@@ -919,6 +945,66 @@ impl Goal {
             capabilities,
             workspaces: vec![],
         });
+    }
+
+    /// The latest delivery-outcome state for a work item (P0-2).
+    pub fn delivery_state(&self, todo_id: &str) -> Option<&DeliveryState> {
+        self.delivery_states.iter().find(|d| d.todo_id == todo_id)
+    }
+
+    /// Fold a `DeliveryOutcomeRecorded` event into the read model (latest
+    /// wins). A fresh `delivered` resets the cycle: the turn stamp moves and
+    /// the follow-through stamp clears, so a re-delivered item can fire its
+    /// own follow-through later. Resolutions keep the original turn stamp.
+    pub fn apply_delivery_outcome(
+        &mut self,
+        todo_id: &str,
+        outcome: &str,
+        note: Option<String>,
+        delivered_turn: u32,
+        seq: u32,
+        ts: u64,
+    ) {
+        let fresh_delivery = outcome == crate::work_items::delivery_outcome::OUTCOME_DELIVERED;
+        if let Some(d) = self
+            .delivery_states
+            .iter_mut()
+            .find(|d| d.todo_id == todo_id)
+        {
+            d.outcome = outcome.to_string();
+            if note.is_some() {
+                d.note = note;
+            }
+            if fresh_delivery {
+                d.delivered_turn = delivered_turn;
+                d.followthrough_todo_id = None;
+            }
+            d.seq = seq;
+            d.updated_at = ts;
+        } else {
+            self.delivery_states.push(DeliveryState {
+                todo_id: todo_id.to_string(),
+                outcome: outcome.to_string(),
+                note,
+                delivered_turn: if fresh_delivery { delivered_turn } else { 0 },
+                followthrough_todo_id: None,
+                seq,
+                updated_at: ts,
+            });
+        }
+    }
+
+    /// Fold a `FollowthroughCreated` event (P0-2②) — stamps the auto-created
+    /// follow-up todo on the pending delivery so it fires exactly once.
+    pub fn apply_followthrough(&mut self, source_todo_id: &str, followup_todo_id: &str, ts: u64) {
+        if let Some(d) = self
+            .delivery_states
+            .iter_mut()
+            .find(|d| d.todo_id == source_todo_id)
+        {
+            d.followthrough_todo_id = Some(followup_todo_id.to_string());
+            d.updated_at = ts;
+        }
     }
 
     /// Done advancement todos that declared NO successor and NO no-follow-up

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -351,6 +351,37 @@ pub enum Event {
         todo_id: String,
         ts: u64,
     },
+    /// P0-2①: post-delivery outcome signal — `delivered` (pending
+    /// verification) → `verified` / `failed` / `rework` (the three terminal
+    /// resolutions). Recorded automatically when an advancement todo
+    /// completes, and manually via `delivery record`. `delivered_turn` is the
+    /// run-turn counter at delivery time (0 = recorded without run context).
+    DeliveryOutcomeRecorded {
+        goal_id: String,
+        todo_id: String,
+        outcome: String,
+        note: Option<String>,
+        delivered_turn: u32,
+        /// Per-todo outcome sequence number (1-based, from the read model at
+        /// append time). Distinguishes cycles: a re-delivery after
+        /// failed/rework would otherwise content-collide with the earlier
+        /// `delivered` event (same todo/turn/note within one second) and be
+        /// swallowed by the G-3 idempotent-append dedupe.
+        #[serde(default)]
+        seq: u32,
+        ts: u64,
+    },
+    /// P0-2②: outcome_followthrough fired — a delivered-but-unverified work
+    /// item aged past the turn threshold, so a follow-up todo was
+    /// auto-created (the followup itself is the TodoAdded event; this event
+    /// stamps the source delivery so the follow-through fires exactly once).
+    FollowthroughCreated {
+        goal_id: String,
+        source_todo_id: String,
+        followup_todo_id: String,
+        turns_overdue: u32,
+        ts: u64,
+    },
     /// G-16: a supervisor proposed a decision for a target agent (LoopX
     /// SUPERVISOR_PROPOSED). Projection-only — supervisor state is read from
     /// the event log, not folded into goal state.
@@ -406,6 +437,8 @@ impl Event {
             | Event::TodoRenewed { goal_id, .. }
             | Event::TodoReleased { goal_id, .. }
             | Event::TodoExpired { goal_id, .. }
+            | Event::DeliveryOutcomeRecorded { goal_id, .. }
+            | Event::FollowthroughCreated { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. } => goal_id,
         }
@@ -1338,6 +1371,24 @@ fn apply(goal: &mut Goal, event: Event) {
                 }
             }
         }
+        // P0-2: delivery outcomes fold into the per-work-item delivery read
+        // model (latest wins; transitions are validated at the command layer
+        // before the event is appended).
+        Event::DeliveryOutcomeRecorded {
+            todo_id,
+            outcome,
+            note,
+            delivered_turn,
+            seq,
+            ts,
+            ..
+        } => goal.apply_delivery_outcome(&todo_id, &outcome, note, delivered_turn, seq, ts),
+        Event::FollowthroughCreated {
+            source_todo_id,
+            followup_todo_id,
+            ts,
+            ..
+        } => goal.apply_followthrough(&source_todo_id, &followup_todo_id, ts),
         // G-16: supervisor events are projection-only (read from the event
         // log by the supervisor domain; goal state is unchanged).
         Event::SupervisorProposed { .. } | Event::SupervisorReceiptRecorded { .. } => {}

--- a/orchestration/loop/src/work_items/delivery_outcome.rs
+++ b/orchestration/loop/src/work_items/delivery_outcome.rs
@@ -1,0 +1,276 @@
+//! P0-2: post-delivery outcome closure — LoopX
+//! `control_plane/work_items/delivery_outcome.py` + `outcome_followthrough.py`,
+//! natively (compact set).
+//!
+//! A completed advancement todo is a DELIVERY, not a verified outcome
+//! ("delivered ≠ succeeded" — the gap the P0-2 report item closes). This
+//! module is the signal chain that closes the loop:
+//!
+//! ① `delivery_outcome` — every delivery starts in `delivered` (pending
+//!    verification) and must be resolved to one of the three terminal
+//!    outcomes — `verified` / `failed` / `rework` — by an operator or
+//!    validator writeback (`delivery record`). The durable signal is the
+//!    `DeliveryOutcomeRecorded` event; the read model is
+//!    [`crate::state::DeliveryState`].
+//! ② `outcome_followthrough` — a delivery left unverified for N turns
+//!    derives a follow-up todo automatically ([`overdue_deliveries`] + the
+//!    run-path / `delivery followthrough` driver), so an unverified delivery
+//!    can never silently age out of the frontier. Fires exactly once per
+//!    delivery cycle (the `FollowthroughCreated` event stamps the delivery).
+
+use crate::state::{DeliveryState, Goal};
+
+/// The pending state: work was delivered, the outcome is not yet verified.
+pub const OUTCOME_DELIVERED: &str = "delivered";
+/// Terminal resolution: the delivery was verified as successful.
+pub const OUTCOME_VERIFIED: &str = "verified";
+/// Terminal resolution: the delivery failed verification.
+pub const OUTCOME_FAILED: &str = "failed";
+/// Terminal resolution: the delivery needs rework.
+pub const OUTCOME_REWORK: &str = "rework";
+
+/// All outcome values (CLI `--outcome` choices).
+pub const DELIVERY_OUTCOME_CHOICES: [&str; 4] = [
+    OUTCOME_DELIVERED,
+    OUTCOME_VERIFIED,
+    OUTCOME_FAILED,
+    OUTCOME_REWORK,
+];
+
+/// Default follow-through threshold: a delivery unverified for this many
+/// turns auto-derives a follow-up todo (P0-2② "交付后 N turn 内未验证").
+pub const DEFAULT_FOLLOWTHROUGH_TURNS: u32 = 3;
+
+/// Normalize an outcome token (case/whitespace-insensitive) to its canonical
+/// value; `None` for unknown values.
+pub fn normalize_outcome(value: &str) -> Option<&'static str> {
+    match value.trim().to_lowercase().as_str() {
+        OUTCOME_DELIVERED => Some(OUTCOME_DELIVERED),
+        OUTCOME_VERIFIED => Some(OUTCOME_VERIFIED),
+        OUTCOME_FAILED => Some(OUTCOME_FAILED),
+        OUTCOME_REWORK => Some(OUTCOME_REWORK),
+        _ => None,
+    }
+}
+
+/// Whether the outcome is one of the three terminal resolutions
+/// (verified / failed / rework) — i.e. not the pending `delivered` state.
+pub fn is_resolution(outcome: &str) -> bool {
+    matches!(outcome, OUTCOME_VERIFIED | OUTCOME_FAILED | OUTCOME_REWORK)
+}
+
+/// Validate an outcome transition against the current read-model state
+/// (checked at the command layer BEFORE the event is appended — replay folds
+/// latest-wins unconditionally):
+///
+/// - `delivered` starts a fresh delivery cycle — legal from nothing, or
+///   after `failed` / `rework` (re-delivery after repair); illegal while
+///   already pending, and illegal after `verified` (a verified delivery is
+///   closed — supersede/reopen the todo for new work instead).
+/// - a resolution (`verified` / `failed` / `rework`) requires a pending
+///   `delivered` state.
+pub fn validate_transition(current: Option<&DeliveryState>, next: &str) -> Result<(), String> {
+    match (current.map(|d| d.outcome.as_str()), next) {
+        (None, OUTCOME_DELIVERED) => Ok(()),
+        (Some(OUTCOME_FAILED), OUTCOME_DELIVERED) | (Some(OUTCOME_REWORK), OUTCOME_DELIVERED) => {
+            Ok(())
+        }
+        (Some(OUTCOME_DELIVERED), OUTCOME_DELIVERED) => Err(
+            "already delivered and pending verification — resolve it with \
+             verified/failed/rework first"
+                .to_string(),
+        ),
+        (Some(OUTCOME_VERIFIED), OUTCOME_DELIVERED) => Err(
+            "already verified — the delivery is closed; open a new todo for new work".to_string(),
+        ),
+        (Some(OUTCOME_DELIVERED), r) if is_resolution(r) => Ok(()),
+        (cur, r) if is_resolution(r) => Err(match cur {
+            None => "no pending delivery for this todo (nothing was delivered yet)".to_string(),
+            Some(c) => format!("delivery is already resolved as `{c}`"),
+        }),
+        _ => Err(format!(
+            "unknown outcome `{next}` (choices: {})",
+            DELIVERY_OUTCOME_CHOICES.join(", ")
+        )),
+    }
+}
+
+/// One delivered-but-unverified work item that aged past the follow-through
+/// threshold (P0-2②).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverdueDelivery {
+    pub todo_id: String,
+    /// Turn counter at delivery time.
+    pub delivered_turn: u32,
+    /// Turns elapsed since delivery (`current_turn - delivered_turn`).
+    pub turns_overdue: u32,
+    /// Source todo text (for the derived follow-up todo).
+    pub todo_text: String,
+}
+
+/// Deliveries pending verification for at least `threshold` turns that have
+/// no follow-through todo yet. `current_turn` is the goal's latest run-turn
+/// counter; nothing is overdue before the first turn (current_turn == 0).
+/// Deterministic order: oldest delivery first.
+pub fn overdue_deliveries(goal: &Goal, current_turn: u32, threshold: u32) -> Vec<OverdueDelivery> {
+    if current_turn == 0 {
+        return vec![];
+    }
+    let mut out: Vec<OverdueDelivery> = goal
+        .delivery_states
+        .iter()
+        .filter(|d| d.outcome == OUTCOME_DELIVERED && d.followthrough_todo_id.is_none())
+        .filter_map(|d| {
+            let elapsed = current_turn.saturating_sub(d.delivered_turn);
+            if elapsed >= threshold {
+                Some(OverdueDelivery {
+                    todo_id: d.todo_id.clone(),
+                    delivered_turn: d.delivered_turn,
+                    turns_overdue: elapsed,
+                    todo_text: goal
+                        .todo(&d.todo_id)
+                        .map(|t| t.text.clone())
+                        .unwrap_or_default(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    out.sort_by_key(|d| d.delivered_turn);
+    out
+}
+
+/// The follow-up todo text derived for an overdue delivery (P0-2②): verify
+/// the delivery or write back a precise failure — mirroring the LoopX
+/// obligation `advance_primary_outcome_or_write_blocker`.
+pub fn followthrough_todo_text(source: &OverdueDelivery) -> String {
+    format!(
+        "Follow-through: verify the delivery of {} — `{}` (delivered at turn {}, unverified for {} turns; \
+         resolve via `future loop delivery record --todo-id {} --outcome verified|failed|rework`)",
+        source.todo_id, source.todo_text, source.delivered_turn, source.turns_overdue, source.todo_id
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Goal, Todo};
+
+    fn goal_with_delivery(outcome: &str, delivered_turn: u32) -> Goal {
+        let mut g = Goal::new("g", "obj", "/tmp");
+        g.add(Todo::advancement("t1", "ship the fix"));
+        g.apply_delivery_outcome("t1", outcome, None, delivered_turn, 1, 100);
+        g
+    }
+
+    #[test]
+    fn normalize_outcome_accepts_canonical_and_case_insensitive() {
+        assert_eq!(normalize_outcome("delivered"), Some(OUTCOME_DELIVERED));
+        assert_eq!(normalize_outcome(" Verified "), Some(OUTCOME_VERIFIED));
+        assert_eq!(normalize_outcome("FAILED"), Some(OUTCOME_FAILED));
+        assert_eq!(normalize_outcome("rework"), Some(OUTCOME_REWORK));
+        assert_eq!(normalize_outcome("nope"), None);
+        assert_eq!(normalize_outcome(""), None);
+    }
+
+    #[test]
+    fn transition_fresh_delivery_then_resolution() {
+        let g = Goal::new("g", "obj", "/tmp");
+        // No state yet: delivered is legal, resolutions are not.
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_DELIVERED).is_ok());
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_VERIFIED).is_err());
+        let g = goal_with_delivery(OUTCOME_DELIVERED, 1);
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_VERIFIED).is_ok());
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_FAILED).is_ok());
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_REWORK).is_ok());
+        // Double delivery while pending is rejected.
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_DELIVERED).is_err());
+    }
+
+    #[test]
+    fn transition_redelivery_after_failure_but_not_after_verified() {
+        let g = goal_with_delivery(OUTCOME_FAILED, 1);
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_DELIVERED).is_ok());
+        let g = goal_with_delivery(OUTCOME_REWORK, 1);
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_DELIVERED).is_ok());
+        let g = goal_with_delivery(OUTCOME_VERIFIED, 1);
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_DELIVERED).is_err());
+        assert!(validate_transition(g.delivery_state("t1"), OUTCOME_VERIFIED).is_err());
+    }
+
+    #[test]
+    fn overdue_only_after_threshold_turns() {
+        let g = goal_with_delivery(OUTCOME_DELIVERED, 2);
+        // turn 3: 1 turn elapsed — not overdue with threshold 3.
+        assert!(overdue_deliveries(&g, 3, 3).is_empty());
+        // turn 5: exactly 3 turns elapsed — overdue.
+        let od = overdue_deliveries(&g, 5, 3);
+        assert_eq!(od.len(), 1);
+        assert_eq!(od[0].todo_id, "t1");
+        assert_eq!(od[0].delivered_turn, 2);
+        assert_eq!(od[0].turns_overdue, 3);
+        assert_eq!(od[0].todo_text, "ship the fix");
+    }
+
+    #[test]
+    fn nothing_overdue_before_first_turn() {
+        let g = goal_with_delivery(OUTCOME_DELIVERED, 0);
+        assert!(overdue_deliveries(&g, 0, 3).is_empty());
+    }
+
+    #[test]
+    fn resolved_or_followed_deliveries_are_not_overdue() {
+        for outcome in [OUTCOME_VERIFIED, OUTCOME_FAILED, OUTCOME_REWORK] {
+            let g = goal_with_delivery(outcome, 1);
+            assert!(overdue_deliveries(&g, 99, 3).is_empty(), "{outcome}");
+        }
+        // A pending delivery that already fired its follow-through is skipped.
+        let mut g = goal_with_delivery(OUTCOME_DELIVERED, 1);
+        g.apply_followthrough("t1", "t-follow", 200);
+        assert!(overdue_deliveries(&g, 99, 3).is_empty());
+    }
+
+    #[test]
+    fn redelivery_resets_the_cycle() {
+        let mut g = goal_with_delivery(OUTCOME_DELIVERED, 1);
+        g.apply_followthrough("t1", "t-follow", 200);
+        g.apply_delivery_outcome("t1", OUTCOME_FAILED, None, 0, 2, 300);
+        // Re-delivery: turn stamp moves, follow-through stamp clears.
+        g.apply_delivery_outcome("t1", OUTCOME_DELIVERED, None, 10, 3, 400);
+        let d = g.delivery_state("t1").unwrap();
+        assert_eq!(d.outcome, OUTCOME_DELIVERED);
+        assert_eq!(d.delivered_turn, 10);
+        assert_eq!(d.followthrough_todo_id, None);
+        // Not overdue until the NEW delivery ages past the threshold.
+        assert!(overdue_deliveries(&g, 12, 3).is_empty());
+        assert_eq!(overdue_deliveries(&g, 13, 3).len(), 1);
+    }
+
+    #[test]
+    fn oldest_delivery_fires_first() {
+        let mut g = Goal::new("g", "obj", "/tmp");
+        g.add(Todo::advancement("t1", "first"));
+        g.add(Todo::advancement("t2", "second"));
+        g.apply_delivery_outcome("t2", OUTCOME_DELIVERED, None, 1, 1, 100);
+        g.apply_delivery_outcome("t1", OUTCOME_DELIVERED, None, 2, 1, 100);
+        let od = overdue_deliveries(&g, 9, 3);
+        assert_eq!(
+            od.iter().map(|d| d.todo_id.as_str()).collect::<Vec<_>>(),
+            vec!["t2", "t1"]
+        );
+    }
+
+    #[test]
+    fn followthrough_text_names_source_and_resolution_path() {
+        let od = OverdueDelivery {
+            todo_id: "t1".into(),
+            delivered_turn: 2,
+            turns_overdue: 4,
+            todo_text: "ship the fix".into(),
+        };
+        let text = followthrough_todo_text(&od);
+        assert!(text.contains("t1") && text.contains("ship the fix"));
+        assert!(text.contains("delivery record"));
+    }
+}

--- a/orchestration/loop/src/work_items/mod.rs
+++ b/orchestration/loop/src/work_items/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod attention;
 pub mod delivery;
+pub mod delivery_outcome;
 pub mod operator_inbox;
 pub mod replan_obligation;
 pub mod task_graph;

--- a/orchestration/loop/tests/delivery_outcome_contract.rs
+++ b/orchestration/loop/tests/delivery_outcome_contract.rs
@@ -1,0 +1,369 @@
+//! P0-2 contract tests: post-delivery outcome closure —
+//!   ① `delivery_outcome` events: completing an advancement todo records a
+//!      `delivered` signal; `delivery record` resolves it to
+//!      verified/failed/rework with validated transitions.
+//!   ② `outcome_followthrough`: a delivery left unverified for N turns
+//!      auto-derives a follow-up todo (exactly once per delivery cycle).
+//!
+//! These exercise the real CLI entry (`console::run`) against an isolated
+//! `FUTURE_LOOP_ROOT`, plus direct store replays for the turn counters.
+
+use future_loop::console;
+use future_loop::state::{Goal, RunRecord};
+use future_loop::store::Store;
+use future_loop::work_items::delivery_outcome as dov;
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; tests run in parallel, so
+    // serialize all CLI tests behind one mutex (each still gets its own
+    // isolated root dir).
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = std::env::temp_dir().join(format!("future-loop-delivery-{tag}-{}", uuid_like()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let root = dir.join(".future/loop");
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", root.to_str().unwrap());
+    f(root.to_str().unwrap());
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    format!(
+        "{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+/// Set up goal `g1` with one advancement todo; return its todo id.
+fn setup_goal_with_todo() -> String {
+    cli(&[
+        "goal",
+        "init",
+        "--objective",
+        "delivery closure test",
+        "--cwd",
+        "/tmp",
+        "--goal-id",
+        "g1",
+    ])
+    .unwrap();
+    cli(&["todo", "add", "--goal", "g1", "--text", "ship the widget"]).unwrap();
+    let store = Store::open(&std::env::var("FUTURE_LOOP_ROOT").unwrap()).unwrap();
+    let g = store.replay("g1").unwrap().unwrap();
+    g.todos
+        .iter()
+        .find(|t| t.text.contains("ship the widget"))
+        .map(|t| t.id.clone())
+        .unwrap()
+}
+
+fn replay(root: &str) -> Goal {
+    Store::open(root).unwrap().replay("g1").unwrap().unwrap()
+}
+
+fn run_record(turn: u32) -> RunRecord {
+    RunRecord {
+        turn,
+        todo_id: "t".into(),
+        run_id: format!("r{turn}"),
+        terminal_state: "completed".into(),
+        error: None,
+        tokens_in_delta: 0,
+        tokens_out_delta: 0,
+        cost_delta: 0.0,
+        tools: vec![],
+        evidence: "ev".into(),
+        recorded_at: 0,
+        spend_source: None,
+        validation: None,
+    }
+}
+
+// ── ① todo complete records a `delivered` outcome; delivery record resolves
+//    it with validated transitions. ─────────────────────────────────────────
+#[test]
+fn completion_records_delivered_and_record_resolves() {
+    with_root("resolve", |root| {
+        let todo_id = setup_goal_with_todo();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+
+        // The completion auto-recorded a pending delivery.
+        let g = replay(root);
+        let d = g
+            .delivery_state(&todo_id)
+            .expect("completion must record a delivery");
+        assert_eq!(d.outcome, dov::OUTCOME_DELIVERED);
+        assert_eq!(d.followthrough_todo_id, None);
+
+        // Resolving without a pending delivery state machine violation:
+        // verified → verified is rejected; bogus outcome is rejected.
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "verified",
+            "--note",
+            "confirmed in production",
+        ])
+        .is_ok());
+        let g = replay(root);
+        assert_eq!(
+            g.delivery_state(&todo_id).unwrap().outcome,
+            dov::OUTCOME_VERIFIED
+        );
+        assert_eq!(
+            g.delivery_state(&todo_id).unwrap().note.as_deref(),
+            Some("confirmed in production")
+        );
+        // A verified delivery is closed — no re-resolution, no re-delivery.
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "failed",
+        ])
+        .is_err());
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "delivered",
+        ])
+        .is_err());
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "bogus",
+        ])
+        .is_err());
+        // Unknown todo id fails closed.
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            "todo_nope",
+            "--outcome",
+            "verified",
+        ])
+        .is_err());
+    });
+}
+
+// ── ① transitions: failed/rework allow re-delivery (a fresh cycle). ───────
+#[test]
+fn failed_delivery_allows_redelivery_cycle() {
+    with_root("redelivery", |root| {
+        let todo_id = setup_goal_with_todo();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "failed",
+        ])
+        .unwrap();
+        // Re-delivery is legal after a failure and resets the cycle.
+        cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "delivered",
+        ])
+        .unwrap();
+        let g = replay(root);
+        assert_eq!(
+            g.delivery_state(&todo_id).unwrap().outcome,
+            dov::OUTCOME_DELIVERED
+        );
+        // Double delivery while pending is rejected.
+        assert!(cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "delivered",
+        ])
+        .is_err());
+    });
+}
+
+// ── ② follow-through: overdue delivery auto-derives a follow-up todo,
+//    exactly once; resolving the delivery stops the follow-through. ────────
+#[test]
+fn followthrough_fires_once_for_overdue_delivery() {
+    with_root("followthrough", |root| {
+        let todo_id = setup_goal_with_todo();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        // Push the run-turn counter past the threshold (delivered at turn 0).
+        let store = Store::open(root).unwrap();
+        store.append_run("g1", &run_record(5)).unwrap();
+        drop(store);
+
+        // Manual scan: derives exactly one follow-up todo.
+        cli(&["delivery", "followthrough", "--goal", "g1"]).unwrap();
+        let g = replay(root);
+        let d = g.delivery_state(&todo_id).unwrap();
+        let followup_id = d
+            .followthrough_todo_id
+            .clone()
+            .expect("overdue delivery must derive a follow-up todo");
+        let followup = g.todo(&followup_id).expect("follow-up todo exists");
+        assert!(followup.text.contains("Follow-through"));
+        assert!(followup.text.contains(&todo_id));
+        assert!(followup.text.contains("ship the widget"));
+        let todo_count = g.todos.len();
+
+        // Second scan: the stamp dedupes — no additional todo.
+        cli(&["delivery", "followthrough", "--goal", "g1"]).unwrap();
+        assert_eq!(replay(root).todos.len(), todo_count);
+
+        // Resolving the source delivery closes the loop; further scans at a
+        // much later turn still derive nothing for it.
+        cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "verified",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        store.append_run("g1", &run_record(99)).unwrap();
+        drop(store);
+        cli(&["delivery", "followthrough", "--goal", "g1"]).unwrap();
+        assert_eq!(replay(root).todos.len(), todo_count);
+    });
+}
+
+// ── ② not-yet-overdue deliveries derive nothing. ──────────────────────────
+#[test]
+fn followthrough_respects_threshold() {
+    with_root("threshold", |root| {
+        let todo_id = setup_goal_with_todo();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        // Turn 2 < default threshold 3 → nothing derived.
+        let store = Store::open(root).unwrap();
+        store.append_run("g1", &run_record(2)).unwrap();
+        drop(store);
+        cli(&["delivery", "followthrough", "--goal", "g1"]).unwrap();
+        let g = replay(root);
+        assert_eq!(
+            g.delivery_state(&todo_id).unwrap().followthrough_todo_id,
+            None
+        );
+        // --turns 1 overrides the threshold → fires.
+        cli(&["delivery", "followthrough", "--goal", "g1", "--turns", "1"]).unwrap();
+        assert!(replay(root)
+            .delivery_state(&todo_id)
+            .unwrap()
+            .followthrough_todo_id
+            .is_some());
+    });
+}
+
+// ── read surface: `delivery status` text + JSON projections. ──────────────
+#[test]
+fn delivery_status_projects_read_model() {
+    with_root("status", |root| {
+        let todo_id = setup_goal_with_todo();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        // JSON read model carries the delivery with its age + pending flag.
+        cli(&["delivery", "status", "--goal", "g1", "--format", "json"]).unwrap();
+        // Replay-level projection: the ledger round-trips the new events.
+        let report = Store::open(root).unwrap().verify("g1").unwrap();
+        assert!(report.ok, "ledger conflicts: {:?}", report.conflicts);
+        let g = replay(root);
+        assert_eq!(g.delivery_states.len(), 1);
+        assert_eq!(g.delivery_states[0].todo_id, todo_id);
+    });
+}


### PR DESCRIPTION
loopx-improvement-report.md **P0-2**（wave1 拆分 PR 4/11）。

- `DeliveryOutcomeRecorded` 事件：delivered→verified/failed/rework 三态（完成 advancement todo 即落 delivered 信号）
- `outcome_followthrough`：交付后 N turn 未验证自动产出跟进 todo（每周期一次）
- backlog_hygiene 留二期
- 新契约测试 delivery_outcome_contract.rs

解决与 main 的融合：保留 main 的 stop-map 预算结构，交付信号插到成功分支。
本地：fmt ✅ clippy ✅ future-loop 68 targets 全绿 ✅。源：claude/loop-wave1 654733f2