### PR TITLE
fix(build): install with `install -m 755` instead of `cp` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ ifeq ($(OS),windows)
 	@if not exist "$(USERPROFILE)\.future\bin" mkdir "$(USERPROFILE)\.future\bin"
 	$(COPY_CMD) target\release\future$(EXE_SUFFIX) "$(PREFIX)\future$(EXE_SUFFIX)"
 else
-	$(SUDO) cp target/release/future "$(PREFIX)/future"
+	# `install` unlinks+creates a fresh inode; plain `cp` overwrites in place
+	# and macOS taskgated can then SIGKILL the binary ("Code Signature
+	# Invalid") because the vnode's cached signing state no longer matches.
+	$(SUDO) install -m 755 target/release/future "$(PREFIX)/future"
 endif
 
 install-desktop: install-cli desktop-sidecars
@@ -66,7 +69,7 @@ install-desktop: install-cli desktop-sidecars
 ifeq ($(OS),windows)
 	$(COPY_CMD) desktop\src-tauri\target\release\futureos$(EXE_SUFFIX) "$(PREFIX)\future-desktop$(EXE_SUFFIX)"
 else
-	$(SUDO) cp desktop/src-tauri/target/release/futureos "$(PREFIX)/future-desktop"
+	$(SUDO) install -m 755 desktop/src-tauri/target/release/futureos "$(PREFIX)/future-desktop"
 endif
 
 # Also removes pre-unification installs (future-agent/-tui/-channel).


### PR DESCRIPTION
## Problem

`make run-tui` works, but after `make install-cli`, `future tui` dies instantly with no output (exit 137).

## Root cause

The Makefile used `cp` to overwrite an existing `/opt/homebrew/bin/future` in place (same inode). On macOS 26, taskgated then SIGKILLs the binary on every invocation. Crash reports (`~/Library/Logs/DiagnosticReports/future-*.ips`) confirm:

```
"exception":   {"signal":"SIGKILL (Code Signature Invalid)"}
"termination": {"namespace":"CODESIGNING","indicator":"Taskgated Invalid Signature"}
```

Evidence:
- Identical bytes copied under a new name or a new inode run fine.
- `rm` + fresh `cp` (new inode) runs fine; only the in-place-overwritten file is killed.
- Debug builds (`make run-tui`) are unaffected — they never go through the install path.

## Fix

Darwin branches of `install-cli` and `install-desktop` now use `install -m 755`, which unlinks and creates a fresh inode. Linux/Windows paths are unchanged (plain copy is fine there).

## Verification

```
$ make install-cli
$ /opt/homebrew/bin/future --version   # works
$ future tui                          # TUI starts and renders normally
```