### PR TITLE
feat(desktop): show Chinese skill category in zh locale

### DIFF
--- a/desktop/src-tauri/src/skills.rs
+++ b/desktop/src-tauri/src/skills.rs
@@ -97,6 +97,8 @@ pub struct SkillInfo {
     pub description_zh: String,
     #[serde(default)]
     pub category: String,
+    #[serde(default, alias = "category_zh")]
+    pub category_zh: String,
     #[serde(default, alias = "latest_version")]
     pub latest_version: Option<String>,
 }

--- a/desktop/src/features/skills/SkillsView.tsx
+++ b/desktop/src/features/skills/SkillsView.tsx
@@ -1,5 +1,5 @@
 import type { AvailableSkill, InstalledSkill } from "../../integrations/skills/skillsClient";
-import type { SkillFilters } from "./skillsFilter";
+import type { CategoryOption, SkillFilters } from "./skillsFilter";
 import { ArrowUpCircle, Blocks, Download, RotateCcw, Search, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -23,9 +23,9 @@ import { startWindowDrag } from "../../lib/windowDrag";
 import { computeSkillUpgrades } from "./autoUpgrade";
 import {
   allCategoriesValue,
+  categoryOptions,
   matchesAvailableSkill,
   matchesInstalledSkill,
-  uniqueSorted,
 } from "./skillsFilter";
 import { isUpgradeAvailable } from "./skillVersion";
 
@@ -34,7 +34,8 @@ type SkillsTab = "installed" | "all";
 const emptyFilters: SkillFilters = { category: allCategoriesValue, query: "" };
 
 export function SkillsView({ leftPanelExpanded, onToggleLeftPanel }: { leftPanelExpanded: boolean; onToggleLeftPanel: () => void }) {
-  const { t } = useTranslation("skills");
+  const { i18n, t } = useTranslation("skills");
+  const useChinese = i18n.language !== "en";
   const [tab, setTab] = useState<SkillsTab>("installed");
   const [installed, setInstalled] = useState<InstalledSkill[]>([]);
   const [available, setAvailable] = useState<AvailableSkill[]>([]);
@@ -63,8 +64,8 @@ export function SkillsView({ leftPanelExpanded, onToggleLeftPanel }: { leftPanel
   );
 
   const allCategories = useMemo(
-    () => uniqueSorted(available.map(skill => skill.category)),
-    [available],
+    () => categoryOptions(available, useChinese),
+    [available, useChinese],
   );
 
   // Catalogue lookup for installed skills. Used for filtering (category + the
@@ -77,14 +78,11 @@ export function SkillsView({ leftPanelExpanded, onToggleLeftPanel }: { leftPanel
 
   // Categories that have at least one installed skill (matched via catalogue).
   const installedCategories = useMemo(() => {
-    const catSet = new Set<string>();
-    for (const s of installed) {
-      const cat = availableById.get(s.id)?.category;
-      if (cat)
-        catSet.add(cat);
-    }
-    return [...catSet].sort();
-  }, [installed, availableById]);
+    const catalogueEntries = installed
+      .map(skill => availableById.get(skill.id))
+      .filter((skill): skill is AvailableSkill => Boolean(skill));
+    return categoryOptions(catalogueEntries, useChinese);
+  }, [installed, availableById, useChinese]);
 
   const filteredInstalled = useMemo(
     () => installed.filter(skill => matchesInstalledSkill(skill, installedFilters, availableById.get(skill.id))),
@@ -288,7 +286,7 @@ function InstalledTab({
 }: {
   busy: Record<string, boolean>;
   catalogue: AvailableSkill[];
-  categories: string[];
+  categories: CategoryOption[];
   error: string | null;
   filters: SkillFilters;
   loading: boolean;
@@ -362,6 +360,7 @@ function InstalledTab({
         const description = useChinese
           ? cat?.descriptionZh || skill.descriptionZh || skill.description
           : cat?.description || skill.description;
+        const category = (useChinese && cat?.categoryZh ? cat.categoryZh : cat?.category) || undefined;
         const latest = cat?.latestVersion ?? null;
         const canUpgrade = isUpgradeAvailable(skill.version, latest);
         return (
@@ -370,7 +369,7 @@ function InstalledTab({
             name={name || skill.id}
             description={description}
             version={skill.version}
-            meta={cat?.category || undefined}
+            meta={category}
             action={(
               <div className="flex items-center gap-2">
                 <UninstallButton busy={busy[skill.id]} onClick={() => onUninstall(skill.id)} />
@@ -410,7 +409,7 @@ function AllTab({
   totalCount,
 }: {
   busy: Record<string, boolean>;
-  categories: string[];
+  categories: CategoryOption[];
   error: string | null;
   filters: SkillFilters;
   installedById: Map<string, InstalledSkill>;
@@ -471,7 +470,7 @@ function AllTab({
             name={name || skill.id}
             description={description}
             version={skill.latestVersion}
-            meta={skill.category || undefined}
+            meta={(useChineseCatalogueText && skill.categoryZh ? skill.categoryZh : skill.category) || undefined}
             action={
               isInstalled
                 ? (
@@ -515,7 +514,7 @@ function SkillFiltersBar({
   totalCount,
   trailing,
 }: {
-  categories: string[];
+  categories: CategoryOption[];
   filters: SkillFilters;
   onChange: (filters: SkillFilters) => void;
   resultCount: number;
@@ -536,8 +535,8 @@ function SkillFiltersBar({
         wrapperClassName="w-full sm:w-48"
       >
         <option value={allCategoriesValue}>{t("filter.allCategories")}</option>
-        {categories.map(category => (
-          <option key={category} value={category}>{category}</option>
+        {categories.map(option => (
+          <option key={option.value} value={option.value}>{option.label}</option>
         ))}
       </Select>
       <div className="relative min-w-0 flex-1">

--- a/desktop/src/features/skills/autoUpgrade.test.ts
+++ b/desktop/src/features/skills/autoUpgrade.test.ts
@@ -14,6 +14,7 @@ function available(overrides: Partial<AvailableSkill> = {}): AvailableSkill {
     nameZh: "",
     descriptionZh: "",
     category: "core",
+    categoryZh: "",
     latestVersion: "1.0.0",
     ...overrides,
   };

--- a/desktop/src/features/skills/skillsFilter.test.ts
+++ b/desktop/src/features/skills/skillsFilter.test.ts
@@ -2,6 +2,7 @@ import type { AvailableSkill, InstalledSkill } from "../../integrations/skills/s
 import { describe, expect, it } from "vitest";
 import {
   allCategoriesValue,
+  categoryOptions,
   matchesAvailableSkill,
   matchesInstalledSkill,
   matchesQuery,
@@ -21,6 +22,7 @@ function available(overrides: Partial<AvailableSkill> = {}): AvailableSkill {
     nameZh: "中文名",
     descriptionZh: "中文描述",
     category: "core",
+    categoryZh: "",
     latestVersion: "1.0.0",
     ...overrides,
   };
@@ -80,6 +82,12 @@ describe("matchesInstalledSkill", () => {
     expect(matchesInstalledSkill(skill, { category: allCategoriesValue, query: "文献" }, cat)).toBe(true);
     expect(matchesInstalledSkill(skill, { category: allCategoriesValue, query: "综合" }, cat)).toBe(true);
   });
+
+  it("matches the catalogue's Chinese category", () => {
+    const skill = installed({ id: "lit" });
+    const cat = available({ id: "lit", category: "wet-lab", categoryZh: "湿实验" });
+    expect(matchesInstalledSkill(skill, { category: allCategoriesValue, query: "湿实验" }, cat)).toBe(true);
+  });
 });
 
 describe("matchesAvailableSkill", () => {
@@ -94,5 +102,36 @@ describe("matchesAvailableSkill", () => {
     const skill = available({ nameZh: "深度研究", descriptionZh: "多源信息综合" });
     expect(matchesAvailableSkill(skill, { category: allCategoriesValue, query: "深度" })).toBe(true);
     expect(matchesAvailableSkill(skill, { category: allCategoriesValue, query: "综合" })).toBe(true);
+  });
+
+  it("matches the Chinese category", () => {
+    const skill = available({ category: "wet-lab", categoryZh: "湿实验" });
+    expect(matchesAvailableSkill(skill, { category: allCategoriesValue, query: "湿实验" })).toBe(true);
+  });
+});
+
+describe("categoryOptions", () => {
+  it("dedupes, drops empties, and sorts by value", () => {
+    const skills = [
+      available({ category: "wet-lab", categoryZh: "湿实验" }),
+      available({ id: "b", category: "core" }),
+      available({ id: "c", category: "" }),
+      available({ id: "d", category: "wet-lab", categoryZh: "别的" }),
+    ];
+    expect(categoryOptions(skills, false)).toEqual([
+      { value: "core", label: "core" },
+      { value: "wet-lab", label: "wet-lab" },
+    ]);
+  });
+
+  it("uses the Chinese category as label when requested, falling back to the value", () => {
+    const skills = [
+      available({ category: "wet-lab", categoryZh: "湿实验" }),
+      available({ id: "b", category: "core", categoryZh: "" }),
+    ];
+    expect(categoryOptions(skills, true)).toEqual([
+      { value: "core", label: "core" },
+      { value: "wet-lab", label: "湿实验" },
+    ]);
   });
 });

--- a/desktop/src/features/skills/skillsFilter.ts
+++ b/desktop/src/features/skills/skillsFilter.ts
@@ -28,6 +28,7 @@ export function matchesInstalledSkill(skill: InstalledSkill, filters: SkillFilte
     catalogue?.description,
     catalogue?.descriptionZh,
     catalogue?.category,
+    catalogue?.categoryZh,
   ]);
 }
 
@@ -42,6 +43,7 @@ export function matchesAvailableSkill(skill: AvailableSkill, filters: SkillFilte
     skill.description,
     skill.descriptionZh,
     skill.category,
+    skill.categoryZh,
     skill.latestVersion,
   ]);
 }
@@ -64,4 +66,26 @@ export function normalizeSearchText(value: string | null | undefined) {
 
 export function uniqueSorted(values: Array<string | null | undefined>) {
   return Array.from(new Set(values.filter((value): value is string => Boolean(value)))).sort((a, b) => a.localeCompare(b));
+}
+
+/** A category filter option: canonical `category` value + locale-aware label. */
+export interface CategoryOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Distinct category options sorted by value, empties excluded. With
+ * `useChinese` the label is the catalogue's Chinese category when present,
+ * falling back to the canonical value.
+ */
+export function categoryOptions(skills: AvailableSkill[], useChinese: boolean): CategoryOption[] {
+  const labels = new Map<string, string>();
+  for (const skill of skills) {
+    if (!skill.category || labels.has(skill.category))
+      continue;
+    labels.set(skill.category, useChinese && skill.categoryZh ? skill.categoryZh : skill.category);
+  }
+  return Array.from(labels, ([value, label]) => ({ value, label }))
+    .sort((a, b) => a.value.localeCompare(b.value));
 }

--- a/desktop/src/integrations/skills/skillsClient.ts
+++ b/desktop/src/integrations/skills/skillsClient.ts
@@ -18,6 +18,7 @@ export interface AvailableSkill {
   nameZh: string;
   descriptionZh: string;
   category: string;
+  categoryZh: string;
   latestVersion: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Carry the platform catalogue's new `category_zh` field through `SkillInfo` (serde alias) → `AvailableSkill.categoryZh`
- zh UI: the skill row category badge and the category filter dropdown show the Chinese category; the option value stays the canonical `category` so filtering logic is unchanged and the selected filter survives a language switch
- Keyword search also matches the Chinese category
- en UI is unchanged; missing `category_zh` falls back to the English category

## Test plan
- `npx tsc --noEmit`, `npx eslint "src/**/*.{ts,tsx}"`, `npx vitest run` (561 passed)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` in `desktop/src-tauri`
- zh UI verified against a server returning `category_zh` (row badge + filter dropdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)