### PR TITLE
feat(loop): P1-6 canary premerge gate — fast profile + CI merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust_workspace: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.rust_workspace == 'true' || steps.filter.outputs.ci == 'true' }}
+      loop_canary: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.loop_canary == 'true' || steps.filter.outputs.ci == 'true' }}
       desktop_tauri: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.desktop_tauri == 'true' || steps.filter.outputs.ci == 'true' }}
       desktop_frontend: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.desktop_frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       mobile: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ci == 'true' }}
@@ -63,7 +64,17 @@ jobs:
               - 'channels/**'
               - 'tui/**'
               - 'cli/**'
+              # The loop control plane is a workspace member — its changes must
+              # run the same fmt/clippy/test gates (previously missing here).
               - 'orchestration/**'
+            # P1-6: what triggers the canary premerge gate — the loop crate
+            # plus its in-repo dependency surface (future-rpc, workspace root).
+            loop_canary:
+              - 'orchestration/**'
+              - 'rpc/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             desktop_tauri:
               - 'desktop/src-tauri/**'
               - '.cargo/**'
@@ -228,6 +239,48 @@ jobs:
       - name: cargo test (desktop backend)
         if: needs.changes.outputs.desktop_tauri == 'true'
         run: cargo test --manifest-path desktop/src-tauri/Cargo.toml
+
+  # ─── Loop canary premerge gate (P1-6) ────────────────────────────────────
+  # Behavioral merge gate for the loop control plane: runs
+  # `future-loop canary premerge` — an isolated temporary state root, a seeded
+  # fixture goal (non-vacuity guard), the fast `premerge` smoke profile, and
+  # the same all-checks-passed rule as the release gate. A non-zero exit fails
+  # the PR before merge; unit-level Rust regressions are still covered by the
+  # rust-tests job above.
+  loop-canary:
+    name: Loop canary premerge gate
+    needs: changes
+    if: needs.changes.outputs.loop_canary == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Pinned to match rust-toolchain.toml (same as the other Rust jobs).
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+          cache-on-failure: true
+          cache-all-crates: true
+
+      # mold: .cargo/config.toml pins -fuse-ld=mold for Linux targets. No
+      # protoc / WebKit / GTK needed — future-loop + future-rpc build pure-Rust
+      # (proto codegen is checked in, gated on REGENERATE_PROTO).
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential mold pkg-config
+
+      - name: Build loop CLI
+        run: cargo build -p future-loop
+
+      - name: Canary premerge gate
+        run: ./target/debug/future-loop canary premerge --json
 
   # ─── Rust 3-platform compile check ───────────────────────────────────────
   # The quality gate above only runs on Linux, so platform-conditional code was

--- a/orchestration/loop/src/canary/mod.rs
+++ b/orchestration/loop/src/canary/mod.rs
@@ -63,6 +63,22 @@ pub fn smoke_suite_profiles() -> Vec<SmokeProfile> {
             ],
             description: "Release-flow gate: the full deterministic surface must pass.".to_string(),
         },
+        SmokeProfile {
+            id: "premerge".to_string(),
+            suite: "premerge".to_string(),
+            modules: vec![
+                "state".to_string(),
+                "quota".to_string(),
+                "scheduler".to_string(),
+                "todo".to_string(),
+                "status".to_string(),
+                "capability-extension".to_string(),
+            ],
+            description: "P1-6 premerge gate (CI): the fast deterministic core surface — \
+                          skips backup/extension/canary-self so the PR check stays hermetic \
+                          and quick."
+                .to_string(),
+        },
     ]
 }
 
@@ -96,6 +112,123 @@ pub struct SmokeRunResult {
 /// when every check passes.
 pub fn run_release_gate(store: &Store) -> Result<SmokeRunResult> {
     run_smoke(store, "release-gate")
+}
+
+// ── P1-6: premerge gate (CI merge gate) ─────────────────────────────────────
+
+pub const PREMERGE_GATE_REPORT_SCHEMA_VERSION: &str = "canary_premerge_gate_v0";
+
+/// The fixture goal seeded into the isolated premerge root so the gate run
+/// is never vacuous (a gate that checked zero goals proves nothing).
+pub const PREMERGE_FIXTURE_GOAL_ID: &str = "canary-premerge-fixture";
+
+/// A gate verdict over a smoke run. The pass rule reuses the release gate's
+/// rule — every check must pass — plus a non-vacuity guard for CI: the run
+/// must have seen at least one registered goal.
+#[derive(Debug, Clone, Serialize)]
+pub struct GateDecision {
+    pub gate: String,
+    pub passed: bool,
+    pub goals_checked: usize,
+    pub failed_checks: Vec<String>,
+    pub reason: String,
+}
+
+/// Evaluate a smoke run as a gate (`gate` = "premerge" / "release").
+pub fn evaluate_gate(run: &SmokeRunResult, gate: &str, goals_checked: usize) -> GateDecision {
+    let failed_checks: Vec<String> = run
+        .checks
+        .iter()
+        .filter(|c| !c.passed)
+        .map(|c| c.id.clone())
+        .collect();
+    let (passed, reason) = if !failed_checks.is_empty() {
+        (
+            false,
+            format!(
+                "{} check(s) failed: {}",
+                failed_checks.len(),
+                failed_checks.join(", ")
+            ),
+        )
+    } else if goals_checked == 0 {
+        (
+            false,
+            "vacuous run: no goals checked — the gate cannot prove health".to_string(),
+        )
+    } else {
+        (
+            true,
+            format!(
+                "all {} check(s) passed over {goals_checked} goal(s)",
+                run.checks.len()
+            ),
+        )
+    };
+    GateDecision {
+        gate: gate.to_string(),
+        passed,
+        goals_checked,
+        failed_checks,
+        reason,
+    }
+}
+
+/// The full premerge report: the gate decision plus the underlying smoke run.
+#[derive(Debug, Clone, Serialize)]
+pub struct PremergeGateReport {
+    pub schema_version: String,
+    pub gate: GateDecision,
+    pub run: SmokeRunResult,
+}
+
+/// Seed a minimal but real fixture goal so the premerge gate is non-vacuous:
+/// one registered goal with a started ledger and one open advancement todo.
+pub fn seed_premerge_fixture(store: &mut Store) -> Result<String> {
+    let goal_id = PREMERGE_FIXTURE_GOAL_ID.to_string();
+    let goal = crate::state::Goal::new(&goal_id, "canary premerge fixture", "/tmp");
+    store.register(&goal)?;
+    store.append(crate::store::Event::GoalStarted {
+        goal_id: goal_id.clone(),
+        ts: crate::state::now_epoch(),
+    })?;
+    store.append(crate::store::Event::TodoAdded {
+        goal_id: goal_id.clone(),
+        todo: crate::state::Todo::advancement("T1", "fixture work item"),
+        ts: crate::state::now_epoch(),
+    })?;
+    Ok(goal_id)
+}
+
+/// Run the premerge gate against an existing state root (the fixture is
+/// seeded in place). Split from [`run_premerge_gate_isolated`] so tests can
+/// point it at their own roots.
+pub fn run_premerge_gate_in(root: &str) -> Result<PremergeGateReport> {
+    let mut store = Store::open(root)?;
+    seed_premerge_fixture(&mut store)?;
+    let run = run_smoke(&store, "premerge")?;
+    let gate = evaluate_gate(&run, "premerge", store.registry().len());
+    Ok(PremergeGateReport {
+        schema_version: PREMERGE_GATE_REPORT_SCHEMA_VERSION.to_string(),
+        gate,
+        run,
+    })
+}
+
+/// Run the premerge gate the way CI does (P1-6): an isolated temporary state
+/// root (never the operator's live root), a seeded fixture goal, the fast
+/// `premerge` profile, and the release-gate pass rule via [`evaluate_gate`].
+/// The temp root is always removed afterwards.
+pub fn run_premerge_gate_isolated() -> Result<PremergeGateReport> {
+    let root = std::env::temp_dir().join(format!(
+        "future-loop-premerge-{}-{}",
+        std::process::id(),
+        crate::state::now_epoch()
+    ));
+    std::fs::create_dir_all(&root)?;
+    let result = run_premerge_gate_in(&root.to_string_lossy());
+    let _ = std::fs::remove_dir_all(&root);
+    result
 }
 
 /// Run the smoke checks of one profile against a live store.
@@ -485,14 +618,68 @@ mod tests {
     #[test]
     fn profile_manifest_is_stable() {
         let profiles = smoke_suite_profiles();
-        assert_eq!(profiles.len(), 3);
+        assert_eq!(profiles.len(), 4);
         let ids: Vec<&str> = profiles.iter().map(|p| p.id.as_str()).collect();
         assert_eq!(
             ids,
-            vec!["core-control-plane", "extension-runtime", "release-gate"]
+            vec![
+                "core-control-plane",
+                "extension-runtime",
+                "release-gate",
+                "premerge"
+            ]
         );
         assert!(resolve_smoke_profile("release-gate").is_ok());
+        assert!(resolve_smoke_profile("premerge").is_ok());
         assert!(resolve_smoke_profile("nope").is_err());
+    }
+
+    #[test]
+    fn premerge_gate_isolated_passes_non_vacuous() {
+        let report = run_premerge_gate_isolated().unwrap();
+        assert_eq!(report.schema_version, PREMERGE_GATE_REPORT_SCHEMA_VERSION);
+        assert_eq!(report.run.profile_id, "premerge");
+        assert_eq!(report.run.suite, "premerge");
+        assert!(report.gate.passed, "{}", report.gate.reason);
+        assert_eq!(report.gate.goals_checked, 1);
+        assert!(report.gate.failed_checks.is_empty());
+    }
+
+    #[test]
+    fn premerge_gate_detects_corrupt_fixture_ledger() {
+        let mut store = tmp_store("premerge-corrupt");
+        let goal_id = seed_premerge_fixture(&mut store).unwrap();
+        let ledger = store.goal_dir(&goal_id).join("events.jsonl");
+        std::fs::write(&ledger, "not-json\n").unwrap();
+        let run = run_smoke(&store, "premerge").unwrap();
+        let gate = evaluate_gate(&run, "premerge", store.registry().len());
+        assert!(!gate.passed);
+        assert!(gate.failed_checks.contains(&"ledger_integrity".to_string()));
+        assert!(gate.reason.contains("ledger_integrity"));
+        let _ = std::fs::remove_dir_all(store.root_path());
+    }
+
+    #[test]
+    fn evaluate_gate_rejects_vacuous_run() {
+        let run = SmokeRunResult {
+            schema_version: CANARY_SMOKE_RUN_SCHEMA_VERSION.to_string(),
+            profile_id: "premerge".to_string(),
+            suite: "premerge".to_string(),
+            all_passed: true,
+            checks: vec![SmokeCheckOutcome {
+                id: "root_writable".to_string(),
+                module: "state".to_string(),
+                passed: true,
+                detail: "ok".to_string(),
+            }],
+        };
+        let gate = evaluate_gate(&run, "premerge", 0);
+        assert!(!gate.passed);
+        assert!(gate.reason.contains("vacuous"));
+        // Same run with goals checked passes.
+        let gate = evaluate_gate(&run, "premerge", 2);
+        assert!(gate.passed, "{}", gate.reason);
+        assert_eq!(gate.goals_checked, 2);
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -554,8 +554,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         canary,
         "canary",
-        "run a smoke profile (release gate default)",
-        "canary smoke [--profile core-control-plane|extension-runtime|release-gate] [--json]",
+        "run a smoke profile (release gate default) or the premerge CI gate",
+        "canary smoke [--profile core-control-plane|extension-runtime|release-gate|premerge] [--json] | canary premerge [--json]",
     );
 
     // P1-9: journey metadata overlay (presentation only — the registry
@@ -6062,7 +6062,22 @@ fn cmd_replay(store: &Store, args: &[String]) -> Result<()> {
 
 /// `loopx canary smoke [--profile X] [--json]` — run a smoke profile
 /// (default release-gate). Fails closed when any check fails.
+/// `loopx canary premerge [--json]` — P1-6 CI merge gate (isolated root).
 fn cmd_canary(store: &Store, args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("premerge") => cmd_canary_premerge(&args[1..]),
+        Some("smoke") => cmd_canary_smoke(store, &args[1..]),
+        Some(other) if !other.starts_with('-') => {
+            anyhow::bail!("unknown canary subcommand `{other}` (expected `smoke` or `premerge`)")
+        }
+        // Legacy bare `canary` (or flags first) keeps the smoke default.
+        _ => cmd_canary_smoke(store, args),
+    }
+}
+
+/// `loopx canary smoke [--profile X] [--json]` — run a smoke profile
+/// (default release-gate). Fails closed when any check fails.
+fn cmd_canary_smoke(store: &Store, args: &[String]) -> Result<()> {
     let mut profile = None;
     let mut json = false;
     reject_unknown_flags(args, &["--json", "--profile"])?;
@@ -6105,6 +6120,48 @@ fn cmd_canary(store: &Store, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// `loopx canary premerge [--json]` — the P1-6 CI merge gate. Runs against an
+/// isolated temporary state root (never the operator's live root) with a
+/// seeded fixture goal so the run is non-vacuous, then applies the release
+/// gate's all-passed rule. Exits non-zero when the gate fails.
+fn cmd_canary_premerge(args: &[String]) -> Result<()> {
+    let mut json = false;
+    reject_unknown_flags(args, &["--json"])?;
+    parse_pairs(args, |k, _v| {
+        if k == "--json" {
+            json = true;
+        }
+    });
+    let report = crate::canary::run_premerge_gate_isolated()?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!(
+            "canary premerge (suite {}): {} check(s) over {} goal(s)",
+            report.run.suite,
+            report.run.checks.len(),
+            report.gate.goals_checked
+        );
+        for check in &report.run.checks {
+            println!(
+                "  [{}] {:<24} {}",
+                if check.passed { "ok" } else { "FAIL" },
+                check.id,
+                check.detail
+            );
+        }
+        println!(
+            "gate: {} — {}",
+            if report.gate.passed { "PASS" } else { "FAIL" },
+            report.gate.reason
+        );
+    }
+    if !report.gate.passed {
+        anyhow::bail!("canary premerge gate failed: {}", report.gate.reason);
+    }
+    Ok(())
+}
+
 // ── P4: diagnostics & command surface (G-27) ───────────────────────────────
 
 /// `loopx version` — version + schema surface.
@@ -6117,6 +6174,7 @@ fn cmd_version(store: &Store, args: &[String]) -> Result<()> {
     println!("  public_safe_decision_replay_v0 (G-19)");
     println!("  model_behavior_corpus_v0 (G-19)");
     println!("  canary_smoke_run_v0 (G-20)");
+    println!("  canary_premerge_gate_v0 (P1-6)");
     println!("  future_loop_turn_envelope_v0 (G-9)");
     println!("  scheduler_arbitration_v0 (G-2/G-11)");
     let _ = store;

--- a/orchestration/loop/tests/canary_contract.rs
+++ b/orchestration/loop/tests/canary_contract.rs
@@ -44,10 +44,57 @@ fn profile_manifest_is_stable() {
     let ids: Vec<&str> = profiles.iter().map(|p| p.id.as_str()).collect();
     assert_eq!(
         ids,
-        vec!["core-control-plane", "extension-runtime", "release-gate"]
+        vec![
+            "core-control-plane",
+            "extension-runtime",
+            "release-gate",
+            "premerge"
+        ]
     );
     assert!(future_loop::canary::resolve_smoke_profile("release-gate").is_ok());
+    assert!(future_loop::canary::resolve_smoke_profile("premerge").is_ok());
     assert!(future_loop::canary::resolve_smoke_profile("nope").is_err());
+}
+
+/// ── P1-6: premerge gate (CI merge gate) ──────────────────────────────────
+
+#[test]
+fn premerge_gate_isolated_passes_and_is_non_vacuous() {
+    let report = future_loop::canary::run_premerge_gate_isolated().unwrap();
+    assert_eq!(report.schema_version, "canary_premerge_gate_v0");
+    assert_eq!(report.run.profile_id, "premerge");
+    assert!(report.gate.passed, "{}", report.gate.reason);
+    // Non-vacuity: the seeded fixture goal must have been checked.
+    assert_eq!(report.gate.goals_checked, 1);
+    assert!(report.gate.failed_checks.is_empty());
+}
+
+#[test]
+fn premerge_gate_fails_on_corrupt_ledger() {
+    let root = tmp_root("premerge-corrupt");
+    let mut store = Store::open(&root).unwrap();
+    let goal_id = future_loop::canary::seed_premerge_fixture(&mut store).unwrap();
+    let ledger = store.goal_dir(&goal_id).join("events.jsonl");
+    std::fs::write(&ledger, "garbage-line\n").unwrap();
+    let run = run_smoke(&store, "premerge").unwrap();
+    let gate = future_loop::canary::evaluate_gate(&run, "premerge", store.registry().len());
+    assert!(!gate.passed);
+    assert!(gate.failed_checks.contains(&"ledger_integrity".to_string()));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn premerge_gate_rejects_vacuous_run() {
+    // A smoke run over zero goals must NOT pass the gate (CI would otherwise
+    // go green on an empty/broken root).
+    let root = tmp_root("premerge-vacuous");
+    let store = Store::open(&root).unwrap();
+    let run = run_smoke(&store, "premerge").unwrap();
+    assert!(run.all_passed, "{:?}", run.checks);
+    let gate = future_loop::canary::evaluate_gate(&run, "premerge", store.registry().len());
+    assert!(!gate.passed);
+    assert!(gate.reason.contains("vacuous"));
+    let _ = std::fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -845,6 +845,29 @@ fn p4_canary_smoke_via_cli() {
     assert!(err.contains("unknown smoke profile"));
 }
 
+/// ── P1-6: canary premerge gate through the CLI ───────────────────────────
+#[test]
+fn p1_6_canary_premerge_via_cli() {
+    let root = tmp_root("p16premerge");
+    // The premerge gate runs on an isolated root (the operator root is
+    // irrelevant); it must pass and be non-vacuous.
+    let (out, err, code) = run(&root, &["canary", "premerge"]);
+    assert_eq!(code, 0, "canary premerge: {err}");
+    assert!(out.contains("gate: PASS"), "premerge: {out}");
+    // --json renders the machine-readable gate report.
+    let (out, _, code) = run(&root, &["canary", "premerge", "--json"]);
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("\"schema_version\": \"canary_premerge_gate_v0\""),
+        "{out}"
+    );
+    assert!(out.contains("\"passed\": true"), "{out}");
+    // Unknown subcommands fail closed (P0-3 hard-error rule).
+    let (_, err, code) = run(&root, &["canary", "bogus"]);
+    assert_ne!(code, 0);
+    assert!(err.contains("unknown canary subcommand"), "{err}");
+}
+
 /// ── P4: help surface lists the new groups ────────────────────────────────
 #[test]
 fn p4_help_lists_new_groups_and_commands() {


### PR DESCRIPTION
loopx-improvement-report.md **P1-6**（wave1 拆分 PR 10/11）。

- canary fast profile + 隔离 fixture run
- CI 新增 canary 合并门禁 job（loop_canary 路径过滤：orchestration/rpc/workspace 根）
- gate 判定复用现有 release gate 逻辑

本地：fmt ✅ clippy ✅ future-loop 72 targets 全绿 ✅；ci.yml YAML 校验通过。源：claude/loop-wave1 58cb47b9