### PR TITLE
feat(loop): P1-3 automation_liveness + monitor poll policy executor

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -423,8 +423,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         ops,
         "scheduler",
-        "scheduler tick/show/record-host-failure/ack",
-        "scheduler tick|show|record-host-failure|ack --goal G [--agent-id A] [--format json (show)]",
+        "scheduler tick/show/record-host-failure/ack/liveness",
+        "scheduler tick|show|record-host-failure|ack|liveness --goal G [--agent-id A] [--threshold-secs N (liveness)] [--format json (show|liveness)]",
     );
     r.command(
         ops,
@@ -2153,7 +2153,10 @@ fn cmd_scheduler(store: &mut Store, args: &[String]) -> Result<()> {
         Some("show") => scheduler_show(store, &args[1..]),
         Some("record-host-failure") => scheduler_record_failure(store, &args[1..]),
         Some("ack") => scheduler_ack(store, &args[1..]),
-        _ => bail!("scheduler subcommand must be `tick`, `show`, `record-host-failure`, or `ack`"),
+        Some("liveness") => scheduler_liveness(store, &args[1..]),
+        _ => bail!(
+            "scheduler subcommand must be `tick`, `show`, `record-host-failure`, `ack`, or `liveness`"
+        ),
     }
 }
 
@@ -2235,7 +2238,9 @@ fn scheduler_scope(
 /// [--progression 15,30,60] [--action tick_next]` — load the persisted state
 /// (or bootstrap it from the cadence profile), advance the progression, and
 /// write the new state. Restart-safe: progression persists across cycles.
-fn scheduler_tick(store: &Store, args: &[String]) -> Result<()> {
+/// P1-3: each tick also lands a `SchedulerTicked` heartbeat (liveness) and
+/// projects the monitor poll plan (tick-driven poll policy executor).
+fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
     let mut cadence_class = "monitor_backoff".to_string();
     let mut progression: Vec<i64> = vec![];
     let mut action = "tick_next".to_string();
@@ -2300,6 +2305,8 @@ fn scheduler_tick(store: &Store, args: &[String]) -> Result<()> {
             "→ bootstrapped (initial rrule {}); next tick advances progression",
             initial_rrule
         );
+        record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
+        print_monitor_poll_plan(store, &goal_id)?;
         return Ok(());
     }
 
@@ -2311,7 +2318,211 @@ fn scheduler_tick(store: &Store, args: &[String]) -> Result<()> {
         Some(r) => println!("→ advanced progression to {r} (persisted)"),
         None => println!("→ no progression (single-execution cadence)"),
     }
+    record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
+    print_monitor_poll_plan(store, &goal_id)?;
     Ok(())
+}
+
+/// P1-3①: land the tick heartbeat event (the liveness check's data source).
+fn record_tick_heartbeat(
+    store: &mut Store,
+    goal_id: &str,
+    agent: &str,
+    action: &str,
+    state: &crate::scheduler::state::SchedulerState,
+) -> Result<()> {
+    store.append(Event::SchedulerTicked {
+        goal_id: goal_id.to_string(),
+        agent_id: agent.to_string(),
+        action: action.to_string(),
+        rrule: if state.last_applied_rrule.is_empty() {
+            None
+        } else {
+            Some(state.last_applied_rrule.clone())
+        },
+        ts: now_epoch(),
+    })?;
+    Ok(())
+}
+
+/// P1-3②: project the monitor poll plan after each tick (the tick-driven
+/// poll policy executor — due monitors with target/policy/cadence and
+/// no-spend eligibility; the run loop executes the actual observation).
+fn print_monitor_poll_plan(store: &Store, goal_id: &str) -> Result<()> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(());
+    };
+    let plan = crate::scheduler::monitor_poll::build_poll_plan(&goal, std::time::SystemTime::now());
+    if plan.due_monitors.is_empty() && plan.stalled_monitors.is_empty() {
+        if let Some(next) = plan.next_due_at {
+            let wait = next.saturating_sub(now_epoch());
+            println!("→ monitor poll plan: none due (next poll in {wait}s)");
+        }
+        return Ok(());
+    }
+    println!(
+        "→ monitor poll plan: {} due, {} stalled",
+        plan.due_monitors.len(),
+        plan.stalled_monitors.len()
+    );
+    for item in &plan.due_monitors {
+        println!(
+            "   poll {} (target={}, policy={}, overdue {}s{})",
+            item.todo_id,
+            item.target.as_deref().unwrap_or("-"),
+            item.policy.as_deref().unwrap_or("default"),
+            item.overdue_secs,
+            if item.no_spend_if_unchanged {
+                ", no-spend on unchanged"
+            } else {
+                ""
+            }
+        );
+    }
+    for id in &plan.stalled_monitors {
+        println!("   stalled {id} (decision kernel replans)");
+    }
+    Ok(())
+}
+
+/// `loopx scheduler liveness --goal G [--agent-id A] [--threshold-secs N]
+/// [--format json]` — P1-3① automation liveness check: compare now against
+/// the latest tick heartbeat (event log ∪ persisted scheduler state). A
+/// breach records an `AutomationLivenessAlert` (cooldown-deduped) and drops
+/// an operator-inbox alert file; the attention projection escalates the
+/// goal until a fresh heartbeat recovers the automation.
+fn scheduler_liveness(store: &mut Store, args: &[String]) -> Result<()> {
+    use crate::scheduler::liveness as lv;
+    let mut threshold = lv::DEFAULT_LIVENESS_THRESHOLD_SECS;
+    reject_unknown_flags(
+        args,
+        &[
+            "--agent-id",
+            "--format",
+            "--goal",
+            "--json",
+            "--threshold-secs",
+        ],
+    )?;
+    parse_pairs(args, |k, v| {
+        if k == "--threshold-secs" {
+            if let Ok(n) = v.parse::<u64>() {
+                if n > 0 {
+                    threshold = n;
+                }
+            }
+        }
+    });
+    let (goal_id, agent) = scheduler_scope(store, args, "codex-app")?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let now = now_epoch();
+    // Last heartbeat = max(heartbeat event ts, persisted state updated_at)
+    // — the state file predates heartbeat events (back-compat).
+    let mut last_tick = goal.scheduler_heartbeats.get(&agent).copied();
+    use crate::scheduler::state as st;
+    if let Some(s) = st::load_scheduler_state(
+        &store.goal_dir(&goal_id),
+        &agent,
+        st::CODEX_APP_SURFACE,
+        st::CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    ) {
+        last_tick = Some(last_tick.map_or(s.updated_at, |t| t.max(s.updated_at)));
+    }
+    let eval = lv::evaluate_liveness(&goal_id, &agent, last_tick, now, threshold);
+    let mut alert_note = String::new();
+    if eval.state == lv::LIVENESS_BREACH {
+        let alerts: Vec<u64> = goal
+            .liveness_alerts
+            .iter()
+            .filter(|a| a.agent_id == agent)
+            .map(|a| a.ts)
+            .collect();
+        if lv::alert_due(alerts.iter().max().copied(), now) {
+            store.append(Event::AutomationLivenessAlert {
+                goal_id: goal_id.clone(),
+                agent_id: agent.clone(),
+                elapsed_secs: eval.elapsed_secs.unwrap_or(0),
+                threshold_secs: threshold,
+                consecutive: alerts.len() as u32 + 1,
+                ts: now,
+            })?;
+            write_liveness_inbox_alert(&goal, &agent, &eval);
+            alert_note =
+                " → alert recorded (attention escalates; operator inbox notified)".to_string();
+        } else {
+            alert_note = " (alert suppressed: cooldown)".to_string();
+        }
+    }
+    if wants_json(args) {
+        println!("{}", serde_json::to_string_pretty(&eval)?);
+        return Ok(());
+    }
+    match eval.state.as_str() {
+        lv::LIVENESS_BREACH => println!(
+            "liveness: BREACH goal={goal_id} agent={agent} silent={}s threshold={}s{alert_note}",
+            eval.elapsed_secs.unwrap_or(0),
+            threshold
+        ),
+        lv::LIVENESS_NO_HEARTBEAT => println!(
+            "liveness: no heartbeat for goal={goal_id} agent={agent} (automation never ticked — run `scheduler tick` to install)"
+        ),
+        _ => println!(
+            "liveness: alive goal={goal_id} agent={agent} last tick {}s ago (threshold {}s)",
+            eval.elapsed_secs.unwrap_or(0),
+            threshold
+        ),
+    }
+    Ok(())
+}
+
+/// Best-effort operator-inbox alert file (LoopX: breach → operator_inbox).
+/// Written under the goal's project `.future/loop/inbox/` so the `inbox`
+/// urgency projection surfaces it as a direct mention.
+fn write_liveness_inbox_alert(
+    goal: &crate::state::Goal,
+    agent: &str,
+    eval: &crate::scheduler::liveness::LivenessEvaluation,
+) {
+    let inbox = std::path::Path::new(&goal.cwd)
+        .join(".future")
+        .join("loop")
+        .join("inbox");
+    if std::fs::create_dir_all(&inbox).is_err() {
+        return;
+    }
+    let clean = |s: &str| {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>()
+    };
+    let path = inbox.join(format!(
+        "liveness-{}-{}-{}.json",
+        clean(&goal.goal_id),
+        clean(agent),
+        now_epoch()
+    ));
+    let payload = serde_json::json!({
+        "message_id": format!("liveness-{}-{}", clean(&goal.goal_id), now_epoch()),
+        "create_time": now_epoch().to_string(),
+        "content": format!(
+            "@operator automation liveness breach: goal {} agent {} silent {}s (> {}s threshold) — check/restart the host automation",
+            goal.goal_id,
+            agent,
+            eval.elapsed_secs.unwrap_or(0),
+            eval.threshold_secs
+        ),
+    });
+    if let Ok(text) = serde_json::to_string_pretty(&payload) {
+        let _ = std::fs::write(path, format!("{text}\n"));
+    }
 }
 
 /// `loopx scheduler show --goal G [--agent-id A] [--format json]` — print the
@@ -6245,6 +6456,28 @@ fn describe_event(event: &crate::store::Event) -> String {
             return format!(
                 "scheduler_ack agent={agent_id} action={action} rrule={}",
                 rrule.as_deref().unwrap_or("-")
+            );
+        }
+        Event::SchedulerTicked {
+            agent_id,
+            action,
+            rrule,
+            ..
+        } => {
+            return format!(
+                "scheduler_tick agent={agent_id} action={action} rrule={}",
+                rrule.as_deref().unwrap_or("-")
+            );
+        }
+        Event::AutomationLivenessAlert {
+            agent_id,
+            elapsed_secs,
+            threshold_secs,
+            consecutive,
+            ..
+        } => {
+            return format!(
+                "liveness_alert agent={agent_id} silent={elapsed_secs}s threshold={threshold_secs}s alert#{consecutive}"
             );
         }
         Event::SupervisorProposed {

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -152,11 +152,14 @@ pub fn writeback(
                 goal.history.push(record.clone());
             } else {
                 m.consecutive_no_change += 1;
+                // P1-3②: cadence-aware reschedule, the same derivation
+                // replay applies to the MonitorPolled event.
+                let next_due = crate::scheduler::monitor_poll::next_poll_due_epoch(
+                    now_epoch(),
+                    m.monitor_cadence.as_deref(),
+                );
                 m.resume_when = Some(
-                    std::time::SystemTime::now()
-                        + std::time::Duration::from_secs(
-                            crate::decision::monitor::MONITOR_NO_CHANGE_BACKOFF_SECS,
-                        ),
+                    std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(next_due),
                 );
             }
         }

--- a/orchestration/loop/src/scheduler/liveness.rs
+++ b/orchestration/loop/src/scheduler/liveness.rs
@@ -1,0 +1,135 @@
+//! Automation liveness (P1-3①) — "is the scheduler itself alive?"
+//! meta-monitoring, the native subset of LoopX
+//! `control_plane/scheduler/automation_liveness.py`.
+//!
+//! Every `scheduler tick` lands a [`crate::store::Event::SchedulerTicked`]
+//! heartbeat (per goal + agent). A liveness check compares now against the
+//! latest heartbeat; when the silence exceeds the threshold the check
+//! records an [`crate::store::Event::AutomationLivenessAlert`] (folded into
+//! `goal.liveness_alerts`) and the attention projection escalates the goal
+//! to a high-severity operator item until a fresh heartbeat recovers it.
+//! This is the overnight-unattended-goal safety net: a dead host automation
+//! surfaces instead of silently starving the goal.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version of the liveness evaluation projection (LoopX
+/// `AUTOMATION_LIVENESS_SCHEMA_VERSION`).
+pub const AUTOMATION_LIVENESS_SCHEMA_VERSION: &str = "automation_liveness_v0";
+
+/// Default silence threshold: 2h. A goal whose cadence tops out at the
+/// hourly class must tick at least this often; anything longer means the
+/// host automation (cron / codex-app / loop driver) is dead or stuck.
+pub const DEFAULT_LIVENESS_THRESHOLD_SECS: u64 = 2 * 60 * 60;
+
+/// Alert cooldown: a sustained breach re-alerts at most this often so a dead
+/// automation does not flood the event ledger (each alert is one event).
+pub const LIVENESS_ALERT_COOLDOWN_SECS: u64 = 60 * 60;
+
+/// Liveness state labels (stable wire values).
+pub const LIVENESS_ALIVE: &str = "alive";
+pub const LIVENESS_BREACH: &str = "breach";
+pub const LIVENESS_NO_HEARTBEAT: &str = "no_heartbeat";
+
+/// The liveness evaluation for one (goal, agent) automation scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivenessEvaluation {
+    pub schema_version: String,
+    pub goal_id: String,
+    pub agent_id: String,
+    /// Latest heartbeat (epoch secs); `None` = the automation never ticked.
+    pub last_tick_at: Option<u64>,
+    /// Silence so far (epoch secs); `None` when there is no heartbeat.
+    pub elapsed_secs: Option<u64>,
+    pub threshold_secs: u64,
+    /// `alive` | `breach` | `no_heartbeat`.
+    pub state: String,
+}
+
+/// Evaluate liveness for one automation scope. Pure + deterministic: the
+/// caller supplies `last_tick_at` (max of the heartbeat-event ts and the
+/// persisted scheduler-state `updated_at`) and `now`.
+///
+/// - no heartbeat → `no_heartbeat` (automation never installed — NOT a
+///   breach: nothing was expected to run);
+/// - silence > threshold → `breach`;
+/// - otherwise → `alive` (equality with the threshold is still alive).
+pub fn evaluate_liveness(
+    goal_id: &str,
+    agent_id: &str,
+    last_tick_at: Option<u64>,
+    now: u64,
+    threshold_secs: u64,
+) -> LivenessEvaluation {
+    let elapsed = last_tick_at.map(|t| now.saturating_sub(t));
+    let state = match elapsed {
+        None => LIVENESS_NO_HEARTBEAT,
+        Some(e) if e > threshold_secs => LIVENESS_BREACH,
+        Some(_) => LIVENESS_ALIVE,
+    };
+    LivenessEvaluation {
+        schema_version: AUTOMATION_LIVENESS_SCHEMA_VERSION.to_string(),
+        goal_id: goal_id.to_string(),
+        agent_id: agent_id.to_string(),
+        last_tick_at,
+        elapsed_secs: elapsed,
+        threshold_secs,
+        state: state.to_string(),
+    }
+}
+
+/// Should a breach append a new alert event? Cooldown dedup: at most one
+/// alert per `LIVENESS_ALERT_COOLDOWN_SECS` window per scope (LoopX
+/// automation_liveness alerts escalate, they do not spam).
+pub fn alert_due(last_alert_at: Option<u64>, now: u64) -> bool {
+    last_alert_at.is_none_or(|t| now.saturating_sub(t) >= LIVENESS_ALERT_COOLDOWN_SECS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_heartbeat_is_not_a_breach() {
+        let eval = evaluate_liveness("g1", "codex-app", None, 1_000_000, 100);
+        assert_eq!(eval.state, LIVENESS_NO_HEARTBEAT);
+        assert_eq!(eval.last_tick_at, None);
+        assert_eq!(eval.elapsed_secs, None);
+    }
+
+    #[test]
+    fn fresh_heartbeat_is_alive() {
+        let eval = evaluate_liveness("g1", "codex-app", Some(1_000_000), 1_000_050, 100);
+        assert_eq!(eval.state, LIVENESS_ALIVE);
+        assert_eq!(eval.elapsed_secs, Some(50));
+    }
+
+    #[test]
+    fn silence_past_threshold_breaches() {
+        let eval = evaluate_liveness("g1", "codex-app", Some(1_000_000), 1_000_101, 100);
+        assert_eq!(eval.state, LIVENESS_BREACH);
+        assert_eq!(eval.elapsed_secs, Some(101));
+    }
+
+    #[test]
+    fn threshold_boundary_is_alive_and_clock_skew_is_clamped() {
+        // Exactly at the threshold: alive (breach is strictly greater).
+        let eval = evaluate_liveness("g1", "codex-app", Some(1_000_000), 1_000_100, 100);
+        assert_eq!(eval.state, LIVENESS_ALIVE);
+        // now BEFORE the heartbeat (clock skew) clamps to 0, never breaches.
+        let skewed = evaluate_liveness("g1", "codex-app", Some(1_000_100), 1_000_000, 100);
+        assert_eq!(skewed.state, LIVENESS_ALIVE);
+        assert_eq!(skewed.elapsed_secs, Some(0));
+    }
+
+    #[test]
+    fn alert_cooldown_dedups() {
+        assert!(alert_due(None, 1_000_000));
+        let alerted = 1_000_000;
+        assert!(!alert_due(Some(alerted), alerted + 60));
+        assert!(alert_due(
+            Some(alerted),
+            alerted + LIVENESS_ALERT_COOLDOWN_SECS
+        ));
+    }
+}

--- a/orchestration/loop/src/scheduler/mod.rs
+++ b/orchestration/loop/src/scheduler/mod.rs
@@ -8,4 +8,6 @@
 //! progression, and atomic persistence. The decision kernel stays pure; the
 //! CLI layer (`loopx scheduler`) drives persistence across decision cycles.
 
+pub mod liveness;
+pub mod monitor_poll;
 pub mod state;

--- a/orchestration/loop/src/scheduler/monitor_poll.rs
+++ b/orchestration/loop/src/scheduler/monitor_poll.rs
@@ -1,0 +1,257 @@
+//! Monitor poll policy executor (P1-3②) — the native subset of LoopX
+//! `control_plane/scheduler/monitor_poll_policy.py` +
+//! `monitor_poll_writeback.py`, driven by `scheduler tick`.
+//!
+//! Two halves:
+//! - **policy**: classify each open monitor into a poll plan — due vs
+//!   waiting vs stalled, with the no-spend-on-unchanged eligibility derived
+//!   from the G-12 `monitor_policy` (LoopX `EXTERNAL_MONITOR_POLICIES`).
+//!   `scheduler tick` projects the plan so the operator / run loop sees
+//!   exactly which read-only polls the cadence has made due.
+//! - **writeback**: the cadence-aware next-due derivation shared by the run
+//!   path (`executor::writeback`) and event replay (`store::apply`) so a
+//!   `1h`-cadence monitor reschedules 1h out instead of the fixed G-8
+//!   no-change backoff. The fallback keeps pre-P1-3 replay parity for
+//!   monitors without a cadence.
+
+use std::time::SystemTime;
+
+use serde::Serialize;
+
+use crate::state::Goal;
+
+/// Schema version of the poll plan projection.
+pub const MONITOR_POLL_PLAN_SCHEMA_VERSION: &str = "monitor_poll_plan_v0";
+
+/// LoopX `EXTERNAL_MONITOR_POLICIES`: the poll policies whose unchanged
+/// observations are guaranteed read-only/no-spend.
+pub const EXTERNAL_MONITOR_POLICIES: [&str; 2] = [
+    "material_transition_only",
+    "read_only_observation_then_no_spend_if_unchanged",
+];
+
+/// No-spend-on-unchanged eligibility (LoopX
+/// `allows_no_spend_external_monitor_poll`, bounded subset): a declared
+/// external monitor policy opts in explicitly; an undeclared policy keeps
+/// the FO default (monitors are read-only observations and a no-change poll
+/// never spends — G-8 quota rule).
+pub fn policy_allows_no_spend(policy: Option<&str>) -> bool {
+    match policy.map(str::trim) {
+        Some(p) if !p.is_empty() => EXTERNAL_MONITOR_POLICIES.contains(&p),
+        _ => true,
+    }
+}
+
+/// Poll interval implied by a cadence declaration, in seconds. Accepts an
+/// interval string (`15m` / `1h` / `2d` / `30s`), a cadence class
+/// (`hourly` / `daily` / `weekly` — mapped through the G-10 rrule), or a
+/// raw MINUTELY rrule. `once` / unknown / absent cadence → `None` (the
+/// caller falls back to the fixed no-change backoff).
+pub fn cadence_poll_interval_secs(cadence: Option<&str>) -> Option<u64> {
+    let cad = cadence?.trim();
+    if cad.is_empty() {
+        return None;
+    }
+    if let Some(secs) = super::state::monitor_cadence_secs(cad) {
+        return Some(secs);
+    }
+    super::state::rrule_for_cadence_class(cad)
+        .and_then(|r| super::state::scheduler_rrule_interval_minutes(&r))
+        .map(|m| (m.max(1)) as u64 * 60)
+}
+
+/// Next due epoch after a poll at `polled_at` — cadence-aware with the G-8
+/// fixed backoff as fallback. THE single source of truth for monitor
+/// rescheduling: the run path and replay both derive the next due through
+/// here so a replayed ledger reproduces the live writeback exactly.
+pub fn next_poll_due_epoch(polled_at: u64, cadence: Option<&str>) -> u64 {
+    polled_at
+        + cadence_poll_interval_secs(cadence)
+            .unwrap_or(crate::decision::MONITOR_NO_CHANGE_BACKOFF_SECS)
+}
+
+/// One due monitor in the poll plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MonitorPollPlanItem {
+    pub todo_id: String,
+    pub title: String,
+    pub target: Option<String>,
+    pub policy: Option<String>,
+    pub cadence: Option<String>,
+    /// Due time (epoch secs).
+    pub due_at: u64,
+    /// How far past due the monitor is (epoch secs; 0 = exactly due).
+    pub overdue_secs: u64,
+    pub no_change_count: u32,
+    /// No-spend-on-unchanged eligibility (policy classification).
+    pub no_spend_if_unchanged: bool,
+}
+
+/// The tick-driven poll plan for one goal (LoopX monitor poll policy
+/// projection): which monitors are due for their one read-only poll, which
+/// stalled (the decision kernel replans those), and when the next poll
+/// becomes due.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MonitorPollPlan {
+    pub schema_version: String,
+    pub goal_id: String,
+    pub due_monitors: Vec<MonitorPollPlanItem>,
+    /// Ids of monitors past the stall threshold (excluded from `due_monitors`
+    /// — the kernel's stall replan owns them).
+    pub stalled_monitors: Vec<String>,
+    /// Earliest future due time across waiting monitors (epoch secs).
+    pub next_due_at: Option<u64>,
+}
+
+/// Build the poll plan for a goal at `now` (pure; the caller persists any
+/// writeback). Due monitors are ordered most-overdue-first.
+pub fn build_poll_plan(goal: &Goal, now: SystemTime) -> MonitorPollPlan {
+    let now_epoch = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut due = vec![];
+    let mut stalled = vec![];
+    let mut next_due_at: Option<u64> = None;
+    for m in goal.open_monitors() {
+        if crate::decision::stall::is_monitor_stalled(m) {
+            stalled.push(m.id.clone());
+            continue;
+        }
+        let due_at = m
+            .resume_when
+            .and_then(|d| d.duration_since(SystemTime::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs());
+        match due_at {
+            Some(d) if d <= now_epoch => due.push(MonitorPollPlanItem {
+                todo_id: m.id.clone(),
+                title: m.title.clone(),
+                target: m.monitor_target.clone(),
+                policy: m.monitor_policy.clone(),
+                cadence: m.monitor_cadence.clone(),
+                due_at: d,
+                overdue_secs: now_epoch - d,
+                no_change_count: m.consecutive_no_change,
+                no_spend_if_unchanged: policy_allows_no_spend(m.monitor_policy.as_deref()),
+            }),
+            Some(d) => {
+                next_due_at = Some(next_due_at.map_or(d, |n| n.min(d)));
+            }
+            None => {}
+        }
+    }
+    due.sort_by(|a, b| {
+        b.overdue_secs
+            .cmp(&a.overdue_secs)
+            .then(a.todo_id.cmp(&b.todo_id))
+    });
+    stalled.sort();
+    MonitorPollPlan {
+        schema_version: MONITOR_POLL_PLAN_SCHEMA_VERSION.to_string(),
+        goal_id: goal.goal_id.clone(),
+        due_monitors: due,
+        stalled_monitors: stalled,
+        next_due_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Todo;
+    use std::time::Duration;
+
+    #[test]
+    fn policy_classification_matches_loopx_vocabulary() {
+        assert!(policy_allows_no_spend(Some("material_transition_only")));
+        assert!(policy_allows_no_spend(Some(
+            "read_only_observation_then_no_spend_if_unchanged"
+        )));
+        // Unknown declared policy: NOT classified as a no-spend external poll.
+        assert!(!policy_allows_no_spend(Some("custom_webhook")));
+        // Undeclared keeps the FO default (read-only observation).
+        assert!(policy_allows_no_spend(None));
+        assert!(policy_allows_no_spend(Some("  ")));
+    }
+
+    #[test]
+    fn cadence_interval_parses_strings_classes_and_rrules() {
+        assert_eq!(cadence_poll_interval_secs(Some("15m")), Some(900));
+        assert_eq!(cadence_poll_interval_secs(Some("2d")), Some(2 * 86400));
+        assert_eq!(cadence_poll_interval_secs(Some("hourly")), Some(3600));
+        assert_eq!(cadence_poll_interval_secs(Some("daily")), Some(86400));
+        assert_eq!(cadence_poll_interval_secs(Some("weekly")), Some(604800));
+        assert_eq!(
+            cadence_poll_interval_secs(Some("FREQ=MINUTELY;INTERVAL=45")),
+            Some(2700)
+        );
+        // `once` and unknown cadences have no recurrence interval.
+        assert_eq!(cadence_poll_interval_secs(Some("once")), None);
+        assert_eq!(cadence_poll_interval_secs(Some("fortnightly")), None);
+        assert_eq!(cadence_poll_interval_secs(None), None);
+        assert_eq!(cadence_poll_interval_secs(Some("")), None);
+    }
+
+    #[test]
+    fn next_due_is_cadence_aware_with_backoff_fallback() {
+        assert_eq!(next_poll_due_epoch(1_000, Some("1h")), 1_000 + 3600);
+        // No cadence → the fixed G-8 no-change backoff (replay parity).
+        assert_eq!(
+            next_poll_due_epoch(1_000, None),
+            1_000 + crate::decision::MONITOR_NO_CHANGE_BACKOFF_SECS
+        );
+    }
+
+    #[test]
+    fn poll_plan_classifies_due_waiting_and_stalled() {
+        let mut g = Goal::new("g1", "o", "/tmp");
+        let now = SystemTime::now();
+        // Due, most overdue.
+        g.add(Todo::monitor_with(
+            "M1",
+            "old due",
+            Some("https://x"),
+            Some("material_transition_only"),
+            Some("1h"),
+            Duration::from_secs(1),
+        ));
+        g.todo_mut("M1").unwrap().resume_when = Some(now - Duration::from_secs(300));
+        // Due, less overdue, unknown policy.
+        g.add(Todo::monitor("M2", "due", Duration::from_secs(1)));
+        g.todo_mut("M2").unwrap().monitor_policy = Some("custom_webhook".into());
+        g.todo_mut("M2").unwrap().resume_when = Some(now - Duration::from_secs(60));
+        // Waiting (due in the future).
+        g.add(Todo::monitor("M3", "waiting", Duration::from_secs(3600)));
+        // Stalled (counter at threshold) — excluded from due, listed separately.
+        g.add(Todo::monitor("M4", "stalled", Duration::from_secs(1)));
+        g.todo_mut("M4").unwrap().consecutive_no_change =
+            crate::decision::MONITOR_NO_CHANGE_REPLAN_THRESHOLD;
+
+        let plan = build_poll_plan(&g, now);
+        assert_eq!(plan.schema_version, MONITOR_POLL_PLAN_SCHEMA_VERSION);
+        assert_eq!(plan.stalled_monitors, vec!["M4".to_string()]);
+        assert_eq!(plan.due_monitors.len(), 2);
+        // Most overdue first.
+        assert_eq!(plan.due_monitors[0].todo_id, "M1");
+        assert!(plan.due_monitors[0].no_spend_if_unchanged);
+        assert_eq!(plan.due_monitors[0].overdue_secs, 300);
+        assert_eq!(plan.due_monitors[1].todo_id, "M2");
+        assert!(!plan.due_monitors[1].no_spend_if_unchanged);
+        // Next due ≈ M3's 3600s-out time.
+        let next = plan.next_due_at.expect("waiting monitor sets next due");
+        let now_e = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!((now_e + 3599..=now_e + 3600).contains(&next));
+    }
+
+    #[test]
+    fn empty_goal_plans_empty() {
+        let g = Goal::new("g1", "o", "/tmp");
+        let plan = build_poll_plan(&g, SystemTime::now());
+        assert!(plan.due_monitors.is_empty());
+        assert!(plan.stalled_monitors.is_empty());
+        assert_eq!(plan.next_due_at, None);
+    }
+}

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -758,6 +758,27 @@ pub struct Goal {
     /// `ShouldRunPacket` as `decision_freshness`.
     #[serde(skip)]
     pub decision_freshness: Option<DecisionFreshness>,
+    /// P1-3①: latest scheduler heartbeat per agent (epoch secs), folded
+    /// from `SchedulerTicked`. The liveness check compares now against this.
+    #[serde(default)]
+    pub scheduler_heartbeats: std::collections::BTreeMap<String, u64>,
+    /// P1-3①: automation liveness breach alerts, folded from
+    /// `AutomationLivenessAlert` (append-only; recovery is derived by
+    /// comparing against `scheduler_heartbeats`).
+    #[serde(default)]
+    pub liveness_alerts: Vec<LivenessAlert>,
+}
+
+/// P1-3①: one automation-liveness breach alert (LoopX automation_liveness):
+/// the scheduler heartbeat for `agent_id` went silent past the threshold.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LivenessAlert {
+    pub agent_id: String,
+    pub elapsed_secs: u64,
+    pub threshold_secs: u64,
+    /// 1-based alert ordinal for this (goal, agent) scope.
+    pub consecutive: u32,
+    pub ts: u64,
 }
 
 /// P1-2②: freshness stamp of the event ledger a decision was compiled
@@ -813,6 +834,8 @@ impl Goal {
             delivery_states: vec![],
             capability_invocations: vec![],
             decision_freshness: None,
+            scheduler_heartbeats: std::collections::BTreeMap::new(),
+            liveness_alerts: vec![],
         }
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -454,6 +454,31 @@ pub enum Event {
         source: String,
         ts: u64,
     },
+    /// P1-3①: scheduler heartbeat — every `scheduler tick` lands one (LoopX
+    /// automation_liveness heartbeat). `rrule` is the cadence in effect
+    /// after the tick. Folded into `goal.scheduler_heartbeats`; the
+    /// liveness check compares now against the latest heartbeat per
+    /// (goal, agent).
+    SchedulerTicked {
+        goal_id: String,
+        agent_id: String,
+        action: String,
+        #[serde(default)]
+        rrule: Option<String>,
+        ts: u64,
+    },
+    /// P1-3①: automation liveness breach alert — the tick heartbeat went
+    /// silent past the threshold. Folded into `goal.liveness_alerts`; the
+    /// attention projection escalates the goal to the operator until a
+    /// fresh heartbeat recovers the automation.
+    AutomationLivenessAlert {
+        goal_id: String,
+        agent_id: String,
+        elapsed_secs: u64,
+        threshold_secs: u64,
+        consecutive: u32,
+        ts: u64,
+    },
     /// G-16: a supervisor proposed a decision for a target agent (LoopX
     /// SUPERVISOR_PROPOSED). Projection-only — supervisor state is read from
     /// the event log, not folded into goal state.
@@ -533,6 +558,8 @@ impl Event {
             | Event::DecisionSummaryRecorded { goal_id, .. }
             | Event::HeartbeatReceiptRecorded { goal_id, .. }
             | Event::SchedulerAcked { goal_id, .. }
+            | Event::SchedulerTicked { goal_id, .. }
+            | Event::AutomationLivenessAlert { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. }
             | Event::ProjectionRepaired { goal_id, .. } => goal_id,
@@ -1412,10 +1439,16 @@ fn apply(goal: &mut Goal, event: Event) {
                     m.status = crate::state::TodoStatus::Done;
                 } else {
                     m.consecutive_no_change = no_change_count;
-                    let backoff = crate::decision::monitor::MONITOR_NO_CHANGE_BACKOFF_SECS;
+                    // P1-3②: cadence-aware reschedule (the same derivation
+                    // the run path uses) with the fixed G-8 backoff as the
+                    // no-cadence fallback — replay stays exact.
+                    let next_due = crate::scheduler::monitor_poll::next_poll_due_epoch(
+                        ts,
+                        m.monitor_cadence.as_deref(),
+                    );
                     m.resume_when = Some(
                         std::time::SystemTime::UNIX_EPOCH
-                            + std::time::Duration::from_secs(ts + backoff),
+                            + std::time::Duration::from_secs(next_due),
                     );
                 }
                 m.updated_at = ts;
@@ -1507,11 +1540,28 @@ fn apply(goal: &mut Goal, event: Event) {
             ts,
             ..
         } => goal.apply_followthrough(&source_todo_id, &followup_todo_id, ts),
-        // P1-5: reward signals are projection-only (read from the event log
-        // by the scoped-feedback query; goal state is unchanged) — same
-        // treatment as the G-16 supervisor events and the P1-1 quota decision
-        // read model (decision summaries / heartbeat receipts / scheduler
-        // acks are served from the event log by `quota::decision_summary`).
+        // P1-3①: liveness heartbeat / alert fold into goal state (they ARE
+        // the state the liveness check + attention escalation read).
+        Event::SchedulerTicked { agent_id, ts, .. } => {
+            let entry = goal.scheduler_heartbeats.entry(agent_id).or_insert(ts);
+            *entry = (*entry).max(ts);
+        }
+        Event::AutomationLivenessAlert {
+            agent_id,
+            elapsed_secs,
+            threshold_secs,
+            consecutive,
+            ts,
+            ..
+        } => goal.liveness_alerts.push(crate::state::LivenessAlert {
+            agent_id,
+            elapsed_secs,
+            threshold_secs,
+            consecutive,
+            ts,
+        }),
+        // P1-5 + P1-1 + G-16 projection-only events: read from the event log
+        // by their read models; goal state is unchanged on replay.
         Event::RewardSignalRecorded { .. }
         | Event::DecisionSummaryRecorded { .. }
         | Event::HeartbeatReceiptRecorded { .. }

--- a/orchestration/loop/src/work_items/attention.rs
+++ b/orchestration/loop/src/work_items/attention.rs
@@ -77,10 +77,27 @@ pub fn build_attention_queue(items: Vec<AttentionItem>) -> AttentionQueue {
     }
 }
 
+/// The latest liveness alert not yet recovered by a fresh heartbeat
+/// (P1-3①): an alert is recovered once a `SchedulerTicked` heartbeat at or
+/// after the alert's second lands for the same agent (second-granularity
+/// ties favor recovery — the tick proves the automation is back). Returns
+/// the newest unrecovered alert across agents.
+pub fn latest_unrecovered_liveness_alert(goal: &Goal) -> Option<&crate::state::LivenessAlert> {
+    goal.liveness_alerts
+        .iter()
+        .filter(|a| {
+            goal.scheduler_heartbeats
+                .get(&a.agent_id)
+                .is_none_or(|hb| *hb < a.ts)
+        })
+        .max_by_key(|a| a.ts)
+}
+
 /// Project one goal's attention item (None when the goal needs nothing).
 /// Routing (LoopX goal_attention):
 /// - open user gate → waiting on user_or_controller;
 /// - replan obligation / projection gap → waiting on codex;
+/// - automation liveness breach → waiting on user_or_controller (P1-3①);
 /// - open monitor due → watching monitor;
 /// - terminal closure → no item.
 pub fn goal_attention_item(goal: &Goal) -> Option<AttentionItem> {
@@ -110,6 +127,21 @@ pub fn goal_attention_item(goal: &Goal) -> Option<AttentionItem> {
             severity: "action".to_string(),
             recommended_action: format!("self-repair projection gap: {gap}"),
             source: "goal_attention".to_string(),
+        });
+    }
+    // P1-3①: a dead/stuck host automation escalates to the operator — the
+    // goal's cadence is silently starving until the scheduler ticks again.
+    if let Some(alert) = latest_unrecovered_liveness_alert(goal) {
+        return Some(AttentionItem {
+            goal_id: goal.goal_id.clone(),
+            status: "automation_liveness_breach".to_string(),
+            waiting_on: AttentionWaitingOn::UserOrController.label().to_string(),
+            severity: "high".to_string(),
+            recommended_action: format!(
+                "scheduler heartbeat silent {}s (> {}s threshold) for agent {} — check/restart the host automation",
+                alert.elapsed_secs, alert.threshold_secs, alert.agent_id
+            ),
+            source: "automation_liveness".to_string(),
         });
     }
     let open_advancement = goal.open_of(crate::state::TaskClass::Advancement).count();

--- a/orchestration/loop/tests/automation_liveness_contract.rs
+++ b/orchestration/loop/tests/automation_liveness_contract.rs
@@ -1,0 +1,411 @@
+//! P1-3 contract tests — automation liveness + monitor poll executor.
+//!
+//! ① liveness heartbeat: `scheduler tick` lands a `SchedulerTicked`
+//!    heartbeat event; `scheduler liveness` evaluates the silence against a
+//!    threshold — a breach records an `AutomationLivenessAlert`
+//!    (cooldown-deduped), drops an operator-inbox alert file, and the
+//!    attention projection escalates to a high-severity operator item until
+//!    a fresh heartbeat recovers the automation.
+//! ② monitor poll executor: the tick-driven poll plan classifies
+//!    due/waiting/stalled monitors with no-spend eligibility, and the
+//!    cadence-aware next-due writeback is shared by the run path and replay.
+
+use future_loop::console;
+use future_loop::scheduler::liveness as lv;
+use future_loop::state::{Goal, Todo};
+use future_loop::store::{Event, Store};
+use future_loop::work_items::attention::{goal_attention_item, latest_unrecovered_liveness_alert};
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-p13-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; serialize CLI tests behind a mutex.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let root = format!("{}/.future/loop", tmp_root(tag));
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", &root);
+    f(&root);
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+fn init_goal(root: &str, goal_id: &str, cwd: &str) {
+    cli(&[
+        "goal",
+        "init",
+        "--objective",
+        "p1-3 liveness",
+        "--cwd",
+        cwd,
+        "--goal-id",
+        goal_id,
+    ])
+    .unwrap();
+    let _ = root;
+}
+
+fn replay(root: &str, goal_id: &str) -> Goal {
+    Store::open(root)
+        .unwrap()
+        .replay(goal_id)
+        .unwrap()
+        .expect("goal exists")
+}
+
+// ── ① heartbeat: tick lands the event; liveness evaluates alive ──────────
+
+#[test]
+fn tick_lands_heartbeat_and_liveness_stays_alive() {
+    with_root("alive", |root| {
+        let proj = tmp_root("alive-proj");
+        init_goal(root, "g1", &proj);
+
+        // No heartbeat yet → no_heartbeat, and crucially NOT a breach (no
+        // alert event may land for an automation that was never installed).
+        cli(&["scheduler", "liveness", "--goal", "g1"]).unwrap();
+        cli(&["scheduler", "liveness", "--goal", "g1", "--format", "json"]).unwrap();
+        let goal = replay(root, "g1");
+        assert!(goal.scheduler_heartbeats.is_empty());
+        assert!(goal.liveness_alerts.is_empty());
+
+        // Tick → heartbeat event folds into the replay projection.
+        cli(&["scheduler", "tick", "--goal", "g1"]).unwrap();
+        let goal = replay(root, "g1");
+        let hb = goal
+            .scheduler_heartbeats
+            .get("codex-app")
+            .copied()
+            .expect("tick lands a heartbeat for the default agent");
+        let now = future_loop::state::now_epoch();
+        assert!(now.saturating_sub(hb) < 60, "heartbeat is fresh");
+
+        // Fresh heartbeat → alive, no alert.
+        cli(&[
+            "scheduler",
+            "liveness",
+            "--goal",
+            "g1",
+            "--threshold-secs",
+            "3600",
+        ])
+        .unwrap();
+        assert!(replay(root, "g1").liveness_alerts.is_empty());
+    });
+}
+
+// ── ① breach: stale heartbeat → alert + inbox + attention; fresh tick ────
+// ── recovers ──────────────────────────────────────────────────────────────
+
+#[test]
+fn stale_heartbeat_breaches_alerts_escalates_and_recovers() {
+    with_root("breach", |root| {
+        let proj = tmp_root("breach-proj");
+        init_goal(root, "g1", &proj);
+        let now = future_loop::state::now_epoch();
+
+        // Fabricate a stale heartbeat (3h ago) — the automation went silent.
+        Store::open(root)
+            .unwrap()
+            .append(Event::SchedulerTicked {
+                goal_id: "g1".into(),
+                agent_id: "codex-app".into(),
+                action: "tick_next".into(),
+                rrule: None,
+                ts: now - 3 * 3600,
+            })
+            .unwrap();
+
+        // Breach: alert lands (consecutive=1) + operator inbox file.
+        cli(&[
+            "scheduler",
+            "liveness",
+            "--goal",
+            "g1",
+            "--threshold-secs",
+            "60",
+        ])
+        .unwrap();
+        let goal = replay(root, "g1");
+        assert_eq!(goal.liveness_alerts.len(), 1, "breach records one alert");
+        let alert = &goal.liveness_alerts[0];
+        assert_eq!(alert.agent_id, "codex-app");
+        assert_eq!(alert.consecutive, 1);
+        assert_eq!(alert.threshold_secs, 60);
+        assert!(alert.elapsed_secs >= 3 * 3600 - 5);
+
+        let inbox = std::path::Path::new(&proj)
+            .join(".future")
+            .join("loop")
+            .join("inbox");
+        let alerts: Vec<_> = std::fs::read_dir(&inbox)
+            .expect("inbox dir created")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("liveness-g1-"))
+            .collect();
+        assert_eq!(alerts.len(), 1, "operator inbox alert file written");
+
+        // Cooldown: an immediate second check does NOT append another alert.
+        cli(&[
+            "scheduler",
+            "liveness",
+            "--goal",
+            "g1",
+            "--threshold-secs",
+            "60",
+        ])
+        .unwrap();
+        assert_eq!(
+            replay(root, "g1").liveness_alerts.len(),
+            1,
+            "cooldown dedups the breach alert"
+        );
+
+        // Attention escalation: high-severity operator item.
+        let goal = replay(root, "g1");
+        let item = goal_attention_item(&goal).expect("breach demands attention");
+        assert_eq!(item.status, "automation_liveness_breach");
+        assert_eq!(item.severity, "high");
+        assert_eq!(item.waiting_on, "user_or_controller");
+        assert!(item.recommended_action.contains("codex-app"));
+
+        // Recovery: a fresh tick lands a heartbeat newer than the alert.
+        cli(&["scheduler", "tick", "--goal", "g1"]).unwrap();
+        let goal = replay(root, "g1");
+        assert!(
+            latest_unrecovered_liveness_alert(&goal).is_none(),
+            "fresh heartbeat recovers the alert"
+        );
+        let item = goal_attention_item(&goal);
+        assert!(
+            item.is_none_or(|i| i.status != "automation_liveness_breach"),
+            "attention no longer escalates liveness"
+        );
+    });
+}
+
+// ── ① alert ordinal: consecutive counts per (goal, agent) scope ───────────
+
+#[test]
+fn repeated_breaches_increment_the_alert_ordinal() {
+    with_root("ordinal", |root| {
+        let proj = tmp_root("ordinal-proj");
+        init_goal(root, "g1", &proj);
+        let now = future_loop::state::now_epoch();
+        let mut store = Store::open(root).unwrap();
+        // Stale heartbeat + an ancient prior alert (outside the cooldown).
+        store
+            .append(Event::SchedulerTicked {
+                goal_id: "g1".into(),
+                agent_id: "codex-app".into(),
+                action: "tick_next".into(),
+                rrule: None,
+                ts: now - 3 * 3600,
+            })
+            .unwrap();
+        store
+            .append(Event::AutomationLivenessAlert {
+                goal_id: "g1".into(),
+                agent_id: "codex-app".into(),
+                elapsed_secs: 8000,
+                threshold_secs: 60,
+                consecutive: 1,
+                ts: now - 2 * lv::LIVENESS_ALERT_COOLDOWN_SECS,
+            })
+            .unwrap();
+        drop(store);
+
+        cli(&[
+            "scheduler",
+            "liveness",
+            "--goal",
+            "g1",
+            "--threshold-secs",
+            "60",
+        ])
+        .unwrap();
+        let goal = replay(root, "g1");
+        assert_eq!(goal.liveness_alerts.len(), 2, "cooldown expired → re-alert");
+        assert_eq!(goal.liveness_alerts[1].consecutive, 2);
+    });
+}
+
+// ── ① evaluation edges (pure) ─────────────────────────────────────────────
+
+#[test]
+fn liveness_evaluation_edges() {
+    // Heartbeat newer than now (clock skew) clamps to alive.
+    let eval = lv::evaluate_liveness("g", "a", Some(2000), 1000, 60);
+    assert_eq!(eval.state, lv::LIVENESS_ALIVE);
+    assert_eq!(eval.elapsed_secs, Some(0));
+    // Exactly at threshold: alive; one second past: breach.
+    assert_eq!(
+        lv::evaluate_liveness("g", "a", Some(0), 60, 60).state,
+        lv::LIVENESS_ALIVE
+    );
+    assert_eq!(
+        lv::evaluate_liveness("g", "a", Some(0), 61, 60).state,
+        lv::LIVENESS_BREACH
+    );
+}
+
+// ── ② cadence-aware writeback: replay + run path share the derivation ────
+
+#[test]
+fn cadence_monitor_reschedules_by_cadence_on_replay() {
+    let root = tmp_root("cadence-replay");
+    let store_root = format!("{root}/.future/loop");
+    std::fs::create_dir_all(&store_root).unwrap();
+    let mut store = Store::open(&store_root).unwrap();
+    let goal = Goal::new("g1", "objective", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: "g1".into(),
+            ts: goal.created_at,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::monitor_with(
+                "M1",
+                "Watch",
+                None,
+                None,
+                Some("1h"),
+                std::time::Duration::from_secs(60),
+            ),
+            ts: goal.created_at,
+        })
+        .unwrap();
+    let poll_ts = 1_784_000_000u64;
+    store
+        .append(Event::MonitorPolled {
+            goal_id: "g1".into(),
+            todo_id: "M1".into(),
+            result: "no_change".into(),
+            no_change_count: 1,
+            ts: poll_ts,
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    let due = goal
+        .todo("M1")
+        .unwrap()
+        .resume_when
+        .unwrap()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert_eq!(
+        due,
+        poll_ts + 3600,
+        "1h cadence ⇒ next due = poll ts + 3600 (not the fixed 12s backoff)"
+    );
+}
+
+#[test]
+fn no_cadence_monitor_keeps_fixed_backoff_replay_parity() {
+    let root = tmp_root("backoff-parity");
+    let store_root = format!("{root}/.future/loop");
+    std::fs::create_dir_all(&store_root).unwrap();
+    let mut store = Store::open(&store_root).unwrap();
+    let goal = Goal::new("g1", "objective", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: "g1".into(),
+            ts: goal.created_at,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g1".into(),
+            todo: Todo::monitor("M1", "Watch", std::time::Duration::from_secs(60)),
+            ts: goal.created_at,
+        })
+        .unwrap();
+    let poll_ts = 1_784_000_000u64;
+    store
+        .append(Event::MonitorPolled {
+            goal_id: "g1".into(),
+            todo_id: "M1".into(),
+            result: "no_change".into(),
+            no_change_count: 1,
+            ts: poll_ts,
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    let due = goal
+        .todo("M1")
+        .unwrap()
+        .resume_when
+        .unwrap()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert_eq!(
+        due,
+        poll_ts + future_loop::decision::MONITOR_NO_CHANGE_BACKOFF_SECS,
+        "no cadence ⇒ the fixed G-8 backoff (pre-P1-3 replay parity)"
+    );
+}
+
+#[test]
+fn run_path_writeback_uses_the_same_cadence_derivation() {
+    let mut goal = Goal::new("g", "objective", "/tmp");
+    goal.add(Todo::monitor_with(
+        "M1",
+        "Watch",
+        None,
+        None,
+        Some("30m"),
+        std::time::Duration::from_millis(1),
+    ));
+    let record = future_loop::state::RunRecord {
+        turn: 1,
+        todo_id: "M1".into(),
+        run_id: "run-1".into(),
+        terminal_state: "completed".into(),
+        error: None,
+        tokens_in_delta: 0,
+        tokens_out_delta: 0,
+        cost_delta: 0.0,
+        tools: vec![],
+        evidence: String::new(),
+        recorded_at: future_loop::state::now_epoch(),
+        spend_source: Some("heartbeat".into()),
+        validation: None,
+    };
+    let before = future_loop::state::now_epoch();
+    future_loop::executor::writeback(&mut goal, &record, Some(false), None);
+    let due = goal
+        .todo("M1")
+        .unwrap()
+        .resume_when
+        .unwrap()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(
+        (before + 1800..=before + 1805).contains(&due),
+        "30m cadence ⇒ run path reschedules ~1800s out, got due={due} before={before}"
+    );
+}


### PR DESCRIPTION
loopx-improvement-report.md **P1-3**（wave1 拆分 PR 8/11）。

- `scheduler liveness --goal G [--threshold-secs N]`（默认 2h）：tick 心跳超时→liveness 告警 + attention 升级，恢复去告警（cooldown 1h）——过夜无人值守 goal 的安全网
- monitor 型 todo 轮询策略执行器（scheduler tick 驱动；cadence-aware 重排期）
- 新契约测试 automation_liveness_contract.rs

本地：fmt ✅ clippy ✅ future-loop 71 targets 全绿 ✅。源：claude/loop-wave1 4a2b42a7