### PR TITLE
ci: split Rust tests (Linux) into 4 parallel per-crate groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,9 +264,12 @@ jobs:
         if: steps.affected.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@1.97.0
 
-      # Same cache key as before the split (both workspaces) so every group
-      # keeps restoring the warm artifacts previous runs saved and only
-      # compiles the crates this PR actually changed.
+      # All groups share the automatic cache key (job id is identical across
+      # matrix entries) so every group restores the same warm snapshot; per-
+      # group `key` slots would quadruple cache storage (~4 × ~500MB) and
+      # push the repo cache quota into LRU eviction of other jobs' entries.
+      # Concurrent saves race on one key (first wins) — the losers just
+      # recompile their own crates next run, which is bounded and parallel.
       - name: Cache Rust
         if: steps.affected.outputs.run == 'true'
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,29 +189,86 @@ jobs:
         if: needs.changes.outputs.desktop_tauri == 'true'
         run: cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
 
-  # ─── Rust test gate (Linux) ───────────────────────────────────────────────
-  # This deliberately duplicates setup from `rust-quality`: separate jobs do
-  # not share a live target directory, but running lint and tests in parallel
-  # reduces PR wall-clock time.
+  # ─── Rust test gates (Linux) ──────────────────────────────────────────────
+  # One matrix job split into four parallel groups, each paying only its own
+  # compile+run cost instead of everything serializing behind one big
+  # `cargo test --workspace` and behind the desktop backend's independent
+  # webkit/gtk dep tree. Groups map to crate clusters that share a build
+  # graph; a PR pays setup+compile+run only for the groups it touches.
   #
-  # `cargo test --workspace` covers every workspace crate including tui/cli
-  # (their former dedicated jobs were folded in here — see #120). The cli/tui
+  # Groups are always-present (per-step `if`, never job-level): branch
+  # protection treats a *skipped* required check as unsatisfied, so e.g. a
+  # mobile-only PR must still report success for every group (no-op echo
+  # below). `rust-tests-gate` aggregates the groups into the single stable
+  # required context "Rust tests (Linux)", so splitting/renaming groups never
+  # requires touching the branch-protection ruleset.
+  #
+  # Workspace groups gate on `rust_workspace` only: workspace crates do not
+  # depend on desktop/src-tauri, so a desktop-only change cannot break them
+  # (the reverse is NOT true — future-rpc feeds the Tauri backend, and the
+  # path filter marks rpc/** as desktop_tauri too, so rpc changes also run
+  # the desktop group).
+  #
+  # CARGO_PROFILE_TEST_DEBUG=1 keeps file:line in panic backtraces while
+  # dropping full debuginfo codegen — the dominant cost of building test
+  # binaries. The cli/tui
   # golden-diff harnesses are NOT part of CI: they were the TS→Rust migration
-  # acceptance gate and now only run manually (make test-cli-diff / test-tui-diff)
-  # before a release.
+  # acceptance gate and now only run manually (make test-cli-diff /
+  # test-tui-diff) before a release.
   rust-tests:
-    name: Rust tests (Linux)
+    name: Rust tests (Linux) (${{ matrix.name }})
     needs: changes
-    if: needs.changes.outputs.rust_workspace == 'true' || needs.changes.outputs.desktop_tauri == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: agent
+            filter: rust_workspace
+            packages: -p future-agent
+            desktop: 'false'
+          - name: tui, cli
+            filter: rust_workspace
+            packages: -p future-tui -p future-cli
+            desktop: 'false'
+          - name: channels, rpc, loop
+            filter: rust_workspace
+            packages: -p future-channel -p future-rpc -p future-loop
+            desktop: 'false'
+          - name: desktop backend
+            filter: desktop_tauri
+            packages: ''
+            desktop: 'true'
     steps:
+      # Per-group affected check: reads the matching `changes` output by name
+      # so each group gates independently without a job-level `if` (which
+      # would skip the whole matrix and leave required checks "Expected").
+      - name: Is this test group affected?
+        id: affected
+        env:
+          FILTER: ${{ matrix.filter }}
+          OUTPUTS: ${{ toJSON(needs.changes.outputs) }}
+        run: |
+          run=$(echo "$OUTPUTS" | jq -r --arg k "$FILTER" '.[$k] // "false"')
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+      - name: No affected Rust tests in this group
+        if: steps.affected.outputs.run != 'true'
+        run: echo "No affected Rust tests in this group; skipped."
+
       - name: Checkout
+        if: steps.affected.outputs.run == 'true'
         uses: actions/checkout@v5
 
       - name: Setup Rust
+        if: steps.affected.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@1.97.0
 
+      # Same cache key as before the split (both workspaces) so every group
+      # keeps restoring the warm artifacts previous runs saved and only
+      # compiles the crates this PR actually changed.
       - name: Cache Rust
+        if: steps.affected.outputs.run == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -220,7 +277,10 @@ jobs:
           cache-on-failure: true
           cache-all-crates: true
 
+      # The WebKit/GTK stack is only needed by the desktop backend's -sys
+      # build scripts; workspace groups skip it (~40s of apt each).
       - name: Install Linux deps
+        if: steps.affected.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -228,26 +288,53 @@ jobs:
             binutils \
             mold \
             pkg-config \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev
+            libssl-dev
+          if [ "${{ matrix.desktop }}" = 'true' ]; then
+            sudo apt-get install -y \
+              libayatana-appindicator3-dev \
+              libgtk-3-dev \
+              librsvg2-dev \
+              libwebkit2gtk-4.1-dev
+          fi
 
+      # tauri-build's build script aborts with `resource path ... doesn't
+      # exist` unless every `bundle.externalBin` sidecar is present; empty
+      # placeholders suffice for tests.
       - name: Create placeholder sidecars
-        if: needs.changes.outputs.desktop_tauri == 'true'
+        if: steps.affected.outputs.run == 'true' && matrix.desktop == 'true'
         run: |
           triple=$(rustc -Vv | sed -n 's/^host: //p')
           mkdir -p desktop/src-tauri/binaries
           : > "desktop/src-tauri/binaries/future-$triple"
 
-      - name: cargo test (workspace)
-        if: needs.changes.outputs.rust_workspace == 'true'
-        run: cargo test --workspace --manifest-path Cargo.toml
+      - name: cargo test (${{ matrix.name }})
+        if: steps.affected.outputs.run == 'true'
+        env:
+          CARGO_PROFILE_TEST_DEBUG: 1
+        run: |
+          if [ "${{ matrix.desktop }}" = 'true' ]; then
+            cargo test --manifest-path desktop/src-tauri/Cargo.toml
+          else
+            cargo test ${{ matrix.packages }}
+          fi
 
-      - name: cargo test (desktop backend)
-        if: needs.changes.outputs.desktop_tauri == 'true'
-        run: cargo test --manifest-path desktop/src-tauri/Cargo.toml
+  # Aggregator keeping the required check name stable across group splits:
+  # fails iff any Rust test group failed. `if: always()` so a failed group
+  # still yields an explicit red X on this required check (a skipped required
+  # check would block the PR with a confusing "Expected" instead).
+  rust-tests-gate:
+    name: Rust tests (Linux)
+    needs: rust-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All Rust test groups passed?
+        run: |
+          if [ "${{ needs.rust-tests.result }}" != 'success' ]; then
+            echo "Rust test groups result: ${{ needs.rust-tests.result }}"
+            exit 1
+          fi
+          echo "All Rust test groups passed."
 
   # ─── Loop canary premerge gate (P1-6) ────────────────────────────────────
   # Behavioral merge gate for the loop control plane: runs


### PR DESCRIPTION
## 动机

`Rust tests (Linux)` 是 PR 的关键路径：一个 job 里先串行跑 `cargo test --workspace`（~7min），再串行跑 desktop 后端测试（~2min，还要自己重编 webkit/gtk 依赖树），测试繁重的 PR 上总耗时 9-12 分钟。

## 改动

- **拆成 4 个并行组**（一个 matrix job，`fail-fast: false`）：`agent` / `tui, cli` / `channels, rpc, loop` / `desktop backend`，每组只付自己的 compile+run 成本，互不等待。
- **`rust-tests-gate` 聚合 job**：保留 required check 名 `Rust tests (Linux)` 不变——任一组失败即失败，branch protection ruleset 无需改动，组名以后可自由重命名。合并后可选把 ruleset 更新为直接要求 4 个组（届时我再改）。
- **`CARGO_PROFILE_TEST_DEBUG=1`**：测试二进制保留 panic 的 file:line，砍掉完整 debuginfo codegen（编译时间的主要成本）。首次运行会因 profile 指纹变化重建一次（本 PR 和合并后第一次 main run 会偏慢，属预期）。
- **按组精简 apt**：webkit/gtk 全家桶只给 desktop 组装，workspace 组省 ~40s。
- **cache key 不变**（workspaces 列表与拆分前一致），4 个组继续恢复之前的暖缓存。
- **always-present matrix**：用 per-step `if` + no-op echo（沿用 rust-build 模式），job 级 `if` 会让无关 PR 的 required check 变成 skip→BLOCKED。
- workspace 组只按 `rust_workspace` 过滤：workspace crate 不依赖 desktop/src-tauri，desktop-only PR 不会再白跑 workspace 测试（rpc/** 变更仍会同时触发 desktop 组，方向依赖已覆盖）。

## 预期

- 快态（main 当前内容）：关键路径 4.5min → ~2.5-3min。
- 分组后失败按 crate 隔离，一个组的 flaky 不再需要等别的组跑完才能看结果。
- 首次运行慢是 debug=1 指纹重建，之后缓存回暖。

## 验证

- [ ] CI 全绿（4 个组 + gate）
- [ ] desktop-only PR 场景：gate 通过、3 个 workspace 组 no-op
- [ ] 合并后 ruleset 更新为 4 个组名（可选，另行确认）