### PR TITLE
feat(loop): P1-5 reward_memory phase 1 — signal ingestion + scoped_feedback

### DIFF
--- a/orchestration/loop/src/capabilities/catalog.rs
+++ b/orchestration/loop/src/capabilities/catalog.rs
@@ -353,7 +353,10 @@ fn builtin_records() -> Vec<(
             CAPABILITY_STATUS_ACTIVE_PREVIEW,
             "Reward/penalty memory with hashed preference references.",
             "Build a compact receipt with hashed preference references for evidence/state writeback.",
-            vec![cmd("reward-memory", "Build a compact reward-memory receipt with hashed preference references.")],
+            // P1-5: the capability graduated from the G-24 propose hook to a
+            // real command surface (`reward-memory query|record`); the
+            // propose pipeline stays reachable via `capability propose`.
+            vec![],
             vec![packet("reward_memory_v0", "reward_memory")],
         ),
         (

--- a/orchestration/loop/src/capabilities/reward_memory.rs
+++ b/orchestration/loop/src/capabilities/reward_memory.rs
@@ -266,6 +266,7 @@ mod tests {
             source_section: None,
             source_line: None,
             privacy: None,
+            fencing_token: None,
             event: Event::RewardSignalRecorded {
                 goal_id: "g".into(),
                 todo_id: todo_id.into(),
@@ -405,6 +406,7 @@ mod tests {
             source_section: None,
             source_line: None,
             privacy: None,
+            fencing_token: None,
             event: Event::GoalStarted {
                 goal_id: "g".into(),
                 ts: 1,

--- a/orchestration/loop/src/capabilities/reward_memory.rs
+++ b/orchestration/loop/src/capabilities/reward_memory.rs
@@ -1,7 +1,213 @@
 //! reward_memory capability (LoopX: reward_memory — deterministic rule translation
 //! into finite typed proposals).
+//!
+//! P1-5 deep implementation, phase 1 (LoopX `capabilities/reward_memory/`
+//! ingestion.py + scoped_feedback.py, compact set): cross-run learning
+//! infrastructure with exactly two surfaces —
+//!
+//! ① ingestion — reward signals land in the goal's event ledger as
+//!    `RewardSignalRecorded` events. Three sources: `validator` (the run
+//!    path auto-records the independent task-validation receipt of every
+//!    turn), `delivery_outcome` (a P0-2 delivery resolution —
+//!    verified/failed/rework — auto-records its signal), and `evidence`
+//!    (an operator/agent scores evidence manually via
+//!    `reward-memory record`). Experiment / dogfood / provider sync from
+//!    the LoopX surface are deliberately out of scope for phase 1.
+//! ② scoped_feedback — [`collect_signals`] + [`summarize`] project the
+//!    ledger back out by scope (goal is implicit; agent / todo / source
+//!    filter), surfaced as `reward-memory query`.
+
+use std::collections::BTreeMap;
 
 use super::{successor_todo, Capability, TypedProposal};
+use crate::state::{TaskValidation, ValidationStatus};
+use crate::store::{Event, StoredEvent};
+
+/// Signal source: the run path's independent task-validation receipt.
+pub const SOURCE_VALIDATOR: &str = "validator";
+/// Signal source: a P0-2 delivery outcome resolution (verified/failed/rework).
+pub const SOURCE_DELIVERY_OUTCOME: &str = "delivery_outcome";
+/// Signal source: a manual evidence score (`reward-memory record`).
+pub const SOURCE_EVIDENCE: &str = "evidence";
+
+/// All ingestion sources (CLI `--source` choices).
+pub const REWARD_SOURCE_CHOICES: [&str; 3] =
+    [SOURCE_VALIDATOR, SOURCE_DELIVERY_OUTCOME, SOURCE_EVIDENCE];
+
+/// Normalize a source token (case/whitespace-insensitive) to its canonical
+/// value; `None` for unknown values.
+pub fn normalize_source(value: &str) -> Option<&'static str> {
+    match value.trim().to_lowercase().as_str() {
+        SOURCE_VALIDATOR => Some(SOURCE_VALIDATOR),
+        SOURCE_DELIVERY_OUTCOME => Some(SOURCE_DELIVERY_OUTCOME),
+        SOURCE_EVIDENCE => Some(SOURCE_EVIDENCE),
+        _ => None,
+    }
+}
+
+/// Phase-1 validator → signal mapping (deterministic):
+/// passed = 1.0, progress = 0.5, failed = 0.0; inconclusive / unavailable
+/// carry no score (the validator could not decide); `not_required` means no
+/// independent validation happened, so nothing is ingested at all.
+pub fn validator_signal(v: &TaskValidation) -> Option<(&'static str, Option<f64>)> {
+    match v.status {
+        ValidationStatus::Passed => Some(("passed", Some(1.0))),
+        ValidationStatus::Progress => Some(("progress", Some(0.5))),
+        ValidationStatus::Failed => Some(("failed", Some(0.0))),
+        ValidationStatus::Inconclusive => Some(("inconclusive", None)),
+        ValidationStatus::Unavailable => Some(("unavailable", None)),
+        ValidationStatus::NotRequired => None,
+    }
+}
+
+/// Phase-1 delivery-outcome → signal mapping (deterministic): the three
+/// terminal resolutions — verified = 1.0, rework = 0.5 (delivered value but
+/// changes required), failed = 0.0. The pending `delivered` state is not a
+/// reward signal (no outcome yet).
+pub fn delivery_outcome_signal(outcome: &str) -> Option<(&'static str, Option<f64>)> {
+    match outcome {
+        crate::work_items::delivery_outcome::OUTCOME_VERIFIED => Some(("verified", Some(1.0))),
+        crate::work_items::delivery_outcome::OUTCOME_REWORK => Some(("rework", Some(0.5))),
+        crate::work_items::delivery_outcome::OUTCOME_FAILED => Some(("failed", Some(0.0))),
+        _ => None,
+    }
+}
+
+/// One ingested reward signal — the read-model view of a
+/// `RewardSignalRecorded` ledger event.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct RewardSignal {
+    pub todo_id: String,
+    pub agent_id: Option<String>,
+    pub run_id: Option<String>,
+    pub source: String,
+    pub signal: String,
+    pub score: Option<f64>,
+    pub note: Option<String>,
+    pub seq: u32,
+    pub ts: u64,
+}
+
+/// Scope filter for the scoped-feedback query. The goal scope is implicit
+/// (the query reads one goal's ledger); agent / todo / source narrow it.
+#[derive(Debug, Clone, Default)]
+pub struct RewardScope<'a> {
+    pub agent_id: Option<&'a str>,
+    pub todo_id: Option<&'a str>,
+    pub source: Option<&'a str>,
+}
+
+impl RewardScope<'_> {
+    fn matches(&self, s: &RewardSignal) -> bool {
+        if let Some(a) = self.agent_id {
+            if s.agent_id.as_deref() != Some(a) {
+                return false;
+            }
+        }
+        if let Some(t) = self.todo_id {
+            if s.todo_id != t {
+                return false;
+            }
+        }
+        if let Some(src) = self.source {
+            if s.source != src {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Collect the reward signals from one goal's ledger, filtered by scope.
+/// Deterministic order: ledger order (append order).
+pub fn collect_signals(events: &[StoredEvent], scope: &RewardScope) -> Vec<RewardSignal> {
+    events
+        .iter()
+        .filter_map(|se| match &se.event {
+            Event::RewardSignalRecorded {
+                todo_id,
+                agent_id,
+                run_id,
+                source,
+                signal,
+                score,
+                note,
+                seq,
+                ts,
+                ..
+            } => Some(RewardSignal {
+                todo_id: todo_id.clone(),
+                agent_id: agent_id.clone(),
+                run_id: run_id.clone(),
+                source: source.clone(),
+                signal: signal.clone(),
+                score: *score,
+                note: note.clone(),
+                seq: *seq,
+                ts: *ts,
+            }),
+            _ => None,
+        })
+        .filter(|s| scope.matches(s))
+        .collect()
+}
+
+/// The next per-todo ingestion sequence (1 + the number of reward signals
+/// already in the ledger for this todo) — the G-3 content-id dedupe anchor
+/// for otherwise-identical signals appended within the same second.
+pub fn next_seq(events: &[StoredEvent], todo_id: &str) -> u32 {
+    let count = events
+        .iter()
+        .filter(|se| matches!(&se.event, Event::RewardSignalRecorded { todo_id: t, .. } if t == todo_id))
+        .count();
+    count as u32 + 1
+}
+
+/// Aggregate view over a scoped signal set (the scoped-feedback summary).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct RewardSummary {
+    pub total: usize,
+    /// Signal count per source (validator / delivery_outcome / evidence).
+    pub by_source: BTreeMap<String, usize>,
+    /// How many signals carry a score; `avg_score` averages exactly those.
+    pub scored: usize,
+    pub avg_score: Option<f64>,
+    /// Validator-signal outcome counts (the phase-1 learning headline:
+    /// does the independent validator keep passing?).
+    pub validator_passed: usize,
+    pub validator_failed: usize,
+}
+
+/// Summarize a scoped signal set (deterministic aggregation).
+pub fn summarize(signals: &[RewardSignal]) -> RewardSummary {
+    let mut by_source: BTreeMap<String, usize> = BTreeMap::new();
+    let mut scored = 0usize;
+    let mut total_score = 0.0f64;
+    let mut validator_passed = 0usize;
+    let mut validator_failed = 0usize;
+    for s in signals {
+        *by_source.entry(s.source.clone()).or_insert(0) += 1;
+        if let Some(score) = s.score {
+            scored += 1;
+            total_score += score;
+        }
+        if s.source == SOURCE_VALIDATOR {
+            match s.signal.as_str() {
+                "passed" => validator_passed += 1,
+                "failed" => validator_failed += 1,
+                _ => {}
+            }
+        }
+    }
+    RewardSummary {
+        total: signals.len(),
+        by_source,
+        scored,
+        avg_score: (scored > 0).then_some(total_score / scored as f64),
+        validator_passed,
+        validator_failed,
+    }
+}
 
 pub struct RewardMemoryCapability;
 
@@ -10,7 +216,7 @@ impl Capability for RewardMemoryCapability {
         "reward_memory"
     }
     fn describe(&self) -> &'static str {
-        "capture a run reward as a memory candidate (gated)"
+        "ingest reward signals (validator / delivery outcome / evidence) into the ledger and query them by scope"
     }
     fn propose(&self, input: &str) -> Vec<TypedProposal> {
         let text = input.trim();
@@ -34,5 +240,252 @@ impl Capability for RewardMemoryCapability {
             ),
             "rule: no marker matched",
         )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::RecoveryKind;
+
+    fn validation(status: ValidationStatus) -> TaskValidation {
+        crate::state::task_validation_receipt(
+            status,
+            "shell",
+            "summary",
+            Some(RecoveryKind::RepairRequired),
+            Some(1),
+        )
+    }
+
+    fn stored_signal(todo_id: &str, source: &str, signal: &str, score: Option<f64>) -> StoredEvent {
+        StoredEvent {
+            event_id: String::new(),
+            producer: None,
+            source_ref: None,
+            source_section: None,
+            source_line: None,
+            privacy: None,
+            event: Event::RewardSignalRecorded {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                agent_id: None,
+                run_id: None,
+                source: source.into(),
+                signal: signal.into(),
+                score,
+                note: None,
+                seq: 1,
+                ts: 100,
+            },
+        }
+    }
+
+    #[test]
+    fn validator_signal_maps_every_status() {
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::Passed)),
+            Some(("passed", Some(1.0)))
+        );
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::Progress)),
+            Some(("progress", Some(0.5)))
+        );
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::Failed)),
+            Some(("failed", Some(0.0)))
+        );
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::Inconclusive)),
+            Some(("inconclusive", None))
+        );
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::Unavailable)),
+            Some(("unavailable", None))
+        );
+        // not_required = no independent validation happened → no ingestion.
+        assert_eq!(
+            validator_signal(&validation(ValidationStatus::NotRequired)),
+            None
+        );
+    }
+
+    #[test]
+    fn delivery_outcome_signal_maps_resolutions_only() {
+        use crate::work_items::delivery_outcome as dov;
+        assert_eq!(
+            delivery_outcome_signal(dov::OUTCOME_VERIFIED),
+            Some(("verified", Some(1.0)))
+        );
+        assert_eq!(
+            delivery_outcome_signal(dov::OUTCOME_REWORK),
+            Some(("rework", Some(0.5)))
+        );
+        assert_eq!(
+            delivery_outcome_signal(dov::OUTCOME_FAILED),
+            Some(("failed", Some(0.0)))
+        );
+        // The pending state is not a reward signal; neither is garbage.
+        assert_eq!(delivery_outcome_signal(dov::OUTCOME_DELIVERED), None);
+        assert_eq!(delivery_outcome_signal("bogus"), None);
+    }
+
+    #[test]
+    fn normalize_source_accepts_canonical_and_rejects_unknown() {
+        assert_eq!(normalize_source("validator"), Some(SOURCE_VALIDATOR));
+        assert_eq!(normalize_source(" Evidence "), Some(SOURCE_EVIDENCE));
+        assert_eq!(
+            normalize_source("DELIVERY_OUTCOME"),
+            Some(SOURCE_DELIVERY_OUTCOME)
+        );
+        assert_eq!(normalize_source("nope"), None);
+    }
+
+    #[test]
+    fn collect_filters_by_agent_todo_and_source_scope() {
+        let mut with_agent = stored_signal("t1", SOURCE_VALIDATOR, "passed", Some(1.0));
+        if let Event::RewardSignalRecorded { agent_id, .. } = &mut with_agent.event {
+            *agent_id = Some("agent-a".into());
+        }
+        let events = vec![
+            with_agent,
+            stored_signal("t1", SOURCE_EVIDENCE, "scored", Some(0.7)),
+            stored_signal("t2", SOURCE_VALIDATOR, "failed", Some(0.0)),
+        ];
+        // No scope: everything, in ledger order.
+        let all = collect_signals(&events, &RewardScope::default());
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].todo_id, "t1");
+        assert_eq!(all[0].agent_id.as_deref(), Some("agent-a"));
+        // Agent scope.
+        let scoped = collect_signals(
+            &events,
+            &RewardScope {
+                agent_id: Some("agent-a"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].source, SOURCE_VALIDATOR);
+        // Todo scope.
+        let scoped = collect_signals(
+            &events,
+            &RewardScope {
+                todo_id: Some("t2"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].signal, "failed");
+        // Source scope.
+        let scoped = collect_signals(
+            &events,
+            &RewardScope {
+                source: Some(SOURCE_EVIDENCE),
+                ..Default::default()
+            },
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].score, Some(0.7));
+        // Combined scope with no match.
+        let scoped = collect_signals(
+            &events,
+            &RewardScope {
+                agent_id: Some("agent-a"),
+                todo_id: Some("t2"),
+                ..Default::default()
+            },
+        );
+        assert!(scoped.is_empty());
+        // Non-reward events are ignored.
+        let other = StoredEvent {
+            event_id: String::new(),
+            producer: None,
+            source_ref: None,
+            source_section: None,
+            source_line: None,
+            privacy: None,
+            event: Event::GoalStarted {
+                goal_id: "g".into(),
+                ts: 1,
+            },
+        };
+        assert!(collect_signals(&[other], &RewardScope::default()).is_empty());
+    }
+
+    #[test]
+    fn next_seq_counts_existing_signals_for_the_todo() {
+        let events = vec![
+            stored_signal("t1", SOURCE_VALIDATOR, "passed", Some(1.0)),
+            stored_signal("t1", SOURCE_EVIDENCE, "scored", Some(0.5)),
+            stored_signal("t2", SOURCE_VALIDATOR, "failed", Some(0.0)),
+        ];
+        assert_eq!(next_seq(&events, "t1"), 3);
+        assert_eq!(next_seq(&events, "t2"), 2);
+        assert_eq!(next_seq(&events, "t3"), 1);
+        assert_eq!(next_seq(&[], "t1"), 1);
+    }
+
+    #[test]
+    fn summarize_aggregates_sources_scores_and_validator_outcomes() {
+        let signals = vec![
+            RewardSignal {
+                todo_id: "t1".into(),
+                agent_id: None,
+                run_id: None,
+                source: SOURCE_VALIDATOR.into(),
+                signal: "passed".into(),
+                score: Some(1.0),
+                note: None,
+                seq: 1,
+                ts: 1,
+            },
+            RewardSignal {
+                todo_id: "t1".into(),
+                agent_id: None,
+                run_id: None,
+                source: SOURCE_VALIDATOR.into(),
+                signal: "failed".into(),
+                score: Some(0.0),
+                note: None,
+                seq: 2,
+                ts: 2,
+            },
+            RewardSignal {
+                todo_id: "t2".into(),
+                agent_id: None,
+                run_id: None,
+                source: SOURCE_EVIDENCE.into(),
+                signal: "scored".into(),
+                score: Some(0.5),
+                note: None,
+                seq: 1,
+                ts: 3,
+            },
+            RewardSignal {
+                todo_id: "t3".into(),
+                agent_id: None,
+                run_id: None,
+                source: SOURCE_VALIDATOR.into(),
+                signal: "inconclusive".into(),
+                score: None,
+                note: None,
+                seq: 1,
+                ts: 4,
+            },
+        ];
+        let s = summarize(&signals);
+        assert_eq!(s.total, 4);
+        assert_eq!(s.by_source.get(SOURCE_VALIDATOR), Some(&3));
+        assert_eq!(s.by_source.get(SOURCE_EVIDENCE), Some(&1));
+        assert_eq!(s.scored, 3);
+        assert_eq!(s.avg_score, Some(0.5));
+        assert_eq!(s.validator_passed, 1);
+        assert_eq!(s.validator_failed, 1);
+        // Empty set: no average.
+        let empty = summarize(&[]);
+        assert_eq!(empty.total, 0);
+        assert_eq!(empty.avg_score, None);
+        assert!(empty.by_source.is_empty());
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -153,6 +153,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "attention" => cmd_attention(&store, &args[1..]),
         "inbox" => cmd_inbox(&store, &args[1..]),
         "delivery" => cmd_delivery(&mut store, &args[1..]),
+        "reward-memory" => cmd_reward_memory(&mut store, &args[1..]),
         "registry" => cmd_registry(&registry, &args[1..]),
         "commands" => cmd_commands(&registry, &args[1..]),
         // ── P4 commands (G-18 / G-19 / G-20 / G-27) ───────────────────────
@@ -200,6 +201,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("attention", Journey::Daily),
     ("inbox", Journey::Daily),
     ("delivery", Journey::Daily),
+    ("reward-memory", Journey::Daily),
     ("diagnose", Journey::Daily),
     ("evidence-log", Journey::Daily),
     ("todo-event", Journey::Daily),
@@ -475,7 +477,7 @@ fn build_cli_registry() -> CommandRegistry {
 
     let work_items = r.group(
         "work-items",
-        "attention / operator inbox (G-15) / delivery outcome closure (P0-2)",
+        "attention / operator inbox (G-15) / delivery outcome closure (P0-2) / reward memory (P1-5)",
     );
     r.command(
         work_items,
@@ -494,6 +496,12 @@ fn build_cli_registry() -> CommandRegistry {
         "delivery",
         "post-delivery outcome closure (P0-2): delivered → verified/failed/rework + follow-through",
         "delivery status --goal G [--format json] | record --goal G --todo-id T --outcome verified|failed|rework [--note N] | followthrough --goal G [--turns N]",
+    );
+    r.command(
+        work_items,
+        "reward-memory",
+        "reward memory (P1-5): validator/delivery/evidence signal ingestion + scoped feedback",
+        "reward-memory query --goal G [--agent-id A] [--todo-id T] [--source S] [--format json] | record --goal G --todo-id T --score 0.0..1.0 [--source evidence] [--note N] [--agent-id A]",
     );
 
     let handoff = r.group("handoff", "project handoff (G-17)");
@@ -2896,6 +2904,11 @@ async fn run_turns(
             record: record.clone(),
             ts: now_epoch(),
         })?;
+        // P1-5 reward_memory ingestion: the turn's independent validation
+        // receipt (if any) lands in the reward ledger (source `validator`).
+        if ingest_validator_reward(store, goal_id, &todo_id, agent_id, &record)? {
+            println!("   ↳ reward signal ingested (validator)");
+        }
         // G-3: quota spend lands as a durable event alongside the run ledger
         // (source mirrors slot accounting; monitor no-change never spends).
         if monitor_changed != Some(false) {
@@ -4585,11 +4598,17 @@ fn delivery_record(store: &mut Store, args: &[String]) -> Result<()> {
         goal_id: goal_id.clone(),
         todo_id: todo_id.clone(),
         outcome: outcome.to_string(),
-        note,
+        note: note.clone(),
         delivered_turn: current_turn,
         seq,
         ts: now_epoch(),
     })?;
+    // P1-5 reward_memory ingestion: a delivery RESOLUTION is a reward
+    // signal (the P0-2 outcome chain is reward_memory's phase-1 signal
+    // source); the pending `delivered` state ingests nothing.
+    if ingest_delivery_reward(store, &goal_id, &todo_id, outcome, note)? {
+        println!("   ↳ reward signal ingested (delivery_outcome/{outcome})");
+    }
     println!("delivery {todo_id} → {outcome} ✔");
     Ok(())
 }
@@ -4657,6 +4676,264 @@ fn run_followthrough_check(
         created.push(followup_id);
     }
     Ok(created)
+}
+
+// ── reward-memory (P1-5: reward memory phase 1 — ingestion + scoped feedback) ──
+
+/// P1-5 ingestion helper: a turn that carried an independent validation
+/// receipt feeds the reward ledger (source `validator`). Returns true when
+/// a signal was appended (`not_required` / no receipt ingests nothing).
+fn ingest_validator_reward(
+    store: &mut Store,
+    goal_id: &str,
+    todo_id: &str,
+    agent_id: Option<&str>,
+    record: &RunRecord,
+) -> Result<bool> {
+    use crate::capabilities::reward_memory as rm;
+    let Some(v) = &record.validation else {
+        return Ok(false);
+    };
+    let Some((signal, score)) = rm::validator_signal(v) else {
+        return Ok(false);
+    };
+    let seq = rm::next_seq(&store.events(goal_id)?, todo_id);
+    store.append(Event::RewardSignalRecorded {
+        goal_id: goal_id.to_string(),
+        todo_id: todo_id.to_string(),
+        agent_id: agent_id.map(str::to_string),
+        run_id: Some(record.run_id.clone()),
+        source: rm::SOURCE_VALIDATOR.to_string(),
+        signal: signal.to_string(),
+        score,
+        note: Some(v.summary.clone()),
+        seq,
+        ts: now_epoch(),
+    })?;
+    Ok(true)
+}
+
+/// P1-5 ingestion helper: a delivery RESOLUTION (verified/failed/rework) is
+/// a reward signal (source `delivery_outcome`) — the P0-2 outcome chain is
+/// reward_memory's phase-1 signal source. Returns true when appended (the
+/// pending `delivered` state ingests nothing).
+fn ingest_delivery_reward(
+    store: &mut Store,
+    goal_id: &str,
+    todo_id: &str,
+    outcome: &str,
+    note: Option<String>,
+) -> Result<bool> {
+    use crate::capabilities::reward_memory as rm;
+    let Some((signal, score)) = rm::delivery_outcome_signal(outcome) else {
+        return Ok(false);
+    };
+    let seq = rm::next_seq(&store.events(goal_id)?, todo_id);
+    store.append(Event::RewardSignalRecorded {
+        goal_id: goal_id.to_string(),
+        todo_id: todo_id.to_string(),
+        agent_id: None,
+        run_id: None,
+        source: rm::SOURCE_DELIVERY_OUTCOME.to_string(),
+        signal: signal.to_string(),
+        score,
+        note,
+        seq,
+        ts: now_epoch(),
+    })?;
+    Ok(true)
+}
+
+/// `reward-memory <query|record>` — the P1-5 surface: scoped_feedback read
+/// model (query) + manual evidence scoring (record). Validator and
+/// delivery-outcome signals ingest automatically (run path / `delivery
+/// record`); experiment/dogfood are out of scope for phase 1.
+fn cmd_reward_memory(store: &mut Store, args: &[String]) -> Result<()> {
+    match args.first().map(|s| s.as_str()) {
+        Some("query") => reward_memory_query(store, &args[1..]),
+        Some("record") => reward_memory_record(store, &args[1..]),
+        _ => bail!("reward-memory subcommand must be `query` or `record`"),
+    }
+}
+
+/// `reward-memory query --goal G [--agent-id A] [--todo-id T] [--source S]
+/// [--format json]` — the scoped_feedback read model: reward signals from
+/// the goal ledger, filtered by agent / todo / source scope, plus a
+/// deterministic aggregate summary.
+fn reward_memory_query(store: &Store, args: &[String]) -> Result<()> {
+    use crate::capabilities::reward_memory as rm;
+    reject_unknown_flags(
+        args,
+        &[
+            "--agent-id",
+            "--format",
+            "--goal",
+            "--json",
+            "--source",
+            "--todo-id",
+        ],
+    )?;
+    let mut goal_id = None;
+    let mut agent_id = None;
+    let mut todo_id = None;
+    let mut source_raw = None;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--agent-id" => agent_id = Some(v),
+        "--todo-id" => todo_id = Some(v),
+        "--source" => source_raw = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let source = match source_raw.as_deref() {
+        None => None,
+        Some(raw) => Some(rm::normalize_source(raw).ok_or_else(|| {
+            anyhow::anyhow!(
+                "--source must be one of: {}",
+                rm::REWARD_SOURCE_CHOICES.join(", ")
+            )
+        })?),
+    };
+    if !store.registered(&goal_id) {
+        bail!("goal {goal_id} not found");
+    }
+    let events = store.events(&goal_id)?;
+    let scope = rm::RewardScope {
+        agent_id: agent_id.as_deref(),
+        todo_id: todo_id.as_deref(),
+        source,
+    };
+    let signals = rm::collect_signals(&events, &scope);
+    let summary = rm::summarize(&signals);
+    if wants_json(args) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "goal_id": goal_id,
+                "scope": {
+                    "agent_id": agent_id,
+                    "todo_id": todo_id,
+                    "source": source,
+                },
+                "signals": signals,
+                "summary": summary,
+            }))?
+        );
+        return Ok(());
+    }
+    if signals.is_empty() {
+        println!(
+            "no reward signals for goal {goal_id} (signals ingest from validator receipts, delivery resolutions, and `reward-memory record`)"
+        );
+        return Ok(());
+    }
+    let avg = summary
+        .avg_score
+        .map(|a| format!("{a:.2}"))
+        .unwrap_or_else(|| "-".to_string());
+    println!(
+        "reward signals for {goal_id}: {} total (validator passed={} failed={}, scored={}, avg_score={})",
+        summary.total, summary.validator_passed, summary.validator_failed, summary.scored, avg
+    );
+    for s in &signals {
+        let score = s
+            .score
+            .map(|v| format!(" score={v:.2}"))
+            .unwrap_or_default();
+        let agent = s
+            .agent_id
+            .as_deref()
+            .map(|a| format!(" agent={a}"))
+            .unwrap_or_default();
+        let run = s
+            .run_id
+            .as_deref()
+            .map(|r| format!(" run={r}"))
+            .unwrap_or_default();
+        let note = s
+            .note
+            .as_deref()
+            .map(|n| format!(" note={n}"))
+            .unwrap_or_default();
+        println!(
+            "  {} [{}/{}]{}{}{}{}",
+            s.todo_id, s.source, s.signal, score, agent, run, note
+        );
+    }
+    Ok(())
+}
+
+/// `reward-memory record --goal G --todo-id T --score 0.0..1.0 [--source
+/// evidence] [--note N] [--agent-id A]` — manual evidence scoring into the
+/// reward ledger (phase-1 ingestion path for evidence that does not come
+/// from a validator receipt or a delivery resolution).
+fn reward_memory_record(store: &mut Store, args: &[String]) -> Result<()> {
+    use crate::capabilities::reward_memory as rm;
+    reject_unknown_flags(
+        args,
+        &[
+            "--agent-id",
+            "--goal",
+            "--note",
+            "--score",
+            "--source",
+            "--todo-id",
+        ],
+    )?;
+    let mut goal_id = None;
+    let mut todo_id = None;
+    let mut score_raw = None;
+    let mut source_raw = None;
+    let mut note = None;
+    let mut agent_id = None;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--todo-id" => todo_id = Some(v),
+        "--score" => score_raw = Some(v),
+        "--source" => source_raw = Some(v),
+        "--note" => note = Some(v),
+        "--agent-id" => agent_id = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let todo_id = todo_id.ok_or_else(|| anyhow::anyhow!("--todo-id required"))?;
+    let score_raw = score_raw.ok_or_else(|| anyhow::anyhow!("--score required"))?;
+    let score: f64 = score_raw
+        .parse()
+        .map_err(|_| anyhow::anyhow!("--score must be a number in 0.0..=1.0"))?;
+    if !score.is_finite() || !(0.0..=1.0).contains(&score) {
+        bail!("--score must be a number in 0.0..=1.0");
+    }
+    let source = match source_raw.as_deref() {
+        None => rm::SOURCE_EVIDENCE,
+        Some(raw) => rm::normalize_source(raw).ok_or_else(|| {
+            anyhow::anyhow!(
+                "--source must be one of: {}",
+                rm::REWARD_SOURCE_CHOICES.join(", ")
+            )
+        })?,
+    };
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    if goal.todo(&todo_id).is_none() {
+        bail!("todo {todo_id} not found in goal {goal_id}");
+    }
+    let seq = rm::next_seq(&store.events(&goal_id)?, &todo_id);
+    store.append(Event::RewardSignalRecorded {
+        goal_id: goal_id.clone(),
+        todo_id: todo_id.clone(),
+        agent_id,
+        run_id: None,
+        source: source.to_string(),
+        signal: "scored".to_string(),
+        score: Some(score),
+        note,
+        seq,
+        ts: now_epoch(),
+    })?;
+    println!("reward signal recorded: {todo_id} [{source}/scored] score={score:.2} ✔");
+    Ok(())
 }
 
 // ── registry (G-26) ────────────────────────────────────────────────────────
@@ -5582,7 +5859,14 @@ fn event_touches_todo(event: &crate::store::Event, todo_id: &str) -> bool {
         | Event::TodoReleased { todo_id: id, .. }
         | Event::TodoExpired { todo_id: id, .. }
         | Event::WorkspaceLockAcquired { todo_id: id, .. }
+        | Event::RewardSignalRecorded { todo_id: id, .. }
+        | Event::DeliveryOutcomeRecorded { todo_id: id, .. }
         | Event::GateResolved { todo_id: id, .. } => id == todo_id,
+        Event::FollowthroughCreated {
+            source_todo_id,
+            followup_todo_id,
+            ..
+        } => source_todo_id == todo_id || followup_todo_id == todo_id,
         Event::RunRecorded { record, .. } => record.todo_id == todo_id,
         _ => false,
     }
@@ -5745,6 +6029,16 @@ fn describe_event(event: &crate::store::Event) -> String {
             return format!(
                 "followthrough_created source={source_todo_id} followup={followup_todo_id}"
             );
+        }
+        Event::RewardSignalRecorded {
+            todo_id,
+            source,
+            signal,
+            score,
+            ..
+        } => {
+            let score = score.map(|v| format!(" score={v:.2}")).unwrap_or_default();
+            return format!("reward_signal todo={todo_id} source={source} signal={signal}{score}");
         }
         Event::SupervisorProposed {
             decision_id,
@@ -7361,5 +7655,310 @@ mod workspace_guard_cli_tests {
         // todo-event filtering picks the lock event up for its todo.
         assert!(event_touches_todo(&event, "t1"));
         assert!(!event_touches_todo(&event, "t2"));
+    }
+}
+
+#[cfg(test)]
+mod reward_memory_cli_tests {
+    use super::*;
+    use crate::state::{task_validation_receipt, RecoveryKind, ValidationStatus};
+
+    fn tmp_store(tag: &str) -> Store {
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-p15-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        Store::open(dir.to_string_lossy().as_ref()).unwrap()
+    }
+
+    fn open_goal(store: &mut Store, goal_id: &str) {
+        let goal = Goal::new(goal_id, "objective", "/tmp");
+        store.register(&goal).unwrap();
+        let ts = goal.created_at;
+        store
+            .append(Event::GoalStarted {
+                goal_id: goal_id.into(),
+                ts,
+            })
+            .unwrap();
+        store
+            .append(Event::TodoAdded {
+                goal_id: goal_id.into(),
+                todo: Todo::advancement("t1", "shared work"),
+                ts,
+            })
+            .unwrap();
+    }
+
+    fn record_with_validation(validation: Option<crate::state::TaskValidation>) -> RunRecord {
+        RunRecord {
+            turn: 1,
+            todo_id: "t1".into(),
+            run_id: "r1".into(),
+            terminal_state: "completed".into(),
+            error: None,
+            tokens_in_delta: 0,
+            tokens_out_delta: 0,
+            cost_delta: 0.0,
+            tools: vec![],
+            evidence: "ev".into(),
+            recorded_at: 0,
+            spend_source: None,
+            validation,
+        }
+    }
+
+    fn signals(
+        store: &Store,
+        goal_id: &str,
+    ) -> Vec<crate::capabilities::reward_memory::RewardSignal> {
+        crate::capabilities::reward_memory::collect_signals(
+            &store.events(goal_id).unwrap(),
+            &crate::capabilities::reward_memory::RewardScope::default(),
+        )
+    }
+
+    #[test]
+    fn validator_ingestion_appends_signal_with_run_and_agent() {
+        let mut store = tmp_store("validator");
+        open_goal(&mut store, "g1");
+        // No receipt → nothing ingested.
+        let rec = record_with_validation(None);
+        assert!(!ingest_validator_reward(&mut store, "g1", "t1", Some("a1"), &rec).unwrap());
+        // not_required = no independent validation happened → nothing ingested.
+        let rec = record_with_validation(Some(task_validation_receipt(
+            ValidationStatus::NotRequired,
+            "shell",
+            "no validator",
+            None,
+            None,
+        )));
+        assert!(!ingest_validator_reward(&mut store, "g1", "t1", Some("a1"), &rec).unwrap());
+        assert!(signals(&store, "g1").is_empty());
+        // A passed receipt ingests score 1.0 with run/agent provenance.
+        let rec = record_with_validation(Some(task_validation_receipt(
+            ValidationStatus::Passed,
+            "shell",
+            "tests green",
+            None,
+            Some(0),
+        )));
+        assert!(ingest_validator_reward(&mut store, "g1", "t1", Some("a1"), &rec).unwrap());
+        let got = signals(&store, "g1");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].source, "validator");
+        assert_eq!(got[0].signal, "passed");
+        assert_eq!(got[0].score, Some(1.0));
+        assert_eq!(got[0].agent_id.as_deref(), Some("a1"));
+        assert_eq!(got[0].run_id.as_deref(), Some("r1"));
+        assert_eq!(got[0].note.as_deref(), Some("tests green"));
+        assert_eq!(got[0].seq, 1);
+        // A failed receipt ingests score 0.0 with the next sequence number.
+        let rec = record_with_validation(Some(task_validation_receipt(
+            ValidationStatus::Failed,
+            "shell",
+            "tests red",
+            Some(RecoveryKind::RepairRequired),
+            Some(1),
+        )));
+        assert!(ingest_validator_reward(&mut store, "g1", "t1", None, &rec).unwrap());
+        let got = signals(&store, "g1");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1].signal, "failed");
+        assert_eq!(got[1].score, Some(0.0));
+        assert_eq!(got[1].agent_id, None);
+        assert_eq!(got[1].seq, 2);
+    }
+
+    #[test]
+    fn delivery_ingestion_appends_only_for_resolutions() {
+        let mut store = tmp_store("delivery");
+        open_goal(&mut store, "g1");
+        // Pending state and garbage ingest nothing.
+        assert!(!ingest_delivery_reward(&mut store, "g1", "t1", "delivered", None).unwrap());
+        assert!(!ingest_delivery_reward(&mut store, "g1", "t1", "bogus", None).unwrap());
+        assert!(signals(&store, "g1").is_empty());
+        // Resolutions ingest their phase-1 scores.
+        assert!(ingest_delivery_reward(
+            &mut store,
+            "g1",
+            "t1",
+            "verified",
+            Some("confirmed".into())
+        )
+        .unwrap());
+        assert!(ingest_delivery_reward(&mut store, "g1", "t1", "rework", None).unwrap());
+        let got = signals(&store, "g1");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].source, "delivery_outcome");
+        assert_eq!(got[0].signal, "verified");
+        assert_eq!(got[0].score, Some(1.0));
+        assert_eq!(got[0].note.as_deref(), Some("confirmed"));
+        assert_eq!(got[1].signal, "rework");
+        assert_eq!(got[1].score, Some(0.5));
+        assert_eq!(got[1].seq, 2);
+    }
+
+    #[test]
+    fn record_command_validates_inputs() {
+        let mut store = tmp_store("record-validate");
+        open_goal(&mut store, "g1");
+        let args = |extra: &[&str]| extra.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // Missing --goal / --todo-id / --score each fail fast.
+        assert!(
+            reward_memory_record(&mut store, &args(&["--todo-id", "t1", "--score", "0.5"]))
+                .is_err()
+        );
+        assert!(
+            reward_memory_record(&mut store, &args(&["--goal", "g1", "--score", "0.5"])).is_err()
+        );
+        assert!(
+            reward_memory_record(&mut store, &args(&["--goal", "g1", "--todo-id", "t1"])).is_err()
+        );
+        // Score must be a finite number in 0.0..=1.0.
+        for bad in ["abc", "1.5", "-0.1", "NaN"] {
+            assert!(
+                reward_memory_record(
+                    &mut store,
+                    &args(&["--goal", "g1", "--todo-id", "t1", "--score", bad])
+                )
+                .is_err(),
+                "score {bad} must be rejected"
+            );
+        }
+        // Unknown todo / goal fail closed.
+        assert!(reward_memory_record(
+            &mut store,
+            &args(&["--goal", "g1", "--todo-id", "nope", "--score", "0.5"])
+        )
+        .is_err());
+        assert!(reward_memory_record(
+            &mut store,
+            &args(&["--goal", "nope", "--todo-id", "t1", "--score", "0.5"])
+        )
+        .is_err());
+        // Unknown source is rejected; unknown flags are rejected.
+        assert!(reward_memory_record(
+            &mut store,
+            &args(&[
+                "--goal",
+                "g1",
+                "--todo-id",
+                "t1",
+                "--score",
+                "0.5",
+                "--source",
+                "nope"
+            ])
+        )
+        .is_err());
+        assert!(reward_memory_record(
+            &mut store,
+            &args(&[
+                "--goal",
+                "g1",
+                "--todo-id",
+                "t1",
+                "--score",
+                "0.5",
+                "--bogus"
+            ])
+        )
+        .is_err());
+        assert!(signals(&store, "g1").is_empty());
+    }
+
+    #[test]
+    fn record_command_appends_evidence_signal() {
+        let mut store = tmp_store("record-ok");
+        open_goal(&mut store, "g1");
+        let args = |extra: &[&str]| extra.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        reward_memory_record(
+            &mut store,
+            &args(&[
+                "--goal",
+                "g1",
+                "--todo-id",
+                "t1",
+                "--score",
+                "0.8",
+                "--note",
+                "solid evidence",
+                "--agent-id",
+                "a9",
+            ]),
+        )
+        .unwrap();
+        let got = signals(&store, "g1");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].source, "evidence");
+        assert_eq!(got[0].signal, "scored");
+        assert_eq!(got[0].score, Some(0.8));
+        assert_eq!(got[0].note.as_deref(), Some("solid evidence"));
+        assert_eq!(got[0].agent_id.as_deref(), Some("a9"));
+        // Boundary scores are legal.
+        reward_memory_record(
+            &mut store,
+            &args(&["--goal", "g1", "--todo-id", "t1", "--score", "0"]),
+        )
+        .unwrap();
+        reward_memory_record(
+            &mut store,
+            &args(&["--goal", "g1", "--todo-id", "t1", "--score", "1"]),
+        )
+        .unwrap();
+        assert_eq!(signals(&store, "g1").len(), 3);
+    }
+
+    #[test]
+    fn describe_event_and_todo_filter_cover_reward_signals() {
+        let event = Event::RewardSignalRecorded {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            agent_id: Some("a1".into()),
+            run_id: None,
+            source: "validator".into(),
+            signal: "passed".into(),
+            score: Some(1.0),
+            note: None,
+            seq: 1,
+            ts: 1,
+        };
+        let text = describe_event(&event);
+        assert!(text.contains("reward_signal"), "got: {text}");
+        assert!(text.contains("validator"), "got: {text}");
+        assert!(text.contains("score=1.00"), "got: {text}");
+        assert!(event_touches_todo(&event, "t1"));
+        assert!(!event_touches_todo(&event, "t2"));
+    }
+
+    #[test]
+    fn todo_filter_covers_delivery_and_followthrough_events() {
+        let delivery = Event::DeliveryOutcomeRecorded {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            outcome: "verified".into(),
+            note: None,
+            delivered_turn: 3,
+            seq: 1,
+            ts: 1,
+        };
+        assert!(event_touches_todo(&delivery, "t1"));
+        assert!(!event_touches_todo(&delivery, "t2"));
+        let follow = Event::FollowthroughCreated {
+            goal_id: "g1".into(),
+            source_todo_id: "t1".into(),
+            followup_todo_id: "t9".into(),
+            turns_overdue: 4,
+            ts: 1,
+        };
+        // Visible from BOTH the source delivery and the derived follow-up.
+        assert!(event_touches_todo(&follow, "t1"));
+        assert!(event_touches_todo(&follow, "t9"));
+        assert!(!event_touches_todo(&follow, "t2"));
     }
 }

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -382,6 +382,36 @@ pub enum Event {
         turns_overdue: u32,
         ts: u64,
     },
+    /// P1-5: reward_memory ingestion (phase 1) — one scoped reward signal
+    /// in the ledger (LoopX `capabilities/reward_memory/ingestion.py`,
+    /// compact set). Sources: `validator` (auto-recorded by the run path
+    /// when a turn carries an independent task-validation receipt),
+    /// `delivery_outcome` (auto-recorded when a P0-2 delivery is resolved
+    /// verified/failed/rework), `evidence` (manual score via
+    /// `reward-memory record`). Projection-only: goal state is unchanged;
+    /// the scoped-feedback query (`reward-memory query`) reads the ledger.
+    RewardSignalRecorded {
+        goal_id: String,
+        todo_id: String,
+        #[serde(default)]
+        agent_id: Option<String>,
+        #[serde(default)]
+        run_id: Option<String>,
+        source: String,
+        signal: String,
+        #[serde(default)]
+        score: Option<f64>,
+        #[serde(default)]
+        note: Option<String>,
+        /// Per-todo ingestion sequence (1-based, from the ledger at append
+        /// time). Distinguishes otherwise-identical signals appended within
+        /// the same second (G-3 content-id dedupe anchor, mirroring
+        /// DeliveryOutcomeRecorded.seq). Old events without the field
+        /// deserialize as 0.
+        #[serde(default)]
+        seq: u32,
+        ts: u64,
+    },
     /// G-16: a supervisor proposed a decision for a target agent (LoopX
     /// SUPERVISOR_PROPOSED). Projection-only — supervisor state is read from
     /// the event log, not folded into goal state.
@@ -439,6 +469,7 @@ impl Event {
             | Event::TodoExpired { goal_id, .. }
             | Event::DeliveryOutcomeRecorded { goal_id, .. }
             | Event::FollowthroughCreated { goal_id, .. }
+            | Event::RewardSignalRecorded { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. } => goal_id,
         }
@@ -1389,9 +1420,12 @@ fn apply(goal: &mut Goal, event: Event) {
             ts,
             ..
         } => goal.apply_followthrough(&source_todo_id, &followup_todo_id, ts),
-        // G-16: supervisor events are projection-only (read from the event
-        // log by the supervisor domain; goal state is unchanged).
-        Event::SupervisorProposed { .. } | Event::SupervisorReceiptRecorded { .. } => {}
+        // P1-5: reward signals are projection-only (read from the event log
+        // by the scoped-feedback query; goal state is unchanged) — same
+        // treatment as the G-16 supervisor events.
+        Event::RewardSignalRecorded { .. }
+        | Event::SupervisorProposed { .. }
+        | Event::SupervisorReceiptRecorded { .. } => {}
     }
 }
 

--- a/orchestration/loop/tests/reward_memory_contract.rs
+++ b/orchestration/loop/tests/reward_memory_contract.rs
@@ -1,0 +1,384 @@
+//! P1-5 contract tests: reward_memory phase 1 —
+//!   ① ingestion: validator receipts (run path) and delivery-outcome
+//!      resolutions (`delivery record`) land in the ledger as
+//!      `RewardSignalRecorded` events; `reward-memory record` scores
+//!      evidence manually.
+//!   ② scoped_feedback: `reward-memory query` projects the signals back
+//!      out, filtered by goal (implicit) / agent / todo / source scope,
+//!      with a deterministic aggregate summary.
+//!
+//! These exercise the real CLI entry (`console::run`) against an isolated
+//! `FUTURE_LOOP_ROOT`, plus direct ledger reads for content assertions.
+
+use future_loop::capabilities::reward_memory as rm;
+use future_loop::console;
+use future_loop::store::{Event, Store};
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; tests run in parallel, so
+    // serialize all CLI tests behind one mutex (each still gets its own
+    // isolated root dir).
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = std::env::temp_dir().join(format!("future-loop-reward-{tag}-{}", uuid_like()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let root = dir.join(".future/loop");
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", root.to_str().unwrap());
+    f(root.to_str().unwrap());
+}
+
+fn uuid_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    format!(
+        "{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+/// Set up goal `g1` with one advancement todo; return its todo id.
+fn setup_goal_with_todo(text: &str) -> String {
+    cli(&[
+        "goal",
+        "init",
+        "--objective",
+        "reward memory test",
+        "--cwd",
+        "/tmp",
+        "--goal-id",
+        "g1",
+    ])
+    .unwrap();
+    cli(&["todo", "add", "--goal", "g1", "--text", text]).unwrap();
+    let store = Store::open(&std::env::var("FUTURE_LOOP_ROOT").unwrap()).unwrap();
+    let g = store.replay("g1").unwrap().unwrap();
+    g.todos
+        .iter()
+        .find(|t| t.text.contains(text))
+        .map(|t| t.id.clone())
+        .unwrap()
+}
+
+fn signals(root: &str) -> Vec<rm::RewardSignal> {
+    let store = Store::open(root).unwrap();
+    rm::collect_signals(&store.events("g1").unwrap(), &rm::RewardScope::default())
+}
+
+// ── ① delivery resolutions auto-ingest reward signals; the pending
+//    `delivered` state ingests nothing. ────────────────────────────────────
+#[test]
+fn delivery_resolution_ingests_reward_signal() {
+    with_root("delivery-ingest", |root| {
+        let todo_id = setup_goal_with_todo("ship the widget");
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        // Completing records the PENDING delivery — no reward signal yet.
+        assert!(
+            signals(root).is_empty(),
+            "a pending delivery is not a reward signal"
+        );
+
+        // verified → score 1.0.
+        cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "verified",
+            "--note",
+            "confirmed in production",
+        ])
+        .unwrap();
+        let got = signals(root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].source, rm::SOURCE_DELIVERY_OUTCOME);
+        assert_eq!(got[0].signal, "verified");
+        assert_eq!(got[0].score, Some(1.0));
+        assert_eq!(got[0].note.as_deref(), Some("confirmed in production"));
+        assert_eq!(got[0].todo_id, todo_id);
+
+        // A second todo cycles failed → re-delivered → rework; only the two
+        // resolutions ingest (re-delivery is pending again).
+        let todo2 = setup_goal_with_todo("second widget");
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo2,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        for outcome in ["failed", "delivered", "rework"] {
+            cli(&[
+                "delivery",
+                "record",
+                "--goal",
+                "g1",
+                "--todo-id",
+                &todo2,
+                "--outcome",
+                outcome,
+            ])
+            .unwrap();
+        }
+        let got = signals(root);
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[1].signal, "failed");
+        assert_eq!(got[1].score, Some(0.0));
+        assert_eq!(got[1].seq, 1);
+        assert_eq!(got[2].signal, "rework");
+        assert_eq!(got[2].score, Some(0.5));
+        assert_eq!(got[2].seq, 2);
+
+        // The ledger stays conflict-free with the new events in it.
+        let report = Store::open(root).unwrap().verify("g1").unwrap();
+        assert!(report.ok, "ledger conflicts: {:?}", report.conflicts);
+    });
+}
+
+// ── ① manual evidence scoring via reward-memory record. ──────────────────
+#[test]
+fn record_scores_evidence_into_the_ledger() {
+    with_root("record", |root| {
+        let todo_id = setup_goal_with_todo("evidence candidate");
+        cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--score",
+            "0.8",
+            "--note",
+            "thorough repro attached",
+            "--agent-id",
+            "agent-7",
+        ])
+        .unwrap();
+        let got = signals(root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].source, rm::SOURCE_EVIDENCE);
+        assert_eq!(got[0].signal, "scored");
+        assert_eq!(got[0].score, Some(0.8));
+        assert_eq!(got[0].agent_id.as_deref(), Some("agent-7"));
+
+        // Bad scores / unknown targets fail closed and record nothing.
+        for bad in ["1.5", "-0.5", "abc"] {
+            assert!(cli(&[
+                "reward-memory",
+                "record",
+                "--goal",
+                "g1",
+                "--todo-id",
+                &todo_id,
+                "--score",
+                bad,
+            ])
+            .is_err());
+        }
+        assert!(cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            "todo_nope",
+            "--score",
+            "0.5",
+        ])
+        .is_err());
+        assert!(cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--score",
+            "0.5",
+            "--source",
+            "bogus",
+        ])
+        .is_err());
+        assert_eq!(signals(root).len(), 1);
+    });
+}
+
+// ── ② scoped_feedback: query filters by agent / todo / source scope. ──────
+#[test]
+fn query_projects_scoped_feedback() {
+    with_root("query", |root| {
+        let todo_id = setup_goal_with_todo("scoped work");
+        // Seed signals from two sources and two agents.
+        cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--score",
+            "0.9",
+            "--agent-id",
+            "agent-a",
+        ])
+        .unwrap();
+        cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--score",
+            "0.3",
+            "--agent-id",
+            "agent-b",
+        ])
+        .unwrap();
+        cli(&[
+            "todo",
+            "complete",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--no-follow-up",
+        ])
+        .unwrap();
+        cli(&[
+            "delivery",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--outcome",
+            "verified",
+        ])
+        .unwrap();
+
+        // Unscoped: everything, aggregated deterministically.
+        let store = Store::open(root).unwrap();
+        let events = store.events("g1").unwrap();
+        let all = rm::collect_signals(&events, &rm::RewardScope::default());
+        assert_eq!(all.len(), 3);
+        let summary = rm::summarize(&all);
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.by_source.get(rm::SOURCE_EVIDENCE), Some(&2));
+        assert_eq!(summary.by_source.get(rm::SOURCE_DELIVERY_OUTCOME), Some(&1));
+        assert_eq!(summary.scored, 3);
+        let avg = summary.avg_score.unwrap();
+        assert!((avg - (0.9 + 0.3 + 1.0) / 3.0).abs() < 1e-9, "avg={avg}");
+
+        // Agent scope.
+        let scoped = rm::collect_signals(
+            &events,
+            &rm::RewardScope {
+                agent_id: Some("agent-a"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].score, Some(0.9));
+        // Source scope.
+        let scoped = rm::collect_signals(
+            &events,
+            &rm::RewardScope {
+                source: Some(rm::SOURCE_DELIVERY_OUTCOME),
+                ..Default::default()
+            },
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].signal, "verified");
+
+        // The CLI surface accepts every scope flag (text + JSON).
+        cli(&["reward-memory", "query", "--goal", "g1"]).unwrap();
+        cli(&[
+            "reward-memory",
+            "query",
+            "--goal",
+            "g1",
+            "--agent-id",
+            "agent-a",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        cli(&[
+            "reward-memory",
+            "query",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--source",
+            "evidence",
+        ])
+        .unwrap();
+        // Unknown goal / source / flag fail closed.
+        assert!(cli(&["reward-memory", "query", "--goal", "nope"]).is_err());
+        assert!(cli(&["reward-memory", "query", "--goal", "g1", "--source", "nope"]).is_err());
+        assert!(cli(&["reward-memory", "query", "--goal", "g1", "--bogus"]).is_err());
+        assert!(cli(&["reward-memory", "frobnicate", "--goal", "g1"]).is_err());
+    });
+}
+
+// ── read surface: reward signals appear in the per-todo event history. ────
+#[test]
+fn reward_signals_appear_in_todo_event_history() {
+    with_root("todo-event", |root| {
+        let todo_id = setup_goal_with_todo("historied work");
+        cli(&[
+            "reward-memory",
+            "record",
+            "--goal",
+            "g1",
+            "--todo-id",
+            &todo_id,
+            "--score",
+            "0.5",
+        ])
+        .unwrap();
+        cli(&["todo-event", "--goal", "g1", "--todo-id", &todo_id]).unwrap();
+        // The raw ledger line carries the flattened event for the todo.
+        let store = Store::open(root).unwrap();
+        let lines = store.raw_ledger_lines("g1").unwrap();
+        let reward_lines: Vec<&String> = lines
+            .iter()
+            .filter(|l| l.contains("reward_signal_recorded"))
+            .collect();
+        assert_eq!(reward_lines.len(), 1);
+        assert!(reward_lines[0].contains(&todo_id));
+        // The event round-trips through the typed ledger reader.
+        let events = store.events("g1").unwrap();
+        assert!(events
+            .iter()
+            .any(|se| matches!(&se.event, Event::RewardSignalRecorded { todo_id: t, .. } if *t == todo_id)));
+    });
+}


### PR DESCRIPTION
loopx-improvement-report.md **P1-5**（wave1 拆分 PR 5/11，依赖 P0-2 的 outcome 事件已合）。

- ingestion：validator 结果 + evidence 评分作为 RewardSignalRecorded 入 ledger（invocation_id 唯一字段规避 G-3 幂等折叠）
- scoped_feedback：按 goal/agent scope 查询历史信号
- experiment/dogfood 二期

本地：fmt ✅ clippy ✅ future-loop 69 targets 全绿 ✅。源：claude/loop-wave1 44d594cd + fencing 适配