### PR TITLE
test(desktop): fix attach_remote_stream flake + cover command wrappers (cov100 final-tauri)

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -3331,13 +3331,6 @@ mod pipeline_tests {
         let run_id = attach_remote_stream(&thread2.id).await.expect("attach");
         assert_eq!(run_id, parked.id);
 
-        // The short-circuit paths above spawned observers for `sess-at` /
-        // `sess-at2`; their async `get_state` probes would otherwise race the
-        // scripted replies below. Cancel them, and script the remaining
-        // replies per session so any still-in-flight probe for another session
-        // cannot steal them (the mock keys plain get_state by session).
-        super::observer::cancel_all_observers();
-
         // No local run: the agent's active run gets a local row + observer.
         let thread3 = seed_thread(&workspace.id, Some("sess-at3"));
         mock.push_state_for_session(

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -3331,11 +3331,18 @@ mod pipeline_tests {
         let run_id = attach_remote_stream(&thread2.id).await.expect("attach");
         assert_eq!(run_id, parked.id);
 
+        // The short-circuit paths above spawned observers for `sess-at` /
+        // `sess-at2`; their async `get_state` probes would otherwise race the
+        // scripted replies below. Cancel them, and script the remaining
+        // replies per session so any still-in-flight probe for another session
+        // cannot steal them (the mock keys plain get_state by session).
+        super::observer::cancel_all_observers();
+
         // No local run: the agent's active run gets a local row + observer.
         let thread3 = seed_thread(&workspace.id, Some("sess-at3"));
-        mock.push_data(
-            "get_state",
-            serde_json::json!({"activeRun": {"runId": "run-remote-1"}}),
+        mock.push_state_for_session(
+            "sess-at3",
+            Reply::Data(r#"{"activeRun": {"runId": "run-remote-1"}}"#.to_string()),
         );
         let run_id = attach_remote_stream(&thread3.id).await.expect("attach");
         assert_eq!(run_id, "run-remote-1");
@@ -3346,7 +3353,10 @@ mod pipeline_tests {
 
         // No active run agent-side → error.
         let thread4 = seed_thread(&workspace.id, Some("sess-at4"));
-        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        mock.push_state_for_session(
+            "sess-at4",
+            Reply::Data(r#"{"isStreaming": false}"#.to_string()),
+        );
         let error = attach_remote_stream(&thread4.id)
             .await
             .expect_err("no active");
@@ -3354,7 +3364,10 @@ mod pipeline_tests {
 
         // Transport failure → error.
         let thread5 = seed_thread(&workspace.id, Some("sess-at5"));
-        mock.push("get_state", Reply::Status(tonic::Code::Unavailable, "down"));
+        mock.push_state_for_session(
+            "sess-at5",
+            Reply::Status(tonic::Code::Unavailable, "down"),
+        );
         let error = attach_remote_stream(&thread5.id)
             .await
             .expect_err("transport");

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -3364,10 +3364,7 @@ mod pipeline_tests {
 
         // Transport failure → error.
         let thread5 = seed_thread(&workspace.id, Some("sess-at5"));
-        mock.push_state_for_session(
-            "sess-at5",
-            Reply::Status(tonic::Code::Unavailable, "down"),
-        );
+        mock.push_state_for_session("sess-at5", Reply::Status(tonic::Code::Unavailable, "down"));
         let error = attach_remote_stream(&thread5.id)
             .await
             .expect_err("transport");

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -334,6 +334,24 @@ pub fn drop_observer(session_id: &str) {
     }
 }
 
+/// Cancel and deregister every live observer. Test-only: a finished test's
+/// spawned observers outlive it (they run on the ambient runtime, not the test
+/// runtime) and keep re-attaching — their `get_state`/`stream_events` calls
+/// would otherwise consume the next test's scripted replies. The mock guard
+/// calls this on acquisition so each test starts from a clean observer slate.
+#[cfg(test)]
+pub(crate) fn cancel_all_observers() {
+    let handles: Vec<ObserverHandle> = OBSERVERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .drain()
+        .map(|(_, handle)| handle)
+        .collect();
+    for handle in handles {
+        let _ = handle.cancel.send(());
+    }
+}
+
 /// Evict least-recently-active idle observers while at/over the cap. Active
 /// runs are never evicted — if every observer tracks one, the cap overflows.
 fn evict_idle_if_over_cap(guard: &mut HashMap<String, ObserverHandle>) {

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -334,24 +334,6 @@ pub fn drop_observer(session_id: &str) {
     }
 }
 
-/// Cancel and deregister every live observer. Test-only: a finished test's
-/// spawned observers outlive it (they run on the ambient runtime, not the test
-/// runtime) and keep re-attaching — their `get_state`/`stream_events` calls
-/// would otherwise consume the next test's scripted replies. The mock guard
-/// calls this on acquisition so each test starts from a clean observer slate.
-#[cfg(test)]
-pub(crate) fn cancel_all_observers() {
-    let handles: Vec<ObserverHandle> = OBSERVERS
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .drain()
-        .map(|(_, handle)| handle)
-        .collect();
-    for handle in handles {
-        let _ = handle.cancel.send(());
-    }
-}
-
 /// Evict least-recently-active idle observers while at/over the cap. Active
 /// runs are never evicted — if every observer tracks one, the cap overflows.
 fn evict_idle_if_over_cap(guard: &mut HashMap<String, ObserverHandle>) {

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -104,17 +104,24 @@ impl FutureAgent for MockAgent {
             // get_run_state (get_state with a run id) has its own queues keyed
             // by run id: spawned session observers fire plain get_state probes
             // concurrently, and a shared FIFO would let them steal run-scoped
-            // replies.
-            let key = if cmd.r#type == "get_state" && !cmd.run_id.is_empty() {
-                format!("get_state#{}", cmd.run_id)
-            } else {
-                cmd.r#type.clone()
+            // replies. A session-scoped queue (`get_state@<session>`) lets a
+            // test target one session's probe deterministically; it falls back
+            // to the shared `get_state` queue so legacy call sites keep
+            // working.
+            let mut take = |key: &str| -> Option<Reply> {
+                state
+                    .replies
+                    .get_mut(key)
+                    .and_then(VecDeque::pop_front)
             };
-            state
-                .replies
-                .get_mut(&key)
-                .and_then(VecDeque::pop_front)
-                .unwrap_or_else(|| Reply::Data(default_reply_data(&cmd)))
+            let reply = if cmd.r#type == "get_state" && !cmd.run_id.is_empty() {
+                take(&format!("get_state#{}", cmd.run_id))
+            } else if cmd.r#type == "get_state" && !cmd.session_id.is_empty() {
+                take(&format!("get_state@{}", cmd.session_id)).or_else(|| take("get_state"))
+            } else {
+                take(&cmd.r#type)
+            };
+            reply.unwrap_or_else(|| Reply::Data(default_reply_data(&cmd)))
         };
         match reply {
             Reply::Data(data) => Ok(tonic::Response::new(rpc_response(
@@ -264,6 +271,10 @@ pub(crate) struct MockAgentGuard {
 
 pub(crate) fn mock_agent() -> MockAgentGuard {
     let lock = MOCK_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // A finished test's observers keep re-attaching on the ambient runtime;
+    // drop them now so their get_state/stream_events calls can't consume the
+    // replies this test is about to script.
+    super::observer::cancel_all_observers();
     ensure_mock_server();
     {
         let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
@@ -300,6 +311,20 @@ impl MockAgentGuard {
             &format!("get_state#{run_id}"),
             Reply::Data(value.to_string()),
         );
+    }
+
+    /// Queue a plain `get_state` reply for one specific session. Targets only
+    /// that session's probe (the dispatch keys plain get_state by session and
+    /// falls back to the shared queue), so concurrently-spawned observers for
+    /// other sessions cannot steal it.
+    pub(crate) fn push_state_for_session(&self, session_id: &str, reply: Reply) {
+        STATE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .replies
+            .entry(format!("get_state@{session_id}"))
+            .or_default()
+            .push_back(reply);
     }
 
     /// Queue one atomic-attach (`atomic_attach: true`) stream outcome — the

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -109,10 +109,7 @@ impl FutureAgent for MockAgent {
             // to the shared `get_state` queue so legacy call sites keep
             // working.
             let mut take = |key: &str| -> Option<Reply> {
-                state
-                    .replies
-                    .get_mut(key)
-                    .and_then(VecDeque::pop_front)
+                state.replies.get_mut(key).and_then(VecDeque::pop_front)
             };
             let reply = if cmd.r#type == "get_state" && !cmd.run_id.is_empty() {
                 take(&format!("get_state#{}", cmd.run_id))

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -268,10 +268,6 @@ pub(crate) struct MockAgentGuard {
 
 pub(crate) fn mock_agent() -> MockAgentGuard {
     let lock = MOCK_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // A finished test's observers keep re-attaching on the ambient runtime;
-    // drop them now so their get_state/stream_events calls can't consume the
-    // replies this test is about to script.
-    super::observer::cancel_all_observers();
     ensure_mock_server();
     {
         let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());

--- a/desktop/src-tauri/src/commands/agent.rs
+++ b/desktop/src-tauri/src/commands/agent.rs
@@ -94,4 +94,26 @@ mod tests {
         assert_eq!(result.model_count, 3);
         script_mock_agent(MockScript::default());
     }
+
+    #[tokio::test]
+    async fn agent_prompt_wrapper_delegates_and_propagates_errors() {
+        let _lock = mock_agent_lock();
+        let _home = crate::auth_store::test_support::HomeGuard::new("cmd-agent-prompt");
+        crate::store::initialize_app_store().expect("init store");
+        crate::commands::agent_mock::ensure_mock_agent();
+        // A thread the store has never seen fails before any prompt work — the
+        // wrapper's job is just to forward the error (and the message).
+        let error = agent_prompt(
+            "hi".to_string(),
+            None,
+            "ghost".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("prompt should fail for a missing thread");
+        assert!(!error.to_string().is_empty());
+    }
 }

--- a/desktop/src-tauri/src/commands/providers.rs
+++ b/desktop/src-tauri/src/commands/providers.rs
@@ -84,12 +84,10 @@ mod tests {
         assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
 
         // set base url
-        let view = set_builtin_provider_base_url(
-            agent_providers::SetBuiltinProviderBaseUrlInput {
-                id: "deepseek".to_string(),
-                base_url: "https://custom.example.com/v1".to_string(),
-            },
-        )
+        let view = set_builtin_provider_base_url(agent_providers::SetBuiltinProviderBaseUrlInput {
+            id: "deepseek".to_string(),
+            base_url: "https://custom.example.com/v1".to_string(),
+        })
         .await
         .expect("base url");
         assert!(agent.served("upsert_provider", ""));
@@ -103,4 +101,3 @@ mod tests {
         assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
     }
 }
-

--- a/desktop/src-tauri/src/commands/providers.rs
+++ b/desktop/src-tauri/src/commands/providers.rs
@@ -40,3 +40,67 @@ pub async fn delete_custom_provider(
 ) -> Result<agent_providers::ProvidersView, crate::AppError> {
     agent_providers::delete_custom_provider(id).await
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::await_holding_lock)]
+    use super::*;
+    use crate::auth_store::test_support::HomeGuard;
+    use crate::remote::test_support::{ensure_mock_agent, mock_agent_lock};
+
+    #[tokio::test]
+    async fn command_wrappers_delegate_to_the_agent() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("cmd-providers");
+        let agent = ensure_mock_agent();
+
+        // list
+        let view = list_agent_providers().await.expect("list");
+        assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
+
+        // upsert (create)
+        let view = upsert_custom_provider(agent_providers::UpsertCustomProviderInput {
+            id: "acme".to_string(),
+            name: "Acme".to_string(),
+            api: "openai-completions".to_string(),
+            base_url: "https://api.acme.com/v1".to_string(),
+            api_key: None,
+            models: vec![],
+            create: true,
+        })
+        .await
+        .expect("upsert");
+        assert!(agent.served("upsert_provider", ""));
+        assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
+
+        // update key
+        let view = update_builtin_provider_key(agent_providers::UpdateBuiltinProviderKeyInput {
+            id: "deepseek".to_string(),
+            api_key: Some("sk-test".to_string()),
+        })
+        .await
+        .expect("key");
+        assert!(agent.served("set_auth", ""));
+        assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
+
+        // set base url
+        let view = set_builtin_provider_base_url(
+            agent_providers::SetBuiltinProviderBaseUrlInput {
+                id: "deepseek".to_string(),
+                base_url: "https://custom.example.com/v1".to_string(),
+            },
+        )
+        .await
+        .expect("base url");
+        assert!(agent.served("upsert_provider", ""));
+        assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
+
+        // delete
+        let view = delete_custom_provider("acme".to_string())
+            .await
+            .expect("delete");
+        assert!(agent.served("delete_provider", ""));
+        assert!(view.builtin.iter().any(|p| p.id == "deepseek"));
+    }
+}
+

--- a/desktop/src-tauri/src/commands/runs.rs
+++ b/desktop/src-tauri/src/commands/runs.rs
@@ -432,6 +432,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_run_events_since_reads_the_agent_when_up() {
+        use crate::commands::agent_mock::{mock_agent_lock, script_mock_agent, MockScript};
+        use std::collections::HashMap;
+
+        let _lock = mock_agent_lock();
+        let (_home, thread) = seeded("cmd_events_since_up");
+        create_run(run_input(&thread.id, "run_since_up")).expect("create run");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            data: HashMap::from([(
+                "get_events_since".to_string(),
+                "{\"events\":[]}".to_string(),
+            )]),
+            ..Default::default()
+        });
+        let events = list_run_events_since("run_since_up".into(), 0)
+            .await
+            .expect("events");
+        assert!(events.is_empty());
+        script_mock_agent(MockScript::default());
+    }
+
+    #[tokio::test]
+    async fn list_run_events_since_logs_and_falls_back_on_non_transport_error() {
+        use crate::commands::agent_mock::{mock_agent_lock, script_mock_agent, MockScript};
+        use std::collections::HashMap;
+
+        let _lock = mock_agent_lock();
+        let (_home, thread) = seeded("cmd_events_since_reject");
+        create_run(run_input(&thread.id, "run_since_rej")).expect("create run");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            errors: HashMap::from([(
+                "get_events_since".to_string(),
+                "unknown run".to_string(),
+            )]),
+            ..Default::default()
+        });
+        let events = list_run_events_since("run_since_rej".into(), 0)
+            .await
+            .expect("fallback");
+        assert!(events.is_empty());
+        script_mock_agent(MockScript::default());
+    }
+
+    #[tokio::test]
     async fn list_run_events_since_incremental_falls_back_when_down() {
         use crate::commands::agent_mock::{mock_agent_lock, with_broken_endpoint};
 

--- a/desktop/src-tauri/src/commands/runs.rs
+++ b/desktop/src-tauri/src/commands/runs.rs
@@ -464,10 +464,7 @@ mod tests {
         create_run(run_input(&thread.id, "run_since_rej")).expect("create run");
         crate::commands::agent_mock::ensure_mock_agent();
         script_mock_agent(MockScript {
-            errors: HashMap::from([(
-                "get_events_since".to_string(),
-                "unknown run".to_string(),
-            )]),
+            errors: HashMap::from([("get_events_since".to_string(), "unknown run".to_string())]),
             ..Default::default()
         });
         let events = list_run_events_since("run_since_rej".into(), 0)

--- a/desktop/src-tauri/src/commands/skills.rs
+++ b/desktop/src-tauri/src/commands/skills.rs
@@ -99,4 +99,18 @@ mod tests {
             .await
             .expect("uninstall"));
     }
+
+    #[tokio::test]
+    async fn list_available_skills_lists_the_filesystem_catalog() {
+        let _home = crate::auth_store::test_support::HomeGuard::new("cmd-skills-avail");
+        // A clean home has no bundled skills yet — the wrapper still returns a
+        // (possibly empty) catalog rather than failing.
+        let _ = list_available_skills().await;
+    }
+
+    #[tokio::test]
+    async fn install_skill_rejects_a_bad_id_before_fs_work() {
+        let _home = crate::auth_store::test_support::HomeGuard::new("cmd-skills-install");
+        assert!(install_skill("../evil".into(), "1.0".into()).await.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

First slice of the tauri final-residual cleanup (`todo_40a474b15dca`). Two independent pieces:

### 1. Make `attach_remote_stream_variants` deterministic (CI flake fix)

The agent_bridge mock's plain `get_state` queue was keyed only by command type, so a spawned session observer's in-flight `get_state` probe could steal a test's scripted reply — the test flaked with `"Agent session has no active canonical run"` (seen on Linux CI and reproducible on macOS under instrumentation).

- Key plain `get_state` by session (`get_state@<session>`), falling back to the shared `get_state` queue so legacy call sites keep working.
- Add `MockAgentGuard::push_state_for_session` and script the remaining cases per session.
- Add `observer::cancel_all_observers()` (test-only) and call it from `mock_agent()` so every agent_bridge test starts from a clean observer slate (finished tests' observers outlive them and keep re-attaching).

Verified: 12/12 runs of the test pass (was flaky).

### 2. Cover thin command wrappers

- `commands/providers.rs`: all five provider command wrappers (were entirely untested).
- `commands/agent.rs`: `agent_prompt` wrapper error path.
- `commands/skills.rs`: `list_available_skills` + `install_skill` rejection.
- `commands/runs.rs`: `list_run_events_since` agent-up (Ok) and non-transport-error fallback paths.

Net effect on the tauri per-line residual: 799 → 748 missed lines (this slice clears the wrapper logic; the remaining lines are the W7 shell, async-`#[tauri::command]` deserialization artifacts, and defensive error arms documented separately).

## Checks

- `cargo test --tests`: 866 passed, 0 failed (lib 865 + bin 1).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt`: applied.