### PR TITLE
feat(loop): pr_review_queue capability — queue observation + review contract + work items + CLI

### DIFF
--- a/orchestration/loop/src/capabilities/catalog.rs
+++ b/orchestration/loop/src/capabilities/catalog.rs
@@ -7,8 +7,9 @@
 //! user-facing value/next-step strings reference requires on every public record.
 //!
 //! All 14 domain packs ship with their reference catalog status; the 15th
-//! capability (`pr_review_queue`) is registered as `experimental` per the P3
-//! plan (the reference package exists; our rule version is a placeholder).
+//! capability (`pr_review_queue`) ships its queue-observation + review-contract
+//! rule version as active-preview (P2-3; the reference package is
+//! `capabilities/pr_review_queue/`).
 
 use std::collections::BTreeMap;
 
@@ -189,8 +190,8 @@ impl CapabilityCatalog {
     }
 
     /// Build the shipped catalog: the 14 domain packs (with their LoopX
-    /// catalog status) + pr_review_queue (15th, experimental) under the
-    /// builtin `future-loop-core` provider.
+    /// catalog status) + pr_review_queue (15th, active-preview — the P2-3
+    /// rule version) under the builtin `future-loop-core` provider.
     pub fn with_builtin() -> Self {
         let mut catalog = Self::new();
         let core = CapabilityProvider::builtin("future-loop-core");
@@ -380,11 +381,22 @@ fn builtin_records() -> Vec<(
         (
             "pr_review_queue",
             "PR Review Queue",
-            CAPABILITY_STATUS_EXPERIMENTAL,
-            "PR review queue projection (15th capability; placeholder rule version).",
-            "Project one PR-review queue bucket from current PR lifecycle state.",
-            vec![cmd("pr-review-queue", "Project one PR-review queue bucket from current PR lifecycle state.")],
-            vec![packet("pr_review_queue_v0", "pr_review_queue")],
+            CAPABILITY_STATUS_ACTIVE_PREVIEW,
+            "Turn one complete open-PR observation into a deterministic exact-head review candidate without repeating unchanged work or granting review writes.",
+            "Persist one observation fingerprint in a continuous-monitor todo, observe a changed head, and materialize exactly one candidate through normal todo authority.",
+            vec![cmd(
+                "pr-review-queue",
+                "Observe one complete PR queue and emit at most one exact-head candidate (capability hook).",
+            )],
+            vec![
+                packet("pr_review_queue_v0", "pr_review_queue"),
+                packet("pull_request_review_queue_observation_v0", "pr_review_queue"),
+                packet("pull_request_review_candidate_v0", "pr_review_queue"),
+                packet("pull_request_review_todo_preview_v0", "pr_review_queue"),
+                packet("pull_request_review_execution_contract_v1", "pr_review_queue"),
+                packet("pull_request_review_plan_v1", "pr_review_queue"),
+                packet("pull_request_review_result_v1", "pr_review_queue"),
+            ],
         ),
     ]
 }
@@ -411,7 +423,9 @@ mod tests {
     #[test]
     fn experimental_commands_hidden_unless_requested() {
         let catalog = CapabilityCatalog::with_builtin();
-        assert!(catalog.commands_for("pr_review_queue", false).is_empty());
+        // pr_review_queue shipped its P2-3 rule version → active-preview, so
+        // its capability hook is visible without --include-experimental.
+        assert_eq!(catalog.commands_for("pr_review_queue", false).len(), 1);
         assert_eq!(catalog.commands_for("pr_review_queue", true).len(), 1);
         assert_eq!(catalog.commands_for("issue_fix", false).len(), 1);
     }

--- a/orchestration/loop/src/capabilities/mod.rs
+++ b/orchestration/loop/src/capabilities/mod.rs
@@ -10,7 +10,9 @@
 //! deterministic rule versions: agent_turn_recall, auto_research,
 //! change_quality, content_ops, context_providers, decision_context,
 //! explore, integration_branch, issue_fix, material_lifecycle,
-//! periodic_report, reward_memory, semantic_preference, value_connectors.
+//! periodic_report, reward_memory, semantic_preference, value_connectors —
+//! plus the 15th (pr_review_queue, P2-3): the queue observation + review
+//! contract rule version.
 
 pub mod agent_turn_recall;
 pub mod auto_research;
@@ -25,6 +27,7 @@ pub mod issue_fix;
 pub mod lifecycle;
 pub mod material_lifecycle;
 pub mod periodic_report;
+pub mod pr_review_queue;
 pub mod resolver;
 pub mod reward_memory;
 pub mod semantic_preference;
@@ -162,6 +165,9 @@ impl CapabilityRegistry {
         ));
         r.register(Box::new(
             crate::capabilities::periodic_report::PeriodicReportCapability,
+        ));
+        r.register(Box::new(
+            crate::capabilities::pr_review_queue::PrReviewQueueCapability,
         ));
         r.register(Box::new(
             crate::capabilities::reward_memory::RewardMemoryCapability,

--- a/orchestration/loop/src/capabilities/pr_review_queue.rs
+++ b/orchestration/loop/src/capabilities/pr_review_queue.rs
@@ -1,0 +1,2298 @@
+//! PR Review Queue capability (LoopX: pull-request-review — the autonomous
+//! PR review queue). P2-3 zero-implementation fill: the reference
+//! `capabilities/pr_review_queue/` (core.py 506 lines + review_contract.py
+//! 369 lines) becomes a deterministic rule version.
+//!
+//! Two surfaces, mirroring the reference split:
+//!
+//! - **queue observation** (core.py): one complete open-PR queue observation
+//!   emits at most one exact-head review candidate. Fingerprints cover exact
+//!   head, review decision, check state, draft state, and mergeability for
+//!   every open PR; unchanged observations emit no duplicate candidate and
+//!   advance only from an explicit handled exact-head cursor
+//!   (`NUMBER@HEAD_OID`). Incomplete reads are `not_observed` and never
+//!   count as unchanged.
+//! - **review contracts** (review_contract.py): the shared execution
+//!   contract (evidence requirements + completion gate + verdict policy),
+//!   the per-PR review plan, the five-block review template
+//!   (动机/改动思路/具体改动/对主干的风险/我的整体评价), and the
+//!   agent-response contract. Host skills route the contract; they must not
+//!   reimplement it.
+//!
+//! Propose-only, as always: candidate selection grants no GitHub review,
+//! comment, push, merge, quota, or todo-write authority.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::monitor_todo;
+use super::successor_todo;
+use super::Capability;
+use super::TypedProposal;
+use crate::state::Priority;
+
+pub const OBSERVATION_SCHEMA_VERSION: &str = "pull_request_review_queue_observation_v0";
+pub const CANDIDATE_SCHEMA_VERSION: &str = "pull_request_review_candidate_v0";
+pub const TODO_PREVIEW_SCHEMA_VERSION: &str = "pull_request_review_todo_preview_v0";
+pub const REVIEW_BACKLOG_SCHEMA_VERSION: &str = "pr_review_queue_backlog_v0";
+pub const EXECUTION_CONTRACT_SCHEMA_VERSION: &str = "pull_request_review_execution_contract_v1";
+pub const REVIEW_PLAN_SCHEMA_VERSION: &str = "pull_request_review_plan_v1";
+pub const REVIEW_RESULT_SCHEMA_VERSION: &str = "pull_request_review_result_v1";
+pub const FIVE_BLOCK_TEMPLATE_SCHEMA_VERSION: &str = "pr_review_five_block_template_v0";
+pub const AGENT_RESPONSE_CONTRACT_SCHEMA_VERSION: &str = "pr_review_agent_response_contract_v0";
+
+/// The five final sections every detailed review must render (reference
+/// REQUIRED_FINAL_SECTIONS).
+pub const REQUIRED_FINAL_SECTIONS: [&str; 5] = [
+    "动机",
+    "改动思路",
+    "具体改动",
+    "对主干的风险",
+    "我的整体评价",
+];
+
+/// Code areas that make a change a code change (reference CODE_AREAS).
+pub const CODE_AREAS: [&str; 4] = [
+    "product_runtime",
+    "app_or_ui_surface",
+    "ci_or_release",
+    "build_or_config",
+];
+
+/// Areas that additionally require a negative walkthrough (reference
+/// NEGATIVE_PATH_AREAS).
+pub const NEGATIVE_PATH_AREAS: [&str; 5] = [
+    "product_runtime",
+    "app_or_ui_surface",
+    "ci_or_release",
+    "build_or_config",
+    "public_entry_or_policy",
+];
+
+// ── review verdict (the 通过 / 驳回 / 再修 contract surface) ────────────────
+
+/// A published review verdict. `approve` 通过 / `request_changes` 驳回 /
+/// `rework` 再修.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewVerdict {
+    #[serde(rename = "approve")]
+    Approve,
+    #[serde(rename = "request_changes")]
+    RequestChanges,
+    #[serde(rename = "rework")]
+    Rework,
+}
+
+impl ReviewVerdict {
+    /// Parse a verdict token: canonical keys plus the operator-facing
+    /// synonyms (`pass` / `reject`) and the Chinese labels.
+    pub fn parse(token: &str) -> Option<Self> {
+        match token.trim().to_lowercase().as_str() {
+            "approve" | "pass" | "通过" => Some(Self::Approve),
+            "request-changes" | "request_changes" | "reject" | "驳回" => {
+                Some(Self::RequestChanges)
+            }
+            "rework" | "再修" => Some(Self::Rework),
+            _ => None,
+        }
+    }
+
+    /// Stable machine key (JSON / todo note encoding).
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::RequestChanges => "request_changes",
+            Self::Rework => "rework",
+        }
+    }
+
+    /// Operator-facing label (通过 / 驳回 / 再修).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Approve => "通过",
+            Self::RequestChanges => "驳回",
+            Self::Rework => "再修",
+        }
+    }
+
+    /// All verdicts in canonical order.
+    pub const ALL: [Self; 3] = [Self::Approve, Self::RequestChanges, Self::Rework];
+}
+
+/// The shared verdict policy (reference review_execution_contract
+/// verdict_policy): which published verdict a finding maps to.
+pub fn published_verdict_for(pr_merged: bool, blocking_finding: bool) -> &'static str {
+    if pr_merged {
+        "POST_MERGE_AUDIT_COMMENT when a new actionable finding exists"
+    } else if blocking_finding {
+        "REQUEST_CHANGES"
+    } else {
+        "COMMENT"
+    }
+}
+
+// ── queue observation (core.py port) ──────────────────────────────────────
+
+/// Compact check counts (reference `_check_snapshot` counts).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckCounts {
+    pub success: i64,
+    pub failure: i64,
+    pub pending: i64,
+    pub unknown: i64,
+}
+
+/// Compact check snapshot: counts + failing/pending check names.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckSnapshot {
+    pub counts: CheckCounts,
+    pub failures: Vec<String>,
+    pub pending: Vec<String>,
+}
+
+/// One ranked PR snapshot (internal + serialized candidate checks).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PrSnapshot {
+    pub number: Option<u64>,
+    pub state: String,
+    pub head_oid: String,
+    pub review_decision: String,
+    pub checks: CheckSnapshot,
+    #[serde(rename = "is_draft")]
+    pub is_draft: bool,
+    pub merge_state: String,
+    pub fingerprint: String,
+    pub rank: u32,
+    pub title: String,
+    pub url: String,
+}
+
+/// One queue item in the observation payload (`number` + `fingerprint`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueueItemRef {
+    pub number: Option<u64>,
+    pub fingerprint: String,
+}
+
+/// The todo preview embedded in a candidate (reference `_candidate_packet`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TodoPreview {
+    pub schema_version: String,
+    pub role: String,
+    pub priority: String,
+    pub task_class: String,
+    pub action_kind: String,
+    pub task_repository: Option<String>,
+    pub target_key: String,
+    pub required_capabilities: Vec<String>,
+    pub text: String,
+}
+
+/// At most one exact-head review candidate per observation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidatePacket {
+    pub schema_version: String,
+    pub repository: Option<String>,
+    pub number: Option<u64>,
+    pub url: String,
+    pub head_oid: String,
+    pub review_decision: String,
+    pub merge_state: String,
+    pub checks: CheckSnapshot,
+    pub fingerprint: Option<String>,
+    pub todo_preview: TodoPreview,
+}
+
+/// Backlog projection: active/quiet cadence from unhandled actionable PRs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewBacklog {
+    pub schema_version: String,
+    pub actionable_unhandled_count: u32,
+    pub pending_candidate_exact_head: Option<String>,
+    pub recommended_poll_interval_minutes: u32,
+    pub recommended_cadence: String,
+}
+
+/// The full read-only queue observation (reference OBSERVATION_STATES).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewQueueObservation {
+    pub schema_version: String,
+    pub repository: Option<String>,
+    pub observation_state: String,
+    pub reason: String,
+    pub queue_fingerprint: Option<String>,
+    pub previous_queue_fingerprint: Option<String>,
+    pub baseline_preserved: bool,
+    pub items: Vec<QueueItemRef>,
+    pub queue_size: Option<usize>,
+    pub changed_pr_numbers: Vec<Option<u64>>,
+    pub removed_pr_numbers: Vec<u64>,
+    pub candidate: Option<CandidatePacket>,
+    pub candidate_count: u32,
+    pub candidate_selection_reason: Option<String>,
+    pub pending_candidate_exact_head: Option<String>,
+    pub review_backlog: ReviewBacklog,
+    pub handled_exact_heads: Vec<String>,
+    pub handled_exact_head_count: usize,
+    pub projected_candidate_exact_heads: Vec<String>,
+    pub projected_candidate_count: usize,
+    pub selection_policy: String,
+    pub write_authority_granted: bool,
+    pub external_write_performed: bool,
+}
+
+/// Stable fingerprint: sha256 of canonical JSON, first 16 hex chars
+/// (reference `_fingerprint`).
+pub fn fingerprint(value: &impl Serialize) -> String {
+    use sha2::Digest;
+    let encoded = serde_json::to_string(value).unwrap_or_default();
+    let digest = sha2::Sha256::digest(encoded.as_bytes());
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    hex[..16].to_string()
+}
+
+/// Uppercase a value or fall back to `default` (reference `_upper`).
+fn upper(value: Option<&Value>, default: &str) -> String {
+    match value {
+        Some(v) => v.as_str().unwrap_or_default().trim().to_uppercase(),
+        None => String::new(),
+    }
+    .pipe(|text| {
+        if text.is_empty() {
+            default.to_string()
+        } else {
+            text
+        }
+    })
+}
+
+/// Extension trait so `Option<T>` chains read naturally in ports.
+trait Pipe: Sized {
+    fn pipe<R>(self, f: impl FnOnce(Self) -> R) -> R {
+        f(self)
+    }
+}
+impl<T> Pipe for T {}
+
+/// Sorted deduped trimmed string list from a JSON array (reference
+/// `_string_list`).
+fn string_list(value: Option<&Value>) -> Vec<String> {
+    let Some(value) = value else { return vec![] };
+    let Some(items) = value.as_array() else {
+        return vec![];
+    };
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for item in items {
+        if let Some(text) = item.as_str() {
+            let text = text.trim();
+            if !text.is_empty() {
+                out.insert(text.to_string());
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Compact a checks mapping (reference `_check_snapshot`).
+fn check_snapshot(value: Option<&Value>) -> CheckSnapshot {
+    let Some(checks) = value else {
+        return CheckSnapshot::default();
+    };
+    let counts = checks.get("counts");
+    let mut compact = CheckCounts::default();
+    if let Some(counts) = counts {
+        for key in ["success", "failure", "pending", "unknown"] {
+            let parsed: i64 = counts.get(key).and_then(Value::as_i64).unwrap_or(0).max(0);
+            match key {
+                "success" => compact.success = parsed,
+                "failure" => compact.failure = parsed,
+                "pending" => compact.pending = parsed,
+                _ => compact.unknown = parsed,
+            }
+        }
+    }
+    CheckSnapshot {
+        counts: compact,
+        failures: string_list(checks.get("failures")),
+        pending: string_list(checks.get("pending")),
+    }
+}
+
+/// Normalize a number-like JSON value to text (reference `str(number)`).
+fn number_text(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::Number(n)) => n.to_string(),
+        Some(Value::String(s)) => s.trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Build one PR snapshot + fingerprint (reference `_pr_snapshot`).
+fn pr_snapshot(item: &Value) -> PrSnapshot {
+    let number = number_text(item.get("number"));
+    let number_parsed = number.parse::<u64>().ok();
+    let snapshot = PrSnapshot {
+        number: number_parsed,
+        state: upper(item.get("state"), "OPEN"),
+        head_oid: item
+            .get("head_oid")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        review_decision: upper(item.get("review_decision"), "UNKNOWN"),
+        checks: check_snapshot(item.get("checks")),
+        is_draft: item.get("is_draft").and_then(Value::as_bool) == Some(true),
+        merge_state: upper(item.get("merge_state"), "UNKNOWN"),
+        fingerprint: String::new(),
+        rank: 0,
+        title: String::new(),
+        url: String::new(),
+    };
+    PrSnapshot {
+        fingerprint: fingerprint(&snapshot),
+        ..snapshot
+    }
+}
+
+/// `NUMBER@HEAD_OID` for a 40- or 64-hex head (reference `_exact_head_key`).
+pub fn exact_head_key(number: Option<&Value>, head_oid: Option<&Value>) -> Option<String> {
+    let number_txt = number_text(number);
+    let head_text = number_text(head_oid).to_lowercase();
+    if number_txt.is_empty() || !number_txt.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let is_hex_oid = (head_text.len() == 40 || head_text.len() == 64)
+        && head_text.chars().all(|c| c.is_ascii_hexdigit());
+    if !is_hex_oid {
+        return None;
+    }
+    Some(format!("{number_txt}@{head_text}"))
+}
+
+/// Normalize + validate handled exact heads (reference
+/// `_normalize_handled_exact_heads`).
+pub fn normalize_handled_exact_heads(value: &[String]) -> Result<Vec<String>, String> {
+    let mut normalized: BTreeSet<String> = BTreeSet::new();
+    for item in value {
+        let text = item.trim();
+        let Some((number, head_oid)) = text.split_once('@') else {
+            return Err(
+                "handled exact head must use NUMBER@HEAD_OID with a 40- or 64-hex head".to_string(),
+            );
+        };
+        let key = exact_head_key(
+            Some(&Value::String(number.to_string())),
+            Some(&Value::String(head_oid.to_string())),
+        )
+        .ok_or_else(|| {
+            "handled exact head must use NUMBER@HEAD_OID with a 40- or 64-hex head".to_string()
+        })?;
+        normalized.insert(key);
+    }
+    Ok(sort_exact_heads(normalized.into_iter().collect()))
+}
+
+/// Sort exact-head keys by (number, key) — lexicographic sort would put
+/// `10@…` before `2@…` (reference sorts numerically).
+pub fn sort_exact_heads(mut keys: Vec<String>) -> Vec<String> {
+    keys.sort_by_key(|key| {
+        let number: u64 = key
+            .split('@')
+            .next()
+            .and_then(|n| n.parse().ok())
+            .unwrap_or(0);
+        (number, key.clone())
+    });
+    keys
+}
+
+/// Decide the candidate action for one ranked snapshot (reference
+/// `_candidate_action`): drafts and non-OPEN PRs are never actionable.
+fn candidate_action(item: &PrSnapshot) -> Option<(&'static str, &'static str)> {
+    if item.is_draft || item.state != "OPEN" {
+        return None;
+    }
+    if item.number.is_none()
+        || (item.head_oid.len() != 40 && item.head_oid.len() != 64)
+        || !item.head_oid.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    match item.review_decision.as_str() {
+        "CHANGES_REQUESTED" => Some(("rereview_pull_request_exact_head", "P0")),
+        "APPROVED" => Some(("qualify_pull_request_merge_readiness", "P1")),
+        _ => Some(("review_pull_request_exact_head", "P1")),
+    }
+}
+
+/// Build the candidate packet for one ranked item (reference
+/// `_candidate_packet`).
+fn candidate_packet(item: &PrSnapshot, repository: &str) -> Option<CandidatePacket> {
+    // `item` is already a ranked snapshot; the action re-derives from the
+    // snapshot fields (draft/state gating matches `_candidate_action`).
+    let (action_kind, priority) = candidate_action(item)?;
+    let number = item.number?;
+    let url = item.url.trim().to_string();
+    let task_repository = if repository.is_empty() {
+        None
+    } else {
+        Some(format!("git:github.com/{repository}"))
+    };
+    let verb = match action_kind {
+        "rereview_pull_request_exact_head" => "Re-review",
+        "qualify_pull_request_merge_readiness" => "Qualify merge readiness for",
+        _ => "Review",
+    };
+    let text = format!(
+        "[{priority}] {verb} PR #{number} at exact head {}; read the diff and checks, publish a review state matching the evidence, and route any merge through repository policy.",
+        item.head_oid
+    );
+    Some(CandidatePacket {
+        schema_version: CANDIDATE_SCHEMA_VERSION.to_string(),
+        repository: if repository.is_empty() {
+            None
+        } else {
+            Some(repository.to_string())
+        },
+        number: Some(number),
+        url,
+        head_oid: item.head_oid.clone(),
+        review_decision: item.review_decision.clone(),
+        merge_state: item.merge_state.clone(),
+        checks: item.checks.clone(),
+        fingerprint: Some(item.fingerprint.clone()),
+        todo_preview: TodoPreview {
+            schema_version: TODO_PREVIEW_SCHEMA_VERSION.to_string(),
+            role: "agent".to_string(),
+            priority: priority.to_string(),
+            task_class: "advancement_task".to_string(),
+            action_kind: action_kind.to_string(),
+            task_repository,
+            target_key: format!("github-pr-review:{repository}#{number}@{}", item.head_oid),
+            required_capabilities: vec![
+                "network".to_string(),
+                "external_evidence_poll".to_string(),
+            ],
+            text,
+        },
+    })
+}
+
+/// Backlog projection (reference `_review_backlog`).
+fn review_backlog(
+    items: &[PrSnapshot],
+    handled_set: &BTreeSet<String>,
+    pending_candidate_exact_head: Option<&str>,
+) -> ReviewBacklog {
+    let mut actionable_unhandled_count = 0u32;
+    for item in items {
+        let Some(number) = item.number else { continue };
+        let key = exact_head_key(
+            Some(&Value::Number(number.into())),
+            Some(&Value::String(item.head_oid.clone())),
+        );
+        let Some(key) = key else { continue };
+        if handled_set.contains(&key) {
+            continue;
+        }
+        let actionable = !item.is_draft
+            && item.state == "OPEN"
+            && (item.head_oid.len() == 40 || item.head_oid.len() == 64)
+            && item.head_oid.chars().all(|c| c.is_ascii_hexdigit());
+        if actionable {
+            actionable_unhandled_count += 1;
+        }
+    }
+    let active = actionable_unhandled_count > 0 || pending_candidate_exact_head.is_some();
+    ReviewBacklog {
+        schema_version: REVIEW_BACKLOG_SCHEMA_VERSION.to_string(),
+        actionable_unhandled_count,
+        pending_candidate_exact_head: pending_candidate_exact_head.map(|s| s.to_string()),
+        recommended_poll_interval_minutes: if active { 3 } else { 15 },
+        recommended_cadence: if active {
+            "active_review".to_string()
+        } else {
+            "quiet_wait".to_string()
+        },
+    }
+}
+
+/// State extracted from a previous observation (reference `_previous_*`).
+#[derive(Debug, Clone, Default)]
+struct PreviousObservation {
+    repository: String,
+    previous_fingerprint: Option<String>,
+    handled_exact_heads: Vec<String>,
+    candidate_exact_head: Option<String>,
+    projected_exact_heads: Vec<String>,
+    /// number → fingerprint of the previous observation's items.
+    items: BTreeMap<u64, String>,
+}
+
+/// Unwrap `{autonomous_review: …}` wrappers (reference
+/// `_previous_observation`) and extract the durable cursor state.
+fn extract_previous(value: Option<&Value>) -> Result<PreviousObservation, String> {
+    let Some(value) = value else {
+        return Ok(PreviousObservation::default());
+    };
+    let observation = value
+        .get("autonomous_review")
+        .filter(|v| v.is_object())
+        .unwrap_or(value);
+    let mut out = PreviousObservation {
+        repository: observation
+            .get("repository")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        ..PreviousObservation::default()
+    };
+    out.previous_fingerprint = ["queue_fingerprint", "previous_queue_fingerprint"]
+        .iter()
+        .find_map(|k| {
+            observation
+                .get(*k)
+                .and_then(Value::as_str)
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+    let handled: Vec<String> = observation
+        .get("handled_exact_heads")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    out.handled_exact_heads = normalize_handled_exact_heads(&handled)?;
+    // candidate exact head: the embedded candidate or the pending cursor.
+    if let Some(candidate) = observation.get("candidate").filter(|v| v.is_object()) {
+        if let Some(key) = exact_head_key(candidate.get("number"), candidate.get("head_oid")) {
+            out.candidate_exact_head = Some(key);
+        }
+    }
+    if out.candidate_exact_head.is_none() {
+        let pending = observation
+            .get("pending_candidate_exact_head")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if pending.contains('@') {
+            if let Some((number, head_oid)) = pending.split_once('@') {
+                out.candidate_exact_head = exact_head_key(
+                    Some(&Value::String(number.to_string())),
+                    Some(&Value::String(head_oid.to_string())),
+                );
+            }
+        }
+    }
+    let projected: Vec<String> = observation
+        .get("projected_candidate_exact_heads")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    out.projected_exact_heads = normalize_handled_exact_heads(&projected)?;
+    // items: only observations that were actually observed carry item
+    // fingerprints (reference `_previous_items`).
+    let state = observation
+        .get("observation_state")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let baseline_preserved = observation
+        .get("baseline_preserved")
+        .and_then(Value::as_bool)
+        == Some(true);
+    let usable = matches!(state, "observed_unchanged" | "material_transition")
+        || (state == "not_observed" && baseline_preserved);
+    if usable {
+        if let Some(items) = observation.get("items").and_then(Value::as_array) {
+            for item in items {
+                let number = item
+                    .get("number")
+                    .and_then(|n| n.as_i64())
+                    .and_then(|n| u64::try_from(n).ok());
+                if let Some(number) = number {
+                    let fp = item
+                        .get("fingerprint")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    out.items.insert(number, fp);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Build one read-only queue observation and at most one exact-head
+/// candidate (reference `build_pull_request_review_queue_observation`).
+///
+/// `pull_requests` items are tolerant JSON objects (`number`, `title`,
+/// `url`, `state`, `head_oid`, `review_decision`, `is_draft`,
+/// `merge_state`, `checks`); `result_completeness` must be
+/// `{"complete": true}` for the queue to count as observed.
+#[allow(clippy::too_many_lines)]
+pub fn build_pull_request_review_queue_observation(
+    repository: Option<&str>,
+    pull_requests: &[Value],
+    result_completeness: &Value,
+    previous_observation: Option<&Value>,
+    handled_exact_heads: &[String],
+) -> Result<ReviewQueueObservation, String> {
+    let normalized_repository = repository.unwrap_or_default().trim().to_string();
+    let previous = extract_previous(previous_observation)?;
+    // Cursors are repository-scoped (reference `_previous_handled_exact_heads`
+    // etc.): a previous observation of a different repository contributes no
+    // handled, candidate, or projected state.
+    let same_repository = previous.repository == normalized_repository;
+    let previous_handled = if same_repository {
+        previous.handled_exact_heads.clone()
+    } else {
+        Vec::new()
+    };
+    let previous_candidate = if same_repository {
+        previous.candidate_exact_head.clone()
+    } else {
+        None
+    };
+    let previous_projected = if same_repository {
+        previous.projected_exact_heads.clone()
+    } else {
+        Vec::new()
+    };
+    let supplied_handled = normalize_handled_exact_heads(handled_exact_heads)?;
+
+    // handled cursors must match a prior candidate or a persisted cursor
+    // (reference: unexpected handled heads are rejected).
+    let mut allowed_supplied: BTreeSet<String> = previous_handled.iter().cloned().collect();
+    let previous_projected: BTreeSet<String> = previous_projected.iter().cloned().collect();
+    let mut projected_set: BTreeSet<String> = previous_projected.clone();
+    for key in &previous_projected {
+        allowed_supplied.insert(key.clone());
+    }
+    if let Some(candidate) = &previous_candidate {
+        projected_set.insert(candidate.clone());
+        allowed_supplied.insert(candidate.clone());
+    }
+    let unexpected: Vec<&String> = supplied_handled
+        .iter()
+        .filter(|key| !allowed_supplied.contains(*key))
+        .collect();
+    if !unexpected.is_empty() {
+        return Err(format!(
+            "handled exact head must match the prior candidate or a persisted handled cursor: {}",
+            unexpected
+                .iter()
+                .map(|k| k.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    let mut handled: BTreeSet<String> = previous_handled.iter().cloned().collect();
+    for key in &supplied_handled {
+        handled.insert(key.clone());
+    }
+    projected_set.retain(|key| !handled.contains(key));
+
+    let previous_fingerprint = previous.previous_fingerprint.clone();
+    let previous_items = previous.items;
+
+    let selection_policy = "rotate through unprojected unhandled PRs in the existing pr-review sequence; exact head required".to_string();
+
+    // Incomplete reads are never observed (reference: complete gate). The
+    // backlog still counts actionable unhandled items over the supplied
+    // payload (reference `_review_backlog(pull_requests, …)`).
+    if result_completeness.get("complete").and_then(Value::as_bool) != Some(true) {
+        let pending_candidate_exact_head = previous_candidate.filter(|key| !handled.contains(key));
+        let supplied_snapshots: Vec<PrSnapshot> = pull_requests.iter().map(pr_snapshot).collect();
+        let backlog = review_backlog(
+            &supplied_snapshots,
+            &handled,
+            pending_candidate_exact_head.as_deref(),
+        );
+        return Ok(ReviewQueueObservation {
+            schema_version: OBSERVATION_SCHEMA_VERSION.to_string(),
+            repository: if normalized_repository.is_empty() {
+                None
+            } else {
+                Some(normalized_repository.clone())
+            },
+            observation_state: "not_observed".to_string(),
+            reason: "complete_open_queue_required".to_string(),
+            queue_fingerprint: None,
+            previous_queue_fingerprint: previous_fingerprint.clone(),
+            baseline_preserved: previous_fingerprint.is_some(),
+            items: previous_items
+                .iter()
+                .map(|(number, fingerprint)| QueueItemRef {
+                    number: Some(*number),
+                    fingerprint: fingerprint.clone(),
+                })
+                .collect(),
+            queue_size: None,
+            changed_pr_numbers: vec![],
+            removed_pr_numbers: vec![],
+            candidate: None,
+            candidate_count: 0,
+            candidate_selection_reason: None,
+            pending_candidate_exact_head,
+            review_backlog: backlog,
+            handled_exact_heads: sort_exact_heads(handled.iter().cloned().collect()),
+            handled_exact_head_count: handled.len(),
+            projected_candidate_exact_heads: sort_exact_heads(
+                projected_set.iter().cloned().collect(),
+            ),
+            projected_candidate_count: projected_set.len(),
+            selection_policy,
+            write_authority_granted: false,
+            external_write_performed: false,
+        });
+    }
+
+    // Rank open PRs in input order; the exact-head key requires a full OID.
+    let mut ranked_items: Vec<PrSnapshot> = Vec::new();
+    for (rank, item) in pull_requests.iter().enumerate() {
+        if upper(item.get("state"), "OPEN") != "OPEN" {
+            continue;
+        }
+        let mut snapshot = pr_snapshot(item);
+        snapshot.rank = u32::try_from(rank + 1).unwrap_or(0);
+        snapshot.title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        snapshot.url = item
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        ranked_items.push(snapshot);
+    }
+
+    let current_exact_heads: BTreeSet<String> = ranked_items
+        .iter()
+        .filter_map(|item| {
+            exact_head_key(
+                item.number.map(|n| Value::Number(n.into())).as_ref(),
+                Some(&Value::String(item.head_oid.clone())),
+            )
+        })
+        .collect();
+    let actionable_exact_heads: BTreeSet<String> = ranked_items
+        .iter()
+        .filter_map(|item| {
+            let key = exact_head_key(
+                item.number.map(|n| Value::Number(n.into())).as_ref(),
+                Some(&Value::String(item.head_oid.clone())),
+            );
+            if candidate_action(item).is_some() {
+                key
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Prune handled/projected cursors to the live queue.
+    handled.retain(|key| current_exact_heads.contains(key));
+    let handled_set = handled.clone();
+    projected_set.retain(|key| current_exact_heads.contains(key) && !handled_set.contains(key));
+
+    let mut queue_items: Vec<QueueItemRef> = ranked_items
+        .iter()
+        .map(|item| QueueItemRef {
+            number: item.number,
+            fingerprint: item.fingerprint.clone(),
+        })
+        .collect();
+    queue_items.sort_by_key(|item| item.number.unwrap_or(0));
+    let queue_fingerprint = fingerprint(&serde_json::json!({
+        "repository": normalized_repository,
+        "items": queue_items,
+    }));
+
+    // Changed detection needs the prior fingerprints of the SAME repository.
+    let previous_repository = previous.repository.clone();
+    let prior_items: BTreeMap<u64, String> = if previous_repository == normalized_repository {
+        previous_items.clone()
+    } else {
+        BTreeMap::new()
+    };
+    let changed: Vec<&PrSnapshot> = ranked_items
+        .iter()
+        .filter(|item| {
+            let prior = item
+                .number
+                .and_then(|n| prior_items.get(&n))
+                .map(|s| s.as_str())
+                .unwrap_or_default();
+            prior != item.fingerprint
+        })
+        .collect();
+    let removed_numbers: Vec<u64> = {
+        let current_numbers: BTreeSet<u64> =
+            ranked_items.iter().filter_map(|item| item.number).collect();
+        prior_items
+            .keys()
+            .filter(|number| !current_numbers.contains(number))
+            .copied()
+            .collect()
+    };
+    let unchanged = previous_fingerprint.as_deref() == Some(queue_fingerprint.as_str());
+    let observation_state = if unchanged {
+        "observed_unchanged"
+    } else {
+        "material_transition"
+    };
+
+    // At most one candidate: unhandled material transitions first, then the
+    // unhandled, unprojected backlog rotation.
+    let mut candidate: Option<CandidatePacket> = None;
+    let mut candidate_selection_reason = None;
+    if observation_state == "material_transition" {
+        for item in &changed {
+            if let Some(number) = item.number {
+                let key = exact_head_key(
+                    Some(&Value::Number(number.into())),
+                    Some(&Value::String(item.head_oid.clone())),
+                );
+                if key.is_none_or(|k| handled_set.contains(&k)) {
+                    continue;
+                }
+            }
+            if let Some(packet) = candidate_packet(item, &normalized_repository) {
+                candidate = Some(packet);
+                candidate_selection_reason = Some("unhandled_material_transition".to_string());
+                break;
+            }
+        }
+    }
+    if candidate.is_none() {
+        for item in &ranked_items {
+            let Some(number) = item.number else { continue };
+            let key = exact_head_key(
+                Some(&Value::Number(number.into())),
+                Some(&Value::String(item.head_oid.clone())),
+            );
+            let Some(key) = key else { continue };
+            if handled_set.contains(&key) || projected_set.contains(&key) {
+                continue;
+            }
+            if let Some(packet) = candidate_packet(item, &normalized_repository) {
+                candidate = Some(packet);
+                candidate_selection_reason = Some("unhandled_backlog_progression".to_string());
+                break;
+            }
+        }
+    }
+    let candidate_exact_head = candidate.as_ref().and_then(|packet| {
+        exact_head_key(
+            packet.number.map(|n| Value::Number(n.into())).as_ref(),
+            Some(&Value::String(packet.head_oid.clone())),
+        )
+    });
+    let mut pending_candidate_exact_head = candidate_exact_head.clone();
+    if pending_candidate_exact_head.is_none() {
+        if let Some(previous_candidate) = &previous_candidate {
+            if actionable_exact_heads.contains(previous_candidate)
+                && !handled_set.contains(previous_candidate)
+            {
+                pending_candidate_exact_head = Some(previous_candidate.clone());
+            }
+        }
+    }
+    if let Some(key) = &candidate_exact_head {
+        projected_set.insert(key.clone());
+    }
+
+    let backlog = review_backlog(
+        &ranked_items,
+        &handled_set,
+        pending_candidate_exact_head.as_deref(),
+    );
+    let reason = if unchanged {
+        "queue_fingerprint_unchanged"
+    } else if previous_fingerprint.is_none() {
+        "initial_complete_observation"
+    } else {
+        "review_material_fingerprint_changed"
+    };
+
+    Ok(ReviewQueueObservation {
+        schema_version: OBSERVATION_SCHEMA_VERSION.to_string(),
+        repository: if normalized_repository.is_empty() {
+            None
+        } else {
+            Some(normalized_repository.clone())
+        },
+        observation_state: observation_state.to_string(),
+        reason: reason.to_string(),
+        queue_fingerprint: Some(queue_fingerprint),
+        previous_queue_fingerprint: previous_fingerprint,
+        baseline_preserved: true,
+        items: queue_items,
+        queue_size: Some(ranked_items.len()),
+        changed_pr_numbers: changed.iter().map(|item| item.number).collect(),
+        removed_pr_numbers: removed_numbers,
+        candidate,
+        candidate_count: if candidate_exact_head.is_some() { 1 } else { 0 },
+        candidate_selection_reason,
+        pending_candidate_exact_head,
+        review_backlog: backlog,
+        handled_exact_heads: sort_exact_heads(handled_set.iter().cloned().collect()),
+        handled_exact_head_count: handled_set.len(),
+        projected_candidate_exact_heads: sort_exact_heads(projected_set.iter().cloned().collect()),
+        projected_candidate_count: projected_set.len(),
+        selection_policy,
+        write_authority_granted: false,
+        external_write_performed: false,
+    })
+}
+
+// ── review contracts (review_contract.py port) ────────────────────────────
+
+/// The shared review execution contract: the evidence that must exist before
+/// a detailed review verdict; host skills route this contract but must not
+/// reimplement it.
+pub fn build_review_execution_contract() -> Value {
+    serde_json::json!({
+        "schema_version": EXECUTION_CONTRACT_SCHEMA_VERSION,
+        "purpose": "Define the evidence that must exist before a detailed review verdict; host skills route this contract but must not reimplement it.",
+        "evidence_status_values": ["verified", "unverified", "not_applicable"],
+        "evidence_requirements": [
+            {
+                "evidence_id": "problem_context",
+                "required_when": "always",
+                "fields": [
+                    "author_claim", "old_behavior", "affected_caller_or_operator",
+                    "compounding_cost", "before_after_scenario", "smaller_fix_analysis",
+                    "observable_outcome", "non_goals"
+                ]
+            },
+            {
+                "evidence_id": "architecture_flow",
+                "required_when": "always",
+                "fields": [
+                    "entry_point", "authoritative_input_or_state", "decision_owner",
+                    "side_effect_or_transition", "receipt_or_consumer",
+                    "failure_or_retry_owner"
+                ]
+            },
+            {
+                "evidence_id": "changed_line_classification",
+                "required_when": "always",
+                "categories": ["production", "tests_or_fixtures", "docs", "generated", "mechanical_moves"],
+                "fields": ["files", "additions", "deletions", "behavior_role"],
+                "rule": "Classify the exact base..head diff before judging code volume."
+            },
+            {
+                "evidence_id": "symbol_map",
+                "required_when": "code_change",
+                "item_count": {"minimum": 2, "maximum": 5},
+                "item_fields": [
+                    "path", "line", "symbol", "responsibility", "before_after_behavior",
+                    "input_or_pre_state", "critical_branch_or_invariant",
+                    "callee_or_side_effect", "return_or_consumer",
+                    "failure_fallback_or_retry_owner", "caller_evidence"
+                ],
+                "source_rule": "Use exact-head definitions plus unchanged surrounding callers; select symbols by behavior, not diff size."
+            },
+            {
+                "evidence_id": "walkthroughs",
+                "required_when": "always",
+                "positive_fields": ["trigger", "ordered_symbols_or_steps", "state_transitions", "observable_result"],
+                "negative_required_when": "runtime, selector, policy, authority, lifecycle, installer, bridge, or public-entry contract changes",
+                "negative_fields": [
+                    "triggering_input_or_state", "ordered_symbols_or_steps",
+                    "rejection_fallback_or_wrong_outcome", "error_or_retry_owner"
+                ]
+            },
+            {
+                "evidence_id": "validation_matrix",
+                "required_when": "always",
+                "item_fields": ["invariant_or_case", "command_or_check", "status", "result", "required", "skip_or_failure_reason"],
+                "required_cases": [
+                    "changed invariant positive case",
+                    "material negative or failure case when applicable",
+                    "repository-required checks"
+                ]
+            },
+            {
+                "evidence_id": "failure_analysis",
+                "required_when": "always",
+                "fields": [
+                    "strongest_regression_scenario", "triggering_state",
+                    "permitting_or_preventing_code_path", "blast_radius", "observability",
+                    "rollback_or_recovery", "minimum_repair", "regression_test"
+                ]
+            },
+            {
+                "evidence_id": "code_volume",
+                "required_when": "always",
+                "verdict_values": ["necessary", "partly_avoidable", "not_yet_proven"],
+                "fields": [
+                    "changed_line_shape", "largest_production_hotspots",
+                    "active_call_site_evidence", "compatibility_or_migration_need",
+                    "verdict", "highest_value_simplification",
+                    "behavior_preserving_validation"
+                ]
+            }
+        ],
+        "finding_contract": {
+            "findings_first": true,
+            "required_fields": [
+                "severity", "trigger", "code_path", "incorrect_or_risky_outcome",
+                "location", "minimum_repair", "regression_test"
+            ],
+            "no_finding_rule": "Say no blocking finding explicitly, then name residual risk and the strongest missing validation."
+        },
+        "completion_gate": {
+            "metadata_only_verdict_allowed": false,
+            "required_status": "Every applicable evidence item is verified or explicitly unverified with a reason.",
+            "code_change_symbol_minimum": 2,
+            "exact_head_recheck_required": true,
+            "stale_head_verdict_allowed": false,
+            "required_final_sections": REQUIRED_FINAL_SECTIONS
+        },
+        "verdict_policy": {
+            "open_pr_blocking_finding": "REQUEST_CHANGES",
+            "open_pr_non_blocking_finding": "COMMENT",
+            "open_pr_no_finding": "COMMENT unless approval was explicitly requested through merge policy",
+            "merged_pr": "POST_MERGE_AUDIT_COMMENT when a new actionable finding exists",
+            "publication_exceptions": ["explicit local-only request", "private or security-sensitive finding"]
+        }
+    })
+}
+
+/// The per-PR review plan: which evidence ids are required, given the
+/// change areas (reference `build_review_plan`).
+pub fn build_review_plan(item: &Value) -> Value {
+    let areas: BTreeSet<String> = item
+        .get("areas")
+        .and_then(Value::as_object)
+        .map(|map| {
+            map.iter()
+                .filter(|(_, count)| {
+                    !count.is_null()
+                        && count != &&Value::Bool(false)
+                        && count != &&Value::Number(0.into())
+                })
+                .map(|(area, _)| area.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let code_change = CODE_AREAS.iter().any(|area| areas.contains(*area));
+    let docs_only = !areas.is_empty()
+        && areas
+            .iter()
+            .all(|area| area == "public_docs" || area == "public_entry_or_policy");
+    let mut required_evidence = vec![
+        "problem_context",
+        "architecture_flow",
+        "changed_line_classification",
+        "walkthroughs",
+        "validation_matrix",
+        "failure_analysis",
+        "code_volume",
+    ];
+    if code_change {
+        required_evidence.insert(3, "symbol_map");
+    }
+    let number = number_text(item.get("number"));
+    let head_oid = item
+        .get("head_oid")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let target_key = if !number.is_empty() && !head_oid.is_empty() {
+        Some(format!("{number}@{head_oid}"))
+    } else {
+        None
+    };
+    serde_json::json!({
+        "schema_version": REVIEW_PLAN_SCHEMA_VERSION,
+        "contract_ref": "agent_response_contract.review_execution_contract",
+        "target": {
+            "number": number.parse::<u64>().ok(),
+            "base_ref": item.get("base_ref").and_then(Value::as_str).unwrap_or_default(),
+            "head_oid": if head_oid.is_empty() { Value::Null } else { Value::String(head_oid) },
+            "exact_head_key": target_key
+        },
+        "applicability": {
+            "areas": areas.iter().cloned().collect::<Vec<_>>(),
+            "code_change": code_change,
+            "docs_only": docs_only,
+            "symbol_map_required": code_change,
+            "negative_walkthrough_required": NEGATIVE_PATH_AREAS.iter().any(|area| areas.contains(*area))
+        },
+        "required_evidence_ids": required_evidence,
+        "result_template": {
+            "schema_version": REVIEW_RESULT_SCHEMA_VERSION,
+            "target_exact_head": target_key,
+            "evidence": required_evidence.iter().map(|id| (id.to_string(), serde_json::json!({"status": "unverified"}))).collect::<serde_json::Map<_, _>>(),
+            "findings": [],
+            "residual_risk": "",
+            "verdict": "unverified"
+        }
+    })
+}
+
+/// The five-block review template: an empty scaffold the reviewer fills from
+/// verified review evidence, not PR metadata (reference `build_review_template`).
+pub fn build_review_template(item: &Value) -> Value {
+    let key_files: Vec<&Value> = item
+        .get("key_files")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter(|candidate| candidate.is_object())
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut ranked: Vec<(&Value, i64)> = key_files
+        .iter()
+        .map(|candidate| {
+            let churn = ["additions", "deletions"]
+                .iter()
+                .filter_map(|field| candidate.get(*field).and_then(Value::as_i64))
+                .sum::<i64>();
+            (*candidate, churn)
+        })
+        .collect();
+    ranked.sort_by_key(|(_, churn)| std::cmp::Reverse(*churn));
+    let review_order: Vec<String> = ranked
+        .iter()
+        .take(5)
+        .filter_map(|(candidate, _)| {
+            candidate
+                .get("path")
+                .and_then(Value::as_str)
+                .map(|path| path.to_string())
+        })
+        .collect();
+
+    fn section(label: &str, word_hint: &str, instruction: &str) -> Value {
+        serde_json::json!({
+            "label": label,
+            "word_hint": word_hint,
+            "content": "",
+            "agent_instruction": instruction
+        })
+    }
+
+    serde_json::json!({
+        "schema_version": FIVE_BLOCK_TEMPLATE_SCHEMA_VERSION,
+        "purpose": "Empty scaffold only; fill it from the verified review evidence, not PR metadata.",
+        "sections": [
+            section(
+                "动机",
+                "200-350字",
+                "Use evidence `problem_context`: old behavior, affected caller, concrete cost, before/after outcome, and why the nearest smaller fix is or is not enough."
+            ),
+            section(
+                "改动思路",
+                "300-500字",
+                "Use `architecture_flow` and `walkthroughs`: entry point, authoritative state, decision boundary, positive path, alternative, and ownership trade-off."
+            ),
+            section(
+                "具体改动",
+                "450-800字",
+                "Use `changed_line_classification` and `symbol_map`. Code changes require `### 关键代码讲解` for 2-5 behavior-bearing exact-head symbols; docs-only changes use `### 关键内容讲解`."
+            ),
+            section(
+                "对主干的风险",
+                "250-500字",
+                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair."
+            ),
+            section(
+                "我的整体评价",
+                "150-300字",
+                "Use `code_volume`, validation results, residual risk, and exact-head freshness to state the verdict and the evidence needed for re-review."
+            )
+        ],
+        "review_order": review_order,
+        "output_hint": "Render the verified structured result using the five sections. The capability-owned review_execution_contract is the evidence and completeness authority."
+    })
+}
+
+/// The agent-response contract (reference `build_agent_response_contract`).
+pub fn build_agent_response_contract() -> Value {
+    serde_json::json!({
+        "schema_version": AGENT_RESPONSE_CONTRACT_SCHEMA_VERSION,
+        "table_only_response_allowed": false,
+        "slash_prefix_dominates_intent": true,
+        "stats_only_requires_explicit_opt_out": true,
+        "queue_table_role": "preface_only",
+        "default_review_scope": "Review PRs in review_groups.unmerged first, then review_groups.merged, bounded by the requested limit.",
+        "required_packet_fields_to_preserve": [
+            "agent_response_contract",
+            "agent_response_contract.review_execution_contract",
+            "result_completeness",
+            "review_groups",
+            "pull_requests[].review_plan",
+            "pull_requests[].review_template",
+            "pull_requests[].evidence_commands"
+        ],
+        "stats_only_opt_out_examples": ["只统计", "只列出", "stats only", "list only", "不要 review", "不用分析"],
+        "required_final_sections": REQUIRED_FINAL_SECTIONS,
+        "review_execution_contract": build_review_execution_contract(),
+        "explanation_depth_contract": {
+            "schema_version": "pr_review_explanation_depth_v0",
+            "authority": "agent_response_contract.review_execution_contract",
+            "reader_profile": "A technically curious reader who may not know this PR or subsystem.",
+            "verdict_preface": "Lead with one evidence-based verdict and the highest-severity reason.",
+            "freshness": "Record and recheck the remote head SHA; do not publish a stale verdict."
+        },
+        "instructions": [
+            "Use review_groups as the queue and require result_completeness.complete=true for exhaustive review.",
+            "Execute each pull_requests[].review_plan against the shared review_execution_contract before drafting prose.",
+            "Do not infer verified evidence from title, labels, changed-file counts, metadata_risk_hint, or green CI alone.",
+            "Recheck the exact remote head before verdict and publication.",
+            "Render the verified result through pull_requests[].review_template; host skills must not maintain a competing depth checklist."
+        ]
+    })
+}
+
+// ── capability ────────────────────────────────────────────────────────────
+
+pub struct PrReviewQueueCapability;
+
+impl PrReviewQueueCapability {
+    /// Extract a queue payload from the proposal input, when present:
+    /// `{"repository": …, "pull_requests": […], "result_completeness": …}`.
+    fn queue_payload(input: &str) -> Option<Value> {
+        let value: Value = serde_json::from_str(input.trim()).ok()?;
+        let object = value.as_object()?;
+        object.get("pull_requests").and_then(Value::as_array)?;
+        Some(value)
+    }
+}
+
+impl Capability for PrReviewQueueCapability {
+    fn name(&self) -> &'static str {
+        "pr_review_queue"
+    }
+
+    fn describe(&self) -> &'static str {
+        "observe one complete open-PR queue and emit at most one exact-head review candidate; verdicts route through the shared review contract"
+    }
+
+    fn propose(&self, input: &str) -> Vec<TypedProposal> {
+        let text = input.trim();
+        if text.is_empty() {
+            return vec![TypedProposal::no_followup(
+                "empty PR review queue observation",
+            )];
+        }
+        let Some(payload) = Self::queue_payload(text) else {
+            return vec![TypedProposal::gate(
+                "Provide a complete PR queue payload (JSON with pull_requests + result_completeness.complete=true) before any review candidate is proposed.",
+                "input is not a PR queue payload",
+            )];
+        };
+        let repository = payload.get("repository").and_then(Value::as_str);
+        let pull_requests = payload
+            .get("pull_requests")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let completeness = payload
+            .get("result_completeness")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"complete": true}));
+        let previous = payload
+            .get("previous_observation")
+            .or_else(|| payload.get("autonomous_review"));
+        let handled: Vec<String> = payload
+            .get("handled_exact_heads")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let observation = match build_pull_request_review_queue_observation(
+            repository,
+            &pull_requests,
+            &completeness,
+            previous,
+            &handled,
+        ) {
+            Ok(observation) => observation,
+            Err(err) => {
+                return vec![TypedProposal::gate(
+                    &format!("Fix the queue payload before re-observing: {err}"),
+                    "queue payload rejected by the observation contract",
+                )];
+            }
+        };
+
+        if observation.observation_state == "not_observed" {
+            if observation.baseline_preserved {
+                let due_secs =
+                    u64::from(observation.review_backlog.recommended_poll_interval_minutes) * 60;
+                let repo = observation.repository.as_deref().unwrap_or("(repository)");
+                let mut todo = monitor_todo(
+                    "pr-review",
+                    &format!(
+                        "Re-poll the {repo} open-PR queue with a complete observation; the previous baseline fingerprint is preserved until a complete read succeeds."
+                    ),
+                    due_secs,
+                );
+                todo.monitor_target = Some(format!("git:github.com/{repo}"));
+                todo.monitor_policy =
+                    Some("read_only_observation_then_no_spend_if_unchanged".to_string());
+                todo.monitor_cadence = Some(format!(
+                    "{}m",
+                    observation.review_backlog.recommended_poll_interval_minutes
+                ));
+                return vec![TypedProposal::monitor(
+                    todo,
+                    "queue read incomplete — baseline preserved, re-poll at the backlog cadence",
+                )];
+            }
+            return vec![TypedProposal::successor(
+                successor_todo(
+                    "pr-review",
+                    "Collect a complete open-PR queue observation (all open PRs with exact heads, review decisions, checks, draft and merge state) before any review candidate.",
+                ),
+                "queue read incomplete and no baseline exists yet — observe completely first",
+            )];
+        }
+
+        if let Some(candidate) = observation.candidate {
+            let priority = if candidate.todo_preview.priority == "P0" {
+                Priority::P0
+            } else {
+                Priority::P1
+            };
+            let mut todo = successor_todo("pr-review", &candidate.todo_preview.text);
+            todo.priority = priority;
+            todo.action_kind = Some(candidate.todo_preview.action_kind.clone());
+            todo.task_repository = candidate.todo_preview.task_repository.clone();
+            todo.required_capability = Some("pr_review_queue".to_string());
+            todo.capability_binding_ref = Some("pr_review_queue".to_string());
+            return vec![TypedProposal::successor(
+                todo,
+                &format!(
+                    "one exact-head review candidate selected ({})",
+                    observation
+                        .candidate_selection_reason
+                        .as_deref()
+                        .unwrap_or("candidate")
+                ),
+            )];
+        }
+
+        if observation.review_backlog.actionable_unhandled_count > 0
+            || observation.pending_candidate_exact_head.is_some()
+        {
+            let due_secs =
+                u64::from(observation.review_backlog.recommended_poll_interval_minutes) * 60;
+            let repo = observation.repository.as_deref().unwrap_or("(repository)");
+            let mut todo = monitor_todo(
+                "pr-review",
+                &format!(
+                    "Re-observe the {repo} open-PR queue; the current projected candidates are handled — advance only from an explicit handled exact-head cursor."
+                ),
+                due_secs,
+            );
+            todo.monitor_target = Some(format!("git:github.com/{repo}"));
+            todo.monitor_policy =
+                Some("read_only_observation_then_no_spend_if_unchanged".to_string());
+            todo.monitor_cadence = Some(format!(
+                "{}m",
+                observation.review_backlog.recommended_poll_interval_minutes
+            ));
+            return vec![TypedProposal::monitor(
+                todo,
+                "backlog still active but no unhandled candidate — periodic re-observation",
+            )];
+        }
+
+        vec![TypedProposal::no_followup(
+            "queue quiet — all actionable exact heads are handled and no candidate is projected",
+        )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::ProposalKind;
+
+    fn pr(
+        number: u64,
+        head: Option<&str>,
+        decision: &str,
+        draft: bool,
+        merge_state: &str,
+        failures: &[&str],
+    ) -> Value {
+        serde_json::json!({
+            "number": number,
+            "title": format!("PR {number}"),
+            "url": format!("https://github.com/owner/repo/pull/{number}"),
+            "state": "OPEN",
+            "head_oid": head.unwrap_or(&format!("{number:040}")).to_string(),
+            "review_decision": decision,
+            "is_draft": draft,
+            "merge_state": merge_state,
+            "checks": {
+                "counts": {"success": 1, "failure": failures.len(), "pending": 0, "unknown": 0},
+                "failures": failures,
+                "pending": []
+            }
+        })
+    }
+
+    fn observe(
+        items: &[Value],
+        complete: bool,
+        previous: Option<&Value>,
+        handled: &[&str],
+    ) -> Result<ReviewQueueObservation, String> {
+        let handled: Vec<String> = handled.iter().map(|s| s.to_string()).collect();
+        build_pull_request_review_queue_observation(
+            Some("owner/repo"),
+            items,
+            &serde_json::json!({"complete": complete}),
+            previous,
+            &handled,
+        )
+    }
+
+    /// Serialize a previous observation into the JSON value the raw builder
+    /// expects.
+    fn prev(observation: &ReviewQueueObservation) -> Value {
+        serde_json::to_value(observation).expect("serialize previous observation")
+    }
+
+    #[test]
+    fn exact_head_key_requires_full_oid() {
+        let key = exact_head_key(
+            Some(&Value::Number(7.into())),
+            Some(&Value::String("a".repeat(40))),
+        );
+        assert_eq!(
+            key.as_deref(),
+            Some(format!("7@{}", "a".repeat(40)).as_str())
+        );
+        assert!(exact_head_key(
+            Some(&Value::Number(7.into())),
+            Some(&Value::String("short".to_string())),
+        )
+        .is_none());
+        assert!(exact_head_key(None, Some(&Value::String("a".repeat(40)))).is_none());
+    }
+
+    #[test]
+    fn handled_exact_heads_normalize_sort_and_validate() {
+        let heads = normalize_handled_exact_heads(&[
+            "10@".to_string() + &"a".repeat(40),
+            "2@".to_string() + &"b".repeat(40),
+        ])
+        .unwrap();
+        assert_eq!(heads.len(), 2);
+        // numeric order, not lexicographic
+        assert!(heads[0].starts_with("2@"));
+        assert!(heads[1].starts_with("10@"));
+        assert!(normalize_handled_exact_heads(&["1@short".to_string()]).is_err());
+        assert!(normalize_handled_exact_heads(&["nope".to_string()]).is_err());
+    }
+
+    #[test]
+    fn incomplete_queue_is_not_observed_and_preserves_baseline() {
+        let baseline = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let result = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            false,
+            Some(&serde_json::json!({"autonomous_review": baseline})),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.observation_state, "not_observed");
+        assert!(result.queue_fingerprint.is_none());
+        assert_eq!(
+            result.previous_queue_fingerprint.as_deref(),
+            baseline.queue_fingerprint.as_deref()
+        );
+        assert!(result.baseline_preserved);
+        assert_eq!(result.items.len(), 1);
+        assert!(result.queue_size.is_none());
+        assert_eq!(result.candidate_count, 0);
+        assert!(result.candidate.is_none());
+        assert_eq!(
+            result.pending_candidate_exact_head.as_deref(),
+            Some(format!("1@{:040}", 1).as_str())
+        );
+
+        // recovery: a complete read of the same queue is observed_unchanged.
+        let recovered = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            Some(&prev(&result)),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(recovered.observation_state, "observed_unchanged");
+        assert!(recovered.candidate.is_none());
+
+        // advancing with an explicit handled cursor picks PR 2.
+        let advanced = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            Some(&prev(&result)),
+            &[&format!("1@{:040}", 1)],
+        )
+        .unwrap();
+        assert_eq!(advanced.candidate.as_ref().unwrap().number, Some(2));
+    }
+
+    #[test]
+    fn initial_complete_observation_selects_one_exact_head_candidate() {
+        let result = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.observation_state, "material_transition");
+        assert_eq!(result.changed_pr_numbers, vec![Some(1), Some(2)]);
+        assert_eq!(result.candidate_count, 1);
+        assert_eq!(result.repository.as_deref(), Some("owner/repo"));
+        assert_eq!(result.queue_size, Some(2));
+        assert!(result.items.iter().all(|item| item.number.is_some()));
+        let candidate = result.candidate.as_ref().unwrap();
+        assert_eq!(candidate.number, Some(1));
+        assert_eq!(candidate.head_oid, format!("{:040}", 1));
+        let todo = &candidate.todo_preview;
+        assert_eq!(todo.action_kind, "review_pull_request_exact_head");
+        assert_eq!(
+            todo.task_repository.as_deref(),
+            Some("git:github.com/owner/repo")
+        );
+        assert_eq!(
+            todo.required_capabilities,
+            vec!["network".to_string(), "external_evidence_poll".to_string()]
+        );
+        assert!(!result.write_authority_granted);
+        assert!(!result.external_write_performed);
+    }
+
+    #[test]
+    fn unchanged_observation_emits_no_duplicate_candidate() {
+        let first = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let repeated = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            Some(&prev(&first)),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(repeated.observation_state, "observed_unchanged");
+        assert!(repeated.changed_pr_numbers.is_empty());
+        assert_eq!(repeated.candidate.as_ref().unwrap().number, Some(2));
+        assert_eq!(
+            repeated.pending_candidate_exact_head.as_deref(),
+            Some(format!("2@{:040}", 2).as_str())
+        );
+    }
+
+    #[test]
+    fn round_robin_rotates_through_projected_candidates() {
+        let items = [
+            pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(3, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+        ];
+        let first = observe(&items, true, None, &[]).unwrap();
+        assert_eq!(first.candidate.as_ref().unwrap().number, Some(1));
+        assert_eq!(
+            first.projected_candidate_exact_heads,
+            vec![format!("1@{:040}", 1)]
+        );
+        let second = observe(&items, true, Some(&prev(&first)), &[]).unwrap();
+        assert_eq!(second.candidate.as_ref().unwrap().number, Some(2));
+        assert_eq!(
+            second.projected_candidate_exact_heads,
+            vec![format!("1@{:040}", 1), format!("2@{:040}", 2)]
+        );
+        let third = observe(&items, true, Some(&prev(&second)), &[]).unwrap();
+        assert_eq!(third.candidate.as_ref().unwrap().number, Some(3));
+        let exhausted = observe(&items, true, Some(&prev(&third)), &[]).unwrap();
+        assert!(exhausted.candidate.is_none());
+        assert_eq!(
+            exhausted.pending_candidate_exact_head.as_deref(),
+            Some(format!("3@{:040}", 3).as_str())
+        );
+        assert_eq!(exhausted.projected_candidate_count, 3);
+    }
+
+    #[test]
+    fn handled_exact_head_advances_unchanged_backlog() {
+        let items = [
+            pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+        ];
+        let first = observe(&items, true, None, &[]).unwrap();
+        let handled = format!("1@{:040}", 1);
+        let repeated = observe(&items, true, Some(&prev(&first)), &[&handled]).unwrap();
+        assert_eq!(repeated.observation_state, "observed_unchanged");
+        assert!(repeated.changed_pr_numbers.is_empty());
+        assert_eq!(repeated.handled_exact_heads, vec![handled.clone()]);
+        assert_eq!(repeated.candidate.as_ref().unwrap().number, Some(2));
+        assert_eq!(
+            repeated.candidate_selection_reason.as_deref(),
+            Some("unhandled_backlog_progression")
+        );
+        // no further handled → no duplicate candidate.
+        let still_pending = observe(&items, true, Some(&prev(&repeated)), &[]).unwrap();
+        assert_eq!(still_pending.observation_state, "observed_unchanged");
+        assert!(still_pending.candidate.is_none());
+        assert_eq!(
+            still_pending.pending_candidate_exact_head.as_deref(),
+            Some(format!("2@{:040}", 2).as_str())
+        );
+    }
+
+    #[test]
+    fn handled_exact_head_must_match_prior_candidate() {
+        let first = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let err = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            Some(&prev(&first)),
+            &[&format!("2@{:040}", 2)],
+        )
+        .unwrap_err();
+        assert!(err.contains("prior candidate"), "{err}");
+    }
+
+    #[test]
+    fn new_head_reopens_a_previously_handled_pr() {
+        let first = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let handled = format!("1@{:040}", 1);
+        let result = observe(
+            &[
+                pr(
+                    1,
+                    Some(&"f".repeat(40)),
+                    "REVIEW_REQUIRED",
+                    false,
+                    "CLEAN",
+                    &[],
+                ),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            Some(&prev(&first)),
+            &[&handled],
+        )
+        .unwrap();
+        let candidate = result.candidate.as_ref().unwrap();
+        assert_eq!(candidate.number, Some(1));
+        assert_eq!(candidate.head_oid, "f".repeat(40));
+        assert_eq!(
+            result.candidate_selection_reason.as_deref(),
+            Some("unhandled_material_transition")
+        );
+        assert!(result.handled_exact_heads.is_empty());
+    }
+
+    #[test]
+    fn approved_transition_routes_to_merge_policy_without_granting_it() {
+        let first = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let approved = observe(
+            &[pr(1, None, "APPROVED", false, "CLEAN", &[])],
+            true,
+            Some(&prev(&first)),
+            &[],
+        )
+        .unwrap();
+        let todo = &approved.candidate.as_ref().unwrap().todo_preview;
+        assert_eq!(todo.action_kind, "qualify_pull_request_merge_readiness");
+        assert!(todo
+            .text
+            .contains("route any merge through repository policy"));
+        assert!(!approved.write_authority_granted);
+    }
+
+    #[test]
+    fn changes_requested_routes_to_p0_rereview() {
+        let first = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let changed = observe(
+            &[pr(1, None, "CHANGES_REQUESTED", false, "CLEAN", &[])],
+            true,
+            Some(&prev(&first)),
+            &[],
+        )
+        .unwrap();
+        let todo = &changed.candidate.as_ref().unwrap().todo_preview;
+        assert_eq!(todo.action_kind, "rereview_pull_request_exact_head");
+        assert_eq!(todo.priority, "P0");
+    }
+
+    #[test]
+    fn drafts_are_never_candidates_but_still_material() {
+        let first = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let draft = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", true, "CLEAN", &[])],
+            true,
+            Some(&prev(&first)),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(draft.observation_state, "material_transition");
+        assert_eq!(draft.changed_pr_numbers, vec![Some(1)]);
+        assert!(draft.candidate.is_none());
+        // draft-only queue: quiet backlog cadence.
+        let only_draft = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", true, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(only_draft.review_backlog.actionable_unhandled_count, 0);
+        assert_eq!(
+            only_draft.review_backlog.recommended_poll_interval_minutes,
+            15
+        );
+        assert_eq!(only_draft.review_backlog.recommended_cadence, "quiet_wait");
+    }
+
+    #[test]
+    fn backlog_tracks_unhandled_count_and_cadence() {
+        let items = [
+            pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(3, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+        ];
+        let first = observe(&items, true, None, &[]).unwrap();
+        assert_eq!(first.review_backlog.actionable_unhandled_count, 3);
+        assert_eq!(first.review_backlog.recommended_poll_interval_minutes, 3);
+        assert_eq!(first.review_backlog.recommended_cadence, "active_review");
+
+        let after_one = observe(
+            &items,
+            true,
+            Some(&prev(&first)),
+            &[&format!("1@{:040}", 1)],
+        )
+        .unwrap();
+        assert_eq!(after_one.candidate.as_ref().unwrap().number, Some(2));
+        assert_eq!(after_one.review_backlog.actionable_unhandled_count, 2);
+
+        let after_two = observe(
+            &items,
+            true,
+            Some(&prev(&after_one)),
+            &[&format!("2@{:040}", 2)],
+        )
+        .unwrap();
+        assert_eq!(after_two.candidate.as_ref().unwrap().number, Some(3));
+        assert_eq!(after_two.review_backlog.actionable_unhandled_count, 1);
+
+        let after_three = observe(
+            &items,
+            true,
+            Some(&prev(&after_two)),
+            &[&format!("3@{:040}", 3)],
+        )
+        .unwrap();
+        assert!(after_three.candidate.is_none());
+        assert_eq!(after_three.review_backlog.actionable_unhandled_count, 0);
+        assert_eq!(
+            after_three.review_backlog.recommended_poll_interval_minutes,
+            15
+        );
+        assert_eq!(after_three.review_backlog.recommended_cadence, "quiet_wait");
+    }
+
+    #[test]
+    fn queue_fingerprint_is_repository_scoped() {
+        let first = build_pull_request_review_queue_observation(
+            Some("owner/one"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            None,
+            &[],
+        )
+        .unwrap();
+        let second = build_pull_request_review_queue_observation(
+            Some("owner/two"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            Some(&serde_json::json!({"autonomous_review": first})),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(second.observation_state, "material_transition");
+        assert_ne!(second.queue_fingerprint, first.queue_fingerprint);
+        assert_eq!(
+            second.candidate.as_ref().unwrap().repository.as_deref(),
+            Some("owner/two")
+        );
+    }
+
+    #[test]
+    fn cursors_do_not_leak_across_repositories() {
+        // Repo A: one observation projects PR 1 as candidate (handled empty,
+        // projected/candidate = 1@…).
+        let first = build_pull_request_review_queue_observation(
+            Some("owner/one"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(first.candidate.as_ref().unwrap().number, Some(1));
+        // Repo B: the same PR number must be re-selectable — repo A's
+        // handled/projected/candidate cursors never suppress it.
+        let second = build_pull_request_review_queue_observation(
+            Some("owner/two"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            Some(&serde_json::json!({"autonomous_review": first})),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(second.candidate.as_ref().unwrap().number, Some(1));
+        assert!(second.handled_exact_heads.is_empty());
+        assert_eq!(second.projected_candidate_count, 1);
+        // A handled cursor supplied from repo A is not a valid cursor for
+        // repo B (the persisted-cursor validation is repository-scoped).
+        let one_at = format!("1@{:040}", 1);
+        let err = build_pull_request_review_queue_observation(
+            Some("owner/two"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            Some(&serde_json::json!({"autonomous_review": first})),
+            std::slice::from_ref(&one_at),
+        )
+        .unwrap_err();
+        assert!(err.contains("handled exact head must match"), "{err}");
+        // The same cursor IS valid for repo A (persisted-cursor advance).
+        let advanced = build_pull_request_review_queue_observation(
+            Some("owner/one"),
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            &serde_json::json!({"complete": true}),
+            Some(&serde_json::json!({"autonomous_review": first})),
+            &[one_at],
+        )
+        .unwrap();
+        assert!(advanced.candidate.is_none());
+        assert_eq!(advanced.handled_exact_head_count, 1);
+    }
+
+    #[test]
+    fn incomplete_read_backlog_counts_the_supplied_items() {
+        // An incomplete read still projects the actionable backlog over the
+        // supplied payload (reference `_review_backlog(pull_requests, …)`).
+        let result = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            false,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.observation_state, "not_observed");
+        assert_eq!(result.review_backlog.actionable_unhandled_count, 2);
+        assert_eq!(result.review_backlog.recommended_poll_interval_minutes, 3);
+        assert_eq!(result.review_backlog.recommended_cadence, "active_review");
+        // A payload with only non-actionable items counts zero and goes quiet.
+        let quiet = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", true, "CLEAN", &[])],
+            false,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(quiet.review_backlog.actionable_unhandled_count, 0);
+        assert_eq!(quiet.review_backlog.recommended_cadence, "quiet_wait");
+    }
+
+    #[test]
+    fn check_and_mergeability_changes_are_material() {
+        let first = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let changed = observe(
+            &[
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "BLOCKED", &["pytest"]),
+            ],
+            true,
+            Some(&prev(&first)),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(changed.changed_pr_numbers, vec![Some(2)]);
+        assert_eq!(changed.candidate.as_ref().unwrap().number, Some(2));
+        assert_eq!(changed.candidate.as_ref().unwrap().merge_state, "BLOCKED");
+        assert_eq!(
+            changed.candidate.as_ref().unwrap().checks.failures,
+            vec!["pytest".to_string()]
+        );
+    }
+
+    // ── review contract tests ─────────────────────────────────────────────
+
+    #[test]
+    fn verdict_parsing_and_labels() {
+        assert_eq!(
+            ReviewVerdict::parse("approve"),
+            Some(ReviewVerdict::Approve)
+        );
+        assert_eq!(ReviewVerdict::parse("pass"), Some(ReviewVerdict::Approve));
+        assert_eq!(ReviewVerdict::parse("通过"), Some(ReviewVerdict::Approve));
+        assert_eq!(
+            ReviewVerdict::parse("request-changes"),
+            Some(ReviewVerdict::RequestChanges)
+        );
+        assert_eq!(
+            ReviewVerdict::parse("驳回"),
+            Some(ReviewVerdict::RequestChanges)
+        );
+        assert_eq!(ReviewVerdict::parse("rework"), Some(ReviewVerdict::Rework));
+        assert_eq!(ReviewVerdict::parse("再修"), Some(ReviewVerdict::Rework));
+        assert_eq!(ReviewVerdict::parse("maybe"), None);
+        assert_eq!(ReviewVerdict::Approve.label(), "通过");
+        assert_eq!(ReviewVerdict::RequestChanges.label(), "驳回");
+        assert_eq!(ReviewVerdict::Rework.label(), "再修");
+        assert_eq!(ReviewVerdict::RequestChanges.key(), "request_changes");
+    }
+
+    #[test]
+    fn execution_contract_defines_all_eight_evidence_ids() {
+        let contract = build_review_execution_contract();
+        let ids: Vec<String> = contract["evidence_requirements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["evidence_id"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "problem_context",
+                "architecture_flow",
+                "changed_line_classification",
+                "symbol_map",
+                "walkthroughs",
+                "validation_matrix",
+                "failure_analysis",
+                "code_volume"
+            ]
+        );
+        let gate = &contract["completion_gate"];
+        assert_eq!(gate["stale_head_verdict_allowed"], false);
+        assert_eq!(gate["code_change_symbol_minimum"], 2);
+        assert_eq!(
+            gate["required_final_sections"].as_array().unwrap().len(),
+            REQUIRED_FINAL_SECTIONS.len()
+        );
+        let policy = &contract["verdict_policy"];
+        assert_eq!(policy["open_pr_blocking_finding"], "REQUEST_CHANGES");
+        assert_eq!(published_verdict_for(false, true), "REQUEST_CHANGES");
+        assert_eq!(published_verdict_for(false, false), "COMMENT");
+        assert!(published_verdict_for(true, true).contains("POST_MERGE_AUDIT_COMMENT"));
+    }
+
+    #[test]
+    fn review_plan_requires_symbol_map_only_for_code_changes() {
+        let code = build_review_plan(&serde_json::json!({
+            "number": 7,
+            "head_oid": "a".repeat(40),
+            "base_ref": "main",
+            "areas": {"product_runtime": 3, "ci_or_release": 1}
+        }));
+        let ids: Vec<String> = code["required_evidence_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(ids.contains(&"symbol_map".to_string()));
+        assert_eq!(code["applicability"]["code_change"], true);
+        assert_eq!(
+            code["target"]["exact_head_key"],
+            format!("7@{}", "a".repeat(40))
+        );
+
+        let docs = build_review_plan(&serde_json::json!({
+            "number": 8,
+            "head_oid": "b".repeat(40),
+            "areas": {"public_docs": 1}
+        }));
+        let ids: Vec<String> = docs["required_evidence_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(!ids.contains(&"symbol_map".to_string()));
+        assert_eq!(docs["applicability"]["docs_only"], true);
+        assert_eq!(docs["applicability"]["code_change"], false);
+    }
+
+    #[test]
+    fn review_template_orders_key_files_by_churn() {
+        let template = build_review_template(&serde_json::json!({
+            "key_files": [
+                {"path": "a.rs", "additions": 10, "deletions": 2},
+                {"path": "b.rs", "additions": 200, "deletions": 50},
+                {"path": "c.md", "additions": 1, "deletions": 0},
+                {"path": "d.rs", "additions": 30, "deletions": 30},
+                {"path": "e.rs", "additions": 5, "deletions": 1},
+                {"path": "f.rs", "additions": 4, "deletions": 4}
+            ]
+        }));
+        let order: Vec<String> = template["review_order"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(order, vec!["b.rs", "d.rs", "a.rs", "f.rs", "e.rs"]);
+        let sections = template["sections"].as_array().unwrap();
+        assert_eq!(sections.len(), REQUIRED_FINAL_SECTIONS.len());
+        let labels: Vec<String> = sections
+            .iter()
+            .map(|s| s["label"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, REQUIRED_FINAL_SECTIONS);
+    }
+
+    #[test]
+    fn agent_response_contract_embeds_execution_contract() {
+        let contract = build_agent_response_contract();
+        assert_eq!(
+            contract["review_execution_contract"]["schema_version"],
+            EXECUTION_CONTRACT_SCHEMA_VERSION
+        );
+        assert_eq!(contract["stats_only_requires_explicit_opt_out"], true);
+    }
+
+    // ── capability propose tests ──────────────────────────────────────────
+
+    fn queue_input(items: Vec<Value>, handled: Vec<&str>) -> String {
+        serde_json::json!({
+            "repository": "owner/repo",
+            "pull_requests": items,
+            "result_completeness": {"complete": true},
+            "handled_exact_heads": handled
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn propose_selects_one_candidate_and_binds_the_capability() {
+        let cap = PrReviewQueueCapability;
+        let input = queue_input(
+            vec![
+                pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+                pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            ],
+            vec![],
+        );
+        let proposals = cap.propose(&input);
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].kind, ProposalKind::SuccessorTodo);
+        let todo = proposals[0].todo.as_ref().unwrap();
+        assert_eq!(
+            todo.action_kind.as_deref(),
+            Some("review_pull_request_exact_head")
+        );
+        assert_eq!(
+            todo.task_repository.as_deref(),
+            Some("git:github.com/owner/repo")
+        );
+        assert_eq!(todo.required_capability.as_deref(), Some("pr_review_queue"));
+        assert_eq!(
+            todo.capability_binding_ref.as_deref(),
+            Some("pr_review_queue")
+        );
+        assert!(todo.text.contains("PR #1"));
+        assert!(todo.text.contains("exact head"));
+    }
+
+    #[test]
+    fn propose_p0_rereview_and_quiet_wait_and_empty_input() {
+        let cap = PrReviewQueueCapability;
+        // CHANGES_REQUESTED → P0 candidate
+        let proposals = cap.propose(&queue_input(
+            vec![pr(1, None, "CHANGES_REQUESTED", false, "CLEAN", &[])],
+            vec![],
+        ));
+        let todo = proposals[0].todo.as_ref().unwrap();
+        assert_eq!(todo.priority, Priority::P0);
+        assert_eq!(
+            todo.action_kind.as_deref(),
+            Some("rereview_pull_request_exact_head")
+        );
+
+        // empty input → no-follow-up
+        let proposals = cap.propose("   ");
+        assert_eq!(proposals[0].kind, ProposalKind::NoFollowUp);
+
+        // non-payload input → gate
+        let proposals = cap.propose("please review pr 5");
+        assert_eq!(proposals[0].kind, ProposalKind::Gate);
+    }
+
+    #[test]
+    fn propose_monitors_an_active_but_handled_backlog() {
+        let cap = PrReviewQueueCapability;
+        let items = [
+            pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+            pr(2, None, "REVIEW_REQUIRED", false, "CLEAN", &[]),
+        ];
+        // Advance the handled cursor past PR 1 and let the round-robin
+        // project PR 2: the candidate stays projected but unhandled — an
+        // active backlog that must keep being re-observed. (Handled heads
+        // must match a prior candidate or persisted cursor, so both heads
+        // cannot be claimed from a single observation.)
+        let first = observe(&items, true, None, &[]).unwrap();
+        let second = observe(
+            &items,
+            true,
+            Some(&prev(&first)),
+            &[&format!("1@{:040}", 1)],
+        )
+        .unwrap();
+        let input = serde_json::json!({
+            "repository": "owner/repo",
+            "pull_requests": items,
+            "result_completeness": {"complete": true},
+            "handled_exact_heads": [format!("1@{:040}", 1)],
+            "previous_observation": second
+        })
+        .to_string();
+        let proposals = cap.propose(&input);
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].kind, ProposalKind::Monitor);
+        assert!(proposals[0].reason.contains("periodic re-observation"));
+    }
+
+    #[test]
+    fn propose_quiet_wait_when_queue_fully_handled() {
+        let cap = PrReviewQueueCapability;
+        let first = observe(
+            &[pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            true,
+            None,
+            &[],
+        )
+        .unwrap();
+        let input = serde_json::json!({
+            "repository": "owner/repo",
+            "pull_requests": [pr(1, None, "REVIEW_REQUIRED", false, "CLEAN", &[])],
+            "result_completeness": {"complete": true},
+            "handled_exact_heads": [format!("1@{:040}", 1)],
+            "previous_observation": first
+        })
+        .to_string();
+        let proposals = cap.propose(&input);
+        assert_eq!(proposals.len(), 1);
+        assert_eq!(proposals[0].kind, ProposalKind::NoFollowUp);
+        assert!(proposals[0].reason.contains("quiet"));
+    }
+}

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -157,6 +157,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "decision-context" => cmd_decision_context(&mut store, &args[1..]),
         "registry" => cmd_registry(&registry, &args[1..]),
         "commands" => cmd_commands(&registry, &args[1..]),
+        "pr-review" => cmd_pr_review(&mut store, &args[1..]),
         // ── P4 commands (G-18 / G-19 / G-20 / G-27) ───────────────────────
         "benchmark" => cmd_benchmark(&store, &args[1..]).await,
         "replay" => cmd_replay(&store, &args[1..]),
@@ -204,6 +205,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("delivery", Journey::Daily),
     ("reward-memory", Journey::Daily),
     ("decision-context", Journey::Daily),
+    ("pr-review", Journey::Daily),
     ("diagnose", Journey::Daily),
     ("evidence-log", Journey::Daily),
     ("todo-event", Journey::Daily),
@@ -532,6 +534,14 @@ fn build_cli_registry() -> CommandRegistry {
         "commands",
         "grouped operator command reference (P1-9 journey view)",
         "commands [--format json|--json] [--include-experimental]",
+    );
+
+    let pr_review = r.group("pr-review", "pull-request review queue (P2-3)");
+    r.command(
+        pr_review,
+        "pr-review",
+        "PR review queue observation / verdict / reviewer recommendation",
+        "pr-review queue|review|claim|recommend|contract --goal G [--repo owner/repo] [--format json]",
     );
 
     let benchmark = r.group("benchmark", "benchmark closed loop (G-18)");
@@ -3796,6 +3806,544 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
         }
         _ => bail!("lease subcommand must be claim|renew|release|expire|status"),
     }
+    Ok(())
+}
+
+// ── pr-review (P2-3) ────────────────────────────────────────────────────
+
+/// `future loop pr-review queue|review|claim|recommend|contract` — the
+/// first-class PR review queue surface: deterministic queue observation
+/// (exact-head candidates + handled cursors), verdict publication through
+/// the review contract (通过/驳回/再修), claim/lease reuse over review work
+/// items, and path-owner reviewer recommendation.
+fn cmd_pr_review(store: &mut Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str()).ok_or_else(|| {
+        anyhow::anyhow!("pr-review requires a subcommand (queue|review|claim|recommend|contract)")
+    })?;
+    match sub {
+        "queue" => pr_review_queue(store, &args[1..]),
+        "review" => pr_review_verdict(store, &args[1..]),
+        "claim" => pr_review_claim(store, &args[1..]),
+        "recommend" => pr_review_recommend(&args[1..]),
+        "contract" => pr_review_contract(&args[1..]),
+        other => bail!("unknown pr-review subcommand `{other}`"),
+    }
+}
+
+/// `pr-review queue` — observe one complete PR queue payload (fixture or
+/// inline JSON) and emit at most one exact-head candidate. Previous
+/// observations and handled `NUMBER@HEAD_OID` cursors drive the rotation.
+fn pr_review_queue(store: &mut Store, args: &[String]) -> Result<()> {
+    let json = wants_json(args);
+    let mut repo = None;
+    let mut fixture = None;
+    let mut input = None;
+    let mut previous_json = None;
+    let mut goal_id = None;
+    let mut handled: Vec<String> = vec![];
+    reject_unknown_flags(
+        args,
+        &[
+            "--fixture",
+            "--format",
+            "--goal",
+            "--handled-exact-head",
+            "--input",
+            "--json",
+            "--previous-observation-json",
+            "--repo",
+        ],
+    )?;
+    parse_pairs(args, |k, v| match k {
+        "--repo" => repo = Some(v),
+        "--fixture" => fixture = Some(v),
+        "--input" => input = Some(v),
+        "--previous-observation-json" => previous_json = Some(v),
+        "--handled-exact-head" => handled.push(v),
+        "--goal" => goal_id = Some(v),
+        _ => {}
+    });
+    if let Some(g) = goal_id.as_deref() {
+        enforce_capability_quota(store, g, "pr_review_queue", "pr-review queue")?;
+    }
+    let payload: serde_json::Value = if let Some(path) = fixture {
+        serde_json::from_str(&std::fs::read_to_string(&path)?)?
+    } else if let Some(text) = input {
+        serde_json::from_str(&text)?
+    } else {
+        bail!("pr-review queue requires --fixture PATH or --input JSON (a payload with pull_requests)");
+    };
+    let repo = repo.or_else(|| {
+        payload
+            .get("repository")
+            .and_then(serde_json::Value::as_str)
+            .map(|s| s.to_string())
+    });
+    let pull_requests = payload
+        .get("pull_requests")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let completeness = payload
+        .get("result_completeness")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({ "complete": true }));
+    let previous: Option<serde_json::Value> = if let Some(path) = previous_json {
+        Some(serde_json::from_str(&std::fs::read_to_string(&path)?)?)
+    } else {
+        payload
+            .get("previous_observation")
+            .or_else(|| payload.get("autonomous_review"))
+            .cloned()
+    };
+    use crate::capabilities::pr_review_queue as queue;
+    let observation = queue::build_pull_request_review_queue_observation(
+        repo.as_deref(),
+        &pull_requests,
+        &completeness,
+        previous.as_ref(),
+        &handled,
+    )
+    .map_err(|err| anyhow::anyhow!("{err}"))?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&observation)?);
+        return Ok(());
+    }
+    let repo_label = observation
+        .repository
+        .as_deref()
+        .unwrap_or("(no repository)");
+    println!(
+        "pr-review queue {repo_label}: {} ({})",
+        observation.observation_state, observation.reason
+    );
+    if let Some(size) = observation.queue_size {
+        println!(
+            "  queue size {size} | fingerprint {}",
+            observation.queue_fingerprint.as_deref().unwrap_or("-")
+        );
+    } else {
+        println!("  queue NOT observed (incomplete read)");
+    }
+    if !observation.changed_pr_numbers.is_empty() {
+        println!(
+            "  changed [{}]",
+            join_ids(
+                &observation
+                    .changed_pr_numbers
+                    .iter()
+                    .map(|n| n.map(|n| n.to_string()).unwrap_or_else(|| "?".into()))
+                    .collect::<Vec<_>>()
+            )
+        );
+    }
+    if !observation.removed_pr_numbers.is_empty() {
+        println!(
+            "  removed [{}]",
+            join_ids(
+                &observation
+                    .removed_pr_numbers
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<_>>()
+            )
+        );
+    }
+    if let Some(candidate) = &observation.candidate {
+        println!(
+            "  candidate: PR #{} at exact head {} [{}] {} — {}",
+            candidate
+                .number
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "?".into()),
+            candidate.head_oid,
+            candidate.todo_preview.priority,
+            candidate.todo_preview.action_kind,
+            observation
+                .candidate_selection_reason
+                .as_deref()
+                .unwrap_or("candidate")
+        );
+    } else {
+        println!("  candidate: none");
+    }
+    let backlog = &observation.review_backlog;
+    println!(
+        "  backlog: {} actionable unhandled | poll every {}m ({})",
+        backlog.actionable_unhandled_count,
+        backlog.recommended_poll_interval_minutes,
+        backlog.recommended_cadence
+    );
+    if let Some(pending) = &observation.pending_candidate_exact_head {
+        println!("  pending cursor: {pending}");
+    }
+    println!(
+        "  handled {} | projected {} | write authority NOT granted (read-only)",
+        observation.handled_exact_head_count, observation.projected_candidate_count
+    );
+    Ok(())
+}
+
+/// Strictly monotonic event timestamp for a goal ledger: wall-clock is
+/// second-granular, so a burst of commands in one second would otherwise
+/// produce identical ts values and indistinguishable completion stamps.
+fn next_event_ts(store: &Store, goal_id: &str) -> u64 {
+    let last = store
+        .events(goal_id)
+        .ok()
+        .and_then(|events| events.last().map(|e| crate::store::event_ts(&e.event)))
+        .unwrap_or(0);
+    now_epoch().max(last.saturating_add(1))
+}
+
+/// `pr-review review` — publish a verdict (通过/驳回/再修) on the review
+/// work item at an exact head. The item is a first-class advancement todo
+/// (`pr-review-<number>`); a new exact head supersedes the previous item.
+/// Publishing completes the review with evidence — a re-review is driven by
+/// the next material transition in the queue observation.
+fn pr_review_verdict(store: &mut Store, args: &[String]) -> Result<()> {
+    let json = wants_json(args);
+    let mut goal_id = None;
+    let mut number = None;
+    let mut head = None;
+    let mut repo = None;
+    let mut reviewer = None;
+    let mut verdict = None;
+    let mut comment = None;
+    reject_unknown_flags(
+        args,
+        &[
+            "--comment",
+            "--format",
+            "--goal",
+            "--head",
+            "--json",
+            "--number",
+            "--repo",
+            "--reviewer",
+            "--verdict",
+        ],
+    )?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--number" => number = Some(v),
+        "--head" => head = Some(v),
+        "--repo" => repo = Some(v),
+        "--reviewer" => reviewer = Some(v),
+        "--verdict" => verdict = Some(v),
+        "--comment" => comment = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let number: u64 = number
+        .ok_or_else(|| anyhow::anyhow!("--number required"))?
+        .parse()?;
+    let head = head.ok_or_else(|| anyhow::anyhow!("--head required"))?;
+    use crate::capabilities::pr_review_queue::ReviewVerdict;
+    let verdict_token = verdict
+        .ok_or_else(|| anyhow::anyhow!("--verdict required (approve|request-changes|rework)"))?;
+    let verdict = ReviewVerdict::parse(&verdict_token).ok_or_else(|| {
+        anyhow::anyhow!("--verdict must be approve|request-changes|rework (got `{verdict_token}`)")
+    })?;
+    use crate::work_items::review_queue::{apply_verdict, ReviewItem};
+    let item = ReviewItem {
+        number,
+        head_oid: head.clone(),
+        repository: repo,
+        title: format!("PR {number}"),
+        url: None,
+    };
+    if item.exact_head_key().is_none() {
+        bail!("--head must be a full 40- or 64-hex OID (exact-head review contract)");
+    }
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let id = item.todo_id();
+    // Strictly monotonic event ts: wall-clock is second-granular and a
+    // second verdict in the same second must still yield a distinct
+    // completion stamp (contract-tested).
+    let now = next_event_ts(store, &goal_id);
+    // A new exact head for the same PR supersedes the previous item. The
+    // work item is an upsert by PR number: the existing todo (open or done)
+    // is updated in place — no duplicate `pr-review-<number>` ids.
+    let mut superseded = false;
+    let new_item = match goal.todo(&id) {
+        Some(existing) => {
+            match ReviewItem::from_todo(existing) {
+                Some(parsed) if parsed.head_oid != item.head_oid => superseded = true,
+                _ => {}
+            }
+            false
+        }
+        None => true,
+    };
+    // Apply the verdict contract on a scratch todo to get note + evidence.
+    let mut todo = item.to_todo(&id);
+    apply_verdict(
+        &mut todo,
+        verdict,
+        reviewer.as_deref(),
+        comment.as_deref(),
+        now,
+    )
+    .map_err(anyhow::Error::msg)?;
+    let note = todo.note.clone();
+    let evidence = todo.evidence.clone().unwrap_or_default();
+    if new_item {
+        store.append(Event::TodoAdded {
+            goal_id: goal_id.clone(),
+            todo: item.to_todo(&id),
+            ts: now,
+        })?;
+    }
+    store.append(Event::TodoUpdated {
+        goal_id: goal_id.clone(),
+        todo_id: id.clone(),
+        // A superseding head must refresh the exact-head text the work item
+        // carries (reviews are exact-head addressed).
+        text: if superseded { Some(item.text()) } else { None },
+        status: None,
+        evidence: None,
+        note,
+        priority: None,
+        resume_when: None,
+        blocks: None,
+        ts: now,
+    })?;
+    store.append(Event::TodoCompleted {
+        goal_id: goal_id.clone(),
+        todo_id: id.clone(),
+        no_follow_up: true,
+        successor_ids: vec![],
+        evidence: Some(evidence.clone()),
+        ts: now,
+    })?;
+    refresh_next_action(store, &goal_id)?;
+    let _ = sync_compat(store, &goal_id);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "goal": goal_id,
+                "todo_id": id,
+                "number": number,
+                "head_oid": head,
+                "verdict": verdict.key(),
+                "label": verdict.label(),
+                "reviewer": reviewer.as_deref().unwrap_or("reviewer"),
+                "evidence": evidence,
+                "superseded": superseded,
+                "new_item": new_item
+            }))?
+        );
+        return Ok(());
+    }
+    println!(
+        "review PR #{number} at exact head {head} in {goal_id}: {} ({}) by {} ✔",
+        verdict.label(),
+        verdict.key(),
+        reviewer.as_deref().unwrap_or("reviewer")
+    );
+    println!("  evidence: {evidence}");
+    if superseded {
+        println!("  (previous exact head superseded)");
+    }
+    Ok(())
+}
+
+/// `pr-review claim` — claim a review work item: the existing task-lease
+/// state machine with the reviewer as lease owner.
+fn pr_review_claim(store: &mut Store, args: &[String]) -> Result<()> {
+    let mut goal_id = None;
+    let mut number = None;
+    let mut reviewer = None;
+    let mut lease_secs = 0u64;
+    reject_unknown_flags(args, &["--goal", "--lease-secs", "--number", "--reviewer"])?;
+    parse_pairs(args, |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--number" => number = Some(v),
+        "--reviewer" => reviewer = Some(v),
+        "--lease-secs" => lease_secs = v.parse().unwrap_or(0),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let number: u64 = number
+        .ok_or_else(|| anyhow::anyhow!("--number required"))?
+        .parse()?;
+    let reviewer = reviewer.unwrap_or_else(|| "default-agent".to_string());
+    let mut goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let id = format!("pr-review-{number}");
+    let existing = goal.todo(&id).cloned().ok_or_else(|| {
+        anyhow::anyhow!("review work item {id} not found (add it with `pr-review review` first)")
+    })?;
+    let item = crate::work_items::review_queue::ReviewItem::from_todo(&existing)
+        .ok_or_else(|| anyhow::anyhow!("todo {id} is not a PR review work item"))?;
+    use crate::work_items::review_queue::claim_review;
+    let now = now_epoch();
+    let op =
+        claim_review(&mut goal, &item, &reviewer, lease_secs, now).map_err(anyhow::Error::msg)?;
+    if !op.idempotent {
+        if op.steal {
+            store.append(Event::TodoExpired {
+                goal_id: goal_id.clone(),
+                todo_id: id.clone(),
+                ts: now,
+            })?;
+        }
+        let expires = goal
+            .todo(&id)
+            .and_then(|todo| todo.lease_expires_at)
+            .unwrap_or(now);
+        store.append(Event::TodoClaimed {
+            goal_id: goal_id.clone(),
+            todo_id: id.clone(),
+            agent_id: reviewer.clone(),
+            lease_expires_at: expires,
+            ts: now,
+        })?;
+    }
+    let _ = sync_compat(store, &goal_id);
+    let expires = goal
+        .todo(&id)
+        .and_then(|todo| todo.lease_expires_at)
+        .unwrap_or(now);
+    println!(
+        "review work item {id} lease acquired by {reviewer} until {expires} {}",
+        if op.steal {
+            "(steal after expiry) "
+        } else {
+            ""
+        }
+    );
+    Ok(())
+}
+
+/// `pr-review recommend` — reviewer recommendation from CODEOWNERS/OWNERS
+/// owner mapping plus a recent-commit heuristic over the changed paths.
+fn pr_review_recommend(args: &[String]) -> Result<()> {
+    let json = wants_json(args);
+    let mut paths: Vec<String> = vec![];
+    let mut codeowners_path = None;
+    let mut owners_root = None;
+    let mut repo_dir = None;
+    let mut since_days = 30u32;
+    reject_unknown_flags(
+        args,
+        &[
+            "--codeowners",
+            "--format",
+            "--json",
+            "--owners-root",
+            "--path",
+            "--repo-dir",
+            "--since-days",
+        ],
+    )?;
+    parse_pairs(args, |k, v| match k {
+        "--path" => paths.extend(
+            v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
+        ),
+        "--codeowners" => codeowners_path = Some(v),
+        "--owners-root" => owners_root = Some(v),
+        "--repo-dir" => repo_dir = Some(v),
+        "--since-days" => since_days = v.parse().unwrap_or(30),
+        _ => {}
+    });
+    if paths.is_empty() {
+        bail!("pr-review recommend requires at least one --path (comma-separated or repeatable)");
+    }
+    use crate::work_items::reviewer;
+    let rules = match codeowners_path {
+        Some(path) => reviewer::parse_codeowners(&std::fs::read_to_string(&path)?),
+        None => vec![],
+    };
+    let dir_owners = match owners_root {
+        Some(root) => reviewer::scan_owners_files(std::path::Path::new(&root)),
+        None => std::collections::BTreeMap::new(),
+    };
+    let commits = match repo_dir {
+        Some(dir) => reviewer::git_recent_commits(std::path::Path::new(&dir), since_days, 200),
+        None => vec![],
+    };
+    let candidates = reviewer::recommend_reviewers(
+        &paths,
+        (!rules.is_empty()).then_some(rules.as_slice()),
+        &dir_owners,
+        &commits,
+    );
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "paths": paths,
+                "candidates": candidates,
+            }))?
+        );
+        return Ok(());
+    }
+    println!("reviewer recommendations for {} path(s):", paths.len());
+    if candidates.is_empty() {
+        println!("  (no owner mapping or recent commits matched — add a CODEOWNERS/OWNERS file)");
+        return Ok(());
+    }
+    for candidate in &candidates {
+        println!(
+            "  {:<24} score {}  ({})",
+            candidate.reviewer,
+            candidate.score,
+            candidate.sources.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// `pr-review contract` — print the shared review execution contract
+/// (evidence requirements, completion gate, verdict policy 通过/驳回/再修).
+fn pr_review_contract(args: &[String]) -> Result<()> {
+    let json = wants_json(args);
+    reject_unknown_flags(args, &["--format", "--json"])?;
+    use crate::capabilities::pr_review_queue as queue;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&queue::build_agent_response_contract())?
+        );
+        return Ok(());
+    }
+    let contract = queue::build_review_execution_contract();
+    let gate = &contract["completion_gate"];
+    let policy = &contract["verdict_policy"];
+    println!(
+        "PR review execution contract ({})",
+        queue::EXECUTION_CONTRACT_SCHEMA_VERSION
+    );
+    println!("  completion gate:");
+    println!(
+        "    exact-head recheck required: {} | stale-head verdicts allowed: {}",
+        gate["exact_head_recheck_required"], gate["stale_head_verdict_allowed"]
+    );
+    println!(
+        "    code-change symbol minimum: {} | required final sections: {}",
+        gate["code_change_symbol_minimum"],
+        queue::REQUIRED_FINAL_SECTIONS.join(" / ")
+    );
+    println!("  verdict policy:");
+    println!(
+        "    blocking finding  → {}",
+        policy["open_pr_blocking_finding"]
+    );
+    println!(
+        "    non-blocking      → {}",
+        policy["open_pr_non_blocking_finding"]
+    );
+    println!("    no finding        → {}", policy["open_pr_no_finding"]);
+    println!("    merged PR         → {}", policy["merged_pr"]);
+    println!("  CLI verdicts: approve (通过) | request-changes (驳回) | rework (再修)");
     Ok(())
 }
 
@@ -7862,6 +8410,347 @@ mod cli_quirks_tests {
         // rows serialize (the --format json path)
         let json = serde_json::to_string(&rows).unwrap();
         assert!(json.contains("\"status\":\"running\""));
+    }
+
+    // ── pr-review (P2-3) CLI contract tests ─────────────────────────────
+
+    fn pr_fixture(number: u64, head: &str) -> serde_json::Value {
+        serde_json::json!({
+            "number": number,
+            "title": format!("PR {number}"),
+            "url": format!("https://github.com/owner/repo/pull/{number}"),
+            "state": "OPEN",
+            "head_oid": head,
+            "review_decision": "REVIEW_REQUIRED",
+            "is_draft": false,
+            "merge_state": "CLEAN",
+            "checks": {"counts": {"success": 1, "failure": 0, "pending": 0, "unknown": 0}, "failures": [], "pending": []}
+        })
+    }
+
+    fn pr_review_store() -> (tempfile::TempDir, Store) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().into_owned();
+        let mut store = Store::open(&root).unwrap();
+        let goal = Goal::new("g", "review PRs", "/tmp");
+        store.register(&goal).unwrap();
+        store
+            .append(Event::GoalStarted {
+                goal_id: "g".into(),
+                ts: 1,
+            })
+            .unwrap();
+        (dir, store)
+    }
+
+    #[test]
+    fn pr_review_queue_projects_the_observation() {
+        let (_dir, mut store) = pr_review_store();
+        let fixture = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            fixture.path(),
+            serde_json::json!({
+                "repository": "owner/repo",
+                "pull_requests": [pr_fixture(1, &"a".repeat(40)), pr_fixture(2, &"b".repeat(40))]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let args = vec![
+            "queue".to_string(),
+            "--fixture".to_string(),
+            fixture.path().to_string_lossy().into_owned(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        // capture stdout is not wired here; assert the observation instead
+        let payload: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(fixture.path()).unwrap()).unwrap();
+        let observation =
+            crate::capabilities::pr_review_queue::build_pull_request_review_queue_observation(
+                Some("owner/repo"),
+                payload["pull_requests"].as_array().unwrap(),
+                &serde_json::json!({"complete": true}),
+                None,
+                &[],
+            )
+            .unwrap();
+        assert_eq!(observation.candidate.as_ref().unwrap().number, Some(1));
+        assert_eq!(observation.queue_size, Some(2));
+        // the CLI path accepts the same flags without panicking
+        pr_review_queue(&mut store, &args).unwrap();
+    }
+
+    #[test]
+    fn pr_review_queue_requires_a_payload_source() {
+        let (_dir, mut store) = pr_review_store();
+        let err = pr_review_queue(&mut store, &["queue".to_string()]).unwrap_err();
+        assert!(format!("{err}").contains("--fixture"), "{err}");
+    }
+
+    #[test]
+    fn pr_review_verdict_creates_and_completes_the_work_item() {
+        let (dir, mut store) = pr_review_store();
+        let args = vec![
+            "review".to_string(),
+            "--goal".to_string(),
+            "g".to_string(),
+            "--number".to_string(),
+            "7".to_string(),
+            "--head".to_string(),
+            "a".repeat(40),
+            "--repo".to_string(),
+            "owner/repo".to_string(),
+            "--reviewer".to_string(),
+            "alice".to_string(),
+            "--verdict".to_string(),
+            "request-changes".to_string(),
+            "--comment".to_string(),
+            "missing regression test".to_string(),
+        ];
+        pr_review_verdict(&mut store, &args).unwrap();
+        let goal = store.replay("g").unwrap().unwrap();
+        let todo = goal.todo("pr-review-7").unwrap();
+        assert_eq!(todo.status, TodoStatus::Done);
+        assert!(todo.no_follow_up);
+        assert_eq!(todo.action_kind.as_deref(), Some("github_pr_review"));
+        assert_eq!(
+            todo.task_repository.as_deref(),
+            Some("git:github.com/owner/repo")
+        );
+        let evidence = todo.evidence.as_deref().unwrap();
+        assert!(evidence.contains("驳回"), "{evidence}");
+        assert!(evidence.contains("alice"));
+        assert!(evidence.contains("missing regression test"));
+        // the active-state projection is in sync
+        let active = std::fs::read_to_string(dir.path().join("goals/g/ACTIVE_GOAL_STATE.md"))
+            .unwrap_or_default();
+        assert!(active.contains("PR #7"), "{active}");
+        // a fresh verdict at the SAME head opens a new item (review completes)
+        pr_review_verdict(&mut store, &args).unwrap();
+        let goal = store.replay("g").unwrap().unwrap();
+        assert_eq!(goal.todo("pr-review-7").unwrap().status, TodoStatus::Done);
+    }
+
+    #[test]
+    fn pr_review_verdict_supersedes_on_a_new_exact_head() {
+        let (_dir, mut store) = pr_review_store();
+        let base = |head: String| {
+            vec![
+                "review".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "3".to_string(),
+                "--head".to_string(),
+                head,
+                "--verdict".to_string(),
+                "approve".to_string(),
+            ]
+        };
+        pr_review_verdict(&mut store, &base("a".repeat(40))).unwrap();
+        let first_ts = store
+            .replay("g")
+            .unwrap()
+            .unwrap()
+            .todo("pr-review-3")
+            .unwrap()
+            .completed_at;
+        pr_review_verdict(&mut store, &base("b".repeat(40))).unwrap();
+        let goal = store.replay("g").unwrap().unwrap();
+        let todo = goal.todo("pr-review-3").unwrap();
+        assert_eq!(todo.status, TodoStatus::Done);
+        assert!(
+            todo.completed_at > first_ts,
+            "new head completes a fresh item"
+        );
+        let evidence = todo.evidence.as_deref().unwrap();
+        assert!(evidence.contains(&"b".repeat(40)), "{evidence}");
+        assert!(evidence.contains("通过"));
+    }
+
+    #[test]
+    fn pr_review_verdict_rejects_bad_heads_and_verdicts() {
+        let (_dir, mut store) = pr_review_store();
+        let bad_head = pr_review_verdict(
+            &mut store,
+            &[
+                "review".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "1".to_string(),
+                "--head".to_string(),
+                "short".to_string(),
+                "--verdict".to_string(),
+                "approve".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(format!("{bad_head}").contains("40- or 64-hex"));
+        let bad_verdict = pr_review_verdict(
+            &mut store,
+            &[
+                "review".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "1".to_string(),
+                "--head".to_string(),
+                "a".repeat(40),
+                "--verdict".to_string(),
+                "meh".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(format!("{bad_verdict}").contains("approve|request-changes|rework"));
+        // no todo materialized on the failed paths
+        let goal = store.replay("g").unwrap().unwrap();
+        assert!(goal.todo("pr-review-1").is_none());
+    }
+
+    #[test]
+    fn pr_review_claim_reuses_the_task_lease_events() {
+        let (_dir, mut store) = pr_review_store();
+        let args = |verdict: &str| {
+            vec![
+                "review".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "5".to_string(),
+                "--head".to_string(),
+                "c".repeat(40),
+                "--verdict".to_string(),
+                verdict.to_string(),
+            ]
+        };
+        pr_review_verdict(&mut store, &args("approve")).unwrap();
+        // the completed item cannot be claimed (task_lease requires open)
+        let err = pr_review_claim(
+            &mut store,
+            &[
+                "claim".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "5".to_string(),
+                "--reviewer".to_string(),
+                "bob".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("open todo"), "{err:#}");
+        // claim an OPEN review item: lease events land in the ledger
+        let open = vec![
+            "review".to_string(),
+            "--goal".to_string(),
+            "g".to_string(),
+            "--number".to_string(),
+            "6".to_string(),
+            "--head".to_string(),
+            "d".repeat(40),
+            "--verdict".to_string(),
+            "rework".to_string(),
+        ];
+        // add an open review item via the work-item builder directly
+        let goal = store.replay("g").unwrap().unwrap();
+        let item = crate::work_items::review_queue::ReviewItem {
+            number: 6,
+            head_oid: "d".repeat(40),
+            repository: Some("owner/repo".to_string()),
+            title: "PR 6".to_string(),
+            url: None,
+        };
+        let todo = item.to_todo("pr-review-6");
+        store
+            .append(Event::TodoAdded {
+                goal_id: "g".into(),
+                todo,
+                ts: 2,
+            })
+            .unwrap();
+        let _ = goal;
+        pr_review_claim(
+            &mut store,
+            &[
+                "claim".to_string(),
+                "--goal".to_string(),
+                "g".to_string(),
+                "--number".to_string(),
+                "6".to_string(),
+                "--reviewer".to_string(),
+                "bob".to_string(),
+            ],
+        )
+        .unwrap();
+        let goal = store.replay("g").unwrap().unwrap();
+        let claimed = goal.todo("pr-review-6").unwrap();
+        assert_eq!(claimed.claimed_by.as_deref(), Some("bob"));
+        assert!(claimed.lease_expires_at.is_some());
+        let _ = open;
+    }
+
+    #[test]
+    fn pr_review_recommend_ranks_from_codeowners_and_owners_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src/deep")).unwrap();
+        std::fs::write(
+            dir.path().join("CODEOWNERS"),
+            "src/** @core\n*.md docs-team\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("src/OWNERS"), "alice\n").unwrap();
+        std::fs::write(dir.path().join("src/deep/OWNERS"), "deep-owner\n").unwrap();
+        let args = vec![
+            "recommend".to_string(),
+            "--path".to_string(),
+            "src/deep/core.rs".to_string(),
+            "--codeowners".to_string(),
+            dir.path().join("CODEOWNERS").to_string_lossy().into_owned(),
+            "--owners-root".to_string(),
+            dir.path().to_string_lossy().into_owned(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        pr_review_recommend(&args).unwrap();
+        // the pure scorer is the contract; assert its deterministic ranking
+        let rules = crate::work_items::reviewer::parse_codeowners("src/** @core\n");
+        let dirs = crate::work_items::reviewer::scan_owners_files(dir.path());
+        let candidates = crate::work_items::reviewer::recommend_reviewers(
+            &["src/deep/core.rs".to_string()],
+            Some(&rules),
+            &dirs,
+            &[],
+        );
+        let names: Vec<&str> = candidates.iter().map(|c| c.reviewer.as_str()).collect();
+        assert_eq!(names, vec!["@core", "deep-owner"]);
+        // no paths → error
+        assert!(pr_review_recommend(&["recommend".to_string()]).is_err());
+    }
+
+    #[test]
+    fn pr_review_contract_prints_the_verdict_policy() {
+        pr_review_contract(&["contract".to_string()]).unwrap();
+        pr_review_contract(&[
+            "contract".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ])
+        .unwrap();
+        let err = pr_review_contract(&["contract".to_string(), "--nope".to_string()]).unwrap_err();
+        assert!(format!("{err}").contains("unknown flag"), "{err}");
+    }
+
+    #[test]
+    fn pr_review_registered_and_journey_assigned() {
+        let registry = build_cli_registry();
+        let (group, def) = registry.find("pr-review", false).unwrap();
+        assert_eq!(group.name, "pr-review");
+        assert_eq!(def.journey, Journey::Daily);
+        assert!(registry
+            .render_help(false)
+            .contains("pr-review queue|review|claim"));
     }
 
     #[test]

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -1268,10 +1268,16 @@ fn apply(goal: &mut Goal, event: Event) {
             no_follow_up,
             successor_ids,
             evidence,
+            ts,
             ..
         } => {
             if let Some(t) = goal.todo_mut(&todo_id) {
                 t.complete(no_follow_up, successor_ids);
+                // The event ts is authoritative for the completion stamp
+                // (wall-clock replay is second-granular; GateResolved already
+                // applies the same rule).
+                t.completed_at = Some(ts);
+                t.updated_at = ts;
                 if let Some(e) = evidence {
                     t.evidence = Some(e);
                 }

--- a/orchestration/loop/src/work_items/mod.rs
+++ b/orchestration/loop/src/work_items/mod.rs
@@ -9,5 +9,7 @@ pub mod delivery;
 pub mod delivery_outcome;
 pub mod operator_inbox;
 pub mod replan_obligation;
+pub mod review_queue;
+pub mod reviewer;
 pub mod task_graph;
 pub mod task_lease;

--- a/orchestration/loop/src/work_items/review_queue.rs
+++ b/orchestration/loop/src/work_items/review_queue.rs
@@ -1,0 +1,553 @@
+//! First-class PR-review work items (the work-item surface of the
+//! `pr_review_queue` capability, P2-3).
+//!
+//! A review item is an **advancement Todo** carrying the review identity:
+//!
+//! - `action_kind = github_pr_review`
+//! - `required_capability = pr_review_queue` (capability-gated runnability)
+//! - `task_repository = git:github.com/<owner/repo>`
+//! - stable per-goal todo id `pr-review-<number>` (upsert by PR number)
+//!
+//! Because the item IS a todo, **claim/lease reuse the existing
+//! `task_lease` state machine** (claim / renew / release / expire / steal)
+//! with the reviewer as the lease owner — no second lease implementation.
+//! Verdicts route through the review contract (通过 approve / 驳回
+//! request_changes / 再修 rework): publishing a verdict completes the
+//! review work item with evidence; a re-review is driven by a new exact
+//! head (the queue observation emits a fresh candidate only on material
+//! transitions or explicit handled cursors).
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::capabilities::pr_review_queue::ReviewVerdict;
+use crate::state::{Goal, TaskClass, Todo, TodoStatus};
+use crate::work_items::task_lease;
+
+pub const REVIEW_ACTION_KIND: &str = "github_pr_review";
+pub const REVIEW_REQUIRED_CAPABILITY: &str = "pr_review_queue";
+pub const REVIEW_TASK_REPOSITORY_PREFIX: &str = "git:github.com/";
+
+/// A first-class review item: the typed projection of one PR exact-head
+/// review over its backing Todo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewItem {
+    pub number: u64,
+    pub head_oid: String,
+    pub repository: Option<String>,
+    pub title: String,
+    pub url: Option<String>,
+}
+
+impl ReviewItem {
+    /// `NUMBER@HEAD_OID` when the head is a full 40/64-hex OID.
+    pub fn exact_head_key(&self) -> Option<String> {
+        let head = self.head_oid.trim().to_lowercase();
+        let is_hex_oid =
+            (head.len() == 40 || head.len() == 64) && head.chars().all(|c| c.is_ascii_hexdigit());
+        if !is_hex_oid {
+            return None;
+        }
+        Some(format!("{}@{head}", self.number))
+    }
+
+    /// Stable per-goal todo id: one open review work item per PR number
+    /// (a new exact head supersedes the previous one).
+    pub fn todo_id(&self) -> String {
+        format!("pr-review-{}", self.number)
+    }
+
+    /// The task repository token (reference `git:github.com/<owner/repo>`).
+    pub fn task_repository(&self) -> Option<String> {
+        self.repository
+            .as_deref()
+            .map(|repo| format!("{REVIEW_TASK_REPOSITORY_PREFIX}{repo}"))
+    }
+
+    /// The work-item text: the review task at this exact head.
+    pub fn text(&self) -> String {
+        format!(
+            "[P1] Review PR #{} at exact head {}; read the diff and checks, publish a review state matching the evidence, and route any merge through repository policy.",
+            self.number, self.head_oid
+        )
+    }
+
+    /// Materialize the first-class work item as an advancement Todo.
+    pub fn to_todo(&self, id: &str) -> Todo {
+        let mut todo = Todo::advancement(id, &self.text());
+        // The todo title stays the PR title (short label); the generic
+        // "Review PR #N" phrasing already lives in the todo text.
+        todo.title = if self.title.trim().is_empty() {
+            format!("Review PR #{}", self.number)
+        } else {
+            self.title.clone()
+        };
+        todo.action_kind = Some(REVIEW_ACTION_KIND.to_string());
+        todo.required_capability = Some(REVIEW_REQUIRED_CAPABILITY.to_string());
+        todo.capability_binding_ref = Some(REVIEW_REQUIRED_CAPABILITY.to_string());
+        todo.task_repository = self.task_repository();
+        todo
+    }
+
+    /// Inverse projection: parse a review work item back out of its Todo.
+    /// Returns `None` for todos that are not review items.
+    pub fn from_todo(todo: &Todo) -> Option<Self> {
+        if todo.class != TaskClass::Advancement {
+            return None;
+        }
+        let is_review = todo.action_kind.as_deref() == Some(REVIEW_ACTION_KIND)
+            || todo.required_capability.as_deref() == Some(REVIEW_REQUIRED_CAPABILITY);
+        if !is_review {
+            return None;
+        }
+        let number = todo
+            .id
+            .strip_prefix("pr-review-")
+            .and_then(|suffix| suffix.parse::<u64>().ok())
+            .or_else(|| parse_pr_number(&todo.title))?;
+        let head_oid = parse_exact_head(&todo.text)?;
+        let repository = todo
+            .task_repository
+            .as_deref()
+            .and_then(|repo| repo.strip_prefix(REVIEW_TASK_REPOSITORY_PREFIX))
+            .map(|repo| repo.to_string());
+        Some(Self {
+            number,
+            head_oid,
+            // The review item type is GitHub-scoped (git:github.com/...), so
+            // the PR URL is deterministic from repository + number.
+            url: repository
+                .as_ref()
+                .map(|repo| format!("https://github.com/{repo}/pull/{number}")),
+            repository,
+            title: todo.title.clone(),
+        })
+    }
+}
+
+/// Parse `PR #<number>` from a title.
+fn parse_pr_number(title: &str) -> Option<u64> {
+    let upper = title.to_uppercase();
+    let hash = upper.find("PR #")?;
+    let rest = &upper[hash + 4..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+/// Parse the `exact head <40|64-hex>` marker from review-item text.
+pub fn parse_exact_head(text: &str) -> Option<String> {
+    let needle = "exact head ";
+    let pos = text.find(needle)?;
+    let rest = &text[pos + needle.len()..];
+    let token: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+    if token.len() == 40 || token.len() == 64 {
+        Some(token.to_lowercase())
+    } else {
+        None
+    }
+}
+
+/// The verdict + comment recorded on a review todo, encoded into its note
+/// (`review_verdict: <key>` / `review_comment: <text>`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RecordedVerdict {
+    pub verdict: Option<ReviewVerdict>,
+    pub comment: Option<String>,
+}
+
+impl RecordedVerdict {
+    /// Encode into the todo note (deterministic, parseable back).
+    pub fn to_note(&self) -> String {
+        let mut lines: Vec<String> = Vec::new();
+        if let Some(verdict) = self.verdict {
+            lines.push(format!("review_verdict: {}", verdict.key()));
+        }
+        if let Some(comment) = &self.comment {
+            for line in comment.lines() {
+                lines.push(format!("review_comment: {line}"));
+            }
+        }
+        lines.join("\n")
+    }
+
+    /// Parse from a todo note.
+    pub fn from_note(note: Option<&str>) -> Self {
+        let mut out = Self::default();
+        for line in note.unwrap_or_default().lines() {
+            if let Some(value) = line.strip_prefix("review_verdict: ") {
+                out.verdict = ReviewVerdict::parse(value.trim());
+            } else if let Some(value) = line.strip_prefix("review_comment: ") {
+                let text = value.to_string();
+                out.comment = Some(match &out.comment {
+                    Some(existing) => format!("{existing}\n{text}"),
+                    None => text,
+                });
+            }
+        }
+        out
+    }
+}
+
+/// The completion evidence for a published verdict.
+pub fn verdict_evidence(
+    item: &ReviewItem,
+    verdict: ReviewVerdict,
+    reviewer: Option<&str>,
+    comment: Option<&str>,
+) -> String {
+    let reviewer = reviewer.unwrap_or("reviewer");
+    let comment = comment.map(|c| format!(": {c}")).unwrap_or_default();
+    format!(
+        "review {} ({}) at exact head {}@{} by {reviewer}{comment}",
+        verdict.label(),
+        verdict.key(),
+        item.number,
+        item.head_oid
+    )
+}
+
+/// The review contract transition (③): publishing a verdict completes the
+/// review work item with evidence. A re-review after 驳回/再修 is driven by
+/// a new exact head — the queue observation re-selects only on material
+/// transitions or explicit handled cursors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerdictOutcome {
+    /// 通过 — the review is published and the item is complete.
+    Approve,
+    /// 驳回 — changes requested; the item completes and re-review waits for
+    /// a new exact head.
+    RequestChanges,
+    /// 再修 — rework requested; same exact-head semantics.
+    Rework,
+}
+
+/// Apply a verdict to a review todo in memory: records the note + evidence
+/// and marks the item done with an explicit no-follow-up (the completion
+/// contract of advancement todos). The caller persists the matching store
+/// events (TodoUpdated / TodoCompleted).
+pub fn apply_verdict(
+    todo: &mut Todo,
+    verdict: ReviewVerdict,
+    reviewer: Option<&str>,
+    comment: Option<&str>,
+    now: u64,
+) -> Result<VerdictOutcome, String> {
+    if todo.action_kind.as_deref() != Some(REVIEW_ACTION_KIND)
+        && todo.required_capability.as_deref() != Some(REVIEW_REQUIRED_CAPABILITY)
+    {
+        return Err(format!("todo {} is not a PR review work item", todo.id));
+    }
+    let item = ReviewItem::from_todo(todo).ok_or_else(|| "review item parse failed".to_string())?;
+    todo.note = Some(
+        RecordedVerdict {
+            verdict: Some(verdict),
+            comment: comment.map(|c| c.to_string()),
+        }
+        .to_note(),
+    );
+    todo.evidence = Some(verdict_evidence(&item, verdict, reviewer, comment));
+    todo.status = TodoStatus::Done;
+    todo.no_follow_up = true;
+    todo.completed_at = Some(now);
+    todo.updated_at = now;
+    Ok(match verdict {
+        ReviewVerdict::Approve => VerdictOutcome::Approve,
+        ReviewVerdict::RequestChanges => VerdictOutcome::RequestChanges,
+        ReviewVerdict::Rework => VerdictOutcome::Rework,
+    })
+}
+
+// ── claim/lease reuse (task_lease over the review todo) ───────────────────
+
+/// Claim a review work item: the existing task-lease state machine with the
+/// reviewer as lease owner. Live leases held by another reviewer conflict;
+/// the same reviewer re-claiming is idempotent; an expired lease is stolen.
+pub fn claim_review(
+    goal: &mut Goal,
+    item: &ReviewItem,
+    reviewer: &str,
+    lease_secs: u64,
+    now: u64,
+) -> Result<task_lease::ClaimOutcome, String> {
+    let todo = goal
+        .todo_mut(&item.todo_id())
+        .ok_or_else(|| format!("review work item {} not found", item.todo_id()))?;
+    task_lease::claim(todo, reviewer, lease_secs, now).map_err(|err| format!("{err:#}"))
+}
+
+/// Renew a review lease held by `reviewer`.
+pub fn renew_review(
+    goal: &mut Goal,
+    item: &ReviewItem,
+    reviewer: &str,
+    lease_secs: u64,
+    now: u64,
+) -> Result<task_lease::LeaseOp, String> {
+    let todo = goal
+        .todo_mut(&item.todo_id())
+        .ok_or_else(|| format!("review work item {} not found", item.todo_id()))?;
+    task_lease::renew(todo, reviewer, lease_secs, now).map_err(|err| format!("{err:#}"))
+}
+
+/// Release a review lease held by `reviewer`.
+pub fn release_review(
+    goal: &mut Goal,
+    item: &ReviewItem,
+    reviewer: &str,
+    now: u64,
+) -> Result<task_lease::LeaseOp, String> {
+    let todo = goal
+        .todo_mut(&item.todo_id())
+        .ok_or_else(|| format!("review work item {} not found", item.todo_id()))?;
+    task_lease::release(todo, reviewer, now).map_err(|err| format!("{err:#}"))
+}
+
+/// Record expiry for a review lease (a lapsed lease returns the item to the
+/// frontier; a new reviewer may steal it).
+pub fn expire_review(
+    goal: &mut Goal,
+    item: &ReviewItem,
+    now: u64,
+) -> Result<task_lease::LeaseOp, String> {
+    let todo = goal
+        .todo_mut(&item.todo_id())
+        .ok_or_else(|| format!("review work item {} not found", item.todo_id()))?;
+    task_lease::expire(todo, now).map_err(|err| format!("{err:#}"))
+}
+
+/// The derived lease state of a review work item.
+pub fn review_lease_status(
+    goal: &Goal,
+    item: &ReviewItem,
+    now: u64,
+) -> Option<task_lease::LeaseStatus> {
+    goal.todo(&item.todo_id())
+        .map(|todo| task_lease::lease_status(todo, now))
+}
+
+/// The first-class queue projection: the open review work items of a goal.
+#[derive(Debug, Clone, Default)]
+pub struct ReviewQueue {
+    pub repository: Option<String>,
+    pub items: Vec<ReviewItem>,
+}
+
+impl ReviewQueue {
+    /// Project the open review work items of a goal (done reviews are
+    /// completed work items, not part of the active queue).
+    pub fn from_goal(goal: &Goal) -> Self {
+        let mut queue = Self::default();
+        for todo in goal.todos.iter() {
+            if todo.status != TodoStatus::Open {
+                continue;
+            }
+            let Some(item) = ReviewItem::from_todo(todo) else {
+                continue;
+            };
+            if queue.repository.is_none() {
+                queue.repository = item.repository.clone();
+            }
+            queue.items.push(item);
+        }
+        queue.items.sort_by_key(|item| item.number);
+        queue
+    }
+
+    pub fn get(&self, number: u64) -> Option<&ReviewItem> {
+        self.items.iter().find(|item| item.number == number)
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::now_epoch;
+
+    fn item(number: u64, head: &str) -> ReviewItem {
+        ReviewItem {
+            number,
+            head_oid: head.to_string(),
+            repository: Some("owner/repo".to_string()),
+            title: format!("PR {number}"),
+            url: Some(format!("https://github.com/owner/repo/pull/{number}")),
+        }
+    }
+
+    #[test]
+    fn todo_roundtrip_preserves_the_review_identity() {
+        let item = item(7, &"a".repeat(40));
+        let todo = item.to_todo("pr-review-7");
+        assert_eq!(todo.class, TaskClass::Advancement);
+        assert_eq!(todo.action_kind.as_deref(), Some(REVIEW_ACTION_KIND));
+        assert_eq!(
+            todo.required_capability.as_deref(),
+            Some(REVIEW_REQUIRED_CAPABILITY)
+        );
+        assert_eq!(
+            todo.task_repository.as_deref(),
+            Some("git:github.com/owner/repo")
+        );
+        assert_eq!(todo.title, "PR 7");
+        let parsed = ReviewItem::from_todo(&todo).unwrap();
+        assert_eq!(parsed, item);
+        assert_eq!(
+            parsed.exact_head_key(),
+            Some(format!("7@{}", "a".repeat(40)))
+        );
+    }
+
+    #[test]
+    fn non_review_todos_do_not_project_as_review_items() {
+        let todo = Todo::advancement("t1", "regular work");
+        assert!(ReviewItem::from_todo(&todo).is_none());
+        // a review-kind todo without a parseable head fails closed
+        let mut todo = Todo::advancement("pr-review-9", "Review PR #9 at exact head short");
+        todo.action_kind = Some(REVIEW_ACTION_KIND.to_string());
+        assert!(ReviewItem::from_todo(&todo).is_none());
+    }
+
+    #[test]
+    fn exact_head_requires_a_full_oid() {
+        assert_eq!(
+            item(1, &"b".repeat(40)).exact_head_key(),
+            Some(format!("1@{}", "b".repeat(40)))
+        );
+        assert_eq!(item(1, &"b".repeat(64)).exact_head_key().unwrap().len(), 66);
+        assert!(item(1, "short").exact_head_key().is_none());
+    }
+
+    #[test]
+    fn parse_exact_head_scans_review_text() {
+        let todo = item(3, &"c".repeat(40)).to_todo("pr-review-3");
+        assert_eq!(parse_exact_head(&todo.text), Some("c".repeat(40)));
+        assert_eq!(parse_exact_head("no marker here"), None);
+    }
+
+    #[test]
+    fn recorded_verdict_note_roundtrips() {
+        let recorded = RecordedVerdict {
+            verdict: Some(ReviewVerdict::RequestChanges),
+            comment: Some("blocking: unsafe unwrap\nline 42".to_string()),
+        };
+        let note = recorded.to_note();
+        assert!(note.contains("review_verdict: request_changes"));
+        assert!(note.contains("review_comment: blocking: unsafe unwrap"));
+        let parsed = RecordedVerdict::from_note(Some(&note));
+        assert_eq!(parsed, recorded);
+        // no verdict recorded → empty
+        assert_eq!(RecordedVerdict::from_note(None), RecordedVerdict::default());
+        assert_eq!(
+            RecordedVerdict::from_note(Some("something else")),
+            RecordedVerdict::default()
+        );
+    }
+
+    #[test]
+    fn verdict_application_completes_the_work_item() {
+        let mut todo = item(5, &"d".repeat(40)).to_todo("pr-review-5");
+        let now = now_epoch();
+        let outcome = apply_verdict(
+            &mut todo,
+            ReviewVerdict::RequestChanges,
+            Some("alice"),
+            Some("missing regression test"),
+            now,
+        )
+        .unwrap();
+        assert_eq!(outcome, VerdictOutcome::RequestChanges);
+        assert_eq!(todo.status, TodoStatus::Done);
+        assert!(todo.no_follow_up);
+        assert_eq!(todo.completed_at, Some(now));
+        let evidence = todo.evidence.as_deref().unwrap();
+        assert!(evidence.contains("驳回"));
+        assert!(evidence.contains("alice"));
+        assert!(evidence.contains("missing regression test"));
+        let recorded = RecordedVerdict::from_note(todo.note.as_deref());
+        assert_eq!(recorded.verdict, Some(ReviewVerdict::RequestChanges));
+    }
+
+    #[test]
+    fn verdict_application_rejects_non_review_todos() {
+        let mut todo = Todo::advancement("t1", "regular work");
+        let err = apply_verdict(&mut todo, ReviewVerdict::Approve, None, None, 1).unwrap_err();
+        assert!(err.contains("not a PR review work item"));
+    }
+
+    #[test]
+    fn claim_review_reuses_the_task_lease_state_machine() {
+        let mut goal = Goal::new("g", "obj", "/tmp");
+        goal.add(item(7, &"e".repeat(40)).to_todo("pr-review-7"));
+        let now = now_epoch();
+        let outcome = claim_review(&mut goal, &item(7, &"e".repeat(40)), "alice", 60, now).unwrap();
+        assert_eq!(
+            outcome,
+            task_lease::ClaimOutcome {
+                idempotent: false,
+                steal: false
+            }
+        );
+        // a live lease held by another reviewer conflicts (task_lease rule)
+        let err = claim_review(&mut goal, &item(7, &"e".repeat(40)), "bob", 60, now).unwrap_err();
+        assert!(err.contains("another agent"), "{err}");
+        // same reviewer re-claiming is idempotent
+        let outcome = claim_review(&mut goal, &item(7, &"e".repeat(40)), "alice", 60, now).unwrap();
+        assert!(outcome.idempotent);
+        // release by the owner clears the lease
+        let op = release_review(&mut goal, &item(7, &"e".repeat(40)), "alice", now).unwrap();
+        assert_eq!(op, task_lease::LeaseOp::Released { missing: false });
+        // release by a non-owner fails
+        claim_review(&mut goal, &item(7, &"e".repeat(40)), "alice", 60, now).unwrap();
+        assert!(release_review(&mut goal, &item(7, &"e".repeat(40)), "bob", now).is_err());
+    }
+
+    #[test]
+    fn expired_review_lease_allows_steal() {
+        let mut goal = Goal::new("g", "obj", "/tmp");
+        goal.add(item(7, &"e".repeat(40)).to_todo("pr-review-7"));
+        let now = now_epoch();
+        claim_review(&mut goal, &item(7, &"e".repeat(40)), "alice", 60, now).unwrap();
+        // after expiry a new reviewer steals the lease
+        let outcome =
+            claim_review(&mut goal, &item(7, &"e".repeat(40)), "bob", 60, now + 120).unwrap();
+        assert_eq!(
+            outcome,
+            task_lease::ClaimOutcome {
+                idempotent: false,
+                steal: true
+            }
+        );
+        assert_eq!(
+            review_lease_status(&goal, &item(7, &"e".repeat(40)), now + 120).map(|s| {
+                matches!(s, task_lease::LeaseStatus::Active { owner, .. } if owner == "bob")
+            }),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn queue_projects_open_review_items_only() {
+        let mut goal = Goal::new("g", "obj", "/tmp");
+        goal.add(item(2, &"f".repeat(40)).to_todo("pr-review-2"));
+        goal.add(item(1, &"f".repeat(40)).to_todo("pr-review-1"));
+        goal.add(Todo::advancement("t1", "regular work"));
+        let mut done = item(3, &"f".repeat(40)).to_todo("pr-review-3");
+        done.status = TodoStatus::Done;
+        goal.add(done);
+        let queue = ReviewQueue::from_goal(&goal);
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.repository.as_deref(), Some("owner/repo"));
+        assert_eq!(queue.items[0].number, 1);
+        assert_eq!(queue.items[1].number, 2);
+        assert_eq!(queue.get(1).unwrap().number, 1);
+        assert!(queue.get(3).is_none());
+        assert!(ReviewQueue::from_goal(&Goal::new("e", "o", "/tmp")).is_empty());
+    }
+}

--- a/orchestration/loop/src/work_items/reviewer.rs
+++ b/orchestration/loop/src/work_items/reviewer.rs
@@ -1,0 +1,536 @@
+//! Reviewer recommendation for the `pr_review_queue` capability (P2-3②):
+//! path-owner mapping as the starting signal — CODEOWNERS / OWNERS-style
+//! mapping files plus a recent-commit heuristic.
+//!
+//! Everything is a deterministic pure function over parsed content (testable
+//! without git); the only side-effecting helper is `git_recent_commits`,
+//! which shells out to `git log` and degrades to an empty heuristic source
+//! on any failure.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// One CODEOWNERS rule: a gitignore-style path pattern + its owners
+/// (last matching rule wins — GitHub CODEOWNERS semantics).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnerRule {
+    pub pattern: String,
+    pub owners: Vec<String>,
+}
+
+/// One ranked reviewer candidate.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ReviewerCandidate {
+    pub reviewer: String,
+    pub score: u32,
+    pub sources: Vec<String>,
+}
+
+/// Parse a CODEOWNERS file: `<pattern> <owner>…` per line, `#` comments and
+/// blank lines skipped. Patterns keep their verbatim shape (`/src/`, `*.rs`,
+/// `docs/**`).
+pub fn parse_codeowners(content: &str) -> Vec<OwnerRule> {
+    let mut rules = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let mut parts = trimmed.split_whitespace();
+        let Some(pattern) = parts.next() else {
+            continue;
+        };
+        let owners: Vec<String> = parts.map(|owner| owner.to_string()).collect();
+        if owners.is_empty() {
+            continue;
+        }
+        rules.push(OwnerRule {
+            pattern: pattern.to_string(),
+            owners,
+        });
+    }
+    rules
+}
+
+/// Parse an OWNERS file: one owner per line, `#` comments and blank lines
+/// skipped (email/handle tokens kept verbatim).
+pub fn parse_owners(content: &str) -> Vec<String> {
+    let mut owners = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        owners.push(trimmed.to_string());
+    }
+    owners
+}
+
+/// `*` within a path segment matches any run not crossing `/`; `?` one
+/// character (gitignore subset used by CODEOWNERS).
+fn segment_matches(pattern: &[char], segment: &[char]) -> bool {
+    match pattern.first() {
+        None => segment.is_empty(),
+        Some('*') => {
+            let mut rest = pattern;
+            while rest.first() == Some(&'*') {
+                rest = &rest[1..];
+            }
+            (0..=segment.len()).any(|skip| segment_matches(rest, &segment[skip..]))
+        }
+        Some('?') => !segment.is_empty() && segment_matches(&pattern[1..], &segment[1..]),
+        Some(ch) => segment.first() == Some(ch) && segment_matches(&pattern[1..], &segment[1..]),
+    }
+}
+
+/// Segment-wise match with `**` crossing segments.
+fn path_segments_match(pattern: &[&str], path: &[&str]) -> bool {
+    match pattern.first() {
+        None => path.is_empty(),
+        Some(segment) if *segment == "**" => {
+            path_segments_match(&pattern[1..], path)
+                || (!path.is_empty() && path_segments_match(pattern, &path[1..]))
+        }
+        Some(segment) => {
+            !path.is_empty()
+                && segment_matches(
+                    &segment.chars().collect::<Vec<_>>(),
+                    &path[0].chars().collect::<Vec<_>>(),
+                )
+                && path_segments_match(&pattern[1..], &path[1..])
+        }
+    }
+}
+
+/// Match a CODEOWNERS pattern against a repo-relative path. Leading `/`
+/// anchors the pattern at the repo root (paths are compared root-relative,
+/// so it is informational); a trailing `/` matches the directory and
+/// everything under it; `**` crosses path segments.
+pub fn path_matches(pattern: &str, path: &str) -> bool {
+    let pattern_raw = pattern.trim();
+    let dir_pattern = pattern_raw.ends_with('/');
+    // GitHub CODEOWNERS semantics: a pattern without `/` (and without a
+    // trailing `/`) matches the basename of the path at any depth, e.g.
+    // `*.md` matches `docs/readme.md`. Anchored forms (`/src/`, `src/`,
+    // `src/**`) match from the root as usual.
+    let basename_pattern =
+        !dir_pattern && !pattern_raw.starts_with('/') && !pattern_raw.contains('/');
+    let pattern = pattern_raw.trim_start_matches('/').trim_end_matches('/');
+    let path = path.trim().trim_start_matches('/').trim_end_matches('/');
+    if pattern.is_empty() {
+        return true;
+    }
+    let pattern_segments: Vec<&str> = pattern.split('/').collect();
+    let path_segments: Vec<&str> = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let segment_match = |p: &str, s: &str| {
+        segment_matches(
+            &p.chars().collect::<Vec<_>>(),
+            &s.chars().collect::<Vec<_>>(),
+        )
+    };
+    if basename_pattern {
+        return path_segments
+            .last()
+            .is_some_and(|segment| segment_match(pattern_segments[0], segment));
+    }
+    if pattern_segments.contains(&"**") {
+        if dir_pattern && pattern_segments.len() == 1 {
+            // `**/` — everything under the root.
+            return true;
+        }
+        if dir_pattern {
+            // `dir/**/` — the prefix before `**` must match, then anything
+            // underneath follows.
+            let prefix: Vec<&str> = pattern_segments
+                .iter()
+                .take_while(|segment| **segment != "**")
+                .copied()
+                .collect();
+            return path_segments.len() >= prefix.len()
+                && prefix
+                    .iter()
+                    .zip(path_segments.iter())
+                    .all(|(p, s)| segment_match(p, s));
+        }
+        return path_segments_match(&pattern_segments, &path_segments);
+    }
+    if dir_pattern {
+        return path_segments.len() >= pattern_segments.len()
+            && pattern_segments
+                .iter()
+                .zip(path_segments.iter())
+                .all(|(p, s)| segment_match(p, s));
+    }
+    path_segments.len() == pattern_segments.len()
+        && pattern_segments
+            .iter()
+            .zip(path_segments.iter())
+            .all(|(p, s)| segment_match(p, s))
+}
+
+/// Resolve the owners of a path from CODEOWNERS rules (last matching rule
+/// wins).
+pub fn codeowners_for_path(rules: &[OwnerRule], path: &str) -> Vec<String> {
+    rules
+        .iter()
+        .rev()
+        .find(|rule| path_matches(&rule.pattern, path))
+        .map(|rule| rule.owners.clone())
+        .unwrap_or_default()
+}
+
+/// Normalize a directory key (no leading/trailing slash; root = "").
+pub fn normalize_dir(dir: &str) -> String {
+    dir.trim().trim_matches('/').to_string()
+}
+
+/// Scan a repository tree for OWNERS files (bounded depth; `.git` skipped)
+/// and map each relative directory → its owners. A missing/unreadable root
+/// degrades to an empty map.
+pub fn scan_owners_files(root: &Path) -> BTreeMap<String, Vec<String>> {
+    const MAX_DEPTH: usize = 8;
+    fn visit(
+        dir: &Path,
+        depth: usize,
+        root: &Path,
+        dir_owners: &mut BTreeMap<String, Vec<String>>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_name = entry.file_name();
+            let name = file_name.to_string_lossy();
+            if name == ".git" {
+                continue;
+            }
+            if path.is_dir() && depth < MAX_DEPTH {
+                visit(&path, depth + 1, root, dir_owners);
+            } else if path.is_file() && name == "OWNERS" {
+                let relative = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .parent()
+                    .unwrap_or(Path::new(""))
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                let key = normalize_dir(&relative);
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    let owners = parse_owners(&content);
+                    if !owners.is_empty() {
+                        dir_owners.insert(key, owners);
+                    }
+                }
+            }
+        }
+    }
+    let mut dir_owners: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    visit(root, 0, root, &mut dir_owners);
+    dir_owners
+}
+
+/// The nearest ancestor OWNERS entry for a path: the deepest directory
+/// (including the root) that has an OWNERS file.
+pub fn nearest_owners<'a>(
+    dir_owners: &'a BTreeMap<String, Vec<String>>,
+    path: &str,
+) -> Option<(String, &'a Vec<String>)> {
+    let mut dir = normalize_dir(path);
+    loop {
+        if let Some(owners) = dir_owners.get(&dir) {
+            return Some((dir, owners));
+        }
+        if dir.is_empty() {
+            return dir_owners.get("").map(|owners| (String::new(), owners));
+        }
+        dir = match dir.rfind('/') {
+            Some(pos) => dir[..pos].to_string(),
+            None => String::new(),
+        };
+    }
+}
+
+/// Aggregate reviewer candidates for the changed paths.
+///
+/// Scoring (deterministic, highest wins; ties broken by name):
+/// - CODEOWNERS owner of a matching rule: +3 (credited once — an ownership
+///   signal is one signal, not one per changed path)
+/// - OWNERS of the nearest ancestor directory: +2 (credited once)
+/// - author of a recent commit touching the path or a parent dir: +1
+///   (per commit — each commit is independent evidence of activity)
+pub fn recommend_reviewers(
+    paths: &[String],
+    codeowners: Option<&[OwnerRule]>,
+    dir_owners: &BTreeMap<String, Vec<String>>,
+    recent_commits: &[(String, String)],
+) -> Vec<ReviewerCandidate> {
+    /// Credit a reviewer; ownership signals (`once = true`) count only the
+    /// first time the same source kind credits that reviewer, while
+    /// per-commit signals accumulate.
+    fn credit(
+        scores: &mut BTreeMap<String, (u32, Vec<String>)>,
+        reviewer: &str,
+        score: u32,
+        source: String,
+        once: bool,
+    ) {
+        let reviewer = reviewer.trim().to_string();
+        if reviewer.is_empty() {
+            return;
+        }
+        let entry = scores.entry(reviewer).or_insert_with(|| (0, Vec::new()));
+        if once {
+            let kind = source.split(':').next().unwrap_or_default();
+            if entry.1.iter().any(|s| s.split(':').next() == Some(kind)) {
+                return;
+            }
+        }
+        entry.0 += score;
+        if !entry.1.contains(&source) {
+            entry.1.push(source);
+        }
+    }
+    let mut scores: BTreeMap<String, (u32, Vec<String>)> = BTreeMap::new();
+    for path in paths {
+        if let Some(rules) = codeowners {
+            // Every matching rule credits its owners (recommendation
+            // aggregates signals; ownership *resolution* stays last-match-wins
+            // in `codeowners_for_path`).
+            for rule in rules {
+                if !path_matches(&rule.pattern, path) {
+                    continue;
+                }
+                for owner in &rule.owners {
+                    credit(&mut scores, owner, 3, format!("codeowners:{path}"), true);
+                }
+            }
+        }
+        if let Some((dir, owners)) = nearest_owners(dir_owners, path) {
+            for owner in owners {
+                credit(&mut scores, owner, 2, format!("owners:{dir}"), true);
+            }
+        }
+        for (author, commit_path) in recent_commits {
+            let related = commit_path == path
+                || path.starts_with(&format!("{commit_path}/"))
+                || commit_path.starts_with(&format!("{path}/"));
+            if related {
+                credit(
+                    &mut scores,
+                    author,
+                    1,
+                    format!("recent-commit:{commit_path}"),
+                    false,
+                );
+            }
+        }
+    }
+    let mut candidates: Vec<ReviewerCandidate> = scores
+        .into_iter()
+        .map(|(reviewer, (score, sources))| ReviewerCandidate {
+            reviewer,
+            score,
+            sources,
+        })
+        .collect();
+    candidates.sort_by(|a, b| {
+        b.score
+            .cmp(&a.score)
+            .then_with(|| a.reviewer.cmp(&b.reviewer))
+    });
+    candidates
+}
+
+/// Load recent commits touching paths via `git log` (author + changed path
+/// pairs). Any failure (missing repo, no git) degrades to an empty heuristic
+/// source — the owner mapping still stands.
+pub fn git_recent_commits(
+    repo: &Path,
+    since_days: u32,
+    max_entries: usize,
+) -> Vec<(String, String)> {
+    // Author lines are marked with an ASCII record separator so the parse
+    // never confuses an author name with a changed path.
+    let separator = '\u{1e}';
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("log")
+        .arg(format!("--since={since_days} days ago"))
+        .arg(format!("--format={separator}%an"))
+        .arg("--name-only")
+        .arg("-n")
+        .arg(max_entries.to_string())
+        .output();
+    let Ok(output) = output else { return vec![] };
+    if !output.status.success() {
+        return vec![];
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut commits: Vec<(String, String)> = Vec::new();
+    let mut current_author = String::new();
+    for line in stdout.lines() {
+        if line.starts_with(separator) {
+            current_author = line.trim_start_matches(separator).trim().to_string();
+        } else if !line.trim().is_empty() && !current_author.is_empty() {
+            commits.push((current_author.clone(), line.trim().to_string()));
+        }
+    }
+    commits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codeowners_parsing_skips_comments_and_blanks() {
+        let content = "# top-level comment\n\n/src/core.rs @alice @bob\n*.md docs-team\n\ninvalid-line-without-owner\n";
+        let rules = parse_codeowners(content);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "/src/core.rs");
+        assert_eq!(rules[0].owners, vec!["@alice", "@bob"]);
+        assert_eq!(rules[1].owners, vec!["docs-team"]);
+    }
+
+    #[test]
+    fn owners_parsing_takes_one_owner_per_line() {
+        let content = "# reviewers\n\nalice@example.com\nbob\n";
+        assert_eq!(parse_owners(content), vec!["alice@example.com", "bob"]);
+    }
+
+    #[test]
+    fn path_matching_covers_file_dir_and_glob_patterns() {
+        // exact file
+        assert!(path_matches("/src/core.rs", "src/core.rs"));
+        assert!(!path_matches("/src/core.rs", "src/other.rs"));
+        // directory prefix
+        assert!(path_matches("docs/", "docs/guide/intro.md"));
+        assert!(path_matches("docs/", "docs/README.md"));
+        assert!(!path_matches("docs/", "other/README.md"));
+        // in-segment wildcard
+        assert!(path_matches("src/*.rs", "src/main.rs"));
+        assert!(!path_matches("src/*.rs", "src/sub/main.rs"));
+        // `**` crosses segments
+        assert!(path_matches("src/**", "src/a/b/c.rs"));
+        assert!(path_matches("**/*.rs", "any/deep/main.rs"));
+        // slash-less patterns match the basename at any depth (GitHub
+        // CODEOWNERS semantics)
+        assert!(path_matches("*.md", "docs/readme.md"));
+        assert!(path_matches("*.md", "README.md"));
+        assert!(!path_matches("*.md", "docs/readme.rst"));
+        assert!(!path_matches("*.rs", "src/deep/main.py"));
+        // empty pattern matches everything
+        assert!(path_matches("/", "anything/at/all.rs"));
+    }
+
+    #[test]
+    fn codeowners_last_matching_rule_wins() {
+        let rules = parse_codeowners("* @global\nsrc/ @core\nsrc/*.rs @lang");
+        assert_eq!(
+            codeowners_for_path(&rules, "src/main.rs"),
+            vec!["@lang".to_string()]
+        );
+        assert_eq!(
+            codeowners_for_path(&rules, "src/util/build.py"),
+            vec!["@core".to_string()]
+        );
+        assert_eq!(
+            codeowners_for_path(&rules, "README.md"),
+            vec!["@global".to_string()]
+        );
+    }
+
+    #[test]
+    fn nearest_owners_walks_ancestors_to_the_root() {
+        let mut dirs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        dirs.insert("".to_string(), vec!["root-owner".to_string()]);
+        dirs.insert("src".to_string(), vec!["src-owner".to_string()]);
+        dirs.insert("src/deep".to_string(), vec!["deep-owner".to_string()]);
+        assert_eq!(
+            nearest_owners(&dirs, "src/deep/file.rs"),
+            Some(("src/deep".to_string(), &vec!["deep-owner".to_string()]))
+        );
+        assert_eq!(
+            nearest_owners(&dirs, "src/main.rs"),
+            Some(("src".to_string(), &vec!["src-owner".to_string()]))
+        );
+        assert_eq!(
+            nearest_owners(&dirs, "README.md"),
+            Some(("".to_string(), &vec!["root-owner".to_string()]))
+        );
+        assert_eq!(nearest_owners(&BTreeMap::new(), "x.rs"), None);
+    }
+
+    #[test]
+    fn recommendation_aggregates_all_three_sources() {
+        let rules = parse_codeowners("src/** @core");
+        let mut dirs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        dirs.insert("src".to_string(), vec!["alice".to_string()]);
+        let commits = vec![
+            ("bob".to_string(), "src/core.rs".to_string()),
+            ("unrelated".to_string(), "docs/readme.md".to_string()),
+        ];
+        let candidates =
+            recommend_reviewers(&["src/core.rs".to_string()], Some(&rules), &dirs, &commits);
+        let by_name: BTreeMap<String, &ReviewerCandidate> =
+            candidates.iter().map(|c| (c.reviewer.clone(), c)).collect();
+        assert_eq!(by_name["@core"].score, 3);
+        assert_eq!(by_name["alice"].score, 2);
+        assert_eq!(by_name["bob"].score, 1);
+        assert!(!by_name.contains_key("unrelated"));
+        // ranked by score desc
+        let names: Vec<&str> = candidates.iter().map(|c| c.reviewer.as_str()).collect();
+        assert_eq!(names, vec!["@core", "alice", "bob"]);
+        // sources dedupe and record where the signal came from
+        assert!(by_name["@core"]
+            .sources
+            .iter()
+            .any(|s| s == "codeowners:src/core.rs"));
+        assert!(by_name["alice"].sources.iter().any(|s| s == "owners:src"));
+        assert!(by_name["bob"]
+            .sources
+            .iter()
+            .any(|s| s == "recent-commit:src/core.rs"));
+    }
+
+    #[test]
+    fn same_reviewer_scores_accumulate_across_sources() {
+        let rules = parse_codeowners("src/** @core");
+        let mut dirs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        dirs.insert("src".to_string(), vec!["alice".to_string()]);
+        let commits = vec![
+            ("alice".to_string(), "src/core.rs".to_string()),
+            ("alice".to_string(), "src/util.rs".to_string()),
+        ];
+        let candidates = recommend_reviewers(
+            &["src/core.rs".to_string(), "src/util.rs".to_string()],
+            Some(&rules),
+            &dirs,
+            &commits,
+        );
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].reviewer, "alice");
+        assert_eq!(candidates[0].score, 2 + 1 + 1);
+        // tie on score broken by name
+        let rules2 = parse_codeowners("src/** @alpha\nsrc/** @beta");
+        let candidates = recommend_reviewers(
+            &["src/core.rs".to_string()],
+            Some(&rules2),
+            &BTreeMap::new(),
+            &[],
+        );
+        assert_eq!(candidates[0].reviewer, "@alpha");
+        assert_eq!(candidates[1].reviewer, "@beta");
+    }
+
+    #[test]
+    fn git_recent_commits_degrades_on_missing_repo() {
+        let commits = git_recent_commits(Path::new("/nonexistent/repo-xyz"), 30, 50);
+        assert!(commits.is_empty());
+    }
+}

--- a/orchestration/loop/tests/capabilities_full_contract.rs
+++ b/orchestration/loop/tests/capabilities_full_contract.rs
@@ -1,11 +1,11 @@
-//! All-14-capabilities contract test: every domain pack in the catalog
+//! All-15-capabilities contract test: every domain pack in the catalog
 //! registers, describes itself, and produces finite typed proposals on
 //! marker inputs. Deterministic.
 
 use future_loop::capabilities::{CapabilityRegistry, ProposalKind};
 
 #[test]
-fn all_14_capabilities_registered() {
+fn all_15_capabilities_registered() {
     let r = CapabilityRegistry::with_builtin();
     let names: Vec<&str> = r.all().iter().map(|c| c.name()).collect();
     for expected in [
@@ -20,6 +20,7 @@ fn all_14_capabilities_registered() {
         "issue_fix",
         "material_lifecycle",
         "periodic_report",
+        "pr_review_queue",
         "reward_memory",
         "semantic_preference",
         "value_connectors",
@@ -27,7 +28,7 @@ fn all_14_capabilities_registered() {
         assert!(names.contains(&expected), "missing capability {expected}");
         assert!(r.get(expected).is_some(), "registry lookup for {expected}");
     }
-    assert_eq!(r.all().len(), 14);
+    assert_eq!(r.all().len(), 15);
 }
 
 #[test]

--- a/orchestration/loop/tests/capability_gate_contract.rs
+++ b/orchestration/loop/tests/capability_gate_contract.rs
@@ -112,7 +112,11 @@ fn per_capability_command_hooks_register_with_status_gate() {
     // Experimental hooks hidden by default, visible with the flag.
     assert!(registry.find("auto-research", false).is_none());
     assert!(registry.find("auto-research", true).is_some());
-    assert!(registry.find("pr-review-queue", false).is_none());
+    assert!(registry.find("context-providers", false).is_none());
+    assert!(registry.find("context-providers", true).is_some());
+    // pr_review_queue shipped its P2-3 rule version as active-preview → its
+    // hook is stable-visible.
+    assert!(registry.find("pr-review-queue", false).is_some());
     assert!(registry.find("pr-review-queue", true).is_some());
     // Hook name ↔ capability id mapping is resolvable (dispatch target).
     let snake = "auto-research".replace('-', "_");

--- a/orchestration/loop/tests/capability_lifecycle_contract.rs
+++ b/orchestration/loop/tests/capability_lifecycle_contract.rs
@@ -31,10 +31,10 @@ fn builtin_catalog_has_15_records_with_future_loop_statuses() {
         catalog.get("periodic_report").unwrap().status,
         "active-preview"
     );
-    // The 15th capability is registered experimental (P3 plan).
+    // The 15th capability shipped its P2-3 rule version as active-preview.
     let pr = catalog.get("pr_review_queue").unwrap();
-    assert_eq!(pr.status, "experimental");
-    assert!(pr.is_experimental());
+    assert_eq!(pr.status, "active-preview");
+    assert!(!pr.is_experimental());
 }
 
 #[test]
@@ -127,12 +127,13 @@ fn unknown_origin_and_duplicate_provider_fail_closed() {
 fn experimental_capability_commands_are_gated() {
     let catalog = CapabilityCatalog::with_builtin();
     // Hidden by default.
-    assert!(catalog.commands_for("pr_review_queue", false).is_empty());
     assert!(catalog.commands_for("auto_research", false).is_empty());
+    assert!(catalog.commands_for("material_lifecycle", false).is_empty());
     // Visible with the include flag (G-24 gate).
-    assert_eq!(catalog.commands_for("pr_review_queue", true).len(), 1);
+    assert_eq!(catalog.commands_for("material_lifecycle", true).len(), 1);
     assert_eq!(catalog.commands_for("auto_research", true).len(), 1);
-    // Stable capability hidden → active-preview visible.
+    // pr_review_queue shipped its P2-3 rule version → active-preview visible.
+    assert_eq!(catalog.commands_for("pr_review_queue", false).len(), 1);
     assert_eq!(catalog.commands_for("issue_fix", false).len(), 1);
 }
 

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -299,8 +299,8 @@ fn doctor_goal_replay_error_arm() {
 #[test]
 fn capability_commands_experimental_note() {
     let _cr = cli_root();
-    // pr_review_queue is experimental: without the flag its commands are
-    // hidden and the note prints; with the flag they list.
+    // pr_review_queue ships as active-preview: its commands list with and
+    // without the flag; experimental-gated capabilities still need it.
     cli_ok(&["capability", "commands", "--name", "pr_review_queue"]);
     cli_ok(&[
         "capability",


### PR DESCRIPTION
Wave 2 第一波 2/3（loopx-improvement-report P2-3 / stub-gaps A 类#1：15 个 capability 中唯一零实现）。

- 评审队列一等 work item（claim/lease 复用现有机制）
- 评审契约：ReviewVerdict（通过/驳回/再修）+ ReviewExecutionContract
- reviewer 推荐：OWNERS/CODEOWNERS 式路径 owner 映射（含 GitHub basename 语义）+ 最近提交启发式
- CLI：`future loop pr-review queue|review|claim|recommend|contract --goal G [--repo owner/repo] [--format json]`
- 新模块 2,298 行，12 文件 +4,333/−23，契约测试齐

未做（后续）：lark 通知面（依赖 P2-13）、review_packet 机制（G35）。
本地：fmt ✅ clippy ✅ future-loop 72 targets 全绿 ✅。源：claude/loop-wave2 eddad0be