### PR TITLE
feat(loop): P1-2 read-model self-healing — index drift detection + repair + decision_freshness

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -429,8 +429,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         ops,
         "store",
-        "event-store schema migration / ledger integrity",
-        "store migrate|verify|bridge --goal G",
+        "event-store schema migration / ledger integrity / read-model repair",
+        "store migrate|verify|bridge --goal G [--repair|--format json (verify)]",
     );
     r.command(
         ops,
@@ -2797,6 +2797,22 @@ async fn run_turns(
     force_workspace: bool,
 ) -> Result<()> {
     let mut turn = 0u32;
+    // P1-2③: read-model self-healing — a drifted run index means run-history
+    // consumers (status, stale-latest-run, run history projection) read stale
+    // state; rebuild it from the run files before the first decision and
+    // record the ProjectionRepaired audit event.
+    if let Some(outcome) = crate::runtime::run_index::repair_index_if_drifted(store, goal_id)? {
+        println!(
+            "⚒ projection self-heal: run_index drifted ({} rows) — rebuilt {} rows (backup {})",
+            outcome.drift.drift_count,
+            outcome.rebuilt.rows_written,
+            if outcome.rebuilt.backup_path.is_empty() {
+                "none".to_string()
+            } else {
+                outcome.rebuilt.backup_path
+            }
+        );
+    }
     loop {
         turn += 1;
         if turn > max_turns {
@@ -3147,8 +3163,38 @@ fn cmd_store(store: &mut Store, args: &[String]) -> Result<()> {
             Ok(())
         }
         Some("verify") => {
-            let goal_id = goal_arg(args)?;
+            let mut goal_id = None;
+            let mut repair = false;
+            reject_unknown_flags(args, &["--format", "--goal", "--json", "--repair"])?;
+            parse_pairs(args, |k, v| match k {
+                "--goal" => goal_id = Some(v),
+                "--repair" => repair = true,
+                _ => {}
+            });
+            let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
             let report = store.verify(&goal_id)?;
+            // P1-2①: run-index drift detection (read-model self-diagnosis)
+            // alongside the ledger integrity check.
+            let drift =
+                crate::runtime::run_index::detect_index_drift(&store.root_path(), &goal_id)?;
+            // P1-2③: `--repair` rebuilds a drifted index (non-destructive)
+            // and records the ProjectionRepaired audit event.
+            let repaired = if repair {
+                crate::runtime::run_index::repair_index_if_drifted(store, &goal_id)?
+            } else {
+                None
+            };
+            if wants_json(args) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ledger": report,
+                        "run_index_drift": drift,
+                        "repaired": repaired,
+                    }))?
+                );
+                return Ok(());
+            }
             println!(
                 "ledger {goal_id}: schema={} events={} unique={} idempotent_dups={} legacy_without_id={} conflicts={:?} → {}",
                 report.schema_version,
@@ -3159,6 +3205,33 @@ fn cmd_store(store: &mut Store, args: &[String]) -> Result<()> {
                 report.conflicts,
                 if report.ok { "ok" } else { "CONFLICT" }
             );
+            println!(
+                "run_index {goal_id}: rows={} files={} missing={} stale={} duplicates={} → {}",
+                drift.index_rows,
+                drift.run_files,
+                drift.missing_rows,
+                drift.stale_rows,
+                drift.duplicate_rows,
+                if drift.repair_recommended {
+                    "DRIFT (repair with `store verify --repair`)"
+                } else {
+                    "ok"
+                }
+            );
+            if let Some(outcome) = repaired {
+                println!(
+                    "repaired run_index {goal_id}: {} drift rows → rebuilt {} rows (backup {})",
+                    outcome.drift.drift_count,
+                    outcome.rebuilt.rows_written,
+                    if outcome.rebuilt.backup_path.is_empty() {
+                        "none (index was missing)"
+                    } else {
+                        outcome.rebuilt.backup_path.as_str()
+                    }
+                );
+            } else if repair {
+                println!("repair: no drift — nothing to rebuild");
+            }
             Ok(())
         }
         Some("bridge") => {
@@ -6188,6 +6261,16 @@ fn describe_event(event: &crate::store::Event) -> String {
         } => {
             return format!("supervisor_receipt decision={decision_id} outcome={outcome}");
         }
+        Event::ProjectionRepaired {
+            projection,
+            drift_count,
+            rows_written,
+            ..
+        } => {
+            return format!(
+                "projection_repaired projection={projection} drift={drift_count} rows_written={rows_written}"
+            );
+        }
     };
     kind.to_string()
 }
@@ -7789,6 +7872,32 @@ mod workspace_guard_cli_tests {
         // todo-event filtering picks the lock event up for its todo.
         assert!(event_touches_todo(&event, "t1"));
         assert!(!event_touches_todo(&event, "t2"));
+    }
+}
+
+#[cfg(test)]
+mod read_model_repair_cli_tests {
+    use super::*;
+
+    #[test]
+    fn describe_event_renders_projection_repair() {
+        let event = Event::ProjectionRepaired {
+            goal_id: "g1".to_string(),
+            projection: "run_index".to_string(),
+            drift_count: 2,
+            missing_rows: 1,
+            stale_rows: 1,
+            duplicate_rows: 0,
+            rows_written: 3,
+            backup_path: "/tmp/backup.jsonl".to_string(),
+            ts: 1,
+        };
+        let text = describe_event(&event);
+        assert!(text.contains("projection_repaired"), "got: {text}");
+        assert!(text.contains("run_index"), "got: {text}");
+        assert!(text.contains("drift=2"), "got: {text}");
+        // The repair audit is goal-scoped, not todo-scoped.
+        assert!(!event_touches_todo(&event, "t1"));
     }
 }
 

--- a/orchestration/loop/src/contract.rs
+++ b/orchestration/loop/src/contract.rs
@@ -268,4 +268,9 @@ pub struct ShouldRunPacket {
     pub scheduler_arbitration: Option<SchedulerArbitration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_closure: Option<TerminalClosure>,
+    /// P1-2②: freshness of the event ledger this decision was compiled
+    /// from (max seq / newest event ts / replay time — LoopX
+    /// `decision_freshness`). `None` for decisions over hand-built state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_freshness: Option<crate::state::DecisionFreshness>,
 }

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -607,6 +607,7 @@ fn packet(
         frontier_projection: frontier_projection(goal, replan_required),
         scheduler_arbitration: None,
         terminal_closure: None,
+        decision_freshness: goal.decision_freshness.clone(),
     };
     // G-2/G-11: record the scheduler arbitration (observe-only by default).
     apply_arbitration(&mut p, ARBITRATION_ENFORCEMENT);

--- a/orchestration/loop/src/runtime/run_index.rs
+++ b/orchestration/loop/src/runtime/run_index.rs
@@ -79,6 +79,118 @@ pub struct RebuildReport {
     pub non_destructive: bool,
 }
 
+/// P1-2③: drift count at which the run path self-heals the index — any
+/// observed drift (a missing, stale, or duplicate row) triggers the
+/// non-destructive rebuild (LoopX `run_ingest_health` → `run_index_rebuild`).
+pub const INDEX_DRIFT_AUTO_REPAIR_THRESHOLD: usize = 1;
+
+/// P1-2①: run-index drift report — the read-model self-diagnosis (LoopX
+/// `run_ingest_health.py` / `run_index_duplicates.py`). The run files on
+/// disk are the source of truth; the append-only index is a rebuildable
+/// projection of them.
+#[derive(Debug, Clone, Serialize)]
+pub struct IndexDriftReport {
+    pub goal_id: String,
+    pub index_path: String,
+    pub index_rows: usize,
+    pub run_files: usize,
+    /// Run files with no index row (index lags the write path).
+    pub missing_rows: usize,
+    /// Index rows whose run file vanished (external deletion / compaction).
+    pub stale_rows: usize,
+    /// Extra rows beyond the first per identity (double ingest).
+    pub duplicate_rows: usize,
+    pub drift_count: usize,
+    pub repair_recommended: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub missing_identities: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stale_identities: Vec<String>,
+}
+
+/// Detect drift between the run index and the run files on disk (the
+/// rebuild source of truth). Identity is the same `timestamp|path` key the
+/// dedup detector uses, so a rebuilt index always reports zero drift.
+pub fn detect_index_drift(runtime_root: &str, goal_id: &str) -> Result<IndexDriftReport> {
+    let runs = crate::runtime::runs_dir(runtime_root, goal_id);
+    let index = runs.join("index.jsonl");
+    let rows = read_index_rows(&index)?;
+    let mut files: Vec<RunIndexRow> = vec![];
+    if runs.exists() {
+        collect_run_files(&runs, goal_id, &mut files)?;
+    }
+
+    let mut index_counts: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for row in &rows {
+        *index_counts.entry(index_identity(row)).or_default() += 1;
+    }
+    let file_identities: std::collections::BTreeSet<String> =
+        files.iter().map(index_identity).collect();
+
+    let missing: Vec<String> = file_identities
+        .iter()
+        .filter(|id| !index_counts.contains_key(*id))
+        .cloned()
+        .collect();
+    let stale: Vec<String> = index_counts
+        .keys()
+        .filter(|id| !file_identities.contains(*id))
+        .cloned()
+        .collect();
+    let duplicate_rows: usize = index_counts.values().map(|n| n.saturating_sub(1)).sum();
+    let drift_count = missing.len() + stale.len() + duplicate_rows;
+    Ok(IndexDriftReport {
+        goal_id: goal_id.to_string(),
+        index_path: index.to_string_lossy().into_owned(),
+        index_rows: rows.len(),
+        run_files: files.len(),
+        missing_rows: missing.len(),
+        stale_rows: stale.len(),
+        duplicate_rows,
+        drift_count,
+        repair_recommended: drift_count >= INDEX_DRIFT_AUTO_REPAIR_THRESHOLD,
+        missing_identities: missing,
+        stale_identities: stale,
+    })
+}
+
+/// Outcome of a drift-triggered index repair (drift report + rebuild report).
+#[derive(Debug, Clone, Serialize)]
+pub struct IndexRepairOutcome {
+    pub drift: IndexDriftReport,
+    pub rebuilt: RebuildReport,
+}
+
+/// P1-2③: projection self-healing — when the run index drifts past
+/// [`INDEX_DRIFT_AUTO_REPAIR_THRESHOLD`], rebuild it from the run files
+/// (non-destructive: backup + tmp + rename) and record a
+/// `ProjectionRepaired` audit event in the ledger. Returns `None` when the
+/// projection is clean. Used by the run path (automatic) and by
+/// `store verify --repair` (operator-triggered).
+pub fn repair_index_if_drifted(
+    store: &mut crate::store::Store,
+    goal_id: &str,
+) -> Result<Option<IndexRepairOutcome>> {
+    let drift = detect_index_drift(&store.root_path(), goal_id)?;
+    if !drift.repair_recommended {
+        return Ok(None);
+    }
+    let rebuilt = rebuild_index(&store.root_path(), goal_id)?;
+    store.append(crate::store::Event::ProjectionRepaired {
+        goal_id: goal_id.to_string(),
+        projection: "run_index".to_string(),
+        drift_count: drift.drift_count,
+        missing_rows: drift.missing_rows,
+        stale_rows: drift.stale_rows,
+        duplicate_rows: drift.duplicate_rows,
+        rows_written: rebuilt.rows_written,
+        backup_path: rebuilt.backup_path.clone(),
+        ts: crate::state::now_epoch(),
+    })?;
+    Ok(Some(IndexRepairOutcome { drift, rebuilt }))
+}
+
 /// Rebuild the run index by rescanning the run files on disk (LoopX
 /// `run_index_rebuild`): the old index is backed up, the new index is
 /// written via tmp+rename, and rows are never deleted. Handles the case
@@ -128,13 +240,26 @@ pub fn rebuild_index(runtime_root: &str, goal_id: &str) -> Result<RebuildReport>
 }
 
 /// Walk run files (including the archive dir) and derive index rows from the
-/// JSON payloads (timestamp field) — the rebuild source of truth.
+/// JSON payloads (timestamp field) — the rebuild source of truth. Row paths
+/// match the writer's format (`goals/<id>/runs/<file>.json`, archive files
+/// `goals/<id>/runs/archive/<file>.json` — see `compat::write_run` and
+/// `run_compaction`) so a rebuilt index is identity-consistent with
+/// writer-appended rows.
 fn collect_run_files(dir: &Path, goal_id: &str, out: &mut Vec<RunIndexRow>) -> Result<()> {
+    collect_run_files_under(dir, dir, goal_id, out)
+}
+
+fn collect_run_files_under(
+    runs_root: &Path,
+    dir: &Path,
+    goal_id: &str,
+    out: &mut Vec<RunIndexRow>,
+) -> Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
-            collect_run_files(&path, goal_id, out)?;
+            collect_run_files_under(runs_root, &path, goal_id, out)?;
             continue;
         }
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
@@ -146,14 +271,14 @@ fn collect_run_files(dir: &Path, goal_id: &str, out: &mut Vec<RunIndexRow>) -> R
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
             continue;
         };
-        let relative = path
-            .strip_prefix(
-                path.parent()
-                    .and_then(|p| p.parent())
-                    .and_then(|p| p.parent())
-                    .unwrap_or(dir),
-            )
-            .unwrap_or(&path);
+        let relative = path.strip_prefix(runs_root).unwrap_or(&path);
+        // Join with `/` explicitly: index row paths are platform-neutral
+        // (the writer and the compaction re-pointing both use `/`).
+        let relative = relative
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
         out.push(RunIndexRow {
             goal_id: goal_id.to_string(),
             timestamp: value
@@ -161,7 +286,7 @@ fn collect_run_files(dir: &Path, goal_id: &str, out: &mut Vec<RunIndexRow>) -> R
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-            path: format!("goals/{goal_id}/runs/{}", relative.display()),
+            path: format!("goals/{goal_id}/runs/{relative}"),
             turn: value.get("turn").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
             classification: value
                 .get("terminal_state")
@@ -260,5 +385,130 @@ mod tests {
         );
         // Classification derives from terminal_state.
         assert_eq!(rows[1].classification, "failed");
+        // Row paths match the writer's format (`compat::write_run`) so a
+        // rebuilt index is identity-consistent with writer-appended rows.
+        assert_eq!(rows[0].path, "goals/g1/runs/a.json");
+    }
+
+    // ── P1-2: drift detection + self-healing repair ──────────────────────
+
+    fn write_run(runs: &Path, name: &str, timestamp: &str, terminal_state: &str) {
+        std::fs::write(
+            runs.join(name),
+            format!(
+                "{{\"goal_id\":\"g1\",\"timestamp\":\"{timestamp}\",\"turn\":1,\"terminal_state\":\"{terminal_state}\"}}"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn drift_detects_missing_stale_and_duplicate_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_str().unwrap().to_string();
+        let runs = dir.path().join("goals").join("g1").join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        write_run(&runs, "a.json", "2026-08-05T00:00:00+00:00", "completed");
+        write_run(&runs, "b.json", "2026-08-04T00:00:00+00:00", "failed");
+        // Index: a.json indexed twice (duplicate), a stale row for a deleted
+        // run file, and b.json not indexed at all (missing).
+        std::fs::write(
+            runs.join("index.jsonl"),
+            "{\"goal_id\":\"g1\",\"timestamp\":\"2026-08-05T00:00:00+00:00\",\"path\":\"goals/g1/runs/a.json\",\"turn\":1,\"classification\":\"completed\"}\n\
+             {\"goal_id\":\"g1\",\"timestamp\":\"2026-08-05T00:00:00+00:00\",\"path\":\"goals/g1/runs/a.json\",\"turn\":1,\"classification\":\"completed\"}\n\
+             {\"goal_id\":\"g1\",\"timestamp\":\"2026-08-03T00:00:00+00:00\",\"path\":\"goals/g1/runs/gone.json\",\"turn\":3,\"classification\":\"failed\"}\n",
+        )
+        .unwrap();
+        let drift = detect_index_drift(&root, "g1").unwrap();
+        assert_eq!(drift.index_rows, 3);
+        assert_eq!(drift.run_files, 2);
+        assert_eq!(drift.missing_rows, 1, "b.json is not indexed");
+        assert_eq!(drift.stale_rows, 1, "gone.json has no run file");
+        assert_eq!(drift.duplicate_rows, 1, "a.json indexed twice");
+        assert_eq!(drift.drift_count, 3);
+        assert!(drift.repair_recommended);
+        assert_eq!(drift.missing_identities.len(), 1);
+        assert_eq!(drift.stale_identities.len(), 1);
+    }
+
+    #[test]
+    fn drift_is_zero_after_a_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_str().unwrap().to_string();
+        let runs = dir.path().join("goals").join("g1").join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        write_run(&runs, "a.json", "2026-08-05T00:00:00+00:00", "completed");
+        rebuild_index(&root, "g1").unwrap();
+        let drift = detect_index_drift(&root, "g1").unwrap();
+        assert_eq!(drift.drift_count, 0);
+        assert!(!drift.repair_recommended);
+        // No runs dir at all → no drift, no repair.
+        let drift = detect_index_drift(&root, "g-empty").unwrap();
+        assert_eq!(drift.drift_count, 0);
+    }
+
+    fn drifted_store(tag: &str) -> (crate::store::Store, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "future-loop-p12-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let runs = dir.join("goals").join("g1").join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        // A run file with no index row → drift.
+        write_run(&runs, "a.json", "2026-08-05T00:00:00+00:00", "completed");
+        let mut store = crate::store::Store::open(dir.to_string_lossy().as_ref()).unwrap();
+        let goal = crate::state::Goal::new("g1", "objective", "/tmp");
+        store.register(&goal).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn repair_rebuilds_and_records_the_audit_event() {
+        let (mut store, dir) = drifted_store("repair");
+        let outcome = repair_index_if_drifted(&mut store, "g1")
+            .unwrap()
+            .expect("drift should trigger repair");
+        assert_eq!(outcome.drift.missing_rows, 1);
+        assert_eq!(outcome.rebuilt.rows_written, 1);
+        assert!(outcome.rebuilt.non_destructive);
+        assert!(
+            dir.join("goals/g1/runs/index.jsonl").exists(),
+            "index rebuilt"
+        );
+        // ProjectionRepaired audit event landed in the ledger.
+        let events = store.events("g1").unwrap();
+        let repairs: Vec<_> = events
+            .iter()
+            .filter_map(|stored| match &stored.event {
+                crate::store::Event::ProjectionRepaired {
+                    projection,
+                    drift_count,
+                    rows_written,
+                    ..
+                } => Some((projection.clone(), *drift_count, *rows_written)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0], ("run_index".to_string(), 1, 1));
+        // Repair is idempotent: the rebuilt index reports zero drift.
+        assert!(repair_index_if_drifted(&mut store, "g1").unwrap().is_none());
+        // The audit event is projection-only: replay ignores it.
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert!(goal.todos.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn repair_is_a_noop_without_drift() {
+        let (mut store, dir) = drifted_store("noop");
+        // Bring the index in sync first.
+        rebuild_index(&store.root_path(), "g1").unwrap();
+        assert!(repair_index_if_drifted(&mut store, "g1").unwrap().is_none());
+        assert!(store.events("g1").unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -752,6 +752,30 @@ pub struct Goal {
     /// ledgered for audit but never folded in. Bounded by
     /// [`CAPABILITY_INVOCATION_PROJECTION_CAP`] (oldest dropped).
     pub capability_invocations: Vec<(u64, String)>,
+    /// P1-2②: replay-time freshness stamp of the event ledger this state
+    /// was rebuilt from (in-memory only — never persisted; `None` for
+    /// hand-built goals). The decision kernel copies it onto every
+    /// `ShouldRunPacket` as `decision_freshness`.
+    #[serde(skip)]
+    pub decision_freshness: Option<DecisionFreshness>,
+}
+
+/// P1-2②: freshness stamp of the event ledger a decision was compiled
+/// against (LoopX `runtime/decision_freshness.py` — decisions annotate the
+/// max seq / timestamp of the state they read, so a consumer can tell a
+/// stale decision from a fresh one without re-running the kernel).
+/// Stamped by `Store::replay`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DecisionFreshness {
+    /// Ledger length at read time = the 1-based sequence number of the
+    /// newest event the decision state was rebuilt from.
+    pub events_max_seq: u64,
+    /// Newest event timestamp (epoch secs) among the events read (`None`
+    /// when the ledger was empty).
+    #[serde(default)]
+    pub events_max_ts: Option<u64>,
+    /// When the state was replayed (epoch secs).
+    pub read_at: u64,
 }
 
 /// Safety bound on the per-tool invocation projection folded into
@@ -788,6 +812,7 @@ impl Goal {
             quota_spent_slots: 0,
             delivery_states: vec![],
             capability_invocations: vec![],
+            decision_freshness: None,
         }
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -480,6 +480,24 @@ pub enum Event {
         rollback_ref: Option<String>,
         ts: u64,
     },
+    /// P1-2③: projection self-healing audit — a read model drifted past
+    /// the repair threshold and was rebuilt from its source of truth
+    /// (`projection` = `run_index`: rescan of the run files on disk,
+    /// non-destructive with a backup). Recorded by both the automatic
+    /// run-path hook and `store verify --repair`. Projection-only: replay
+    /// ignores it; the drift/rebuild counters make the repair auditable
+    /// from the ledger (history / todo-event / status).
+    ProjectionRepaired {
+        goal_id: String,
+        projection: String,
+        drift_count: usize,
+        missing_rows: usize,
+        stale_rows: usize,
+        duplicate_rows: usize,
+        rows_written: usize,
+        backup_path: String,
+        ts: u64,
+    },
 }
 
 impl Event {
@@ -516,9 +534,21 @@ impl Event {
             | Event::HeartbeatReceiptRecorded { goal_id, .. }
             | Event::SchedulerAcked { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
-            | Event::SupervisorReceiptRecorded { goal_id, .. } => goal_id,
+            | Event::SupervisorReceiptRecorded { goal_id, .. }
+            | Event::ProjectionRepaired { goal_id, .. } => goal_id,
         }
     }
+}
+
+/// Event timestamp (every variant carries `ts`). Used by the P1-2②
+/// decision-freshness stamp; 0 when the field is absent (defensive — the
+/// schema guarantees it). Derived via serde so new variants never strand
+/// this accessor.
+pub fn event_ts(event: &Event) -> u64 {
+    serde_json::to_value(event)
+        .ok()
+        .and_then(|v| v.get("ts").and_then(|t| t.as_u64()))
+        .unwrap_or(0)
 }
 
 // ── Store ──────────────────────────────────────────────────────────────────
@@ -806,6 +836,18 @@ impl Store {
             .goal_schema_version(goal_id)
             .unwrap_or_else(|| LEGACY_EVENT_STORE_SCHEMA_VERSION.to_string());
         let ledger = read_ledger(&self.goal_dir(goal_id), &from).context("read ledger")?;
+        // P1-2②: stamp the decision-freshness read model — arbitration
+        // decisions compiled from this state carry the max ledger seq /
+        // newest event ts they were rebuilt against.
+        goal.decision_freshness = Some(crate::state::DecisionFreshness {
+            events_max_seq: ledger.len() as u64,
+            events_max_ts: ledger
+                .iter()
+                .map(|stored| event_ts(&stored.event))
+                .filter(|ts| *ts > 0)
+                .max(),
+            read_at: crate::state::now_epoch(),
+        });
         for stored in ledger {
             apply(&mut goal, stored.event);
         }
@@ -1475,7 +1517,8 @@ fn apply(goal: &mut Goal, event: Event) {
         | Event::HeartbeatReceiptRecorded { .. }
         | Event::SchedulerAcked { .. }
         | Event::SupervisorProposed { .. }
-        | Event::SupervisorReceiptRecorded { .. } => {}
+        | Event::SupervisorReceiptRecorded { .. }
+        | Event::ProjectionRepaired { .. } => {}
     }
 }
 

--- a/orchestration/loop/tests/legacy/decision_pre_split.rs
+++ b/orchestration/loop/tests/legacy/decision_pre_split.rs
@@ -631,6 +631,8 @@ fn legacy_packet(
                 .count(),
         },
         terminal_closure: None,
+        // P1-2②: hand-built pre-split goals have no replay stamp.
+        decision_freshness: None,
         // G-2/G-11 delta (the ONLY struct change since the pre-split baseline):
         // the arbitration record is added post-hoc by `apply_arbitration`.
         scheduler_arbitration: None,

--- a/orchestration/loop/tests/quota_read_model_contract.rs
+++ b/orchestration/loop/tests/quota_read_model_contract.rs
@@ -381,3 +381,119 @@ fn quota_decisions_and_scheduler_ack_cli() {
 fn _summary_shape_anchor(s: &DecisionSummary) {
     let _ = &s.schema_version;
 }
+
+// ── P1-2② decision_freshness: replayed decisions carry the ledger stamp. ──
+
+#[test]
+fn replayed_decisions_carry_decision_freshness() {
+    let root = tmp_root("freshness");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+    let goal = store.replay("g1").unwrap().unwrap();
+
+    // The replay stamps the read position of the ledger.
+    let freshness = goal
+        .decision_freshness
+        .clone()
+        .expect("replay stamps freshness");
+    assert_eq!(freshness.events_max_seq, 1, "one ledger event read");
+    assert_eq!(
+        freshness.events_max_ts,
+        Some(goal.created_at),
+        "newest event ts"
+    );
+    assert!(freshness.read_at >= goal.created_at);
+
+    // The kernel copies the stamp onto every packet; the JSON wire shape
+    // carries it for host consumers.
+    let packet = decide(&goal, std::time::SystemTime::now());
+    assert_eq!(packet.decision_freshness, goal.decision_freshness);
+    let json = serde_json::to_value(&packet).unwrap();
+    assert_eq!(json["decision_freshness"]["events_max_seq"], 1);
+
+    // Hand-built goals (no replay) have no stamp → the field stays absent
+    // from the wire (skip_serializing_if).
+    let hand = Goal::new("g2", "objective", "/tmp");
+    let packet = decide(&hand, std::time::SystemTime::now());
+    assert!(packet.decision_freshness.is_none());
+    let json = serde_json::to_value(&packet).unwrap();
+    assert!(json.get("decision_freshness").is_none());
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ── P1-2①③ store verify: drift visibility + --repair self-healing. ───────
+
+#[test]
+fn store_verify_repairs_drifted_run_index() {
+    with_root("verify-repair", |root| {
+        cli(&[
+            "goal",
+            "init",
+            "--goal-id",
+            "g1",
+            "--objective",
+            "o",
+            "--cwd",
+            "/tmp",
+        ])
+        .unwrap();
+        // Drift: a run file on disk with no index row.
+        let runs = std::path::Path::new(root)
+            .join("goals")
+            .join("g1")
+            .join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        std::fs::write(
+            runs.join("a.json"),
+            "{\"goal_id\":\"g1\",\"timestamp\":\"2026-08-05T00:00:00+00:00\",\"turn\":1,\"terminal_state\":\"completed\"}",
+        )
+        .unwrap();
+
+        // Plain verify: drift is visible, index untouched.
+        cli(&["store", "verify", "--goal", "g1"]).unwrap();
+        assert!(!runs.join("index.jsonl").exists(), "verify is read-only");
+
+        // --repair rebuilds the index and records the audit event.
+        cli(&["store", "verify", "--goal", "g1", "--repair"]).unwrap();
+        let rows =
+            future_loop::runtime::run_history::read_index_rows(&runs.join("index.jsonl")).unwrap();
+        assert_eq!(rows.len(), 1, "index rebuilt from the run file");
+
+        let store = Store::open(root).unwrap();
+        let events = store.events("g1").unwrap();
+        let repairs = events
+            .iter()
+            .filter(|stored| matches!(stored.event, Event::ProjectionRepaired { .. }))
+            .count();
+        assert_eq!(repairs, 1, "ProjectionRepaired audit event recorded");
+        assert!(store.verify("g1").unwrap().ok, "ledger stays consistent");
+
+        // JSON mode reports ledger + drift + repair outcome.
+        cli(&["store", "verify", "--goal", "g1", "--format", "json"]).unwrap();
+
+        // Strict flags (P0-3): unknown flags are rejected.
+        assert!(cli(&["store", "verify", "--goal", "g1", "--bogus", "x"]).is_err());
+    });
+}
+
+#[test]
+fn projection_repaired_event_kind_roundtrip() {
+    // The new event serializes with the flattened `kind` tag and parses back
+    // (legacy readers ignore unknown kinds).
+    let event = Event::ProjectionRepaired {
+        goal_id: "g1".into(),
+        projection: "run_index".into(),
+        drift_count: 2,
+        missing_rows: 1,
+        stale_rows: 1,
+        duplicate_rows: 0,
+        rows_written: 3,
+        backup_path: "/tmp/backup.jsonl".into(),
+        ts: 1000,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"kind\":\"projection_repaired\""));
+    let back: Event = serde_json::from_str(&json).unwrap();
+    assert!(matches!(back, Event::ProjectionRepaired { .. }));
+}


### PR DESCRIPTION
loopx-improvement-report.md **P1-2**（wave1 拆分 PR 7/11）。

- run_index 漂移检测 + `loop store verify` 修复路径
- `decision_freshness`：仲裁决策标注所读事件的 max seq/时间戳（防过期状态做决策）
- 投影漂移超限自动触发 repair 并记录事件

本地：fmt ✅ clippy ✅ future-loop 70 targets 全绿 ✅。源：claude/loop-wave1 39d80c0f