### PR TITLE
feat(loop): P1-4 decision_context deep implementation — assembler + providers + audited outcome feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/orchestration/loop/Cargo.toml
+++ b/orchestration/loop/Cargo.toml
@@ -28,6 +28,7 @@ thiserror.workspace = true
 chrono.workspace = true
 futures-util.workspace = true
 fs2 = "0.4"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/orchestration/loop/src/capabilities/decision_context.rs
+++ b/orchestration/loop/src/capabilities/decision_context.rs
@@ -1,5 +1,20 @@
 //! decision_context capability (LoopX: decision_context — deterministic rule translation
 //! into finite typed proposals).
+//!
+//! P1-4 deep implementation (LoopX `capabilities/decision_context/`,
+//! compact set): the decision-context assembler + providers (run history /
+//! outcome streak / quota status) + outcome-feedback writeback live in the
+//! submodules. The rule proposer below stays the G-24 capability surface.
+//!
+//! The assembled packet is also the replay record-time capture: it carries
+//! the goal-level decision state (outcome streak, goal status, open
+//! acceptance gaps) that the compact todo snapshot cannot, fixing the
+//! replay record→run mismatch from incomplete context.
+
+pub mod assembler;
+pub mod outcome_feedback;
+pub mod packets;
+pub mod providers;
 
 use super::{successor_todo, Capability, TypedProposal};
 

--- a/orchestration/loop/src/capabilities/decision_context/assembler.rs
+++ b/orchestration/loop/src/capabilities/decision_context/assembler.rs
@@ -1,0 +1,161 @@
+//! Decision-context assembler (P1-4) — LoopX
+//! `capabilities/decision_context/assembler.py`, compact set.
+//!
+//! The assembler composes one [`DecisionContextPacket`] from the registered
+//! providers: a goal-boundary header (status + open acceptance gap ids)
+//! plus each provider's typed section, folded in registration order (a
+//! later provider's section replaces an earlier one of the same kind —
+//! deterministic). The packet is the record-time capture that fixes the
+//! replay record→run mismatch: `replay record` stores it in the case and
+//! `goal_from_case` rebuilds the decision-relevant goal state from it.
+
+use crate::state::Goal;
+
+use super::packets::{
+    DecisionContextPacket, OutcomeStreakSection, QuotaStatusSection, RunHistorySection,
+    DECISION_CONTEXT_PACKET_SCHEMA_VERSION,
+};
+use super::providers::{builtin_providers, DecisionContextProvider, ProviderSection};
+
+/// Composes decision-context packets from a provider set.
+pub struct DecisionContextAssembler {
+    providers: Vec<Box<dyn DecisionContextProvider>>,
+}
+
+impl Default for DecisionContextAssembler {
+    fn default() -> Self {
+        Self::with_builtin()
+    }
+}
+
+impl DecisionContextAssembler {
+    pub fn new(providers: Vec<Box<dyn DecisionContextProvider>>) -> Self {
+        Self { providers }
+    }
+
+    /// The builtin provider set (run history / outcome streak / quota
+    /// status), in deterministic assembly order.
+    pub fn with_builtin() -> Self {
+        Self::new(builtin_providers())
+    }
+
+    /// Assemble the packet for `goal` stamped at `now` (epoch secs).
+    pub fn assemble(&self, goal: &Goal, now: u64) -> DecisionContextPacket {
+        let mut packet = DecisionContextPacket {
+            schema_version: DECISION_CONTEXT_PACKET_SCHEMA_VERSION.to_string(),
+            goal_id: goal.goal_id.clone(),
+            goal_status: goal.status.clone(),
+            assembled_at: now,
+            providers: Vec::with_capacity(self.providers.len()),
+            open_acceptance_gaps: goal
+                .unsatisfied_gaps()
+                .iter()
+                .map(|g| g.id.clone())
+                .collect(),
+            run_history: RunHistorySection::default(),
+            outcome_streak: OutcomeStreakSection::default(),
+            quota: QuotaStatusSection::default(),
+        };
+        for provider in &self.providers {
+            packet.providers.push(provider.id().to_string());
+            match provider.collect(goal) {
+                ProviderSection::RunHistory(section) => packet.run_history = section,
+                ProviderSection::OutcomeStreak(section) => packet.outcome_streak = section,
+                ProviderSection::QuotaStatus(section) => packet.quota = section,
+            }
+        }
+        packet
+    }
+}
+
+/// One-shot convenience: assemble with the builtin provider set, stamped at
+/// the current time.
+pub fn assemble_decision_context(goal: &Goal) -> DecisionContextPacket {
+    DecisionContextAssembler::with_builtin().assemble(goal, crate::state::now_epoch())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Todo;
+
+    #[test]
+    fn assemble_captures_goal_boundary_and_all_sections() {
+        let mut g = Goal::new("g1", "objective", "/tmp").with_acceptance(vec![("A1", "match")]);
+        g.add(Todo::advancement("T1", "work"));
+        g.execution_profile.outcome_floor_streak_threshold = 2;
+        g.outcome_streak = 2;
+        let packet = DecisionContextAssembler::with_builtin().assemble(&g, 42);
+        assert_eq!(
+            packet.schema_version,
+            DECISION_CONTEXT_PACKET_SCHEMA_VERSION
+        );
+        assert_eq!(packet.goal_id, "g1");
+        assert_eq!(packet.goal_status, "active");
+        assert_eq!(packet.assembled_at, 42);
+        assert_eq!(
+            packet.providers,
+            vec![
+                "run_history".to_string(),
+                "outcome_streak".to_string(),
+                "quota_status".to_string()
+            ]
+        );
+        assert_eq!(packet.open_acceptance_gaps, vec!["A1".to_string()]);
+        assert!(packet.outcome_streak.floor_breached);
+        assert_eq!(packet.run_history.run_count, 0);
+        assert_eq!(
+            packet.quota.allowed_slots,
+            crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS
+        );
+    }
+
+    #[test]
+    fn cancelled_goal_status_is_captured() {
+        let mut g = Goal::new("g1", "objective", "/tmp");
+        g.status = "cancelled".to_string();
+        let packet = assemble_decision_context(&g);
+        assert_eq!(packet.goal_status, "cancelled");
+    }
+
+    struct DuplicateRunHistory;
+    impl DecisionContextProvider for DuplicateRunHistory {
+        fn id(&self) -> &'static str {
+            "run_history"
+        }
+        fn describe(&self) -> &'static str {
+            "test double"
+        }
+        fn collect(&self, _goal: &Goal) -> ProviderSection {
+            ProviderSection::RunHistory(RunHistorySection {
+                run_count: 99,
+                ..RunHistorySection::default()
+            })
+        }
+    }
+
+    #[test]
+    fn later_section_replaces_earlier_of_same_kind() {
+        let g = Goal::new("g1", "objective", "/tmp");
+        let assembler = DecisionContextAssembler::new(vec![
+            Box::new(super::super::providers::RunHistoryProvider),
+            Box::new(DuplicateRunHistory),
+        ]);
+        let packet = assembler.assemble(&g, 1);
+        assert_eq!(packet.run_history.run_count, 99, "last writer wins");
+        assert_eq!(
+            packet.providers,
+            vec!["run_history".to_string(), "run_history".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_provider_set_yields_header_only_packet() {
+        let g = Goal::new("g1", "objective", "/tmp");
+        let packet = DecisionContextAssembler::new(vec![]).assemble(&g, 7);
+        assert!(packet.providers.is_empty());
+        assert_eq!(packet.run_history, RunHistorySection::default());
+        assert_eq!(packet.outcome_streak, OutcomeStreakSection::default());
+        assert_eq!(packet.quota, QuotaStatusSection::default());
+    }
+}

--- a/orchestration/loop/src/capabilities/decision_context/outcome_feedback.rs
+++ b/orchestration/loop/src/capabilities/decision_context/outcome_feedback.rs
@@ -1,0 +1,267 @@
+//! Audited feedback from decision outcomes into the ledger and reward
+//! memory (P1-4) — LoopX `capabilities/decision_context/outcome_feedback.py`,
+//! compact set.
+//!
+//! Lifecycle: a receipt begins `pending` at decision time (carrying the
+//! context digest — the tamper-evident link to the packet the decision was
+//! assembled from) and settles to a terminal status (verified / refuted /
+//! inconclusive) once the outcome is observed. The settle is the writeback:
+//! one `DecisionOutcomeRecorded` ledger event (projection-only, like the
+//! P1-1 decision summaries) plus — for decisive outcomes — one reward
+//! signal under the `decision_outcome` source, so reward_memory learns
+//! which decisions held up.
+//!
+//! Audited = fail closed: feedback must anchor to a persisted decision
+//! summary (`DecisionSummaryRecorded` for the same goal + turn); settling
+//! against a decision that never happened is rejected.
+
+use anyhow::{bail, Result};
+
+use super::packets::{
+    is_terminal_status, normalize_verification_status, DecisionContextPacket,
+    DecisionOutcomeReceipt, DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION, VERIFICATION_INCONCLUSIVE,
+    VERIFICATION_PENDING, VERIFICATION_REFUTED, VERIFICATION_VERIFIED,
+};
+use crate::capabilities::reward_memory as rm;
+use crate::contract::ShouldRunPacket;
+use crate::store::{Event, Store, StoredEvent};
+
+/// Begin a pending receipt for a decision made against `context`.
+/// `decision_id` anchors the receipt (`turn-{N}`, matching
+/// `HeartbeatReceiptRecorded.turn_instance_id`). `seq` is the per-decision
+/// feedback sequence ([`next_seq`]) — the G-3 dedupe anchor.
+pub fn begin_receipt(
+    packet: &ShouldRunPacket,
+    context: &DecisionContextPacket,
+    decision_id: &str,
+    agent_id: Option<&str>,
+    seq: u32,
+    now: u64,
+) -> DecisionOutcomeReceipt {
+    DecisionOutcomeReceipt {
+        schema_version: DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION.to_string(),
+        receipt_id: DecisionOutcomeReceipt::derive_receipt_id(&packet.goal_id, decision_id, seq),
+        goal_id: packet.goal_id.clone(),
+        decision_id: decision_id.to_string(),
+        agent_id: agent_id.map(str::to_string),
+        accepted_decision: packet.effective_action.clone(),
+        reason_code: packet.reason_code.clone(),
+        context_digest: context.digest(),
+        verification_status: VERIFICATION_PENDING.to_string(),
+        note: None,
+        seq,
+        recorded_at: now,
+        settled_at: None,
+    }
+}
+
+/// Settle a pending receipt to a terminal status. Fails closed on an
+/// unknown status, on `pending` (not a settle target), and on a
+/// double-settle (a settled receipt is immutable — record a new one with
+/// the next seq instead).
+pub fn settle_receipt(
+    receipt: &mut DecisionOutcomeReceipt,
+    status: &str,
+    note: Option<String>,
+    now: u64,
+) -> Result<()> {
+    if receipt.verification_status != VERIFICATION_PENDING {
+        bail!(
+            "receipt {} already settled ({}) — record a new receipt instead",
+            receipt.receipt_id,
+            receipt.verification_status
+        );
+    }
+    let status = normalize_verification_status(status)
+        .ok_or_else(|| anyhow::anyhow!("unknown verification status `{status}`"))?;
+    if !is_terminal_status(status) {
+        bail!("verification status `{status}` is not a terminal settle target");
+    }
+    receipt.verification_status = status.to_string();
+    receipt.note = note;
+    receipt.settled_at = Some(now);
+    Ok(())
+}
+
+/// Deterministic outcome → reward-signal mapping (phase 1): verified = 1.0,
+/// refuted = 0.0, inconclusive carries no score (the observer could not
+/// decide); `pending` is not an outcome and yields no signal.
+pub fn outcome_signal(status: &str) -> Option<(&'static str, Option<f64>)> {
+    match status {
+        VERIFICATION_VERIFIED => Some(("verified", Some(1.0))),
+        VERIFICATION_REFUTED => Some(("refuted", Some(0.0))),
+        VERIFICATION_INCONCLUSIVE => Some(("inconclusive", None)),
+        _ => None,
+    }
+}
+
+/// Read model: all settled outcome receipts in ledger order.
+pub fn decision_outcomes(events: &[StoredEvent]) -> Vec<&DecisionOutcomeReceipt> {
+    events
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            Event::DecisionOutcomeRecorded { receipt, .. } => Some(receipt),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The latest receipt recorded against one decision anchor, if any.
+pub fn outcome_for<'a>(
+    events: &'a [StoredEvent],
+    decision_id: &str,
+) -> Option<&'a DecisionOutcomeReceipt> {
+    decision_outcomes(events)
+        .into_iter()
+        .rev()
+        .find(|r| r.decision_id == decision_id)
+}
+
+/// The next per-decision feedback sequence (1 + the number of receipts
+/// already recorded against this decision) — mirrors reward_memory's
+/// per-todo seq as the G-3 content-id dedupe anchor.
+pub fn next_seq(events: &[StoredEvent], decision_id: &str) -> u32 {
+    let count = events
+        .iter()
+        .filter(|se| matches!(&se.event, Event::DecisionOutcomeRecorded { receipt, .. } if receipt.decision_id == decision_id))
+        .count();
+    count as u32 + 1
+}
+
+/// The settle writeback (`decision-context feedback`): anchor the receipt
+/// to the persisted decision summary for `turn`, append the
+/// `DecisionOutcomeRecorded` event, and — for decisive outcomes — ingest
+/// the reward signal under the `decision_outcome` source.
+///
+/// `context_digest` links the receipt to the assembled packet when the
+/// caller has one at hand (e.g. a replay-recorded case); empty otherwise.
+pub fn record_outcome_feedback(
+    store: &mut Store,
+    goal_id: &str,
+    turn: u32,
+    status: &str,
+    note: Option<String>,
+    agent_id: Option<String>,
+    context_digest: &str,
+) -> Result<DecisionOutcomeReceipt> {
+    let events = store.events(goal_id)?;
+    let decision_id = format!("turn-{turn}");
+    // Audited: the feedback must anchor to a persisted decision. Use the
+    // latest summary for the turn for the decision payload.
+    let summary = crate::quota::decision_summary::decision_summaries(&events)
+        .into_iter()
+        .rev()
+        .find(|s| s.turn == turn)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no persisted decision summary for goal {goal_id} turn {turn} — feedback must anchor to a real decision"
+            )
+        })?;
+    let status = normalize_verification_status(status).ok_or_else(|| {
+        anyhow::anyhow!("--status must be one of: verified, refuted, inconclusive")
+    })?;
+    let now = crate::state::now_epoch();
+    let seq = next_seq(&events, &decision_id);
+    let mut receipt = DecisionOutcomeReceipt {
+        schema_version: DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION.to_string(),
+        receipt_id: DecisionOutcomeReceipt::derive_receipt_id(goal_id, &decision_id, seq),
+        goal_id: goal_id.to_string(),
+        decision_id: decision_id.clone(),
+        agent_id: agent_id.clone(),
+        accepted_decision: summary.effective_action.clone(),
+        reason_code: summary.reason_code.clone(),
+        context_digest: context_digest.to_string(),
+        verification_status: VERIFICATION_PENDING.to_string(),
+        note: None,
+        seq,
+        recorded_at: now,
+        settled_at: None,
+    };
+    settle_receipt(&mut receipt, status, note, now)?;
+    store.append(Event::DecisionOutcomeRecorded {
+        goal_id: goal_id.to_string(),
+        receipt: receipt.clone(),
+        ts: now,
+    })?;
+    // Reward-memory writeback (LoopX: audited feedback into reward memory):
+    // decisive outcomes become a `decision_outcome` signal, scoped to the
+    // anchored decision's selected todo (empty = goal-scoped).
+    if let Some((signal, score)) = outcome_signal(status) {
+        let todo_id = summary.selected_todo.clone().unwrap_or_default();
+        let reward_seq = rm::next_seq(&store.events(goal_id)?, &todo_id);
+        store.append(Event::RewardSignalRecorded {
+            goal_id: goal_id.to_string(),
+            todo_id,
+            agent_id,
+            run_id: None,
+            source: rm::SOURCE_DECISION_OUTCOME.to_string(),
+            signal: signal.to_string(),
+            score,
+            note: Some(format!("decision {decision_id} {}", receipt.receipt_id)),
+            seq: reward_seq,
+            ts: now,
+        })?;
+    }
+    Ok(receipt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::decision_context::assembler::assemble_decision_context;
+    use crate::state::{Goal, Todo};
+
+    fn decision_fixture() -> (Goal, ShouldRunPacket, DecisionContextPacket) {
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "work"));
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        let context = assemble_decision_context(&goal);
+        (goal, packet, context)
+    }
+
+    #[test]
+    fn receipt_lifecycle_pending_to_settled() {
+        let (_goal, packet, context) = decision_fixture();
+        let mut receipt = begin_receipt(&packet, &context, "turn-1", Some("agent-a"), 1, 100);
+        assert_eq!(receipt.verification_status, VERIFICATION_PENDING);
+        assert_eq!(receipt.settled_at, None);
+        assert_eq!(receipt.context_digest, context.digest());
+        assert_eq!(receipt.accepted_decision, packet.effective_action);
+        assert_eq!(
+            receipt.receipt_id,
+            DecisionOutcomeReceipt::derive_receipt_id("g1", "turn-1", 1)
+        );
+        settle_receipt(&mut receipt, "verified", Some("held up".to_string()), 200).unwrap();
+        assert_eq!(receipt.verification_status, VERIFICATION_VERIFIED);
+        assert_eq!(receipt.settled_at, Some(200));
+        assert_eq!(receipt.note.as_deref(), Some("held up"));
+    }
+
+    #[test]
+    fn settle_fails_closed_on_bad_status_pending_and_double_settle() {
+        let (_goal, packet, context) = decision_fixture();
+        let mut receipt = begin_receipt(&packet, &context, "turn-1", None, 1, 100);
+        assert!(settle_receipt(&mut receipt, "bogus", None, 200).is_err());
+        assert!(settle_receipt(&mut receipt, "pending", None, 200).is_err());
+        settle_receipt(&mut receipt, "refuted", None, 200).unwrap();
+        let err = settle_receipt(&mut receipt, "verified", None, 300).unwrap_err();
+        assert!(err.to_string().contains("already settled"), "{err}");
+    }
+
+    #[test]
+    fn outcome_signal_mapping() {
+        assert_eq!(
+            outcome_signal(VERIFICATION_VERIFIED),
+            Some(("verified", Some(1.0)))
+        );
+        assert_eq!(
+            outcome_signal(VERIFICATION_REFUTED),
+            Some(("refuted", Some(0.0)))
+        );
+        assert_eq!(
+            outcome_signal(VERIFICATION_INCONCLUSIVE),
+            Some(("inconclusive", None))
+        );
+        assert_eq!(outcome_signal(VERIFICATION_PENDING), None);
+    }
+}

--- a/orchestration/loop/src/capabilities/decision_context/packets.rs
+++ b/orchestration/loop/src/capabilities/decision_context/packets.rs
@@ -1,0 +1,242 @@
+//! Public-safe packet contracts for decision_context (P1-4) — LoopX
+//! `capabilities/decision_context/packets.py`, compact set.
+//!
+//! Two contracts:
+//!   - [`DecisionContextPacket`] (`decision_context_packet_v0`) — the
+//!     assembled decision context: a goal-boundary header plus one typed
+//!     section per provider (run history / outcome streak / quota status).
+//!     Ids, counters and enums only — never free text — so a packet can be
+//!     persisted inside a public-safe decision-replay case without leaking
+//!     private content (todo text, gap descriptions, paths).
+//!   - [`DecisionOutcomeReceipt`] (`decision_outcome_receipt_v0`) — the
+//!     outcome-feedback writeback: links a settled outcome back to the
+//!     anchored decision and to the digest of the context packet the
+//!     decision was assembled from (the tamper-evident audit link).
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const DECISION_CONTEXT_PACKET_SCHEMA_VERSION: &str = "decision_context_packet_v0";
+pub const DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION: &str = "decision_outcome_receipt_v0";
+
+/// The decision is fresh; no outcome observed yet.
+pub const VERIFICATION_PENDING: &str = "pending";
+/// The outcome confirms the decision held up.
+pub const VERIFICATION_VERIFIED: &str = "verified";
+/// The outcome contradicts the decision (the context was wrong or stale).
+pub const VERIFICATION_REFUTED: &str = "refuted";
+/// The outcome neither confirms nor contradicts (observer could not decide).
+pub const VERIFICATION_INCONCLUSIVE: &str = "inconclusive";
+
+/// LoopX `DECISION_OUTCOME_VERIFICATION_STATUSES`.
+pub const DECISION_OUTCOME_VERIFICATION_STATUSES: [&str; 4] = [
+    VERIFICATION_PENDING,
+    VERIFICATION_VERIFIED,
+    VERIFICATION_REFUTED,
+    VERIFICATION_INCONCLUSIVE,
+];
+
+/// Normalize a verification-status token (case/whitespace-insensitive);
+/// `None` for unknown values.
+pub fn normalize_verification_status(value: &str) -> Option<&'static str> {
+    match value.trim().to_lowercase().as_str() {
+        VERIFICATION_PENDING => Some(VERIFICATION_PENDING),
+        VERIFICATION_VERIFIED => Some(VERIFICATION_VERIFIED),
+        VERIFICATION_REFUTED => Some(VERIFICATION_REFUTED),
+        VERIFICATION_INCONCLUSIVE => Some(VERIFICATION_INCONCLUSIVE),
+        _ => None,
+    }
+}
+
+/// Terminal statuses a pending receipt may settle to (settle targets).
+pub fn is_terminal_status(status: &str) -> bool {
+    matches!(
+        status,
+        VERIFICATION_VERIFIED | VERIFICATION_REFUTED | VERIFICATION_INCONCLUSIVE
+    )
+}
+
+/// First 20 hex chars of the sha256 of `content` (LoopX `_packet_ref`
+/// digest shape).
+pub fn digest20(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let bytes = hasher.finalize();
+    bytes[..10].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Run-history section (provider `run_history`): how the goal's turns have
+/// been landing. Counts + terminal-state enums only.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunHistorySection {
+    pub run_count: u64,
+    /// Turns that produced a validated artifact (tools invoked + evidence)
+    /// — the outcome-floor materiality rule (executor writeback).
+    pub material_runs: u64,
+    /// `terminal_state` of the most recent runs, newest first (≤3).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent_terminal_states: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<u64>,
+}
+
+/// Outcome-streak section (provider `outcome_streak`): the surface-only
+/// progress loop counter and its configured floor.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeStreakSection {
+    /// Consecutive turns without a material outcome.
+    pub surface_streak: u32,
+    /// Configured floor (0 = disabled).
+    pub threshold: u32,
+    /// `threshold > 0 && surface_streak >= threshold` — the kernel replans
+    /// on this (decision::stall::outcome_floor_breach).
+    pub floor_breached: bool,
+}
+
+/// Quota-status section (provider `quota_status`): the slot budget view the
+/// packet's quota snapshot is compiled from.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuotaStatusSection {
+    pub allowed_slots: u64,
+    /// Slots spent per the run history (the kernel's spend counter).
+    pub spent_slots: u64,
+    /// Slots spent per the `QuotaSpent` event projection (G-3). Divergence
+    /// from `spent_slots` is a read-model drift signal.
+    #[serde(default)]
+    pub projected_spent_slots: u32,
+}
+
+/// The assembled decision context (LoopX evidence packet, compact set).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionContextPacket {
+    pub schema_version: String,
+    pub goal_id: String,
+    /// Goal lifecycle status at assembly time (`active` / `cancelled`) —
+    /// the kernel's cancelled branch reads it.
+    pub goal_status: String,
+    pub assembled_at: u64,
+    /// Provider ids in assembly order (deterministic: registration order).
+    pub providers: Vec<String>,
+    /// Unsatisfied acceptance gap ids at assembly time (ids are public-safe
+    /// tokens; gap descriptions never leave private state).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub open_acceptance_gaps: Vec<String>,
+    pub run_history: RunHistorySection,
+    pub outcome_streak: OutcomeStreakSection,
+    pub quota: QuotaStatusSection,
+}
+
+impl DecisionContextPacket {
+    /// sha256-20 of the canonical JSON (struct field order is fixed, so the
+    /// serialization is deterministic). An outcome receipt carries this
+    /// digest back as the tamper-evident link to the context the decision
+    /// was assembled from.
+    pub fn digest(&self) -> String {
+        let canonical = serde_json::to_string(self).unwrap_or_default();
+        digest20(&canonical)
+    }
+}
+
+/// Outcome-feedback receipt (LoopX outcome receipt, compact set). Identity
+/// is content-addressed on (goal, decision anchor, seq) so it is stable
+/// across the pending → settled transition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionOutcomeReceipt {
+    pub schema_version: String,
+    /// `decision-outcome-{digest20(goal_id:decision_id:seq)}`.
+    pub receipt_id: String,
+    pub goal_id: String,
+    /// Anchor to the persisted decision: `turn-{N}` (matches
+    /// `HeartbeatReceiptRecorded.turn_instance_id` / `DecisionSummary.turn`).
+    pub decision_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// `effective_action` of the anchored decision.
+    pub accepted_decision: String,
+    #[serde(default)]
+    pub reason_code: String,
+    /// Digest of the context packet the decision was assembled from
+    /// (empty when settled without an assembled packet at hand).
+    #[serde(default)]
+    pub context_digest: String,
+    pub verification_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// Per-decision feedback sequence (1-based) — the G-3 dedupe anchor for
+    /// otherwise-identical settles appended within the same second.
+    #[serde(default)]
+    pub seq: u32,
+    pub recorded_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settled_at: Option<u64>,
+}
+
+impl DecisionOutcomeReceipt {
+    /// Content-addressed receipt identity (stable across settle).
+    pub fn derive_receipt_id(goal_id: &str, decision_id: &str, seq: u32) -> String {
+        format!(
+            "decision-outcome-{}",
+            digest20(&format!("{goal_id}:{decision_id}:{seq}"))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verification_status_normalization() {
+        assert_eq!(
+            normalize_verification_status(" Verified "),
+            Some(VERIFICATION_VERIFIED)
+        );
+        assert_eq!(
+            normalize_verification_status("REFUTED"),
+            Some(VERIFICATION_REFUTED)
+        );
+        assert_eq!(
+            normalize_verification_status("inconclusive"),
+            Some(VERIFICATION_INCONCLUSIVE)
+        );
+        assert_eq!(
+            normalize_verification_status("pending"),
+            Some(VERIFICATION_PENDING)
+        );
+        assert_eq!(normalize_verification_status("bogus"), None);
+        assert!(is_terminal_status(VERIFICATION_VERIFIED));
+        assert!(is_terminal_status(VERIFICATION_REFUTED));
+        assert!(is_terminal_status(VERIFICATION_INCONCLUSIVE));
+        assert!(!is_terminal_status(VERIFICATION_PENDING));
+    }
+
+    #[test]
+    fn packet_digest_is_deterministic_and_content_sensitive() {
+        let packet = DecisionContextPacket {
+            schema_version: DECISION_CONTEXT_PACKET_SCHEMA_VERSION.to_string(),
+            goal_id: "g1".to_string(),
+            goal_status: "active".to_string(),
+            assembled_at: 100,
+            providers: vec!["run_history".to_string()],
+            open_acceptance_gaps: vec![],
+            run_history: RunHistorySection::default(),
+            outcome_streak: OutcomeStreakSection::default(),
+            quota: QuotaStatusSection::default(),
+        };
+        assert_eq!(packet.digest(), packet.digest());
+        assert_eq!(packet.digest().len(), 20);
+        let mut other = packet.clone();
+        other.goal_status = "cancelled".to_string();
+        assert_ne!(packet.digest(), other.digest());
+    }
+
+    #[test]
+    fn receipt_id_is_stable_per_decision_and_seq() {
+        let a = DecisionOutcomeReceipt::derive_receipt_id("g1", "turn-3", 1);
+        let b = DecisionOutcomeReceipt::derive_receipt_id("g1", "turn-3", 1);
+        let c = DecisionOutcomeReceipt::derive_receipt_id("g1", "turn-3", 2);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a.starts_with("decision-outcome-"));
+    }
+}

--- a/orchestration/loop/src/capabilities/decision_context/providers.rs
+++ b/orchestration/loop/src/capabilities/decision_context/providers.rs
@@ -1,0 +1,230 @@
+//! Replaceable current-authority providers for decision_context (P1-4) —
+//! LoopX `capabilities/decision_context/providers.py`, compact set.
+//!
+//! A provider reads one slice of current-authority state (the replayed
+//! goal) and returns its typed section. Pure: no I/O, no clock (the
+//! assembler stamps `assembled_at`). The builtin set is the report's P1-4
+//! scope — run history / outcome streak / quota status — in a fixed
+//! assembly order so packets are deterministic.
+
+use crate::state::Goal;
+
+use super::packets::{OutcomeStreakSection, QuotaStatusSection, RunHistorySection};
+
+/// One provider's contribution to the packet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderSection {
+    RunHistory(RunHistorySection),
+    OutcomeStreak(OutcomeStreakSection),
+    QuotaStatus(QuotaStatusSection),
+}
+
+impl ProviderSection {
+    pub fn provider_id(&self) -> &'static str {
+        match self {
+            ProviderSection::RunHistory(_) => RunHistoryProvider.id(),
+            ProviderSection::OutcomeStreak(_) => OutcomeStreakProvider.id(),
+            ProviderSection::QuotaStatus(_) => QuotaStatusProvider.id(),
+        }
+    }
+}
+
+/// A decision-context provider (LoopX `DecisionSourceProvider`, compact):
+/// stable id + a pure collect over the goal.
+pub trait DecisionContextProvider: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn describe(&self) -> &'static str;
+    fn collect(&self, goal: &Goal) -> ProviderSection;
+}
+
+/// Provider `run_history`: how the goal's turns have been landing.
+pub struct RunHistoryProvider;
+
+impl DecisionContextProvider for RunHistoryProvider {
+    fn id(&self) -> &'static str {
+        "run_history"
+    }
+    fn describe(&self) -> &'static str {
+        "run count, material-outcome count and recent terminal states from the run history"
+    }
+    fn collect(&self, goal: &Goal) -> ProviderSection {
+        ProviderSection::RunHistory(RunHistorySection {
+            run_count: goal.history.len() as u64,
+            // Materiality rule shared with the executor writeback: a turn is
+            // material when it produced a validated artifact (tools +
+            // evidence); surface-only turns accumulate the outcome streak.
+            material_runs: goal
+                .history
+                .iter()
+                .filter(|r| !r.tools.is_empty() && !r.evidence.trim().is_empty())
+                .count() as u64,
+            recent_terminal_states: goal
+                .history
+                .iter()
+                .rev()
+                .take(3)
+                .map(|r| r.terminal_state.clone())
+                .collect(),
+            last_run_at: goal.history.last().map(|r| r.recorded_at),
+        })
+    }
+}
+
+/// Provider `outcome_streak`: the surface-only progress loop counter and
+/// its configured floor (the kernel replans when the floor is breached).
+pub struct OutcomeStreakProvider;
+
+impl DecisionContextProvider for OutcomeStreakProvider {
+    fn id(&self) -> &'static str {
+        "outcome_streak"
+    }
+    fn describe(&self) -> &'static str {
+        "surface-only turn streak vs the configured outcome floor"
+    }
+    fn collect(&self, goal: &Goal) -> ProviderSection {
+        let threshold = goal.execution_profile.outcome_floor_streak_threshold;
+        ProviderSection::OutcomeStreak(OutcomeStreakSection {
+            surface_streak: goal.outcome_streak,
+            threshold,
+            floor_breached: threshold > 0 && goal.outcome_streak >= threshold,
+        })
+    }
+}
+
+/// Provider `quota_status`: the slot budget view (history counter vs the
+/// G-3 `QuotaSpent` projection — divergence is read-model drift).
+pub struct QuotaStatusProvider;
+
+impl DecisionContextProvider for QuotaStatusProvider {
+    fn id(&self) -> &'static str {
+        "quota_status"
+    }
+    fn describe(&self) -> &'static str {
+        "allowed/spent quota slots (history counter + QuotaSpent projection)"
+    }
+    fn collect(&self, goal: &Goal) -> ProviderSection {
+        ProviderSection::QuotaStatus(QuotaStatusSection {
+            allowed_slots: crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS,
+            spent_slots: goal.history.len() as u64,
+            projected_spent_slots: goal.quota_spent_slots,
+        })
+    }
+}
+
+/// The builtin provider set in deterministic assembly order (the report's
+/// P1-4 compact set: run history / outcome streak / quota status).
+pub fn builtin_providers() -> Vec<Box<dyn DecisionContextProvider>> {
+    vec![
+        Box::new(RunHistoryProvider),
+        Box::new(OutcomeStreakProvider),
+        Box::new(QuotaStatusProvider),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{RunRecord, Todo};
+
+    fn run_record(terminal_state: &str, tools: Vec<String>, evidence: &str, at: u64) -> RunRecord {
+        RunRecord {
+            turn: 1,
+            todo_id: "T1".to_string(),
+            run_id: "r1".to_string(),
+            validation: None,
+            terminal_state: terminal_state.to_string(),
+            error: None,
+            tokens_in_delta: 0,
+            tokens_out_delta: 0,
+            cost_delta: 0.0,
+            tools,
+            evidence: evidence.to_string(),
+            recorded_at: at,
+            spend_source: None,
+        }
+    }
+
+    #[test]
+    fn run_history_provider_counts_and_materiality() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "work"));
+        g.history.push(run_record(
+            "completed",
+            vec!["shell".to_string()],
+            "artifact",
+            10,
+        ));
+        g.history.push(run_record("continue", vec![], "", 20));
+        g.history
+            .push(run_record("failed", vec!["shell".to_string()], "", 30));
+        let section = RunHistoryProvider.collect(&g);
+        let ProviderSection::RunHistory(s) = section else {
+            panic!("expected run history section")
+        };
+        assert_eq!(s.run_count, 3);
+        assert_eq!(s.material_runs, 1, "only tools+evidence turns are material");
+        assert_eq!(
+            s.recent_terminal_states,
+            vec![
+                "failed".to_string(),
+                "continue".to_string(),
+                "completed".to_string()
+            ]
+        );
+        assert_eq!(s.last_run_at, Some(30));
+        assert_eq!(ProviderSection::RunHistory(s).provider_id(), "run_history");
+    }
+
+    #[test]
+    fn outcome_streak_provider_marks_floor_breach() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.execution_profile.outcome_floor_streak_threshold = 3;
+        g.outcome_streak = 2;
+        let ProviderSection::OutcomeStreak(s) = OutcomeStreakProvider.collect(&g) else {
+            panic!("expected outcome streak section")
+        };
+        assert!(!s.floor_breached);
+        assert_eq!(s.surface_streak, 2);
+        assert_eq!(s.threshold, 3);
+        g.outcome_streak = 3;
+        let ProviderSection::OutcomeStreak(s) = OutcomeStreakProvider.collect(&g) else {
+            panic!("expected outcome streak section")
+        };
+        assert!(s.floor_breached);
+        // disabled floor never breaches
+        g.execution_profile.outcome_floor_streak_threshold = 0;
+        let ProviderSection::OutcomeStreak(s) = OutcomeStreakProvider.collect(&g) else {
+            panic!("expected outcome streak section")
+        };
+        assert!(!s.floor_breached);
+        assert_eq!(
+            ProviderSection::OutcomeStreak(s).provider_id(),
+            "outcome_streak"
+        );
+    }
+
+    #[test]
+    fn quota_status_provider_reads_both_counters() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.history.push(run_record("completed", vec![], "e", 10));
+        g.quota_spent_slots = 2;
+        let section = QuotaStatusProvider.collect(&g);
+        assert_eq!(section.provider_id(), "quota_status");
+        let ProviderSection::QuotaStatus(s) = section else {
+            panic!("expected quota section")
+        };
+        assert_eq!(
+            s.allowed_slots,
+            crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS
+        );
+        assert_eq!(s.spent_slots, 1);
+        assert_eq!(s.projected_spent_slots, 2);
+    }
+
+    #[test]
+    fn builtin_order_is_deterministic() {
+        let ids: Vec<&str> = builtin_providers().iter().map(|p| p.id()).collect();
+        assert_eq!(ids, vec!["run_history", "outcome_streak", "quota_status"]);
+        assert!(!builtin_providers().iter().any(|p| p.describe().is_empty()));
+    }
+}

--- a/orchestration/loop/src/capabilities/reward_memory.rs
+++ b/orchestration/loop/src/capabilities/reward_memory.rs
@@ -29,10 +29,18 @@ pub const SOURCE_VALIDATOR: &str = "validator";
 pub const SOURCE_DELIVERY_OUTCOME: &str = "delivery_outcome";
 /// Signal source: a manual evidence score (`reward-memory record`).
 pub const SOURCE_EVIDENCE: &str = "evidence";
+/// Signal source: a P1-4 decision-outcome feedback settle
+/// (`decision-context feedback` — verified/refuted/inconclusive against an
+/// anchored decision).
+pub const SOURCE_DECISION_OUTCOME: &str = "decision_outcome";
 
 /// All ingestion sources (CLI `--source` choices).
-pub const REWARD_SOURCE_CHOICES: [&str; 3] =
-    [SOURCE_VALIDATOR, SOURCE_DELIVERY_OUTCOME, SOURCE_EVIDENCE];
+pub const REWARD_SOURCE_CHOICES: [&str; 4] = [
+    SOURCE_VALIDATOR,
+    SOURCE_DELIVERY_OUTCOME,
+    SOURCE_EVIDENCE,
+    SOURCE_DECISION_OUTCOME,
+];
 
 /// Normalize a source token (case/whitespace-insensitive) to its canonical
 /// value; `None` for unknown values.
@@ -41,6 +49,7 @@ pub fn normalize_source(value: &str) -> Option<&'static str> {
         SOURCE_VALIDATOR => Some(SOURCE_VALIDATOR),
         SOURCE_DELIVERY_OUTCOME => Some(SOURCE_DELIVERY_OUTCOME),
         SOURCE_EVIDENCE => Some(SOURCE_EVIDENCE),
+        SOURCE_DECISION_OUTCOME => Some(SOURCE_DECISION_OUTCOME),
         _ => None,
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -154,6 +154,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "inbox" => cmd_inbox(&store, &args[1..]),
         "delivery" => cmd_delivery(&mut store, &args[1..]),
         "reward-memory" => cmd_reward_memory(&mut store, &args[1..]),
+        "decision-context" => cmd_decision_context(&mut store, &args[1..]),
         "registry" => cmd_registry(&registry, &args[1..]),
         "commands" => cmd_commands(&registry, &args[1..]),
         // ── P4 commands (G-18 / G-19 / G-20 / G-27) ───────────────────────
@@ -202,6 +203,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("inbox", Journey::Daily),
     ("delivery", Journey::Daily),
     ("reward-memory", Journey::Daily),
+    ("decision-context", Journey::Daily),
     ("diagnose", Journey::Daily),
     ("evidence-log", Journey::Daily),
     ("todo-event", Journey::Daily),
@@ -502,6 +504,12 @@ fn build_cli_registry() -> CommandRegistry {
         "reward-memory",
         "reward memory (P1-5): validator/delivery/evidence signal ingestion + scoped feedback",
         "reward-memory query --goal G [--agent-id A] [--todo-id T] [--source S] [--format json] | record --goal G --todo-id T --score 0.0..1.0 [--source evidence] [--note N] [--agent-id A]",
+    );
+    r.command(
+        work_items,
+        "decision-context",
+        "decision context (P1-4): assembler read model + audited outcome-feedback writeback",
+        "decision-context assemble --goal G [--format json] | outcomes --goal G [--format json] | feedback --goal G --turn N --status verified|refuted|inconclusive [--note N] [--agent-id A] [--context-digest D]",
     );
 
     let handoff = r.group("handoff", "project handoff (G-17)");
@@ -5323,6 +5331,173 @@ fn reward_memory_record(store: &mut Store, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+// ── decision-context (P1-4: assembler + outcome feedback) ─────────────────
+
+/// `decision-context <assemble|outcomes|feedback>` — the P1-4 surface:
+/// the decision-context assembler read model plus the audited
+/// outcome-feedback writeback (LoopX `capabilities/decision_context/cli.py`,
+/// compact set).
+fn cmd_decision_context(store: &mut Store, args: &[String]) -> Result<()> {
+    match args.first().map(|s| s.as_str()) {
+        Some("assemble") => decision_context_assemble(store, &args[1..]),
+        Some("outcomes") => decision_context_outcomes(store, &args[1..]),
+        Some("feedback") => decision_context_feedback(store, &args[1..]),
+        _ => bail!("decision-context subcommand must be `assemble`, `outcomes` or `feedback`"),
+    }
+}
+
+/// `decision-context assemble --goal G [--format json]` — assemble the
+/// decision context for the goal's current state (run history / outcome
+/// streak / quota status providers + the goal-boundary header).
+fn decision_context_assemble(store: &Store, args: &[String]) -> Result<()> {
+    use crate::capabilities::decision_context::assembler::assemble_decision_context;
+    let mut goal_id = None;
+    reject_unknown_flags(args, &["--format", "--goal", "--json"])?;
+    parse_pairs(args, |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v)
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let packet = assemble_decision_context(&goal);
+    if wants_json(args) {
+        println!("{}", serde_json::to_string_pretty(&packet)?);
+        return Ok(());
+    }
+    println!(
+        "decision context for {goal_id} (digest {}):",
+        packet.digest()
+    );
+    println!(
+        "  goal_status={} providers=[{}]",
+        packet.goal_status,
+        packet.providers.join(", ")
+    );
+    println!(
+        "  run_history: runs={} material={} recent=[{}]",
+        packet.run_history.run_count,
+        packet.run_history.material_runs,
+        packet.run_history.recent_terminal_states.join(", ")
+    );
+    println!(
+        "  outcome_streak: streak={} threshold={} floor_breached={}",
+        packet.outcome_streak.surface_streak,
+        packet.outcome_streak.threshold,
+        packet.outcome_streak.floor_breached
+    );
+    println!(
+        "  quota: spent={}/{} (projected {})",
+        packet.quota.spent_slots, packet.quota.allowed_slots, packet.quota.projected_spent_slots
+    );
+    if !packet.open_acceptance_gaps.is_empty() {
+        println!(
+            "  open_acceptance_gaps: [{}]",
+            packet.open_acceptance_gaps.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// `decision-context outcomes --goal G [--format json]` — the outcome
+/// feedback read model: settled receipts in ledger order.
+fn decision_context_outcomes(store: &Store, args: &[String]) -> Result<()> {
+    use crate::capabilities::decision_context::outcome_feedback::decision_outcomes;
+    let mut goal_id = None;
+    reject_unknown_flags(args, &["--format", "--goal", "--json"])?;
+    parse_pairs(args, |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v)
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let events = store.events(&goal_id)?;
+    let receipts = decision_outcomes(&events);
+    if wants_json(args) {
+        println!("{}", serde_json::to_string_pretty(&receipts)?);
+        return Ok(());
+    }
+    if receipts.is_empty() {
+        println!(
+            "no decision outcome feedback for goal {goal_id} (settle one via `decision-context feedback`)"
+        );
+        return Ok(());
+    }
+    println!(
+        "decision outcome feedback for {goal_id} ({} receipt(s)):",
+        receipts.len()
+    );
+    for r in receipts {
+        println!(
+            "  {} {} → {} (decision={}, code={}, seq={})",
+            r.receipt_id,
+            r.decision_id,
+            r.verification_status,
+            r.accepted_decision,
+            r.reason_code,
+            r.seq
+        );
+    }
+    Ok(())
+}
+
+/// `decision-context feedback --goal G --turn N --status
+/// verified|refuted|inconclusive [--note N] [--agent-id A]
+/// [--context-digest D]` — settle an outcome against the persisted decision
+/// for turn N. Audited: fails closed when no decision summary anchors the
+/// turn. Decisive outcomes also ingest a `decision_outcome` reward signal.
+fn decision_context_feedback(store: &mut Store, args: &[String]) -> Result<()> {
+    use crate::capabilities::decision_context::outcome_feedback::record_outcome_feedback;
+    let mut goal_id = None;
+    let mut turn_raw = None;
+    let mut status = None;
+    let mut note = None;
+    let mut agent_id = None;
+    let mut context_digest = None;
+    reject_unknown_flags(
+        args,
+        &[
+            "--agent-id",
+            "--context-digest",
+            "--goal",
+            "--note",
+            "--status",
+            "--turn",
+        ],
+    )?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--turn" => turn_raw = Some(v),
+        "--status" => status = Some(v),
+        "--note" => note = Some(v),
+        "--agent-id" => agent_id = Some(v),
+        "--context-digest" => context_digest = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let turn: u32 = turn_raw
+        .ok_or_else(|| anyhow::anyhow!("--turn required"))?
+        .parse()
+        .map_err(|_| anyhow::anyhow!("--turn must be a run-turn number"))?;
+    let status = status.ok_or_else(|| anyhow::anyhow!("--status required"))?;
+    let receipt = record_outcome_feedback(
+        store,
+        &goal_id,
+        turn,
+        &status,
+        note,
+        agent_id,
+        context_digest.as_deref().unwrap_or(""),
+    )?;
+    println!(
+        "decision outcome recorded: {} turn-{turn} → {} ✔",
+        receipt.receipt_id, receipt.verification_status
+    );
+    Ok(())
+}
+
 // ── registry (G-26) ────────────────────────────────────────────────────────
 
 /// `loopx registry [--format json|--json] [--include-experimental]` — inspect
@@ -6502,6 +6677,12 @@ fn describe_event(event: &crate::store::Event) -> String {
         } => {
             return format!(
                 "projection_repaired projection={projection} drift={drift_count} rows_written={rows_written}"
+            );
+        }
+        Event::DecisionOutcomeRecorded { receipt, .. } => {
+            return format!(
+                "decision_outcome {} {} → {}",
+                receipt.receipt_id, receipt.decision_id, receipt.verification_status
             );
         }
     };

--- a/orchestration/loop/src/replay/decision_replay.rs
+++ b/orchestration/loop/src/replay/decision_replay.rs
@@ -33,6 +33,13 @@ pub const BANNED_KEYS: &[&str] = &[
 
 /// Compact todo fields (reference _TODO_FIELDS; `decision` is our additive field
 /// so closed gate decisions replay deterministically).
+///
+/// P1-4: the snapshot now carries every per-todo input the decision kernel
+/// reads (priority / gate + capability blocks / repair + monitor counters /
+/// closure intent / resume + lease epochs / frontier index). Pre-P1-4 cases
+/// stored status/class only, so decisions depending on the missing counters
+/// (outcome floor, repair budget, monitor stall, succession replan) drifted
+/// on replay — the record→run mismatch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompactTodo {
     pub todo_id: String,
@@ -52,6 +59,37 @@ pub struct CompactTodo {
     pub resume_ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<String>,
+    /// Frontier sort key (P0/P1/P2; absent = the P1 default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    /// Comma-joined predecessor ids (gates, blockers, todo→todo blocks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_by_gate: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_capability: Option<String>,
+    /// Repair-budget counter (absent = 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_attempts: Option<u32>,
+    /// Monitor stall counter (absent = 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consecutive_no_change: Option<u32>,
+    /// Completion contract: no-follow-up closure intent (absent = false).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_follow_up: Option<bool>,
+    /// Completion contract: declared successor ids (empty = none).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub successor_ids: Vec<String>,
+    /// Monitor poll / deferred resume due time (epoch secs) — reconstructed
+    /// as a real `SystemTime` so due-ness replays deterministically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_when_epoch: Option<u64>,
+    /// Lease expiry (epoch secs) — a live lease hides the todo from other
+    /// agents' frontiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at: Option<u64>,
+    /// Goal-relative ordering index (absent = enumeration order).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
 }
 
 /// The reduced decision fields (reference decision block).
@@ -108,6 +146,11 @@ pub struct DecisionCase {
     pub schema_version: String,
     pub case_id: String,
     pub agent_id: String,
+    /// P1-4: capabilities the recording agent declared (the capability gate
+    /// hides todos requiring an undeclared capability). Empty for anonymous
+    /// recordings and on legacy cases.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent_capabilities: Vec<String>,
     pub decision: DecisionFields,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_todo: Option<CompactTodo>,
@@ -117,6 +160,13 @@ pub struct DecisionCase {
     pub user_todos: Vec<CompactTodo>,
     pub interaction_contract: InteractionCase,
     pub expected: ExpectedCase,
+    /// P1-4: the decision context assembled at record time (run history /
+    /// outcome streak / quota status + the goal-boundary header). Replay
+    /// rebuilds the goal-level decision state from it; `None` on legacy
+    /// pre-P1-4 cases (replay then reconstructs todos only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_context:
+        Option<crate::capabilities::decision_context::packets::DecisionContextPacket>,
 }
 
 impl DecisionCase {
@@ -211,6 +261,22 @@ fn compact_todo(todo: &Todo, now_epoch: u64) -> CompactTodo {
                 .unwrap_or(false)
         }),
         decision: todo.decision.clone(),
+        priority: (todo.priority != crate::state::Priority::default())
+            .then(|| todo.priority.to_string()),
+        blocked_by_gate: todo.blocked_by_gate.clone(),
+        required_capability: todo.required_capability.clone(),
+        failed_attempts: (todo.failed_attempts > 0).then_some(todo.failed_attempts),
+        consecutive_no_change: (todo.consecutive_no_change > 0)
+            .then_some(todo.consecutive_no_change),
+        no_follow_up: todo.no_follow_up.then_some(true),
+        successor_ids: todo.successor_ids.clone(),
+        resume_when_epoch: todo.resume_when.and_then(|r| {
+            r.duration_since(std::time::UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_secs())
+        }),
+        lease_expires_at: todo.lease_expires_at,
+        index: Some(todo.index),
     }
 }
 
@@ -247,6 +313,9 @@ pub fn reduce_public_safe_decision(
         schema_version: PUBLIC_SAFE_DECISION_CASE_SCHEMA_VERSION.to_string(),
         case_id: case_id.to_string(),
         agent_id: agent_id.unwrap_or("replay-agent").to_string(),
+        agent_capabilities: agent_id
+            .map(|a| goal.agent_capabilities(a))
+            .unwrap_or_default(),
         decision: DecisionFields {
             should_run: packet.should_run,
             effective_action: packet.effective_action.clone(),
@@ -277,6 +346,12 @@ pub fn reduce_public_safe_decision(
             scheduler_interval_minutes: packet.scheduler_hint.next_due_ms.map(|ms| ms / 60_000),
             decision_scope_status: "consistent".to_string(),
         },
+        // P1-4: capture the assembled decision context (run history /
+        // outcome streak / quota status + goal boundary) so replay can
+        // rebuild the goal-level decision state the compact todos can't.
+        decision_context: Some(
+            crate::capabilities::decision_context::assembler::assemble_decision_context(goal),
+        ),
     }
 }
 
@@ -354,7 +429,10 @@ fn class_from_str(s: &str) -> TaskClass {
 /// Reconstruct a goal from a case's compact todos (LoopX
 /// `_source_todo_item` + `quota_status_payload`). The replayed kernel runs
 /// against this reconstructed state — the recording must capture everything
-/// the decision depends on.
+/// the decision depends on. P1-4: the per-todo counters/intent come from
+/// the compact todos; the goal-level state (status / outcome streak /
+/// floor threshold / open acceptance gaps) comes from the case's assembled
+/// decision context (absent on legacy pre-P1-4 cases).
 pub fn goal_from_case(case: &DecisionCase) -> Goal {
     let mut goal = Goal::new(&case.case_id, "decision replay", "/tmp");
     for (index, item) in case
@@ -366,13 +444,28 @@ pub fn goal_from_case(case: &DecisionCase) -> Goal {
         let mut todo = Todo::advancement(&item.todo_id, &format!("Replay item {}.", item.todo_id));
         todo.class = class_from_str(&item.task_class);
         todo.status = status_from_str(&item.status);
-        todo.index = index as u32;
+        todo.index = item.index.unwrap_or(index as u32);
         todo.action_kind = item.action_kind.clone();
         todo.claimed_by = item.claimed_by.clone();
         todo.goal_bound = item.goal_bound.unwrap_or(false);
         todo.global_gate = item.global_gate.unwrap_or(false);
         todo.resume_when_text = item.resume_when.clone();
         todo.decision = item.decision.clone();
+        todo.priority = match item.priority.as_deref() {
+            Some("P0") => crate::state::Priority::P0,
+            Some("P2") => crate::state::Priority::P2,
+            _ => crate::state::Priority::P1,
+        };
+        todo.blocked_by_gate = item.blocked_by_gate.clone();
+        todo.required_capability = item.required_capability.clone();
+        todo.failed_attempts = item.failed_attempts.unwrap_or(0);
+        todo.consecutive_no_change = item.consecutive_no_change.unwrap_or(0);
+        todo.no_follow_up = item.no_follow_up.unwrap_or(false);
+        todo.successor_ids = item.successor_ids.clone();
+        todo.lease_expires_at = item.lease_expires_at;
+        todo.resume_when = item
+            .resume_when_epoch
+            .map(|epoch| std::time::UNIX_EPOCH + std::time::Duration::from_secs(epoch));
         if let Some(role) = case
             .agent_todos
             .iter()
@@ -388,6 +481,23 @@ pub fn goal_from_case(case: &DecisionCase) -> Goal {
             todo.role = role;
         }
         goal.add(todo);
+    }
+    // P1-4: rebuild the goal-level decision state from the assembled
+    // context (the mismatch fix — without it an outcome-floor replan, a
+    // cancelled-goal skip, or an acceptance-gap replan replays as run /
+    // terminal because the fresh goal defaults to streak 0 / active / no
+    // gaps). Legacy cases without a context keep the pre-P1-4 behavior.
+    if let Some(context) = &case.decision_context {
+        goal.status = context.goal_status.clone();
+        goal.outcome_streak = context.outcome_streak.surface_streak;
+        goal.execution_profile.outcome_floor_streak_threshold = context.outcome_streak.threshold;
+        for gap_id in &context.open_acceptance_gaps {
+            goal.acceptance.push(crate::state::AcceptanceGap {
+                id: gap_id.clone(),
+                description: format!("Replay gap {gap_id}."),
+                satisfied: false,
+            });
+        }
     }
     goal
 }
@@ -413,9 +523,11 @@ pub fn replay_public_safe_decision_case(case: &DecisionCase) -> Result<ReplayCom
     validate_public_safe_decision_case(case)?;
     let mut goal = goal_from_case(case);
     // Register the replay agent (LoopX: coordination.registered_agents =
-    // [agent_id]) so the identity gate does not misfire on replay.
+    // [agent_id]) so the identity gate does not misfire on replay. P1-4:
+    // register with the capabilities the recording agent declared, so the
+    // capability gate sees the same frontier.
     if !goal.registered_agents.iter().any(|a| a == &case.agent_id) {
-        goal.register_agent(&case.agent_id, vec![]);
+        goal.register_agent(&case.agent_id, case.agent_capabilities.clone());
     }
     let now = std::time::SystemTime::now();
     let packet = crate::decision::decide_for(&goal, now, Some(&case.agent_id));
@@ -727,6 +839,193 @@ mod tests {
         assert_eq!(reconstructed.todo("G1").unwrap().status, TodoStatus::Done);
         // replay still matches because the recorded case captured the closure
         let comparison = replay_public_safe_decision_case(&case).unwrap();
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    // ── P1-4: record→run mismatch regression tests ──────────────────────
+    // Each test pins one decision-input class the pre-P1-4 compact snapshot
+    // dropped (replay used to drift on it); the recorded case must now
+    // replay exactly.
+
+    fn reduce_and_replay(goal: &Goal, case_id: &str) -> ReplayComparison {
+        let packet = crate::decision::decide(goal, std::time::SystemTime::now());
+        let case = reduce_public_safe_decision(&packet, goal, case_id, None);
+        validate_public_safe_decision_case(&case).unwrap();
+        replay_public_safe_decision_case(&case).unwrap()
+    }
+
+    #[test]
+    fn replay_matches_outcome_floor_breach_replan() {
+        // Live: outcome floor breached → replan. Pre-P1-4 replay lost the
+        // streak + threshold → replayed as normal_run (MISMATCH).
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "work"));
+        goal.execution_profile.outcome_floor_streak_threshold = 2;
+        goal.outcome_streak = 2;
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.decision, "replan", "fixture must breach the floor");
+        let comparison = reduce_and_replay(&goal, "case-floor");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_repair_budget_exhaustion_and_attempt_count() {
+        // failed_attempts drives both the retryable filter (repair budget)
+        // and the repair-attempt reason; pre-P1-4 replay reset it to 0.
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "work"));
+        goal.todo_mut("T1").unwrap().failed_attempts = crate::decision::MAX_REPAIR_ATTEMPTS + 1;
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.decision, "replan", "fixture must exhaust repair");
+        let comparison = reduce_and_replay(&goal, "case-repair");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_stalled_monitor_replan() {
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::monitor(
+            "M1",
+            "watch",
+            std::time::Duration::from_secs(3600),
+        ));
+        goal.todo_mut("M1").unwrap().consecutive_no_change =
+            crate::decision::MONITOR_NO_CHANGE_REPLAN_THRESHOLD;
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.decision, "replan", "fixture must stall the monitor");
+        let comparison = reduce_and_replay(&goal, "case-stall");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_due_monitor_poll() {
+        // A due monitor (resume_when in the past) must replay as due — the
+        // pre-P1-4 snapshot kept only the text form, so the reconstructed
+        // monitor was never due.
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::monitor(
+            "M1",
+            "watch",
+            std::time::Duration::from_secs(3600),
+        ));
+        goal.todo_mut("M1").unwrap().resume_when =
+            Some(std::time::SystemTime::now() - std::time::Duration::from_secs(60));
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.effective_action, "monitor_poll");
+        let comparison = reduce_and_replay(&goal, "case-due");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_cancelled_goal_skip() {
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "work"));
+        goal.status = "cancelled".to_string();
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.decision, "skip");
+        let comparison = reduce_and_replay(&goal, "case-cancelled");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_acceptance_gap_replan() {
+        // Open acceptance gap with no runnable work → replan; pre-P1-4
+        // replay had no gaps → terminal closure (MISMATCH).
+        let goal = Goal::new("g1", "objective", "/tmp").with_acceptance(vec![("A1", "match")]);
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        assert_eq!(packet.decision, "replan", "fixture must have an open gap");
+        let comparison = reduce_and_replay(&goal, "case-gap");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn replay_matches_blocked_frontier_and_closure_intent() {
+        // T1 done with no-follow-up (closure intent), T2 blocked by T3
+        // (todo→todo block), T3 open at P0. Live: run T3. Pre-P1-4 replay
+        // lost the block (T2 also runnable), the priority, AND the closure
+        // intent (T1 looked unclosed → succession replan, MISMATCH).
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "first"));
+        goal.add(Todo::advancement("T2", "gated work").blocking(&["T3"]));
+        goal.add(Todo::advancement("T3", "predecessor"));
+        goal.todo_mut("T3").unwrap().priority = crate::state::Priority::P0;
+        goal.todo_mut("T1").unwrap().complete(true, vec![]);
+        let comparison = reduce_and_replay(&goal, "case-frontier");
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+        let reconstructed = goal_from_case(&reduce_public_safe_decision(
+            &crate::decision::decide(&goal, std::time::SystemTime::now()),
+            &goal,
+            "case-frontier",
+            None,
+        ));
+        assert!(reconstructed.todo("T1").unwrap().no_follow_up);
+        assert_eq!(
+            reconstructed.todo("T2").unwrap().blocked_by_gate.as_deref(),
+            Some("T3")
+        );
+        assert_eq!(
+            reconstructed.todo("T3").unwrap().priority,
+            crate::state::Priority::P0
+        );
+    }
+
+    #[test]
+    fn replay_matches_capability_gated_frontier() {
+        // T1 requires capability "shell"; the recording agent declared it →
+        // runnable live. Replay must register the same capabilities.
+        let mut goal = Goal::new("g1", "objective", "/tmp");
+        goal.add(Todo::advancement("T1", "work").with_action_kind("shell"));
+        goal.todo_mut("T1").unwrap().required_capability = Some("shell".to_string());
+        goal.register_agent("agent-x", vec!["shell".to_string()]);
+        let packet =
+            crate::decision::decide_for(&goal, std::time::SystemTime::now(), Some("agent-x"));
+        assert!(
+            packet.should_run,
+            "fixture todo must be runnable for agent-x"
+        );
+        let case = reduce_public_safe_decision(&packet, &goal, "case-caps", Some("agent-x"));
+        assert_eq!(case.agent_capabilities, vec!["shell".to_string()]);
+        let comparison = replay_public_safe_decision_case(&case).unwrap();
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+    }
+
+    #[test]
+    fn legacy_case_without_context_still_loads_and_replays() {
+        // Pre-P1-4 recordings carry no decision_context and no P1-4 compact
+        // fields — they must keep deserializing and replaying (back-compat).
+        let goal = sample_goal();
+        let packet = crate::decision::decide(&goal, std::time::SystemTime::now());
+        let case = reduce_public_safe_decision(&packet, &goal, "case-legacy", None);
+        let mut value = serde_json::to_value(&case).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("decision_context");
+        obj.remove("agent_capabilities");
+        let strip = |t: &mut serde_json::Map<String, serde_json::Value>| {
+            for key in [
+                "priority",
+                "blocked_by_gate",
+                "required_capability",
+                "failed_attempts",
+                "consecutive_no_change",
+                "no_follow_up",
+                "successor_ids",
+                "resume_when_epoch",
+                "lease_expires_at",
+                "index",
+            ] {
+                t.remove(key);
+            }
+        };
+        for todo in value["agent_todos"].as_array_mut().unwrap().iter_mut() {
+            strip(todo.as_object_mut().unwrap());
+        }
+        for todo in value["user_todos"].as_array_mut().unwrap().iter_mut() {
+            strip(todo.as_object_mut().unwrap());
+        }
+        let legacy: DecisionCase = serde_json::from_value(value).unwrap();
+        assert!(legacy.decision_context.is_none());
+        assert!(legacy.agent_capabilities.is_empty());
+        let comparison = replay_public_safe_decision_case(&legacy).unwrap();
         assert!(comparison.matched, "{:?}", comparison.mismatches);
     }
 }

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -523,6 +523,18 @@ pub enum Event {
         backup_path: String,
         ts: u64,
     },
+    /// P1-4: decision_context outcome feedback — one settled outcome
+    /// receipt against an anchored decision (LoopX
+    /// `capabilities/decision_context/outcome_feedback.py`). Recorded via
+    /// `decision-context feedback`; the receipt's `seq` is the G-3 dedupe
+    /// anchor for same-second repeat settles. Projection-only: replay
+    /// ignores it; the read model (`decision-context outcomes`) and the
+    /// reward-memory `decision_outcome` source read the ledger.
+    DecisionOutcomeRecorded {
+        goal_id: String,
+        receipt: crate::capabilities::decision_context::packets::DecisionOutcomeReceipt,
+        ts: u64,
+    },
 }
 
 impl Event {
@@ -562,7 +574,8 @@ impl Event {
             | Event::AutomationLivenessAlert { goal_id, .. }
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. }
-            | Event::ProjectionRepaired { goal_id, .. } => goal_id,
+            | Event::ProjectionRepaired { goal_id, .. }
+            | Event::DecisionOutcomeRecorded { goal_id, .. } => goal_id,
         }
     }
 }
@@ -1560,15 +1573,16 @@ fn apply(goal: &mut Goal, event: Event) {
             consecutive,
             ts,
         }),
-        // P1-5 + P1-1 + G-16 projection-only events: read from the event log
-        // by their read models; goal state is unchanged on replay.
+        // P1-5 + P1-1 + P1-4 + G-16 projection-only events: read from the
+        // event log by their read models; goal state is unchanged on replay.
         Event::RewardSignalRecorded { .. }
         | Event::DecisionSummaryRecorded { .. }
         | Event::HeartbeatReceiptRecorded { .. }
         | Event::SchedulerAcked { .. }
         | Event::SupervisorProposed { .. }
         | Event::SupervisorReceiptRecorded { .. }
-        | Event::ProjectionRepaired { .. } => {}
+        | Event::ProjectionRepaired { .. }
+        | Event::DecisionOutcomeRecorded { .. } => {}
     }
 }
 

--- a/orchestration/loop/tests/decision_context_contract.rs
+++ b/orchestration/loop/tests/decision_context_contract.rs
@@ -1,0 +1,375 @@
+//! P1-4 contract tests: decision_context deep implementation —
+//!   ① assembler + providers: `decision-context assemble` composes the
+//!      packet from the builtin providers (run history / outcome streak /
+//!      quota status) over current goal state.
+//!   ② outcome feedback: `decision-context feedback` settles an audited
+//!      receipt against a persisted decision summary (fail closed without
+//!      an anchor) and writes decisive outcomes back into reward memory
+//!      under the `decision_outcome` source; `decision-context outcomes`
+//!      is the read model.
+//!   ③ replay integration: `replay record` captures the assembled context
+//!      in the case (the record→run mismatch fix).
+//!
+//! These exercise the real CLI entry (`console::run`) against an isolated
+//! `FUTURE_LOOP_ROOT`, plus direct ledger reads for content assertions.
+
+use future_loop::capabilities::decision_context::assembler::assemble_decision_context;
+use future_loop::capabilities::decision_context::outcome_feedback as feedback;
+use future_loop::capabilities::decision_context::packets::DECISION_CONTEXT_PACKET_SCHEMA_VERSION;
+use future_loop::capabilities::reward_memory as rm;
+use future_loop::console;
+use future_loop::store::{Event, Store};
+
+fn with_root<F: FnOnce(&str)>(tag: &str, f: F) {
+    // FUTURE_LOOP_ROOT is process-global; tests run in parallel, so
+    // serialize all CLI tests behind one mutex (each still gets its own
+    // isolated root dir).
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-decision-context-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let root = dir.join(".future/loop");
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("FUTURE_LOOP_ROOT", root.to_str().unwrap());
+    f(root.to_str().unwrap());
+}
+
+fn cli(args: &[&str]) -> Result<(), String> {
+    console::run(
+        "future-loop",
+        args.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| format!("{e:#}"))
+}
+
+/// Set up goal `g1` with one advancement todo `T1`.
+fn setup_goal() {
+    cli(&[
+        "goal",
+        "init",
+        "--objective",
+        "decision context test",
+        "--cwd",
+        "/tmp",
+        "--goal-id",
+        "g1",
+    ])
+    .unwrap();
+    cli(&["todo", "add", "--goal", "g1", "--text", "do work"]).unwrap();
+}
+
+/// Persist a decision summary anchoring `turn` (the run path's P1-1
+/// writeback, staged directly: a full agent run is out of scope here).
+fn anchor_decision(root: &str, turn: u32) {
+    let store = Store::open(root).unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    let packet = future_loop::decision::decide(&goal, std::time::SystemTime::now());
+    let summary =
+        future_loop::quota::decision_summary::DecisionSummary::from_packet(&packet, None, turn);
+    let mut store = Store::open(root).unwrap();
+    store
+        .append(Event::DecisionSummaryRecorded {
+            goal_id: "g1".to_string(),
+            summary,
+            ts: 1_000,
+        })
+        .unwrap();
+}
+
+// ── ① assembler read model ───────────────────────────────────────────────
+
+#[test]
+fn assemble_reflects_goal_state_and_runs_via_cli() {
+    with_root("assemble", |root| {
+        setup_goal();
+        // One material run (tools + evidence) lands in the history.
+        let store = Store::open(root).unwrap();
+        let goal = store.replay("g1").unwrap().unwrap();
+        let todo_id = goal.todos[0].id.clone();
+        drop(store);
+        let store = Store::open(root).unwrap();
+        store
+            .append_run(
+                "g1",
+                &future_loop::state::RunRecord {
+                    turn: 1,
+                    todo_id,
+                    run_id: "r1".to_string(),
+                    validation: None,
+                    terminal_state: "completed".to_string(),
+                    error: None,
+                    tokens_in_delta: 0,
+                    tokens_out_delta: 0,
+                    cost_delta: 0.0,
+                    tools: vec!["shell".to_string()],
+                    evidence: "artifact".to_string(),
+                    recorded_at: 900,
+                    spend_source: None,
+                },
+            )
+            .unwrap();
+        // Surface streak just under the floor: not breached.
+        let goal = store.replay("g1").unwrap().unwrap();
+        let packet = assemble_decision_context(&goal);
+        assert_eq!(
+            packet.schema_version,
+            DECISION_CONTEXT_PACKET_SCHEMA_VERSION
+        );
+        assert_eq!(
+            packet.providers,
+            vec![
+                "run_history".to_string(),
+                "outcome_streak".to_string(),
+                "quota_status".to_string()
+            ]
+        );
+        assert_eq!(packet.run_history.run_count, 1);
+        assert_eq!(packet.run_history.material_runs, 1);
+        assert_eq!(packet.run_history.recent_terminal_states, vec!["completed"]);
+        assert_eq!(packet.quota.spent_slots, 1);
+        // CLI surfaces assemble/outcomes read-only without error.
+        cli(&["decision-context", "assemble", "--goal", "g1"]).unwrap();
+        cli(&[
+            "decision-context",
+            "assemble",
+            "--goal",
+            "g1",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        cli(&["decision-context", "outcomes", "--goal", "g1"]).unwrap();
+    });
+}
+
+// ── ② outcome feedback writeback ─────────────────────────────────────────
+
+#[test]
+fn feedback_fails_closed_without_a_decision_anchor() {
+    with_root("no-anchor", |_root| {
+        setup_goal();
+        let err = cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "7",
+            "--status",
+            "verified",
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("no persisted decision summary"),
+            "unexpected error: {err}"
+        );
+    });
+}
+
+#[test]
+fn feedback_settles_receipt_and_ingests_reward_signal() {
+    with_root("settle", |root| {
+        setup_goal();
+        anchor_decision(root, 3);
+        cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "3",
+            "--status",
+            "verified",
+            "--note",
+            "held up",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        let events = store.events("g1").unwrap();
+        // Receipt settled + anchored to turn-3 with the decision payload.
+        let receipt = feedback::outcome_for(&events, "turn-3").expect("receipt recorded");
+        assert_eq!(receipt.verification_status, "verified");
+        assert_eq!(receipt.accepted_decision, "normal_run");
+        assert_eq!(receipt.reason_code, "runnable_todo");
+        assert_eq!(receipt.seq, 1);
+        assert!(receipt.settled_at.is_some());
+        assert_eq!(receipt.note.as_deref(), Some("held up"));
+        // Reward-memory writeback: verified = 1.0 under decision_outcome.
+        let signals = rm::collect_signals(&events, &rm::RewardScope::default());
+        let signal = signals
+            .iter()
+            .find(|s| s.source == rm::SOURCE_DECISION_OUTCOME)
+            .expect("decision_outcome signal ingested");
+        assert_eq!(signal.signal, "verified");
+        assert_eq!(signal.score, Some(1.0));
+        assert!(
+            signal.note.as_deref().unwrap_or("").contains("turn-3"),
+            "signal note links the receipt: {:?}",
+            signal.note
+        );
+        // The outcomes read model lists it (CLI + json).
+        cli(&["decision-context", "outcomes", "--goal", "g1"]).unwrap();
+        cli(&[
+            "decision-context",
+            "outcomes",
+            "--goal",
+            "g1",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+    });
+}
+
+#[test]
+fn feedback_refuted_and_inconclusive_signals() {
+    with_root("signals", |root| {
+        setup_goal();
+        anchor_decision(root, 1);
+        anchor_decision(root, 2);
+        cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "1",
+            "--status",
+            "refuted",
+        ])
+        .unwrap();
+        cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "2",
+            "--status",
+            "inconclusive",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        let events = store.events("g1").unwrap();
+        let receipts = feedback::decision_outcomes(&events);
+        assert_eq!(receipts.len(), 2);
+        assert_eq!(receipts[0].verification_status, "refuted");
+        assert_eq!(receipts[1].verification_status, "inconclusive");
+        let signals = rm::collect_signals(&events, &rm::RewardScope::default());
+        let by_signal: std::collections::BTreeMap<_, _> = signals
+            .iter()
+            .filter(|s| s.source == rm::SOURCE_DECISION_OUTCOME)
+            .map(|s| (s.signal.as_str(), s.score))
+            .collect();
+        assert_eq!(by_signal.get("refuted"), Some(&Some(0.0)));
+        assert_eq!(by_signal.get("inconclusive"), Some(&None));
+        // Scoped query surfaces the source.
+        cli(&["decision-context", "outcomes", "--goal", "g1"]).unwrap();
+        cli(&[
+            "reward-memory",
+            "query",
+            "--goal",
+            "g1",
+            "--source",
+            "decision_outcome",
+        ])
+        .unwrap();
+    });
+}
+
+#[test]
+fn feedback_rejects_unknown_status_and_repeat_settles_get_fresh_seq() {
+    with_root("seq", |root| {
+        setup_goal();
+        anchor_decision(root, 5);
+        let err = cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "5",
+            "--status",
+            "bogus",
+        ])
+        .unwrap_err();
+        assert!(err.contains("--status"), "unexpected error: {err}");
+        // Two settles against the same decision both land (per-decision seq
+        // is the G-3 content-id dedupe anchor).
+        cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "5",
+            "--status",
+            "verified",
+        ])
+        .unwrap();
+        cli(&[
+            "decision-context",
+            "feedback",
+            "--goal",
+            "g1",
+            "--turn",
+            "5",
+            "--status",
+            "refuted",
+        ])
+        .unwrap();
+        let store = Store::open(root).unwrap();
+        let events = store.events("g1").unwrap();
+        let receipts = feedback::decision_outcomes(&events);
+        assert_eq!(receipts.len(), 2, "both settles must land");
+        assert_eq!(receipts[0].seq, 1);
+        assert_eq!(receipts[1].seq, 2);
+        assert_ne!(receipts[0].receipt_id, receipts[1].receipt_id);
+        assert_eq!(feedback::next_seq(&events, "turn-5"), 3);
+    });
+}
+
+// ── ③ replay integration: the case carries the assembled context ─────────
+
+#[test]
+fn replay_record_captures_decision_context() {
+    with_root("replay", |root| {
+        setup_goal();
+        let out = std::path::Path::new(root).join("replay.json");
+        cli(&[
+            "replay",
+            "record",
+            "--goal",
+            "g1",
+            "--case-id",
+            "case-1",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .unwrap();
+        let replay = future_loop::replay::decision_replay::DecisionReplay::load(&out).unwrap();
+        assert_eq!(replay.cases.len(), 1);
+        let case = &replay.cases[0];
+        let context = case
+            .decision_context
+            .as_ref()
+            .expect("recorded case must carry the assembled context");
+        assert_eq!(
+            context.schema_version,
+            DECISION_CONTEXT_PACKET_SCHEMA_VERSION
+        );
+        assert_eq!(context.goal_id, "g1");
+        // The recorded case replays exactly (context applied on rebuild).
+        let comparison =
+            future_loop::replay::decision_replay::replay_public_safe_decision_case(case).unwrap();
+        assert!(comparison.matched, "{:?}", comparison.mismatches);
+        // And the whole file passes the CLI replay gate.
+        cli(&["replay", "run", "--case", out.to_str().unwrap()]).unwrap();
+    });
+}


### PR DESCRIPTION
loopx-improvement-report.md **P1-4**（wave1 拆分 PR 9/11）。

- 决策上下文 assembler + 2-3 个 provider（run 历史 / outcome streak / quota 状态）
- outcome_feedback 回写（经审计）
- 解决 replay record→run 决策 mismatch 的上下文不全问题（FUTURE.md 记录的症状）
- 新契约测试 decision_context_contract.rs

本地：fmt ✅ clippy ✅ future-loop 72 targets 全绿 ✅。源：claude/loop-wave1 e0f872bf