### PR TITLE
feat(mobile): session long-press menu (pin/rename/delete) + pinned sort sync

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -649,7 +649,14 @@ async fn handle_command(
             match crate::agent_bridge::rename_session(cmd.session_id.clone(), cmd.name.clone())
                 .await
             {
-                Ok(()) => reply(client, &msg, true, json!({}), None).await,
+                Ok(()) => {
+                    if let Ok(Some(thread)) =
+                        crate::store::find_thread_by_agent_session(&cmd.session_id)
+                    {
+                        crate::emit_remote_activity(&thread.id);
+                    }
+                    reply(client, &msg, true, json!({}), None).await
+                }
                 Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
             }
         }
@@ -658,7 +665,10 @@ async fn handle_command(
                 thread_id: cmd.thread_id.clone(),
                 pinned: cmd.pinned,
             }) {
-                Ok(_) => reply(client, &msg, true, json!({}), None).await,
+                Ok(_) => {
+                    crate::emit_remote_activity(&cmd.thread_id);
+                    reply(client, &msg, true, json!({}), None).await
+                }
                 Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
             }
         }
@@ -672,7 +682,10 @@ async fn handle_command(
                 reply(client, &msg, false, Value::Null, Some("missing thread_id")).await;
             } else {
                 match crate::store::delete_thread_with_files(&cmd.thread_id, false) {
-                    Ok(_) => reply(client, &msg, true, json!({}), None).await,
+                    Ok(_) => {
+                        crate::emit_remote_activity(&cmd.thread_id);
+                        reply(client, &msg, true, json!({}), None).await
+                    }
                     Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
                 }
             }

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -98,6 +98,9 @@ struct IncomingCmd {
     // set_session_name
     name: String,
     transfer_name: String,
+    // delete_session / set_session_pinned (thread-scoped, see ThreadRecord)
+    thread_id: String,
+    pinned: bool,
     // prompt creation mode / existing workspace selection
     workspace_id: String,
     // file transfer control + prompt attachment references
@@ -138,6 +141,8 @@ impl Default for IncomingCmd {
             level: String::new(),
             name: String::new(),
             transfer_name: String::new(),
+            thread_id: String::new(),
+            pinned: false,
             workspace_id: String::new(),
             mime_type: String::new(),
             kind: String::new(),
@@ -345,10 +350,11 @@ async fn handle_command(
                             let status = run_status_by_thread.get(t.id.as_str()).copied();
                             json!({
                                 "sessionId": sid,
-                                "title": t.title,
                                 "threadId": t.id,
+                                "title": t.title,
                                 "mode": t.mode,
                                 "workspaceId": t.workspace_id,
+                                "pinned": t.pinned,
                                 "streaming": streaming,
                                 "status": status,
                             })
@@ -645,6 +651,30 @@ async fn handle_command(
             {
                 Ok(()) => reply(client, &msg, true, json!({}), None).await,
                 Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
+            }
+        }
+        "set_session_pinned" => {
+            match crate::store::pin_thread(crate::store::PinThreadInput {
+                thread_id: cmd.thread_id.clone(),
+                pinned: cmd.pinned,
+            }) {
+                Ok(_) => reply(client, &msg, true, json!({}), None).await,
+                Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
+            }
+        }
+        "delete_session" => {
+            // Matches the desktop single-thread delete: the session record is
+            // removed (and, when it is the only owner, the agent session too),
+            // but the temporary chat workspace files are kept (delete_files =
+            // false). Only reachable with a non-empty thread id from the remote
+            // client; a missing id is a malformed request, not a deletion.
+            if cmd.thread_id.is_empty() {
+                reply(client, &msg, false, Value::Null, Some("missing thread_id")).await;
+            } else {
+                match crate::store::delete_thread_with_files(&cmd.thread_id, false) {
+                    Ok(_) => reply(client, &msg, true, json!({}), None).await,
+                    Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
+                }
             }
         }
         other => {

--- a/desktop/src-tauri/src/remote/mod.rs
+++ b/desktop/src-tauri/src/remote/mod.rs
@@ -935,6 +935,7 @@ fn build_presence_snapshot(pair_id: &str, bridge_instance_id: &str) -> (serde_js
             "title": t.title,
             "mode": t.mode,
             "workspaceId": t.workspace_id,
+            "pinned": t.pinned,
             "streaming": streaming,
             "status": status,
         }));
@@ -944,6 +945,7 @@ fn build_presence_snapshot(pair_id: &str, bridge_instance_id: &str) -> (serde_js
         push_sig_field(&mut signature, &t.title);
         push_sig_field(&mut signature, &t.mode);
         push_sig_field(&mut signature, &t.workspace_id);
+        push_sig_field(&mut signature, if t.pinned { "1" } else { "0" });
         push_sig_field(&mut signature, if streaming { "1" } else { "0" });
         push_sig_field(&mut signature, status.unwrap_or(""));
     }
@@ -1009,6 +1011,7 @@ fn build_sessions_snapshot(pair_id: &str) -> (serde_json::Value, String) {
             "title": t.title,
             "mode": t.mode,
             "workspaceId": t.workspace_id,
+            "pinned": t.pinned,
             "streaming": streaming,
             "status": status,
         }));
@@ -1017,6 +1020,7 @@ fn build_sessions_snapshot(pair_id: &str) -> (serde_json::Value, String) {
         push_sig_field(&mut signature, &t.title);
         push_sig_field(&mut signature, &t.mode);
         push_sig_field(&mut signature, &t.workspace_id);
+        push_sig_field(&mut signature, if t.pinned { "1" } else { "0" });
         push_sig_field(&mut signature, if streaming { "1" } else { "0" });
         push_sig_field(&mut signature, status.unwrap_or(""));
     }

--- a/desktop/src-tauri/src/store/threads.rs
+++ b/desktop/src-tauri/src/store/threads.rs
@@ -42,7 +42,7 @@ pub fn list_threads() -> Result<Vec<ThreadRecord>, crate::AppError> {
         "SELECT {THREAD_COLUMNS}
              FROM threads
              WHERE status != 'deleted'
-             ORDER BY pinned DESC, COALESCE(last_message_at, updated_at) DESC"
+             ORDER BY pinned DESC, COALESCE(last_message_at, last_opened_at, updated_at) DESC"
     ))?;
     let rows = stmt.query_map([], thread_from_row)?;
     rows.collect::<rusqlite::Result<Vec<_>>>()

--- a/desktop/src-tauri/src/store/threads.rs
+++ b/desktop/src-tauri/src/store/threads.rs
@@ -251,13 +251,16 @@ pub fn move_thread_to_workspace(
 }
 
 pub fn pin_thread(input: PinThreadInput) -> Result<ThreadRecord, crate::AppError> {
-    let now = now_millis();
+    // `updated_at` is deliberately untouched: pinning is an ordering flag, not
+    // an activity event. If it stamped `updated_at`, unpinning a thread would
+    // push it to the top of the recency sort (it just became "most recently
+    // updated") and the sidebar order would appear not to change.
     let conn = connect()?;
     conn.execute(
         "UPDATE threads
-         SET pinned = ?1, updated_at = ?2
-         WHERE id = ?3 AND status != 'deleted'",
-        params![if input.pinned { 1 } else { 0 }, now, input.thread_id],
+         SET pinned = ?1
+         WHERE id = ?2 AND status != 'deleted'",
+        params![if input.pinned { 1 } else { 0 }, input.thread_id],
     )?;
 
     loaded(get_thread(&input.thread_id)?, "Thread")

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -1,5 +1,4 @@
 import { Linking, StyleSheet, Text, View } from "react-native";
-import type { StyleProp, TextStyle, ViewStyle } from "react-native";
 import { colors, radius, spacing } from "../theme/tokens";
 
 interface MarkdownTextProps {
@@ -191,7 +190,7 @@ function InlineMarkdown({ text }: { text: string }) {
         if (/^`[^`]+`$/.test(part)) {
           return (
             <Text key={index} style={styles.inlineCode}>
-              {"\u00A0" + part.slice(1, -1) + "\u00A0"}
+              {part.slice(1, -1)}
             </Text>
           );
         }
@@ -217,62 +216,6 @@ function InlineMarkdown({ text }: { text: string }) {
         return part;
       })}
     </>
-  );
-}
-
-// iOS renders nested <Text> as an attributed string whose runs can't carry
-// padding/borderRadius (TextAttributes has no such fields), and the run
-// background fills the whole line fragment — a decorated chip is impossible
-// inside one <Text>. Compromise that keeps the inline flow: SHORT code spans
-// become real chip views (they fit on a line, so the flow is undisturbed and
-// they get genuine padding/rounding/gaps); LONG code spans stay inline in the
-// prose run (wrapping mid-code, sharing lines with text) with nbsp padding —
-// the two properties iOS can't do inline (rounding, wrapped-line gap) are the
-// accepted platform cost.
-const CHIP_MAX = 24;
-
-function CodeFlow({
-  text,
-  containerStyle,
-  proseStyle,
-}: {
-  text: string;
-  containerStyle: StyleProp<ViewStyle>;
-  proseStyle: TextStyle;
-}) {
-  const parts = text.split(/(`[^`]+`)/g);
-  const items: { kind: "prose" | "chip"; text: string }[] = [];
-  let buffer = "";
-  const flush = () => {
-    if (buffer) {
-      items.push({ kind: "prose", text: buffer });
-      buffer = "";
-    }
-  };
-  for (const part of parts) {
-    const code = part.match(/^`([^`]+)`$/)?.[1];
-    if (code && code.length <= CHIP_MAX) {
-      flush();
-      items.push({ kind: "chip", text: code });
-    } else {
-      buffer += part;
-    }
-  }
-  flush();
-  return (
-    <View style={containerStyle}>
-      {items.map((item, index) =>
-        item.kind === "chip" ? (
-          <Text key={index} selectable style={styles.codeChip}>
-            {item.text}
-          </Text>
-        ) : (
-          <Text key={index} selectable style={proseStyle}>
-            <InlineMarkdown text={item.text} />
-          </Text>
-        ),
-      )}
-    </View>
   );
 }
 
@@ -367,23 +310,18 @@ function renderBlock(block: Block, index: number, isLast = false) {
                 {item.checked ? <Text style={styles.checkMark}>✓</Text> : null}
               </View>
             )}
-            <CodeFlow
-              containerStyle={styles.listItemFlow}
-              proseStyle={styles.listItemProse}
-              text={item.text}
-            />
+            <Text selectable style={styles.listItemText}>
+              <InlineMarkdown text={item.text} />
+            </Text>
           </View>
         ))}
       </View>
     );
   }
   return (
-    <CodeFlow
-      key={index}
-      containerStyle={[styles.flowParagraph, isLast && styles.noBottom]}
-      proseStyle={styles.flowProse}
-      text={block.text}
-    />
+    <Text key={index} selectable style={[styles.paragraph, isLast && styles.noBottom]}>
+      <InlineMarkdown text={block.text} />
+    </Text>
   );
 }
 
@@ -402,30 +340,7 @@ const styles = StyleSheet.create({
   // bubble/segment layout owns outer spacing (otherwise every bubble ends
   // with a stray gap after its final row).
   noBottom: { marginBottom: 0 },
-  // Wrapping flex-row layout for code-bearing text (see CodeFlow): prose
-  // chunks wrap inside their Text item, code spans are chip views, and
-  // rowGap is the wrapped-line breathing room iOS can't do inline.
-  flowParagraph: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    rowGap: 3,
-    marginBottom: spacing.md,
-  },
-  flowProse: { color: colors.ink, fontSize: 17, lineHeight: 26 },
-  codeChip: {
-    alignSelf: "flex-start",
-    maxWidth: "100%",
-    marginVertical: 1,
-    paddingHorizontal: 5,
-    paddingVertical: 2,
-    borderRadius: radius.sm,
-    backgroundColor: colors.surfaceSubtle,
-    color: colors.ink,
-    fontFamily: "monospace",
-    fontSize: 13,
-    lineHeight: 20,
-  },
+  paragraph: { color: colors.ink, fontSize: 17, lineHeight: 26, marginBottom: spacing.md },
   heading: {
     color: colors.inkStrong,
     fontSize: 19,
@@ -438,15 +353,15 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Inline rendering for long code spans (and code inside headings): subtle
-    // bg, ~0.92em. Horizontal padding is an nbsp inside the run (InlineMarkdown)
-    // because iOS drops per-run padding; short code spans get the fully
-    // decorated chip view instead (see CodeFlow).
+    // Parity with the desktop inline <code>: rounded, subtle bg, ~0.92em, text-ink.
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
     borderRadius: radius.sm,
+    overflow: "hidden",
   },
   link: { color: colors.accent, textDecorationLine: "underline" },
   rule: { height: 1, marginVertical: spacing.md, backgroundColor: colors.line },
@@ -475,14 +390,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
   },
-  listItemFlow: {
-    flex: 1,
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    rowGap: 2,
-  },
-  listItemProse: { color: colors.ink, fontSize: 17, lineHeight: 26 },
+  listItemText: { flex: 1, color: colors.ink, fontSize: 17, lineHeight: 26 },
   checkbox: {
     width: 18,
     height: 18,

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -190,7 +190,7 @@ function InlineMarkdown({ text }: { text: string }) {
         if (/^`[^`]+`$/.test(part)) {
           return (
             <Text key={index} style={styles.inlineCode}>
-              {part.slice(1, -1)}
+              {"\u00A0" + part.slice(1, -1) + "\u00A0"}
             </Text>
           );
         }
@@ -219,11 +219,12 @@ function InlineMarkdown({ text }: { text: string }) {
   );
 }
 
-function renderBlock(block: Block, index: number) {
-  if (block.kind === "rule") return <View key={index} style={styles.rule} />;
+function renderBlock(block: Block, index: number, isLast = false) {
+  if (block.kind === "rule")
+    return <View key={index} style={[styles.rule, isLast && styles.noBottom]} />;
   if (block.kind === "code") {
     return (
-      <Text key={index} selectable style={styles.code}>
+      <Text key={index} selectable style={[styles.code, isLast && styles.noBottom]}>
         {block.text}
       </Text>
     );
@@ -233,7 +234,11 @@ function renderBlock(block: Block, index: number) {
       <Text
         key={index}
         selectable
-        style={[styles.heading, block.level <= 2 ? styles.headingLarge : null]}
+        style={[
+          styles.heading,
+          block.level <= 2 ? styles.headingLarge : null,
+          isLast && styles.noBottom,
+        ]}
       >
         <InlineMarkdown text={block.text} />
       </Text>
@@ -241,14 +246,16 @@ function renderBlock(block: Block, index: number) {
   }
   if (block.kind === "quote") {
     return (
-      <View key={index} style={styles.quote}>
-        {blocksFromMarkdown(block.text).map((child, childIndex) => renderBlock(child, childIndex))}
+      <View key={index} style={[styles.quote, isLast && styles.noBottom]}>
+        {blocksFromMarkdown(block.text).map((child, childIndex, all) =>
+          renderBlock(child, childIndex, childIndex === all.length - 1),
+        )}
       </View>
     );
   }
   if (block.kind === "table") {
     return (
-      <View key={index} style={styles.table}>
+      <View key={index} style={[styles.table, isLast && styles.noBottom]}>
         <View style={[styles.tableRow, styles.tableHead]}>
           {block.headers.map((header, columnIndex) => (
             <Text
@@ -293,7 +300,7 @@ function renderBlock(block: Block, index: number) {
   }
   if (block.kind === "list") {
     return (
-      <View key={index} style={styles.list}>
+      <View key={index} style={[styles.list, isLast && styles.noBottom]}>
         {block.items.map((item, itemIndex) => (
           <View key={itemIndex} style={styles.listRow}>
             {item.checked === null ? (
@@ -312,17 +319,27 @@ function renderBlock(block: Block, index: number) {
     );
   }
   return (
-    <Text key={index} selectable style={styles.paragraph}>
+    <Text key={index} selectable style={[styles.paragraph, isLast && styles.noBottom]}>
       <InlineMarkdown text={block.text} />
     </Text>
   );
 }
 
 export function MarkdownText({ text }: MarkdownTextProps) {
-  return <View>{blocksFromMarkdown(text).map((block, index) => renderBlock(block, index))}</View>;
+  return (
+    <View>
+      {blocksFromMarkdown(text).map((block, index, all) =>
+        renderBlock(block, index, index === all.length - 1),
+      )}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  // The last block of a message drops its bottom margin — the surrounding
+  // bubble/segment layout owns outer spacing (otherwise every bubble ends
+  // with a stray gap after its final row).
+  noBottom: { marginBottom: 0 },
   paragraph: { color: colors.ink, fontSize: 17, lineHeight: 26, marginBottom: spacing.md },
   heading: {
     color: colors.inkStrong,
@@ -336,15 +353,17 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Parity with the desktop inline <code>: rounded, subtle bg, ~0.92em, text-ink.
+    // Parity with the desktop inline <code>: rounded, subtle bg, ~0.92em.
+    // iOS renders nested <Text> as an attributed string and ignores its
+    // padding/borderRadius, so horizontal padding is an nbsp inside the run
+    // (InlineMarkdown) and a lineHeight shorter than the paragraph's leaves
+    // breathing room between wrapped chip lines.
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
-    paddingHorizontal: 4,
-    paddingVertical: 1,
+    lineHeight: 20,
     borderRadius: radius.sm,
-    overflow: "hidden",
   },
   link: { color: colors.accent, textDecorationLine: "underline" },
   rule: { height: 1, marginVertical: spacing.md, backgroundColor: colors.line },

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -1,4 +1,5 @@
 import { Linking, StyleSheet, Text, View } from "react-native";
+import type { StyleProp, TextStyle, ViewStyle } from "react-native";
 import { colors, radius, spacing } from "../theme/tokens";
 
 interface MarkdownTextProps {
@@ -219,6 +220,45 @@ function InlineMarkdown({ text }: { text: string }) {
   );
 }
 
+// iOS renders nested <Text> as an attributed string whose runs can't carry
+// padding/borderRadius (TextAttributes has no such fields), and the run
+// background fills the whole line fragment — so an inline code chip with
+// desktop parity is impossible inside one <Text>. Instead, code-bearing text
+// lays out as a wrapping flex row: prose chunks are Text items (wrapping
+// internally, CJK-safe at chunk level) and every code span is a real chip
+// view with genuine padding, rounding and line gaps.
+function CodeFlow({
+  text,
+  containerStyle,
+  proseStyle,
+}: {
+  text: string;
+  containerStyle: StyleProp<ViewStyle>;
+  proseStyle: TextStyle;
+}) {
+  const chunks = text.split(/(`[^`]+`)/g);
+  return (
+    <View style={containerStyle}>
+      {chunks.map((chunk, index) => {
+        const code = chunk.match(/^`([^`]+)`$/);
+        if (code) {
+          return (
+            <Text key={index} selectable style={styles.codeChip}>
+              {code[1]}
+            </Text>
+          );
+        }
+        if (!chunk) return null;
+        return (
+          <Text key={index} selectable style={proseStyle}>
+            <InlineMarkdown text={chunk} />
+          </Text>
+        );
+      })}
+    </View>
+  );
+}
+
 function renderBlock(block: Block, index: number, isLast = false) {
   if (block.kind === "rule")
     return <View key={index} style={[styles.rule, isLast && styles.noBottom]} />;
@@ -310,18 +350,23 @@ function renderBlock(block: Block, index: number, isLast = false) {
                 {item.checked ? <Text style={styles.checkMark}>✓</Text> : null}
               </View>
             )}
-            <Text selectable style={styles.listItemText}>
-              <InlineMarkdown text={item.text} />
-            </Text>
+            <CodeFlow
+              containerStyle={styles.listItemFlow}
+              proseStyle={styles.listItemProse}
+              text={item.text}
+            />
           </View>
         ))}
       </View>
     );
   }
   return (
-    <Text key={index} selectable style={[styles.paragraph, isLast && styles.noBottom]}>
-      <InlineMarkdown text={block.text} />
-    </Text>
+    <CodeFlow
+      key={index}
+      containerStyle={[styles.flowParagraph, isLast && styles.noBottom]}
+      proseStyle={styles.flowProse}
+      text={block.text}
+    />
   );
 }
 
@@ -340,7 +385,30 @@ const styles = StyleSheet.create({
   // bubble/segment layout owns outer spacing (otherwise every bubble ends
   // with a stray gap after its final row).
   noBottom: { marginBottom: 0 },
-  paragraph: { color: colors.ink, fontSize: 17, lineHeight: 26, marginBottom: spacing.md },
+  // Wrapping flex-row layout for code-bearing text (see CodeFlow): prose
+  // chunks wrap inside their Text item, code spans are chip views, and
+  // rowGap is the wrapped-line breathing room iOS can't do inline.
+  flowParagraph: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    rowGap: 3,
+    marginBottom: spacing.md,
+  },
+  flowProse: { color: colors.ink, fontSize: 17, lineHeight: 26 },
+  codeChip: {
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+    marginVertical: 1,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+    backgroundColor: colors.surfaceSubtle,
+    color: colors.ink,
+    fontFamily: "monospace",
+    fontSize: 13,
+    lineHeight: 20,
+  },
   heading: {
     color: colors.inkStrong,
     fontSize: 19,
@@ -353,21 +421,13 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Desktop-parity inline <code>: subtle bg, ~0.92em, rounded, padded, with a
-    // gap between wrapped lines. iOS renders nested <Text> as an attributed
-    // string and drops per-run padding/borderRadius, and the run background
-    // fills the whole line fragment (wrapped lines stick together). A
-    // same-color text shadow (NSShadow per run, honored on both platforms)
-    // fakes the rest: the blur extends the fill ~3px on every side — padding
-    // and soft rounding — and stays shorter than the paragraph line height,
-    // leaving breathing room between wrapped chip lines.
+    // Fallback for code spans inside headings (paragraphs/list items use the
+    // CodeFlow chip instead): subtle bg, ~0.92em. iOS ignores per-run
+    // padding/borderRadius on nested Text, so chips live outside <Text>.
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
-    textShadowColor: colors.surfaceSubtle,
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 3,
   },
   link: { color: colors.accent, textDecorationLine: "underline" },
   rule: { height: 1, marginVertical: spacing.md, backgroundColor: colors.line },
@@ -396,7 +456,14 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
   },
-  listItemText: { flex: 1, color: colors.ink, fontSize: 17, lineHeight: 26 },
+  listItemFlow: {
+    flex: 1,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    rowGap: 2,
+  },
+  listItemProse: { color: colors.ink, fontSize: 17, lineHeight: 26 },
   checkbox: {
     width: 18,
     height: 18,

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -219,6 +219,43 @@ function InlineMarkdown({ text }: { text: string }) {
   );
 }
 
+// A wrapped inline-code run can't get padding/rounding/line spacing on iOS
+// (attributed-string limitation), so long codes are lifted into a real chip
+// view: one rounded background, real horizontal padding, and outer margins —
+// the desktop code-chip look. Short codes stay inline in the text flow.
+const LONG_CODE_RE = /^`([^`]{32,})`$/;
+
+function CodeParagraph({ text, last }: { text: string; last: boolean }) {
+  const chunks = text.split(/(`[^`]+`)/g);
+  if (!chunks.some(chunk => LONG_CODE_RE.test(chunk))) {
+    return (
+      <Text selectable style={[styles.paragraph, last && styles.noBottom]}>
+        <InlineMarkdown text={text} />
+      </Text>
+    );
+  }
+  return (
+    <View style={[styles.paragraphColumn, last && styles.noBottom]}>
+      {chunks.map((chunk, index) => {
+        const long = chunk.match(LONG_CODE_RE);
+        if (long) {
+          return (
+            <Text key={index} selectable style={styles.codeChip}>
+              {long[1]}
+            </Text>
+          );
+        }
+        if (!chunk) return null;
+        return (
+          <Text key={index} selectable style={styles.paragraphPart}>
+            <InlineMarkdown text={chunk} />
+          </Text>
+        );
+      })}
+    </View>
+  );
+}
+
 function renderBlock(block: Block, index: number, isLast = false) {
   if (block.kind === "rule")
     return <View key={index} style={[styles.rule, isLast && styles.noBottom]} />;
@@ -318,11 +355,7 @@ function renderBlock(block: Block, index: number, isLast = false) {
       </View>
     );
   }
-  return (
-    <Text key={index} selectable style={[styles.paragraph, isLast && styles.noBottom]}>
-      <InlineMarkdown text={block.text} />
-    </Text>
-  );
+  return <CodeParagraph key={index} text={block.text} last={isLast} />;
 }
 
 export function MarkdownText({ text }: MarkdownTextProps) {
@@ -341,6 +374,22 @@ const styles = StyleSheet.create({
   // with a stray gap after its final row).
   noBottom: { marginBottom: 0 },
   paragraph: { color: colors.ink, fontSize: 17, lineHeight: 26, marginBottom: spacing.md },
+  // Column form of a paragraph that contains a long code span: the container
+  // owns the bottom margin, text parts keep the paragraph typography.
+  paragraphColumn: { marginBottom: spacing.md },
+  paragraphPart: { color: colors.ink, fontSize: 17, lineHeight: 26 },
+  codeChip: {
+    alignSelf: "flex-start",
+    marginVertical: 2,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderRadius: radius.md,
+    backgroundColor: colors.surfaceSubtle,
+    color: colors.ink,
+    fontFamily: "monospace",
+    fontSize: 13,
+    lineHeight: 19,
+  },
   heading: {
     color: colors.inkStrong,
     fontSize: 19,
@@ -353,16 +402,15 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Parity with the desktop inline <code>: rounded, subtle bg, ~0.92em.
-    // iOS renders nested <Text> as an attributed string and ignores its
-    // padding/borderRadius, so horizontal padding is an nbsp inside the run
-    // (InlineMarkdown) and a lineHeight shorter than the paragraph's leaves
-    // breathing room between wrapped chip lines.
+    // Parity with the desktop inline <code>: subtle bg, ~0.92em. iOS renders
+    // nested <Text> as an attributed string and ignores its padding/borderRadius,
+    // so horizontal padding is an nbsp inside the run (InlineMarkdown). Long
+    // codes are promoted to a real chip view (see CodeParagraph) where padding,
+    // rounding and line spacing can actually render on iOS.
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
-    lineHeight: 20,
     borderRadius: radius.sm,
   },
   link: { color: colors.accent, textDecorationLine: "underline" },

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -190,7 +190,7 @@ function InlineMarkdown({ text }: { text: string }) {
         if (/^`[^`]+`$/.test(part)) {
           return (
             <Text key={index} style={styles.inlineCode}>
-              {"\u00A0" + part.slice(1, -1) + "\u00A0"}
+              {part.slice(1, -1)}
             </Text>
           );
         }
@@ -216,43 +216,6 @@ function InlineMarkdown({ text }: { text: string }) {
         return part;
       })}
     </>
-  );
-}
-
-// A wrapped inline-code run can't get padding/rounding/line spacing on iOS
-// (attributed-string limitation), so long codes are lifted into a real chip
-// view: one rounded background, real horizontal padding, and outer margins —
-// the desktop code-chip look. Short codes stay inline in the text flow.
-const LONG_CODE_RE = /^`([^`]{32,})`$/;
-
-function CodeParagraph({ text, last }: { text: string; last: boolean }) {
-  const chunks = text.split(/(`[^`]+`)/g);
-  if (!chunks.some(chunk => LONG_CODE_RE.test(chunk))) {
-    return (
-      <Text selectable style={[styles.paragraph, last && styles.noBottom]}>
-        <InlineMarkdown text={text} />
-      </Text>
-    );
-  }
-  return (
-    <View style={[styles.paragraphColumn, last && styles.noBottom]}>
-      {chunks.map((chunk, index) => {
-        const long = chunk.match(LONG_CODE_RE);
-        if (long) {
-          return (
-            <Text key={index} selectable style={styles.codeChip}>
-              {long[1]}
-            </Text>
-          );
-        }
-        if (!chunk) return null;
-        return (
-          <Text key={index} selectable style={styles.paragraphPart}>
-            <InlineMarkdown text={chunk} />
-          </Text>
-        );
-      })}
-    </View>
   );
 }
 
@@ -355,7 +318,11 @@ function renderBlock(block: Block, index: number, isLast = false) {
       </View>
     );
   }
-  return <CodeParagraph key={index} text={block.text} last={isLast} />;
+  return (
+    <Text key={index} selectable style={[styles.paragraph, isLast && styles.noBottom]}>
+      <InlineMarkdown text={block.text} />
+    </Text>
+  );
 }
 
 export function MarkdownText({ text }: MarkdownTextProps) {
@@ -374,22 +341,6 @@ const styles = StyleSheet.create({
   // with a stray gap after its final row).
   noBottom: { marginBottom: 0 },
   paragraph: { color: colors.ink, fontSize: 17, lineHeight: 26, marginBottom: spacing.md },
-  // Column form of a paragraph that contains a long code span: the container
-  // owns the bottom margin, text parts keep the paragraph typography.
-  paragraphColumn: { marginBottom: spacing.md },
-  paragraphPart: { color: colors.ink, fontSize: 17, lineHeight: 26 },
-  codeChip: {
-    alignSelf: "flex-start",
-    marginVertical: 2,
-    paddingHorizontal: 6,
-    paddingVertical: 4,
-    borderRadius: radius.md,
-    backgroundColor: colors.surfaceSubtle,
-    color: colors.ink,
-    fontFamily: "monospace",
-    fontSize: 13,
-    lineHeight: 19,
-  },
   heading: {
     color: colors.inkStrong,
     fontSize: 19,
@@ -402,16 +353,21 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Parity with the desktop inline <code>: subtle bg, ~0.92em. iOS renders
-    // nested <Text> as an attributed string and ignores its padding/borderRadius,
-    // so horizontal padding is an nbsp inside the run (InlineMarkdown). Long
-    // codes are promoted to a real chip view (see CodeParagraph) where padding,
-    // rounding and line spacing can actually render on iOS.
+    // Desktop-parity inline <code>: subtle bg, ~0.92em, rounded, padded, with a
+    // gap between wrapped lines. iOS renders nested <Text> as an attributed
+    // string and drops per-run padding/borderRadius, and the run background
+    // fills the whole line fragment (wrapped lines stick together). A
+    // same-color text shadow (NSShadow per run, honored on both platforms)
+    // fakes the rest: the blur extends the fill ~3px on every side — padding
+    // and soft rounding — and stays shorter than the paragraph line height,
+    // leaving breathing room between wrapped chip lines.
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
-    borderRadius: radius.sm,
+    textShadowColor: colors.surfaceSubtle,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 3,
   },
   link: { color: colors.accent, textDecorationLine: "underline" },
   rule: { height: 1, marginVertical: spacing.md, backgroundColor: colors.line },

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -191,7 +191,7 @@ function InlineMarkdown({ text }: { text: string }) {
         if (/^`[^`]+`$/.test(part)) {
           return (
             <Text key={index} style={styles.inlineCode}>
-              {part.slice(1, -1)}
+              {"\u00A0" + part.slice(1, -1) + "\u00A0"}
             </Text>
           );
         }
@@ -222,11 +222,15 @@ function InlineMarkdown({ text }: { text: string }) {
 
 // iOS renders nested <Text> as an attributed string whose runs can't carry
 // padding/borderRadius (TextAttributes has no such fields), and the run
-// background fills the whole line fragment — so an inline code chip with
-// desktop parity is impossible inside one <Text>. Instead, code-bearing text
-// lays out as a wrapping flex row: prose chunks are Text items (wrapping
-// internally, CJK-safe at chunk level) and every code span is a real chip
-// view with genuine padding, rounding and line gaps.
+// background fills the whole line fragment — a decorated chip is impossible
+// inside one <Text>. Compromise that keeps the inline flow: SHORT code spans
+// become real chip views (they fit on a line, so the flow is undisturbed and
+// they get genuine padding/rounding/gaps); LONG code spans stay inline in the
+// prose run (wrapping mid-code, sharing lines with text) with nbsp padding —
+// the two properties iOS can't do inline (rounding, wrapped-line gap) are the
+// accepted platform cost.
+const CHIP_MAX = 24;
+
 function CodeFlow({
   text,
   containerStyle,
@@ -236,25 +240,38 @@ function CodeFlow({
   containerStyle: StyleProp<ViewStyle>;
   proseStyle: TextStyle;
 }) {
-  const chunks = text.split(/(`[^`]+`)/g);
+  const parts = text.split(/(`[^`]+`)/g);
+  const items: { kind: "prose" | "chip"; text: string }[] = [];
+  let buffer = "";
+  const flush = () => {
+    if (buffer) {
+      items.push({ kind: "prose", text: buffer });
+      buffer = "";
+    }
+  };
+  for (const part of parts) {
+    const code = part.match(/^`([^`]+)`$/)?.[1];
+    if (code && code.length <= CHIP_MAX) {
+      flush();
+      items.push({ kind: "chip", text: code });
+    } else {
+      buffer += part;
+    }
+  }
+  flush();
   return (
     <View style={containerStyle}>
-      {chunks.map((chunk, index) => {
-        const code = chunk.match(/^`([^`]+)`$/);
-        if (code) {
-          return (
-            <Text key={index} selectable style={styles.codeChip}>
-              {code[1]}
-            </Text>
-          );
-        }
-        if (!chunk) return null;
-        return (
-          <Text key={index} selectable style={proseStyle}>
-            <InlineMarkdown text={chunk} />
+      {items.map((item, index) =>
+        item.kind === "chip" ? (
+          <Text key={index} selectable style={styles.codeChip}>
+            {item.text}
           </Text>
-        );
-      })}
+        ) : (
+          <Text key={index} selectable style={proseStyle}>
+            <InlineMarkdown text={item.text} />
+          </Text>
+        ),
+      )}
     </View>
   );
 }
@@ -421,13 +438,15 @@ const styles = StyleSheet.create({
   italic: { fontStyle: "italic" },
   strike: { textDecorationLine: "line-through" },
   inlineCode: {
-    // Fallback for code spans inside headings (paragraphs/list items use the
-    // CodeFlow chip instead): subtle bg, ~0.92em. iOS ignores per-run
-    // padding/borderRadius on nested Text, so chips live outside <Text>.
+    // Inline rendering for long code spans (and code inside headings): subtle
+    // bg, ~0.92em. Horizontal padding is an nbsp inside the run (InlineMarkdown)
+    // because iOS drops per-run padding; short code spans get the fully
+    // decorated chip view instead (see CodeFlow).
     color: colors.ink,
     backgroundColor: colors.surfaceSubtle,
     fontFamily: "monospace",
     fontSize: 13,
+    borderRadius: radius.sm,
   },
   link: { color: colors.accent, textDecorationLine: "underline" },
   rule: { height: 1, marginVertical: spacing.md, backgroundColor: colors.line },

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -595,7 +595,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.md,
-    marginTop: -spacing.xs,
+    marginTop: spacing.sm,
   },
   stoppedMarker: { color: colors.inkMuted, fontSize: 12, fontStyle: "italic" },
   truncatedMarker: { color: colors.warning, fontSize: 12 },

--- a/mobile/src/i18n/locales.ts
+++ b/mobile/src/i18n/locales.ts
@@ -48,6 +48,10 @@ export const resources = {
         unpair: "Unpair device",
         unpairConfirm: "Unpair this phone? A new desktop QR code will be required.",
         unnamed: "Untitled",
+        pin: "Pin",
+        unpin: "Unpin",
+        delete: "Delete",
+        deleteConfirm: 'Delete "{{title}}"? This conversation can\'t be restored.',
       },
       chat: {
         new: "New conversation",
@@ -203,6 +207,10 @@ export const resources = {
         unpair: "解除设备配对",
         unpairConfirm: "确定解除这台手机的配对吗？之后需要重新扫描桌面二维码。",
         unnamed: "未命名",
+        pin: "置顶",
+        unpin: "取消置顶",
+        delete: "删除",
+        deleteConfirm: "删除「{{title}}」？此对话无法恢复。",
       },
       chat: {
         new: "新对话",

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -172,6 +172,18 @@ async function attemptPendingRevoke(pending: PendingRevoke): Promise<void> {
   });
 }
 
+/**
+ * Stable pinned-first reorder for optimistic pin/unpin. Pinned sessions move
+ * to the top in their original relative order; everything else keeps the
+ * incoming (desktop-sorted) order. Matches the desktop sidebar's `pinned DESC`
+ * grouping, which the pushed snapshot also converges on.
+ */
+function sortPinnedFirst(list: RemoteSession[]): RemoteSession[] {
+  const pinned = list.filter(session => session.pinned);
+  const rest = list.filter(session => !session.pinned);
+  return [...pinned, ...rest];
+}
+
 interface RemoteContextValue {
   phase: ConnectionPhase;
   error: string | null;
@@ -212,7 +224,9 @@ interface RemoteContextValue {
   abort(): Promise<void>;
   setModel(modelId: string): Promise<void>;
   setThinkingLevel(level: ThinkingLevel): Promise<void>;
-  rename(name: string): Promise<void>;
+  rename(sessionId: string, name: string): Promise<void>;
+  deleteSession(sessionId: string, threadId: string): Promise<void>;
+  setSessionPinned(sessionId: string, threadId: string, pinned: boolean): Promise<void>;
   decideApproval(id: string, decision: "approved" | "rejected"): Promise<void>;
 }
 
@@ -562,6 +576,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
             title: overrides[s.sessionId] ?? s.title,
             mode: s.mode,
             workspaceId: s.workspaceId,
+            pinned: s.pinned,
             streaming: s.streaming,
             status: s.status,
           }));
@@ -1088,17 +1103,49 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
-  const rename = useCallback(async (name: string) => {
+  const rename = useCallback(async (sessionId: string, name: string) => {
     const client = clientRef.current;
-    const sessionId = selectedRef.current;
     if (!client || !sessionId || !name.trim()) return;
-    await client.request({ type: "set_session_name", sessionId, name: name.trim() }, sessionId);
+    const trimmed = name.trim();
+    await client.request({ type: "set_session_name", sessionId, name: trimmed }, sessionId);
+    setTitleOverrides(prev => ({ ...prev, [sessionId]: trimmed }));
     setSessions(current =>
       current.map(session =>
-        session.sessionId === sessionId ? { ...session, title: name.trim() } : session,
+        session.sessionId === sessionId ? { ...session, title: trimmed } : session,
       ),
     );
   }, []);
+
+  const deleteSession = useCallback(
+    async (sessionId: string, threadId: string) => {
+      const client = clientRef.current;
+      if (!client || !sessionId || !threadId) return;
+      await client.request({ type: "delete_session", sessionId, threadId }, sessionId);
+      setSessions(current => current.filter(session => session.sessionId !== sessionId));
+      if (selectedRef.current === sessionId) closeConversation();
+    },
+    [closeConversation],
+  );
+
+  const setSessionPinned = useCallback(
+    async (sessionId: string, threadId: string, pinned: boolean) => {
+      const client = clientRef.current;
+      if (!client || !sessionId || !threadId) return;
+      await client.request(
+        { type: "set_session_pinned", sessionId, threadId, pinned },
+        sessionId,
+      );
+      // Optimistic local reorder: pinned sessions stay on top, everything else
+      // keeps the desktop's recency order. The pushed snapshot converges on the
+      // same layout (the desktop sorts by `pinned DESC, last_message_at DESC`).
+      setSessions(current =>
+        sortPinnedFirst(current.map(session =>
+          session.sessionId === sessionId ? { ...session, pinned } : session,
+        )),
+      );
+    },
+    [],
+  );
 
   const decideApproval = useCallback(async (id: string, decision: "approved" | "rejected") => {
     const client = clientRef.current;
@@ -1167,6 +1214,8 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       setModel,
       setThinkingLevel,
       rename,
+      deleteSession,
+      setSessionPinned,
       decideApproval,
     }),
     [
@@ -1177,6 +1226,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       closeConversation,
       decideApproval,
       desktopOnline,
+      deleteSession,
       draft,
       error,
       modelId,
@@ -1193,6 +1243,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       selectedSessionId,
       selectedTitle,
       sendMessage,
+      setSessionPinned,
       prepareAttachment,
       cachedAttachment,
       downloadAttachment,

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -34,6 +34,8 @@ export interface RemoteSession {
   title: string;
   mode?: "chat" | "workspace";
   workspaceId?: string;
+  /** Pinned to the top of the session list (desktop `threads.pinned`). */
+  pinned?: boolean;
   streaming: boolean;
   status?: string;
 }
@@ -51,6 +53,8 @@ export interface PresenceSession {
   title: string;
   mode?: "chat" | "workspace";
   workspaceId?: string;
+  /** Desktop `threads.pinned` — hoisted to the top of the session list. */
+  pinned?: boolean;
   streaming: boolean;
   status?: string;
 }
@@ -307,6 +311,9 @@ export interface RemoteCommand {
   name?: string;
   transferName?: string;
   workspaceId?: string;
+  /** Thread-scoped mutating commands (delete_session / set_session_pinned). */
+  threadId?: string;
+  pinned?: boolean;
   protocolVersion?: number;
   pairId?: string;
   deviceId?: string;

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -196,7 +196,7 @@ export function ChatScreen() {
     if (!name) return;
     setRenameOpen(false);
     try {
-      await remote.rename(name);
+      await remote.rename(remote.selectedSessionId, name);
     } catch {
       Alert.alert(t("common.error"));
     }

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -785,7 +785,7 @@ const styles = StyleSheet.create({
   },
   menuTitle: {
     color: colors.inkMuted,
-    fontSize: 15,
+    fontSize: 16,
     fontWeight: "600",
     paddingHorizontal: spacing.md,
     paddingBottom: spacing.xs,

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -4,8 +4,12 @@ import {
   Link2,
   LogOut,
   MessageCircle,
+  Pencil,
+  Pin,
+  PinOff,
   Plus,
   Settings,
+  Trash2,
   Unplug,
   X,
 } from "lucide-react-native";
@@ -20,6 +24,8 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
+  TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -98,6 +104,9 @@ export function SessionsScreen() {
   const [newMode, setNewMode] = useState<Tab>("chat");
   const [workspaceId, setWorkspaceId] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [menuSession, setMenuSession] = useState<RemoteSession | null>(null);
+  const [renameTarget, setRenameTarget] = useState<RemoteSession | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   const chats = useMemo(
     () => remote.sessions.filter(session => session.mode !== "workspace"),
@@ -132,10 +141,57 @@ export function SessionsScreen() {
     void remote.newConversation(newMode, workspaceId);
   };
 
+  const openRename = (session: RemoteSession) => {
+    setRenameTarget(session);
+    setRenameValue(session.title || "");
+  };
+
+  const submitRename = async () => {
+    const session = renameTarget;
+    const name = renameValue.trim();
+    if (!session || !name) return;
+    setRenameTarget(null);
+    try {
+      await remote.rename(session.sessionId, name);
+    } catch {
+      Alert.alert(t("common.error"));
+    }
+  };
+
+  const togglePin = (session: RemoteSession) => {
+    setMenuSession(null);
+    void remote
+      .setSessionPinned(session.sessionId, session.threadId, !session.pinned)
+      .catch(() => Alert.alert(t("common.error")));
+  };
+
+  const confirmDelete = (session: RemoteSession) => {
+    setMenuSession(null);
+    Alert.alert(
+      t("sessions.delete"),
+      t("sessions.deleteConfirm", {
+        title: session.title || t("sessions.unnamed"),
+      }),
+      [
+        { text: t("chat.cancel"), style: "cancel" },
+        {
+          text: t("sessions.delete"),
+          style: "destructive",
+          onPress: () => {
+            void remote
+              .deleteSession(session.sessionId, session.threadId)
+              .catch(() => Alert.alert(t("common.error")));
+          },
+        },
+      ],
+    );
+  };
+
   const renderSession = (item: RemoteSession, inWorkspace = false) => (
     <Pressable
       accessibilityRole="button"
       key={item.sessionId}
+      onLongPress={() => setMenuSession(item)}
       onPress={() => void remote.selectSession(item.sessionId)}
       style={({ pressed }) => [
         styles.session,
@@ -146,6 +202,13 @@ export function SessionsScreen() {
       <Text numberOfLines={1} style={styles.sessionTitle}>
         {item.title || t("sessions.unnamed")}
       </Text>
+      {item.pinned && (
+        <Pin
+          accessibilityLabel={t("sessions.pin")}
+          color={colors.accent}
+          size={14}
+        />
+      )}
       <SessionStatusIndicator
         status={item.status}
         streaming={item.streaming}
@@ -397,6 +460,118 @@ export function SessionsScreen() {
             </View>
           </View>
         </Modal>
+
+        <Modal
+          animationType="fade"
+          onRequestClose={() => setMenuSession(null)}
+          transparent
+          visible={menuSession !== null}
+        >
+          <TouchableWithoutFeedback onPress={() => setMenuSession(null)}>
+            <View style={styles.menuOverlay}>
+              <TouchableWithoutFeedback>
+                <View style={styles.menu}>
+                  <Text numberOfLines={1} style={styles.menuTitle}>
+                    {menuSession?.title || t("sessions.unnamed")}
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => {
+                      if (menuSession) togglePin(menuSession);
+                    }}
+                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
+                  >
+                    {menuSession?.pinned ? (
+                      <PinOff color={colors.ink} size={18} />
+                    ) : (
+                      <Pin color={colors.ink} size={18} />
+                    )}
+                    <Text style={styles.menuOptionText}>
+                      {menuSession?.pinned ? t("sessions.unpin") : t("sessions.pin")}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => {
+                      if (menuSession) {
+                        openRename(menuSession);
+                        setMenuSession(null);
+                      }
+                    }}
+                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
+                  >
+                    <Pencil color={colors.ink} size={18} />
+                    <Text style={styles.menuOptionText}>{t("chat.rename")}</Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => {
+                      if (menuSession) confirmDelete(menuSession);
+                    }}
+                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
+                  >
+                    <Trash2 color={colors.danger} size={18} />
+                    <Text style={[styles.menuOptionText, styles.menuOptionDanger]}>
+                      {t("sessions.delete")}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => setMenuSession(null)}
+                    style={({ pressed }) => [
+                      styles.menuOption,
+                      styles.menuOptionCancel,
+                      pressed && styles.pressed,
+                    ]}
+                  >
+                    <Text style={styles.menuOptionCancelText}>{t("chat.cancel")}</Text>
+                  </Pressable>
+                </View>
+              </TouchableWithoutFeedback>
+            </View>
+          </TouchableWithoutFeedback>
+        </Modal>
+
+        <Modal
+          animationType="fade"
+          onRequestClose={() => setRenameTarget(null)}
+          transparent
+          visible={renameTarget !== null}
+        >
+          <View style={styles.overlay}>
+            <View style={styles.dialog}>
+              <Text style={styles.dialogTitle}>{t("chat.renameTitle")}</Text>
+              <TextInput
+                autoFocus
+                onChangeText={setRenameValue}
+                onSubmitEditing={() => void submitRename()}
+                placeholder={t("sessions.unnamed")}
+                placeholderTextColor={colors.inkMuted}
+                returnKeyType="done"
+                style={styles.nameInput}
+                value={renameValue}
+              />
+              <View style={styles.dialogActions}>
+                <View style={styles.dialogAction}>
+                  <Button
+                    compact
+                    label={t("chat.cancel")}
+                    onPress={() => setRenameTarget(null)}
+                    variant="secondary"
+                  />
+                </View>
+                <View style={styles.dialogAction}>
+                  <Button
+                    compact
+                    disabled={!renameValue.trim()}
+                    label={t("chat.save")}
+                    onPress={() => void submitRename()}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </Modal>
       </View>
     </SafeAreaView>
   );
@@ -586,4 +761,47 @@ const styles = StyleSheet.create({
   workspaceOptionActive: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
   workspaceOptionName: { flex: 1, color: colors.ink, fontSize: 14, fontWeight: "600" },
   settingsPlaceholder: { color: colors.inkSoft, fontSize: 14, lineHeight: 20 },
+  menuOverlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: colors.overlay,
+  },
+  menu: {
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+  },
+  menuTitle: {
+    color: colors.inkMuted,
+    fontSize: 13,
+    fontWeight: "600",
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.xs,
+  },
+  menuOption: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+    padding: spacing.md,
+    borderRadius: radius.md,
+  },
+  menuOptionText: { color: colors.ink, fontSize: 16, fontWeight: "500" },
+  menuOptionDanger: { color: colors.danger, fontWeight: "600" },
+  menuOptionCancel: { justifyContent: "center" },
+  menuOptionCancelText: { color: colors.inkSoft, fontSize: 16, fontWeight: "600" },
+  nameInput: {
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    color: colors.ink,
+    fontSize: 15,
+  },
+  dialogActions: { flexDirection: "row", gap: spacing.md },
+  dialogAction: { flex: 1 },
 });

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -191,7 +191,11 @@ export function SessionsScreen() {
     <Pressable
       accessibilityRole="button"
       key={item.sessionId}
-      onLongPress={() => setMenuSession(item)}
+      onLongPress={() => {
+        // Session management goes through the desktop bridge — with the link
+        // down every action would just fail, so don't offer the menu.
+        if (remote.desktopOnline) setMenuSession(item);
+      }}
       onPress={() => void remote.selectSession(item.sessionId)}
       style={({ pressed }) => [
         styles.session,
@@ -211,7 +215,7 @@ export function SessionsScreen() {
         <Pin
           accessibilityLabel={t("sessions.pin")}
           color={colors.accent}
-          size={14}
+          size={16}
         />
       )}
     </Pressable>

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -202,6 +202,11 @@ export function SessionsScreen() {
       <Text numberOfLines={1} style={styles.sessionTitle}>
         {item.title || t("sessions.unnamed")}
       </Text>
+      <SessionStatusIndicator
+        status={item.status}
+        streaming={item.streaming}
+        unread={remote.unreadSessions.has(item.sessionId)}
+      />
       {item.pinned && (
         <Pin
           accessibilityLabel={t("sessions.pin")}
@@ -209,11 +214,6 @@ export function SessionsScreen() {
           size={14}
         />
       )}
-      <SessionStatusIndicator
-        status={item.status}
-        streaming={item.streaming}
-        unread={remote.unreadSessions.has(item.sessionId)}
-      />
     </Pressable>
   );
 

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -785,7 +785,7 @@ const styles = StyleSheet.create({
   },
   menuTitle: {
     color: colors.inkMuted,
-    fontSize: 13,
+    fontSize: 15,
     fontWeight: "600",
     paddingHorizontal: spacing.md,
     paddingBottom: spacing.xs,

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -788,7 +788,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
     paddingHorizontal: spacing.md,
-    paddingBottom: spacing.xs,
+    paddingTop: spacing.xs,
+    paddingBottom: spacing.sm,
   },
   menuOption: {
     flexDirection: "row",

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -196,7 +196,11 @@ export function SessionsScreen() {
         // down every action would just fail, so don't offer the menu.
         if (remote.desktopOnline) setMenuSession(item);
       }}
-      onPress={() => void remote.selectSession(item.sessionId)}
+      onPress={() => {
+        // Opening a conversation needs the desktop for state/history — a tap
+        // while offline would just land on an error, so keep the list inert.
+        if (remote.desktopOnline) void remote.selectSession(item.sessionId);
+      }}
       style={({ pressed }) => [
         styles.session,
         inWorkspace && styles.workspaceSession,


### PR DESCRIPTION
## Summary
- **Mobile session management**: long-pressing a session opens an action sheet with pin/unpin, rename and delete (with confirmation). Pinned sessions get a row glyph; the menu stays inert while the desktop link is down.
- **Remote bridge**: session snapshots and their push signature now carry `pinned`; new `delete_session` / `set_session_pinned` commands; `remote-activity` is emitted on pin/delete/rename so the desktop sidebar refreshes immediately.
- **Pinned ordering**: `pin_thread` no longer stamps `updated_at` (unpinning now falls back to recency instead of staying on top), and `list_threads` sorts with `last_opened_at` so desktop and phone agree on the non-pinned order.

## Test plan
- Desktop rebuild required (bridge commands + snapshot fields are backend-side).
- Long-press → pin moves the session to the top with a glyph on both phone and desktop; unpin returns it to its recency position.
- Rename/delete sync to the desktop sidebar without a manual refresh.
- 手机上刷新即用（纯移动端改动部分）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)