### PR TITLE
feat(loop): P1-1 quota decision read model — error_codes + decision_summary + receipts

### DIFF
--- a/orchestration/loop/src/cli_projection.rs
+++ b/orchestration/loop/src/cli_projection.rs
@@ -36,6 +36,10 @@ pub fn render_quota_projection(
     out.push_str(&render_decision_line(packet));
     out.push('\n');
     out.push_str(&format!("reason: {}\n", packet.reason));
+    // P1-1①: the machine-readable code next to the prose reason.
+    if !packet.reason_code.is_empty() {
+        out.push_str(&format!("reason_code: {}\n", packet.reason_code));
+    }
     if let Some(todo) = packet
         .interaction_contract
         .agent_channel

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1929,7 +1929,9 @@ fn cmd_quota(store: &Store, args: &[String]) -> Result<()> {
         Some("spend") => quota_spend(store, &args[1..]),
         Some("tools") => quota_tools(store, &args[1..]),
         Some("decisions") => quota_decisions(store, &args[1..]),
-        _ => bail!("quota subcommand must be `should-run`, `usage`, `spend`, `tools`, or `decisions`"),
+        _ => bail!(
+            "quota subcommand must be `should-run`, `usage`, `spend`, `tools`, or `decisions`"
+        ),
     }
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -129,7 +129,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "profile" => cmd_profile(&mut store, &args[1..]),
         "status" => cmd_status(&store, &args[1..]),
         "quota" => cmd_quota(&store, &args[1..]),
-        "scheduler" => cmd_scheduler(&store, &args[1..]),
+        "scheduler" => cmd_scheduler(&mut store, &args[1..]),
         "store" => cmd_store(&mut store, &args[1..]),
         "backfill" => cmd_backfill(&mut store, &args[1..]),
         "privacy" => cmd_privacy(&store, &args[1..]),
@@ -417,14 +417,14 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         ops,
         "quota",
-        "quota should-run / usage / spend / tools",
-        "quota should-run --goal G [--format json] | usage [--goal G] [--all] | spend --goal G | tools --goal G [--format json]",
+        "quota should-run / usage / spend / tools / decisions",
+        "quota should-run --goal G [--format json] | usage [--goal G] [--all] | spend --goal G | tools --goal G [--format json] | decisions --goal G [--limit N]",
     );
     r.command(
         ops,
         "scheduler",
-        "scheduler tick/show/record-host-failure",
-        "scheduler tick|show|record-host-failure --goal G [--agent-id A] [--format json (show)]",
+        "scheduler tick/show/record-host-failure/ack",
+        "scheduler tick|show|record-host-failure|ack --goal G [--agent-id A] [--format json (show)]",
     );
     r.command(
         ops,
@@ -1928,8 +1928,51 @@ fn cmd_quota(store: &Store, args: &[String]) -> Result<()> {
         Some("usage") => quota_usage(store, &args[1..]),
         Some("spend") => quota_spend(store, &args[1..]),
         Some("tools") => quota_tools(store, &args[1..]),
-        _ => bail!("quota subcommand must be `should-run`, `usage`, `spend`, or `tools`"),
+        Some("decisions") => quota_decisions(store, &args[1..]),
+        _ => bail!("quota subcommand must be `should-run`, `usage`, `spend`, `tools`, or `decisions`"),
     }
+}
+
+/// `loopx quota decisions --goal G [--limit N] [--format json]` — the
+/// persisted decision_summary projection (P1-1②): recent compact decisions
+/// (newest first) read straight from the ledger, so status/TUI/desktop-style
+/// consumers reuse the kernel's decision without re-running it.
+fn quota_decisions(store: &Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut format_json = false;
+    let mut limit = 10usize;
+    reject_unknown_flags(args, &["--format", "--goal", "--limit"])?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--format" => format_json = v == "json",
+        "--limit" => limit = v.parse().unwrap_or(10),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let events = store.events(&goal_id)?;
+    let summaries = crate::quota::decision_summary::decision_summaries(&events);
+    let recent: Vec<_> = summaries.into_iter().rev().take(limit).collect();
+    if format_json {
+        println!("{}", serde_json::to_string_pretty(&recent)?);
+        return Ok(());
+    }
+    if recent.is_empty() {
+        println!("goal {goal_id}: no decision summaries recorded yet (run a turn first)");
+        return Ok(());
+    }
+    for s in recent {
+        println!(
+            "turn={} decision={} action={} code={} selected={} slots={}/{}",
+            s.turn,
+            s.decision,
+            s.effective_action,
+            s.reason_code,
+            s.selected_todo.as_deref().unwrap_or("-"),
+            s.spent_slots,
+            s.allowed_slots
+        );
+    }
+    Ok(())
 }
 
 /// `loopx quota should-run --goal G [--format json] [--agent-id A]` — emit
@@ -2102,13 +2145,68 @@ fn quota_tools(store: &Store, args: &[String]) -> Result<()> {
 
 /// `loopx scheduler <tick|show|record-host-failure> --goal G [--agent-id A]`
 /// — drive the persisted scheduler state machine across decision cycles.
-fn cmd_scheduler(store: &Store, args: &[String]) -> Result<()> {
+fn cmd_scheduler(store: &mut Store, args: &[String]) -> Result<()> {
     match args.first().map(|s| s.as_str()) {
         Some("tick") => scheduler_tick(store, &args[1..]),
         Some("show") => scheduler_show(store, &args[1..]),
         Some("record-host-failure") => scheduler_record_failure(store, &args[1..]),
-        _ => bail!("scheduler subcommand must be `tick`, `show`, or `record-host-failure`"),
+        Some("ack") => scheduler_ack(store, &args[1..]),
+        _ => bail!("scheduler subcommand must be `tick`, `show`, `record-host-failure`, or `ack`"),
     }
+}
+
+/// `loopx scheduler ack --goal G [--agent-id A] --action tick_next
+/// [--cadence-class C] [--rrule R] [--source S]` — record the host
+/// scheduler's acknowledgement that it applied the cadence hint (P1-1③;
+/// LoopX `scheduler_ack`). Projection-only audit event; scheduler state
+/// itself is still owned by `scheduler tick`.
+fn scheduler_ack(store: &mut Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut agent_id = None;
+    let mut action = None;
+    let mut cadence_class = String::new();
+    let mut rrule = None;
+    let mut source = "scheduler_cli".to_string();
+    reject_unknown_flags(
+        args,
+        &[
+            "--action",
+            "--agent-id",
+            "--cadence-class",
+            "--goal",
+            "--rrule",
+            "--source",
+        ],
+    )?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--agent-id" => agent_id = Some(v),
+        "--action" => action = Some(v),
+        "--cadence-class" => cadence_class = v,
+        "--rrule" => rrule = Some(v),
+        "--source" => source = v,
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let action = action.ok_or_else(|| anyhow::anyhow!("--action required"))?;
+    store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let agent = agent_id.unwrap_or_else(|| "codex-app".to_string());
+    store.append(Event::SchedulerAcked {
+        goal_id: goal_id.clone(),
+        agent_id: agent.clone(),
+        action: action.clone(),
+        cadence_class,
+        rrule: rrule.clone(),
+        source,
+        ts: now_epoch(),
+    })?;
+    println!(
+        "scheduler ack recorded: goal={goal_id} agent={agent} action={action} rrule={}",
+        rrule.as_deref().unwrap_or("-")
+    );
+    Ok(())
 }
 
 fn scheduler_scope(
@@ -2706,6 +2804,9 @@ async fn run_turns(
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
         let packet = decide_for(&goal, SystemTime::now(), agent_id);
+        // P1-1②③: persist the compact decision projection + the heartbeat
+        // receipt for this turn (projection-only; replay ignores both).
+        crate::quota::decision_summary::record_turn_decision(store, &packet, agent_id, turn)?;
         println!(
             "── turn {turn}: decision={} mode={} | {}",
             packet.decision,
@@ -5868,6 +5969,7 @@ fn event_touches_todo(event: &crate::store::Event, todo_id: &str) -> bool {
             ..
         } => source_todo_id == todo_id || followup_todo_id == todo_id,
         Event::RunRecorded { record, .. } => record.todo_id == todo_id,
+        Event::HeartbeatReceiptRecorded { todo_id: id, .. } => id.as_deref() == Some(todo_id),
         _ => false,
     }
 }
@@ -6039,6 +6141,36 @@ fn describe_event(event: &crate::store::Event) -> String {
         } => {
             let score = score.map(|v| format!(" score={v:.2}")).unwrap_or_default();
             return format!("reward_signal todo={todo_id} source={source} signal={signal}{score}");
+        }
+        Event::DecisionSummaryRecorded { summary, .. } => {
+            return format!(
+                "decision_summary decision={} action={} code={} turn={}",
+                summary.decision, summary.effective_action, summary.reason_code, summary.turn
+            );
+        }
+        Event::HeartbeatReceiptRecorded {
+            agent_id,
+            turn_instance_id,
+            todo_id,
+            ..
+        } => {
+            return format!(
+                "heartbeat_receipt agent={} turn={} todo={}",
+                agent_id.as_deref().unwrap_or("anonymous"),
+                turn_instance_id,
+                todo_id.as_deref().unwrap_or("-")
+            );
+        }
+        Event::SchedulerAcked {
+            agent_id,
+            action,
+            rrule,
+            ..
+        } => {
+            return format!(
+                "scheduler_ack agent={agent_id} action={action} rrule={}",
+                rrule.as_deref().unwrap_or("-")
+            );
         }
         Event::SupervisorProposed {
             decision_id,

--- a/orchestration/loop/src/contract.rs
+++ b/orchestration/loop/src/contract.rs
@@ -201,6 +201,10 @@ pub struct ShouldRunPacket {
     pub should_run: bool,
     pub effective_action: String,
     pub reason: String,
+    /// P1-1①: machine-readable decision reason code (typed-RPC oneof style;
+    /// wire values of `quota::error_codes::DecisionReasonCode`). The prose
+    /// `reason` stays human-facing; this is the stable machine contract.
+    pub reason_code: String,
     pub state: String,
     pub waiting_on: String,
     pub status: String,

--- a/orchestration/loop/src/decision/identity.rs
+++ b/orchestration/loop/src/decision/identity.rs
@@ -17,6 +17,7 @@ pub(crate) fn identity_gate(goal: &Goal, agent_id: Option<&str>) -> Option<Shoul
     // LoopX: state=blocked_health, status=quota_collection_failed, ok=false.
     let mut p = packet(
         goal,
+        crate::quota::error_codes::DecisionReasonCode::IdentityNotRegistered,
         "skip",
         false,
         "automation_prompt_upgrade_required",
@@ -61,6 +62,7 @@ mod tests {
         assert_eq!(p.status, "quota_collection_failed");
         assert_eq!(p.decision, "skip");
         assert_eq!(p.effective_action, "automation_prompt_upgrade_required");
+        assert_eq!(p.reason_code, "identity_not_registered");
         assert!(p.reason.contains("register this agent identity"));
     }
 }

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -54,6 +54,7 @@ use self::monitor::{monitor_outcome, MonitorOutcome};
 use self::oscillation::oscillation_replan_reason;
 use self::primary_action::agent_channel;
 use self::stall::{is_monitor_stalled, outcome_floor_breach, repair_exhausted};
+use crate::quota::error_codes::DecisionReasonCode;
 
 pub use self::arbitration::{
     build_scheduler_arbitration, SchedulerArbitration, SchedulerDisposition,
@@ -78,6 +79,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     if goal.status == "cancelled" {
         let mut p = packet(
             goal,
+            DecisionReasonCode::GoalCancelled,
             "skip",
             false,
             "cancelled",
@@ -129,6 +131,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         let has_fallback = fallback.is_some();
         return packet(
             goal,
+            DecisionReasonCode::OpenUserGate,
             "run",
             true,
             "ask_user",
@@ -166,20 +169,26 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     // ── 2b. Outcome floor (LoopX: surface-only progress loop). ──────────
     if let Some(todo) = retryable.first() {
         if let Some(reason) = outcome_floor_breach(goal) {
-            return replan_packet(goal, &reason);
+            return replan_packet(goal, DecisionReasonCode::OutcomeFloorBreach, &reason);
         }
         // Oscillation guard (LoopX 对比改进项 ③): the goal's recent delivery
         // outcomes strictly alternate accept/reject (A→V→A→V) — the
         // action/verify flip-flop that burns spend without converging.
         // Force a frontier-changing replan instead of the next delivery.
         if let Some(reason) = oscillation_replan_reason(goal) {
-            return replan_packet(goal, &reason);
+            return replan_packet(goal, DecisionReasonCode::OscillationDetected, &reason);
         }
         let attempt = todo.failed_attempts + 1;
-        let reason = if attempt > 1 {
-            format!("repair attempt {attempt} for todo {}", todo.id)
+        let (reason, code) = if attempt > 1 {
+            (
+                format!("repair attempt {attempt} for todo {}", todo.id),
+                DecisionReasonCode::RepairAttempt,
+            )
         } else {
-            format!("runnable todo {}", todo.id)
+            (
+                format!("runnable todo {}", todo.id),
+                DecisionReasonCode::RunnableTodo,
+            )
         };
         // Non-blocking user actions surface in the user channel alongside
         // delivery (LoopX: user_action never freezes the agent).
@@ -201,6 +210,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         };
         return packet(
             goal,
+            code,
             "run",
             true,
             "normal_run",
@@ -218,7 +228,11 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         );
     }
     if repair_exhausted(goal) {
-        return replan_packet(goal, "advancement todo(s) exhausted repair budget");
+        return replan_packet(
+            goal,
+            DecisionReasonCode::RepairBudgetExhausted,
+            "advancement todo(s) exhausted repair budget",
+        );
     }
 
     // ── 2c. Blocked by an external blocker with no fallback: quiet wait. ──
@@ -226,6 +240,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     if !blockers.is_empty() {
         return packet(
             goal,
+            DecisionReasonCode::BlockedNoFallback,
             "wait",
             false,
             "quiet_wait",
@@ -249,6 +264,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     if !unclosed.is_empty() {
         return replan_packet(
             goal,
+            DecisionReasonCode::SuccessionClosureMissing,
             &format!(
                 "completed advancement without closure intent: {} — complete must declare successor or --no-follow-up",
                 unclosed.iter().map(|t| t.id.as_str()).collect::<Vec<_>>().join(", ")
@@ -261,6 +277,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         MonitorOutcome::Stalled(stalled) => {
             return replan_packet(
                 goal,
+                DecisionReasonCode::MonitorStalled,
                 &format!(
                     "monitor {} stalled ({} consecutive no-change polls)",
                     stalled.id, stalled.consecutive_no_change
@@ -270,6 +287,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         MonitorOutcome::Due(due) => {
             return packet(
                 goal,
+                DecisionReasonCode::MonitorDue,
                 "run",
                 true,
                 "monitor_poll",
@@ -292,6 +310,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         MonitorOutcome::Waiting(next_due_ms) => {
             return packet(
                 goal,
+                DecisionReasonCode::MonitorBackoff,
                 "wait",
                 false,
                 "quiet_wait",
@@ -310,6 +329,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     if !gaps.is_empty() {
         return replan_packet(
             goal,
+            DecisionReasonCode::AcceptanceGapOpen,
             &format!(
                 "acceptance gap(s) open with no runnable work: {}",
                 gaps.iter()
@@ -329,6 +349,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     {
         return packet(
             goal,
+            DecisionReasonCode::DeferredNotDue,
             "wait",
             false,
             "quiet_wait",
@@ -342,6 +363,7 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     // ── 6. Validated closure. ───────────────────────────────────────────
     let mut p = packet(
         goal,
+        DecisionReasonCode::ValidatedClosure,
         "skip",
         false,
         "terminal_no_followup",
@@ -358,9 +380,10 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     p
 }
 
-fn replan_packet(goal: &Goal, reason: &str) -> ShouldRunPacket {
+fn replan_packet(goal: &Goal, code: DecisionReasonCode, reason: &str) -> ShouldRunPacket {
     packet(
         goal,
+        code,
         "replan",
         true,
         "replan",
@@ -374,6 +397,7 @@ fn replan_packet(goal: &Goal, reason: &str) -> ShouldRunPacket {
 #[allow(clippy::too_many_arguments)]
 fn packet(
     goal: &Goal,
+    reason_code: DecisionReasonCode,
     decision: &str,
     should_run: bool,
     effective_action: &str,
@@ -401,6 +425,7 @@ fn packet(
         should_run,
         effective_action: effective_action.to_string(),
         reason: reason.to_string(),
+        reason_code: reason_code.as_str().to_string(),
         state: if should_run { "eligible".to_string() } else { "waiting".to_string() },
         waiting_on: "codex".to_string(),
         status: match mode {

--- a/orchestration/loop/src/quota/decision_summary.rs
+++ b/orchestration/loop/src/quota/decision_summary.rs
@@ -1,0 +1,197 @@
+//! Decision summary projection (P1-1②) + receipt writeback (P1-1③).
+//!
+//! LoopX `control_plane/quota/decision_summary.py` compacts each quota
+//! decision into a `QuotaDecisionPacket` projection that CLI / status / host
+//! surfaces consume without re-running the kernel; `heartbeat_receipt.py`
+//! and `scheduler_ack.py` record the corresponding receipts. Pre-P1-1 the
+//! decision reached consumers only through the one-shot turn envelope —
+//! nothing was persisted, so status/TUI/desktop had to re-derive the
+//! decision from goal state.
+//!
+//! This module owns:
+//!   - [`DecisionSummary`] — the compact, serializable decision projection
+//!     (LoopX `compact_quota_decision`);
+//!   - the ledger writeback helper [`record_turn_decision`] — appends one
+//!     `DecisionSummaryRecorded` + one `HeartbeatReceiptRecorded` event per
+//!     executed turn (both projection-only: replay ignores them);
+//!   - the read model ([`decision_summaries`] / [`latest_decision_summary`])
+//!     over the raw ledger, reused by `quota decisions` and available to
+//!     any external consumer reading the event log.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::contract::ShouldRunPacket;
+use crate::store::{Event, Store, StoredEvent};
+
+pub const DECISION_SUMMARY_SCHEMA_VERSION: &str = "quota_decision_summary_v0";
+
+/// Compact decision projection (LoopX `QuotaDecisionPacket`): the fields a
+/// consumer needs to render the decision without re-running the kernel.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecisionSummary {
+    pub schema_version: String,
+    pub goal_id: String,
+    /// Agent the decision was compiled for (`None` = anonymous path).
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    pub decision: String,
+    pub should_run: bool,
+    pub effective_action: String,
+    /// P1-1① machine-readable reason code
+    /// (`quota::error_codes::DecisionReasonCode` wire string).
+    #[serde(default)]
+    pub reason_code: String,
+    /// Turn mode (`TurnMode::as_str`).
+    pub mode: String,
+    pub state: String,
+    #[serde(default)]
+    pub selected_todo: Option<String>,
+    pub spent_slots: u64,
+    pub allowed_slots: u64,
+    pub normal_delivery_allowed: bool,
+    pub recovery_delivery_allowed: bool,
+    pub self_repair_allowed: bool,
+    pub safe_bypass_allowed: bool,
+    #[serde(default)]
+    pub safe_bypass_kind: Option<String>,
+    #[serde(default)]
+    pub blocked_action_scope: Option<String>,
+    /// Run-turn counter at record time (0 = recorded outside a run loop).
+    #[serde(default)]
+    pub turn: u32,
+}
+
+impl DecisionSummary {
+    /// Compact a full kernel packet into the projection (LoopX
+    /// `compact_quota_decision` — same field selection).
+    pub fn from_packet(packet: &ShouldRunPacket, agent_id: Option<&str>, turn: u32) -> Self {
+        Self {
+            schema_version: DECISION_SUMMARY_SCHEMA_VERSION.to_string(),
+            goal_id: packet.goal_id.clone(),
+            agent_id: agent_id.map(str::to_string),
+            decision: packet.decision.clone(),
+            should_run: packet.should_run,
+            effective_action: packet.effective_action.clone(),
+            reason_code: packet.reason_code.clone(),
+            mode: packet.interaction_contract.mode.as_str().to_string(),
+            state: packet.state.clone(),
+            selected_todo: packet
+                .interaction_contract
+                .agent_channel
+                .selected_todo
+                .clone(),
+            spent_slots: packet.quota.spent_slots,
+            allowed_slots: packet.quota.allowed_slots,
+            normal_delivery_allowed: packet.normal_delivery_allowed,
+            recovery_delivery_allowed: packet.recovery_delivery_allowed,
+            self_repair_allowed: packet.self_repair_allowed,
+            safe_bypass_allowed: packet.safe_bypass_allowed,
+            safe_bypass_kind: packet.safe_bypass_kind.clone(),
+            blocked_action_scope: packet.blocked_action_scope.clone(),
+            turn,
+        }
+    }
+}
+
+/// Read model: all persisted decision summaries in ledger order.
+pub fn decision_summaries(events: &[StoredEvent]) -> Vec<&DecisionSummary> {
+    events
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            Event::DecisionSummaryRecorded { summary, .. } => Some(summary),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Read model: the most recent persisted decision summary, if any.
+pub fn latest_decision_summary(events: &[StoredEvent]) -> Option<&DecisionSummary> {
+    decision_summaries(events).into_iter().next_back()
+}
+
+/// Per-turn writeback (P1-1②+③): persist the compact decision projection
+/// and the heartbeat receipt for one executed turn. Both events are
+/// projection-only — replay never folds them into goal state, so recording
+/// can never change future decisions.
+///
+/// `turn_instance_id` anchors the receipt the way LoopX keys heartbeat
+/// receipts on (goal, agent, run/turn instance, todo).
+pub fn record_turn_decision(
+    store: &mut Store,
+    packet: &ShouldRunPacket,
+    agent_id: Option<&str>,
+    turn: u32,
+) -> Result<()> {
+    let now = crate::state::now_epoch();
+    let summary = DecisionSummary::from_packet(packet, agent_id, turn);
+    store.append(Event::DecisionSummaryRecorded {
+        goal_id: packet.goal_id.clone(),
+        summary,
+        ts: now,
+    })?;
+    store.append(Event::HeartbeatReceiptRecorded {
+        goal_id: packet.goal_id.clone(),
+        agent_id: agent_id.map(str::to_string),
+        turn_instance_id: format!("turn-{turn}"),
+        todo_id: packet
+            .interaction_contract
+            .agent_channel
+            .selected_todo
+            .clone(),
+        decision: packet.decision.clone(),
+        reason_code: packet.reason_code.clone(),
+        ts: now,
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decision::decide;
+    use crate::state::{Goal, Todo};
+
+    #[test]
+    fn summary_compacts_the_packet() {
+        let mut g = Goal::new("g1", "objective", "/tmp");
+        g.add(Todo::advancement("t1", "do work"));
+        let packet = decide(&g, std::time::SystemTime::now());
+        let s = DecisionSummary::from_packet(&packet, Some("agent-1"), 3);
+        assert_eq!(s.schema_version, DECISION_SUMMARY_SCHEMA_VERSION);
+        assert_eq!(s.goal_id, "g1");
+        assert_eq!(s.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(s.decision, "run");
+        assert!(s.should_run);
+        assert_eq!(s.effective_action, "normal_run");
+        assert_eq!(s.reason_code, "runnable_todo");
+        assert_eq!(s.mode, "bounded_delivery");
+        assert_eq!(s.selected_todo.as_deref(), Some("t1"));
+        assert_eq!(
+            s.allowed_slots,
+            crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS
+        );
+        assert!(s.normal_delivery_allowed);
+        assert!(!s.self_repair_allowed);
+        assert_eq!(s.turn, 3);
+    }
+
+    #[test]
+    fn summary_serde_roundtrip_and_legacy_default() {
+        let mut g = Goal::new("g1", "objective", "/tmp");
+        g.add(Todo::advancement("t1", "do work"));
+        let packet = decide(&g, std::time::SystemTime::now());
+        let s = DecisionSummary::from_packet(&packet, None, 0);
+        let json = serde_json::to_string(&s).unwrap();
+        let back: DecisionSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+
+        // Legacy shape: pre-P1-1 summaries without reason_code/turn parse.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("reason_code");
+        value.as_object_mut().unwrap().remove("turn");
+        let legacy: DecisionSummary = serde_json::from_value(value).unwrap();
+        assert_eq!(legacy.reason_code, "");
+        assert_eq!(legacy.turn, 0);
+    }
+}

--- a/orchestration/loop/src/quota/error_codes.rs
+++ b/orchestration/loop/src/quota/error_codes.rs
@@ -1,0 +1,232 @@
+//! Machine-readable quota / decision reason codes (P1-1①).
+//!
+//! LoopX `control_plane/quota/error_codes.py` maps quota-state collection
+//! failures to stable string codes, and every quota decision carries a
+//! compact machine classification alongside the prose `reason`. Pre-P1-1,
+//! the kernel emitted free-text reasons only, so consumers (status / TUI /
+//! desktop) had to substring-match prose. This module enumerates both
+//! surfaces in the typed-RPC oneof style: every variant has a stable
+//! snake_case wire code (`as_str` == serde), and the kernel stamps
+//! `ShouldRunPacket.reason_code` at construction time.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Quota state collection failures (LoopX `quota_error_code`). These classify
+/// the errors a quota read-model collector can hit while loading persisted
+/// quota/scheduler state, so an operator surface can render a stable code
+/// instead of an OS-specific error string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuotaErrorCode {
+    /// Persisted state is not valid JSON (LoopX: JSONDecodeError).
+    QuotaStateInvalidJson,
+    /// Caller supplied malformed arguments (LoopX: ValueError).
+    QuotaInvalidArguments,
+    /// State file unreadable due to permissions (LoopX: PermissionError).
+    QuotaStatePermissionDenied,
+    /// State file I/O failed (LoopX: OSError).
+    QuotaStateIoFailed,
+    /// Required field / file missing (LoopX: KeyError).
+    QuotaStateMissingField,
+    /// State parsed but has the wrong shape (LoopX: TypeError).
+    QuotaStateShapeError,
+    /// Anything else (LoopX: fallback).
+    QuotaUnexpectedCollectionError,
+}
+
+impl QuotaErrorCode {
+    /// Stable wire code (identical to the serde representation).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::QuotaStateInvalidJson => "quota_state_invalid_json",
+            Self::QuotaInvalidArguments => "quota_invalid_arguments",
+            Self::QuotaStatePermissionDenied => "quota_state_permission_denied",
+            Self::QuotaStateIoFailed => "quota_state_io_failed",
+            Self::QuotaStateMissingField => "quota_state_missing_field",
+            Self::QuotaStateShapeError => "quota_state_shape_error",
+            Self::QuotaUnexpectedCollectionError => "quota_unexpected_collection_error",
+        }
+    }
+
+    /// Classify an I/O error the way LoopX classifies OSError subclasses.
+    pub fn from_io_error(err: &std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::NotFound => Self::QuotaStateMissingField,
+            std::io::ErrorKind::PermissionDenied => Self::QuotaStatePermissionDenied,
+            _ => Self::QuotaStateIoFailed,
+        }
+    }
+
+    /// Classify a JSON parse failure (LoopX: JSONDecodeError).
+    pub fn from_serde_error(_err: &serde_json::Error) -> Self {
+        Self::QuotaStateInvalidJson
+    }
+}
+
+impl fmt::Display for QuotaErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Decision reason codes — one variant per kernel exit path in
+/// [`crate::decision::decide_for`]. The prose `reason` stays human-facing;
+/// this code is the machine contract (typed-RPC oneof style: stable wire
+/// strings, exhaustive variants, no wildcards).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionReasonCode {
+    /// Goal was cancelled — automation stopped, state retained.
+    GoalCancelled,
+    /// `--agent-id` present but not a registered coordination peer
+    /// (fail-closed identity gate; LoopX `automation_prompt_upgrade_required`).
+    IdentityNotRegistered,
+    /// Open user gate(s) — the ask channel owns the turn.
+    OpenUserGate,
+    /// Runnable advancement todo selected (first attempt).
+    RunnableTodo,
+    /// Runnable advancement todo selected (repair attempt N > 1).
+    RepairAttempt,
+    /// Surface-only progress loop breached the outcome floor → replan.
+    OutcomeFloorBreach,
+    /// Advancement todo(s) exhausted the repair budget → replan.
+    RepairBudgetExhausted,
+    /// External blocker(s) open with no runnable fallback → quiet wait.
+    BlockedNoFallback,
+    /// Completed advancement without closure intent → replan obligation.
+    SuccessionClosureMissing,
+    /// Monitor stalled (consecutive no-change polls over threshold) → replan.
+    MonitorStalled,
+    /// Monitor due — one read-only poll.
+    MonitorDue,
+    /// Monitor(s) present, none due — quiet wait with backoff.
+    MonitorBackoff,
+    /// Acceptance gap(s) open with no runnable work → replan.
+    AcceptanceGapOpen,
+    /// Deferred todo(s) not yet due — quiet wait.
+    DeferredNotDue,
+    /// Validated closure — todos done, gaps closed, closure intent declared.
+    ValidatedClosure,
+}
+
+impl DecisionReasonCode {
+    /// Stable wire code (identical to the serde representation).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GoalCancelled => "goal_cancelled",
+            Self::IdentityNotRegistered => "identity_not_registered",
+            Self::OpenUserGate => "open_user_gate",
+            Self::RunnableTodo => "runnable_todo",
+            Self::RepairAttempt => "repair_attempt",
+            Self::OutcomeFloorBreach => "outcome_floor_breach",
+            Self::RepairBudgetExhausted => "repair_budget_exhausted",
+            Self::BlockedNoFallback => "blocked_no_fallback",
+            Self::SuccessionClosureMissing => "succession_closure_missing",
+            Self::MonitorStalled => "monitor_stalled",
+            Self::MonitorDue => "monitor_due",
+            Self::MonitorBackoff => "monitor_backoff",
+            Self::AcceptanceGapOpen => "acceptance_gap_open",
+            Self::DeferredNotDue => "deferred_not_due",
+            Self::ValidatedClosure => "validated_closure",
+        }
+    }
+
+    /// Parse a wire code back (read-model side; returns `None` for unknown
+    /// codes so forward-compatible readers degrade instead of failing).
+    pub fn parse(code: &str) -> Option<Self> {
+        serde_json::from_value(serde_json::Value::String(code.to_string())).ok()
+    }
+}
+
+impl fmt::Display for DecisionReasonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quota_error_codes_wire_roundtrip() {
+        let all = [
+            QuotaErrorCode::QuotaStateInvalidJson,
+            QuotaErrorCode::QuotaInvalidArguments,
+            QuotaErrorCode::QuotaStatePermissionDenied,
+            QuotaErrorCode::QuotaStateIoFailed,
+            QuotaErrorCode::QuotaStateMissingField,
+            QuotaErrorCode::QuotaStateShapeError,
+            QuotaErrorCode::QuotaUnexpectedCollectionError,
+        ];
+        for code in all {
+            let json = serde_json::to_string(&code).unwrap();
+            assert_eq!(json, format!("\"{}\"", code.as_str()));
+            let back: QuotaErrorCode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, code);
+            assert_eq!(code.to_string(), code.as_str());
+        }
+        // LoopX wire names (parity anchor).
+        assert_eq!(
+            QuotaErrorCode::QuotaUnexpectedCollectionError.as_str(),
+            "quota_unexpected_collection_error"
+        );
+    }
+
+    #[test]
+    fn quota_error_code_classification() {
+        let not_found = std::io::Error::from(std::io::ErrorKind::NotFound);
+        assert_eq!(
+            QuotaErrorCode::from_io_error(&not_found),
+            QuotaErrorCode::QuotaStateMissingField
+        );
+        let denied = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            QuotaErrorCode::from_io_error(&denied),
+            QuotaErrorCode::QuotaStatePermissionDenied
+        );
+        let other = std::io::Error::from(std::io::ErrorKind::ConnectionReset);
+        assert_eq!(
+            QuotaErrorCode::from_io_error(&other),
+            QuotaErrorCode::QuotaStateIoFailed
+        );
+        let json_err = serde_json::from_str::<serde_json::Value>("{nope").unwrap_err();
+        assert_eq!(
+            QuotaErrorCode::from_serde_error(&json_err),
+            QuotaErrorCode::QuotaStateInvalidJson
+        );
+    }
+
+    #[test]
+    fn decision_reason_codes_wire_roundtrip() {
+        let all = [
+            DecisionReasonCode::GoalCancelled,
+            DecisionReasonCode::IdentityNotRegistered,
+            DecisionReasonCode::OpenUserGate,
+            DecisionReasonCode::RunnableTodo,
+            DecisionReasonCode::RepairAttempt,
+            DecisionReasonCode::OutcomeFloorBreach,
+            DecisionReasonCode::RepairBudgetExhausted,
+            DecisionReasonCode::BlockedNoFallback,
+            DecisionReasonCode::SuccessionClosureMissing,
+            DecisionReasonCode::MonitorStalled,
+            DecisionReasonCode::MonitorDue,
+            DecisionReasonCode::MonitorBackoff,
+            DecisionReasonCode::AcceptanceGapOpen,
+            DecisionReasonCode::DeferredNotDue,
+            DecisionReasonCode::ValidatedClosure,
+        ];
+        // 15 variants — one per kernel exit path.
+        assert_eq!(all.len(), 15);
+        let mut seen = std::collections::HashSet::new();
+        for code in all {
+            assert!(seen.insert(code.as_str()), "duplicate wire code {code}");
+            let json = serde_json::to_string(&code).unwrap();
+            assert_eq!(json, format!("\"{}\"", code.as_str()));
+            assert_eq!(DecisionReasonCode::parse(code.as_str()), Some(code));
+            assert_eq!(code.to_string(), code.as_str());
+        }
+        assert_eq!(DecisionReasonCode::parse("future_unknown_code"), None);
+    }
+}

--- a/orchestration/loop/src/quota/error_codes.rs
+++ b/orchestration/loop/src/quota/error_codes.rs
@@ -108,6 +108,9 @@ pub enum DecisionReasonCode {
     DeferredNotDue,
     /// Validated closure — todos done, gaps closed, closure intent declared.
     ValidatedClosure,
+    /// A↔V oscillation signature detected (main #163) — force a
+    /// frontier-changing replan instead of the next flip-flop delivery.
+    OscillationDetected,
 }
 
 impl DecisionReasonCode {
@@ -129,6 +132,7 @@ impl DecisionReasonCode {
             Self::AcceptanceGapOpen => "acceptance_gap_open",
             Self::DeferredNotDue => "deferred_not_due",
             Self::ValidatedClosure => "validated_closure",
+            Self::OscillationDetected => "oscillation_detected",
         }
     }
 

--- a/orchestration/loop/src/quota/mod.rs
+++ b/orchestration/loop/src/quota/mod.rs
@@ -15,7 +15,17 @@
 //!   - [`tool_quota`]      per-tool quota at the capability boundary
 //!     (invocation count / limit / trailing window) feeding the packet's
 //!     `capability_repair_allowed` predicate.
+//!
+//! P1-1 adds the quota decision read model:
+//!
+//!   - [`error_codes`]      machine-readable rejection/decision codes
+//!     (typed-RPC oneof style) stamped on every kernel packet;
+//!   - [`decision_summary`] the compact decision projection persisted to the
+//!     ledger per turn (+ heartbeat receipt), with the read model consumers
+//!     (status / TUI / desktop / `quota decisions`) share.
 
+pub mod decision_summary;
+pub mod error_codes;
 pub mod slot_accounting;
 pub mod stall_repair;
 pub mod tool_quota;

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -412,6 +412,48 @@ pub enum Event {
         seq: u32,
         ts: u64,
     },
+    /// P1-1②: decision_summary projection — one compact quota decision
+    /// persisted per executed turn (LoopX `decision_summary.py` /
+    /// `compact_quota_decision`). Projection-only: replay ignores it; the
+    /// read model (`quota::decision_summary`) serves status/TUI/desktop and
+    /// `quota decisions` without re-running the kernel.
+    DecisionSummaryRecorded {
+        goal_id: String,
+        summary: crate::quota::decision_summary::DecisionSummary,
+        ts: u64,
+    },
+    /// P1-1③: heartbeat receipt — the per-turn heartbeat packet was issued
+    /// to a host executor with this decision (LoopX `heartbeat_receipt.py`).
+    /// `turn_instance_id` anchors the receipt the way LoopX keys on
+    /// (goal, agent, run/turn instance); `todo_id` is the selected todo when
+    /// the turn had one. Projection-only (audit trail).
+    HeartbeatReceiptRecorded {
+        goal_id: String,
+        #[serde(default)]
+        agent_id: Option<String>,
+        turn_instance_id: String,
+        #[serde(default)]
+        todo_id: Option<String>,
+        decision: String,
+        #[serde(default)]
+        reason_code: String,
+        ts: u64,
+    },
+    /// P1-1③: scheduler ack — the host scheduler acknowledged the cadence
+    /// hint it applied (LoopX `scheduler_ack.py`). Recorded via
+    /// `scheduler ack`; `source` identifies the acking surface
+    /// (`scheduler_cli`, `codex_app`, …). Projection-only (audit trail).
+    SchedulerAcked {
+        goal_id: String,
+        agent_id: String,
+        action: String,
+        #[serde(default)]
+        cadence_class: String,
+        #[serde(default)]
+        rrule: Option<String>,
+        source: String,
+        ts: u64,
+    },
     /// G-16: a supervisor proposed a decision for a target agent (LoopX
     /// SUPERVISOR_PROPOSED). Projection-only — supervisor state is read from
     /// the event log, not folded into goal state.
@@ -470,6 +512,9 @@ impl Event {
             | Event::DeliveryOutcomeRecorded { goal_id, .. }
             | Event::FollowthroughCreated { goal_id, .. }
             | Event::RewardSignalRecorded { goal_id, .. }
+            | Event::DecisionSummaryRecorded { goal_id, .. }
+            | Event::HeartbeatReceiptRecorded { goal_id, .. }
+            | Event::SchedulerAcked { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. } => goal_id,
         }
@@ -1422,8 +1467,13 @@ fn apply(goal: &mut Goal, event: Event) {
         } => goal.apply_followthrough(&source_todo_id, &followup_todo_id, ts),
         // P1-5: reward signals are projection-only (read from the event log
         // by the scoped-feedback query; goal state is unchanged) — same
-        // treatment as the G-16 supervisor events.
+        // treatment as the G-16 supervisor events and the P1-1 quota decision
+        // read model (decision summaries / heartbeat receipts / scheduler
+        // acks are served from the event log by `quota::decision_summary`).
         Event::RewardSignalRecorded { .. }
+        | Event::DecisionSummaryRecorded { .. }
+        | Event::HeartbeatReceiptRecorded { .. }
+        | Event::SchedulerAcked { .. }
         | Event::SupervisorProposed { .. }
         | Event::SupervisorReceiptRecorded { .. } => {}
     }

--- a/orchestration/loop/src/worker_bridge.rs
+++ b/orchestration/loop/src/worker_bridge.rs
@@ -63,6 +63,14 @@ pub async fn run_bridge(store: &mut Store, opts: &BridgeOptions) -> Result<()> {
             std::time::SystemTime::now(),
             opts.agent_id.as_deref(),
         );
+        // P1-1②③: persist the compact decision projection + the heartbeat
+        // receipt for this turn (projection-only; replay ignores both).
+        crate::quota::decision_summary::record_turn_decision(
+            store,
+            &packet,
+            opts.agent_id.as_deref(),
+            turn,
+        )?;
         let mode = packet.interaction_contract.mode;
         if mode == TurnMode::Terminal {
             println!("BRIDGE terminal: validated closure — stopping");

--- a/orchestration/loop/tests/decision_split_regression.rs
+++ b/orchestration/loop/tests/decision_split_regression.rs
@@ -77,9 +77,9 @@ fn assert_packet_parity(goal: &Goal, now: SystemTime, agent_id: Option<&str>) ->
     mask_volatile(&mut legacy_json);
     mask_volatile(&mut current_json);
 
-    // G-2/G-11: the arbitration record is the ONLY struct field added since
-    // the pre-split baseline — assert it is present (observe-only), then
-    // exclude it so the comparison covers every pre-split field.
+    // G-2/G-11: the arbitration record was added after the pre-split
+    // baseline — assert it is present (observe-only), then exclude it so
+    // the comparison covers every pre-split field.
     let arbitration = current_json
         .get("scheduler_arbitration")
         .cloned()
@@ -108,6 +108,27 @@ fn assert_packet_parity(goal: &Goal, now: SystemTime, agent_id: Option<&str>) ->
     }
     if let serde_json::Value::Object(map) = &mut legacy_json {
         map.remove("capability_repair_allowed");
+    }
+
+    // P1-1①: the kernel now stamps a machine-readable reason code on every
+    // packet — assert it is present + parseable, then exclude it from the
+    // pre-split parity diff.
+    let reason_code = current_json
+        .get("reason_code")
+        .and_then(|c| c.as_str())
+        .expect("P1-1 must stamp reason_code")
+        .to_string();
+    assert!(
+        future_loop::quota::error_codes::DecisionReasonCode::parse(&reason_code).is_some(),
+        "reason_code `{reason_code}` must be a known DecisionReasonCode"
+    );
+    // The legacy baseline serializes the field as "" (it predates the
+    // codes) — exclude it from BOTH sides of the parity diff.
+    if let serde_json::Value::Object(map) = &mut current_json {
+        map.remove("reason_code");
+    }
+    if let serde_json::Value::Object(map) = &mut legacy_json {
+        map.remove("reason_code");
     }
 
     assert_eq!(

--- a/orchestration/loop/tests/legacy/decision_pre_split.rs
+++ b/orchestration/loop/tests/legacy/decision_pre_split.rs
@@ -423,6 +423,10 @@ fn legacy_packet(
         should_run,
         effective_action: effective_action.to_string(),
         reason: reason.to_string(),
+        // P1-1: the pre-split baseline predates machine-readable reason
+        // codes; the split-regression harness asserts the current packet
+        // carries one, then excludes it from the parity diff.
+        reason_code: String::new(),
         state: if should_run { "eligible".to_string() } else { "waiting".to_string() },
         waiting_on: "codex".to_string(),
         status: match mode {

--- a/orchestration/loop/tests/quota_read_model_contract.rs
+++ b/orchestration/loop/tests/quota_read_model_contract.rs
@@ -1,0 +1,383 @@
+//! P1-1 contract tests: quota decision read model —
+//!   ① `quota::error_codes` — every kernel exit stamps a stable
+//!      machine-readable `reason_code` on the packet (typed-RPC oneof
+//!      style); quota-state failures classify into stable error codes.
+//!   ② decision_summary projection — `record_turn_decision` (the run-path
+//!      hook) persists one `DecisionSummaryRecorded` + one
+//!      `HeartbeatReceiptRecorded` per turn; both are projection-only
+//!      (replay ignores them) and the read model serves them back.
+//!   ③ receipts — `scheduler ack` records the host scheduler's
+//!      acknowledgement as a `SchedulerAcked` ledger event.
+//!
+//! CLI-level tests exercise the real entry (`console::run`) against an
+//! isolated `FUTURE_LOOP_ROOT`.
+
+use future_loop::console;
+use future_loop::decision::{decide, decide_for};
+use future_loop::quota::decision_summary::{
+    decision_summaries, latest_decision_summary, record_turn_decision, DecisionSummary,
+};
+use future_loop::quota::error_codes::{DecisionReasonCode, QuotaErrorCode};
+use future_loop::state::{Goal, Todo};
+use future_loop::store::{Event, Store};
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-p11-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn open_goal(store: &mut Store, goal_id: &str) {
+    let goal = Goal::new(goal_id, "objective", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: goal_id.into(),
+            ts: goal.created_at,
+        })
+        .unwrap();
+}
+
+// ── ① reason codes: every kernel exit stamps the right code. ─────────────
+
+#[test]
+fn kernel_exits_stamp_reason_codes() {
+    let now = std::time::SystemTime::now();
+
+    // Runnable advancement → runnable_todo.
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.add(Todo::advancement("t1", "work"));
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "runnable_todo");
+    assert_eq!(
+        DecisionReasonCode::parse(&p.reason_code),
+        Some(DecisionReasonCode::RunnableTodo)
+    );
+
+    // Repair attempt (failed_attempts > 0) → repair_attempt.
+    let mut g = Goal::new("g", "o", "/tmp");
+    let mut t = Todo::advancement("t1", "work");
+    t.failed_attempts = 1;
+    g.add(t);
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "repair_attempt");
+
+    // Cancelled goal → goal_cancelled.
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.status = "cancelled".to_string();
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "goal_cancelled");
+
+    // Unregistered identity → identity_not_registered (fail closed).
+    let g = Goal::new("g", "o", "/tmp");
+    let p = decide_for(&g, now, Some("ghost"));
+    assert_eq!(p.reason_code, "identity_not_registered");
+    assert!(!p.ok);
+
+    // Open user gate → open_user_gate.
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.add(Todo::user_gate("u1", "approve the plan?", &[]));
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "open_user_gate");
+
+    // External blocker, no fallback → blocked_no_fallback.
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.add(Todo::blocker("b1", "waiting on upstream", &[]));
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "blocked_no_fallback");
+
+    // Nothing left → validated_closure.
+    let g = Goal::new("g", "o", "/tmp");
+    let p = decide(&g, now);
+    assert_eq!(p.reason_code, "validated_closure");
+
+    // Every emitted code parses back into the enum (no free-form strings).
+    for code in [
+        "runnable_todo",
+        "repair_attempt",
+        "goal_cancelled",
+        "identity_not_registered",
+        "open_user_gate",
+        "blocked_no_fallback",
+        "validated_closure",
+    ] {
+        assert!(
+            DecisionReasonCode::parse(code).is_some(),
+            "unparseable code {code}"
+        );
+    }
+}
+
+#[test]
+fn quota_error_code_classification_is_stable() {
+    // LoopX `quota_error_code` parity anchors.
+    assert_eq!(
+        QuotaErrorCode::QuotaStateInvalidJson.as_str(),
+        "quota_state_invalid_json"
+    );
+    assert_eq!(
+        QuotaErrorCode::from_io_error(&std::io::Error::from(std::io::ErrorKind::NotFound)).as_str(),
+        "quota_state_missing_field"
+    );
+    assert_eq!(
+        QuotaErrorCode::from_io_error(&std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+            .as_str(),
+        "quota_state_permission_denied"
+    );
+}
+
+// ── ② decision_summary projection: writeback + read model + replay-noop. ──
+
+#[test]
+fn turn_decision_writeback_projects_to_ledger() {
+    let root = tmp_root("writeback");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::advancement("t1", "work"),
+            ts: 1_000,
+        })
+        .unwrap();
+    // The identity gate is fail-closed: register the peer before deciding.
+    store
+        .append(Event::AgentRegistered {
+            goal_id: "g1".into(),
+            agent_id: "agent-1".into(),
+            workspaces: vec![],
+            ts: 1_001,
+        })
+        .unwrap();
+
+    let goal = store.replay("g1").unwrap().unwrap();
+    let packet = decide_for(&goal, std::time::SystemTime::now(), Some("agent-1"));
+    assert_eq!(packet.decision, "run", "setup: {packet:?}");
+    record_turn_decision(&mut store, &packet, Some("agent-1"), 1).unwrap();
+
+    let events = store.events("g1").unwrap();
+    let summaries = decision_summaries(&events);
+    assert_eq!(summaries.len(), 1);
+    let s = summaries[0];
+    assert_eq!(s.goal_id, "g1");
+    assert_eq!(s.agent_id.as_deref(), Some("agent-1"));
+    assert_eq!(s.decision, "run");
+    assert_eq!(s.reason_code, "runnable_todo");
+    assert_eq!(s.selected_todo.as_deref(), Some("t1"));
+    assert_eq!(s.turn, 1);
+    assert_eq!(latest_decision_summary(&events), Some(s));
+
+    // The heartbeat receipt lands alongside.
+    let receipts: Vec<_> = events
+        .iter()
+        .filter_map(|se| match &se.event {
+            Event::HeartbeatReceiptRecorded {
+                agent_id,
+                turn_instance_id,
+                todo_id,
+                decision,
+                reason_code,
+                ..
+            } => Some((
+                agent_id.clone(),
+                turn_instance_id.clone(),
+                todo_id.clone(),
+                decision.clone(),
+                reason_code.clone(),
+            )),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0].0.as_deref(), Some("agent-1"));
+    assert_eq!(receipts[0].1, "turn-1");
+    assert_eq!(receipts[0].2.as_deref(), Some("t1"));
+    assert_eq!(receipts[0].3, "run");
+    assert_eq!(receipts[0].4, "runnable_todo");
+
+    // Projection-only: replay is byte-identical with and without the
+    // projection events (they never fold into goal state).
+    let before = store.replay("g1").unwrap().unwrap();
+    record_turn_decision(&mut store, &packet, Some("agent-1"), 2).unwrap();
+    let after = store.replay("g1").unwrap().unwrap();
+    assert_eq!(before.todos.len(), after.todos.len());
+    assert_eq!(before.history.len(), after.history.len());
+    assert_eq!(before.quota_spent_slots, after.quota_spent_slots);
+    assert_eq!(decision_summaries(&store.events("g1").unwrap()).len(), 2);
+    assert_eq!(
+        latest_decision_summary(&store.events("g1").unwrap())
+            .unwrap()
+            .turn,
+        2,
+        "latest wins"
+    );
+
+    // Ledger integrity holds with the new event kinds.
+    assert!(store.verify("g1").unwrap().ok);
+}
+
+#[test]
+fn projection_events_serde_roundtrip_and_legacy_parse() {
+    // New events serialize with the flattened `kind` tag and parse back.
+    let event = Event::SchedulerAcked {
+        goal_id: "g1".into(),
+        agent_id: "codex-app".into(),
+        action: "tick_next".into(),
+        cadence_class: "bounded_segment".into(),
+        rrule: Some("FREQ=MINUTELY;INTERVAL=15".into()),
+        source: "scheduler_cli".into(),
+        ts: 1_000,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"kind\":\"scheduler_acked\""));
+    let back: Event = serde_json::from_str(&json).unwrap();
+    match back {
+        Event::SchedulerAcked {
+            goal_id,
+            agent_id,
+            action,
+            rrule,
+            ..
+        } => {
+            assert_eq!(goal_id, "g1");
+            assert_eq!(agent_id, "codex-app");
+            assert_eq!(action, "tick_next");
+            assert_eq!(rrule.as_deref(), Some("FREQ=MINUTELY;INTERVAL=15"));
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+
+    // Legacy receipt line without the defaulted fields still parses.
+    let legacy = r#"{"kind":"heartbeat_receipt_recorded","goal_id":"g1","turn_instance_id":"turn-1","decision":"run","ts":1000}"#;
+    let back: Event = serde_json::from_str(legacy).unwrap();
+    match back {
+        Event::HeartbeatReceiptRecorded {
+            agent_id,
+            todo_id,
+            reason_code,
+            ..
+        } => {
+            assert_eq!(agent_id, None);
+            assert_eq!(todo_id, None);
+            assert_eq!(reason_code, "");
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+// ── ②+③ CLI surface: `quota decisions` + `scheduler ack`. ────────────────
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; serialize CLI tests behind a mutex.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let root = format!("{}/.future/loop", tmp_root(tag));
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", &root);
+    f(&root);
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+#[test]
+fn quota_decisions_and_scheduler_ack_cli() {
+    with_root("cli", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--objective",
+            "p1-1 read model",
+            "--cwd",
+            "/tmp",
+            "--goal-id",
+            "g1",
+        ])
+        .unwrap();
+
+        // No turns yet → empty projection, clean message (not an error).
+        cli(&["quota", "decisions", "--goal", "g1"]).unwrap();
+        cli(&["quota", "decisions", "--goal", "g1", "--format", "json"]).unwrap();
+
+        // Record one decision through the run-path hook directly (driving a
+        // real `run` needs a live agent; the hook is the unit under test).
+        let mut store = Store::open(root).unwrap();
+        let goal = store.replay("g1").unwrap().unwrap();
+        let packet = decide(&goal, std::time::SystemTime::now());
+        record_turn_decision(&mut store, &packet, None, 1).unwrap();
+        drop(store);
+
+        // `quota decisions` serves the persisted projection.
+        cli(&["quota", "decisions", "--goal", "g1"]).unwrap();
+        cli(&["quota", "decisions", "--goal", "g1", "--limit", "5"]).unwrap();
+
+        // `scheduler ack` records the receipt event.
+        cli(&[
+            "scheduler",
+            "ack",
+            "--goal",
+            "g1",
+            "--agent-id",
+            "codex-app",
+            "--action",
+            "tick_next",
+            "--rrule",
+            "FREQ=MINUTELY;INTERVAL=15",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        let acks: Vec<_> = store
+            .events("g1")
+            .unwrap()
+            .into_iter()
+            .filter_map(|se| match se.event {
+                Event::SchedulerAcked {
+                    agent_id,
+                    action,
+                    rrule,
+                    source,
+                    ..
+                } => Some((agent_id, action, rrule, source)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(acks.len(), 1);
+        assert_eq!(acks[0].0, "codex-app");
+        assert_eq!(acks[0].1, "tick_next");
+        assert_eq!(acks[0].2.as_deref(), Some("FREQ=MINUTELY;INTERVAL=15"));
+        assert_eq!(acks[0].3, "scheduler_cli");
+
+        // --action is required; unknown flags are rejected (P0-3 strictness).
+        assert!(cli(&["scheduler", "ack", "--goal", "g1"]).is_err());
+        assert!(cli(&[
+            "scheduler",
+            "ack",
+            "--goal",
+            "g1",
+            "--action",
+            "tick_next",
+            "--bogus",
+            "x",
+        ])
+        .is_err());
+        assert!(cli(&["quota", "decisions", "--goal", "g1", "--bogus", "x"]).is_err());
+    });
+}
+
+// Keep the helper type referenced so the read model's public shape is part
+// of the contract surface.
+#[allow(dead_code)]
+fn _summary_shape_anchor(s: &DecisionSummary) {
+    let _ = &s.schema_version;
+}


### PR DESCRIPTION
loopx-improvement-report.md **P1-1**（wave1 拆分 PR 6/11）。

- `quota/error_codes.rs`：决策/拒绝理由机器可读枚举（含 main #163 振荡检测的 OscillationDetected 新码）
- `decision_summary` 投影落 ledger（status/TUI/desktop 复用）；`quota decisions --goal G` 读取
- heartbeat_receipt / scheduler_ack 回执事件

与 main 融合：quota 命令 dispatch 同时保留 tools（#162）与 decisions。
本地：fmt ✅ clippy ✅ future-loop 70 targets 全绿 ✅。源：claude/loop-wave1 1b3c57a8