### PR TITLE
test(desktop): cover commands/review + commands/threads residual (cov100 final-tauri)

### DIFF
--- a/desktop/src-tauri/src/commands/review.rs
+++ b/desktop/src-tauri/src/commands/review.rs
@@ -80,3 +80,156 @@ pub fn get_git_review(
 ) -> Result<git_review::GitReview, crate::AppError> {
     git_review::get_git_review(workspace_id, base, custom_base)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth_store::test_support::HomeGuard;
+    use crate::store::{CreateThreadInput, CreateWorkspaceInput};
+    use std::path::PathBuf;
+
+    fn init(label: &str) -> HomeGuard {
+        let home = HomeGuard::new(label);
+        crate::store::initialize_app_store().expect("init store");
+        home
+    }
+
+    fn workspace(label: &str) -> crate::store::WorkspaceRecord {
+        let path = PathBuf::from(std::env::var("HOME").expect("test home"))
+            .join(label)
+            .display()
+            .to_string();
+        crate::store::create_workspace(CreateWorkspaceInput {
+            name: Some(label.to_string()),
+            path,
+            description: None,
+            create_directory: Some(true),
+        })
+        .expect("create workspace")
+    }
+
+    fn thread_in(workspace: &crate::store::WorkspaceRecord) -> crate::store::ThreadRecord {
+        crate::store::create_thread(CreateThreadInput {
+            mode: "workspace".to_string(),
+            title: Some("Review".to_string()),
+            workspace_id: Some(workspace.id.clone()),
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: None,
+        })
+        .expect("create thread")
+    }
+
+    fn git_repo(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "futureos-cmd-review-{}-{}",
+            std::process::id(),
+            label
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        run_git(&dir, &["init", "-q", "-b", "main"]);
+        run_git(&dir, &["config", "user.email", "t@example.com"]);
+        run_git(&dir, &["config", "user.name", "T"]);
+        std::fs::write(dir.join("a.txt"), "hello\n").unwrap();
+        run_git(&dir, &["add", "a.txt"]);
+        run_git(&dir, &["commit", "-qm", "init"]);
+        dir
+    }
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(out.status.success(), "git {args:?} failed: {stderr}");
+    }
+
+    #[test]
+    fn get_workspace_review_capabilities_errors_for_unknown_workspace() {
+        let _home = init("cmd_review_caps_ghost");
+        assert!(get_workspace_review_capabilities("ghost".into()).is_err());
+    }
+
+    #[test]
+    fn get_workspace_review_capabilities_reports_a_non_git_workspace() {
+        let _home = init("cmd_review_caps_nongit");
+        let ws = workspace("plain_ws");
+        let caps = get_workspace_review_capabilities(ws.id).expect("caps");
+        assert!(!caps.is_git_workspace);
+        assert_eq!(caps.views, vec!["last_run".to_string()]);
+        assert_eq!(caps.default_view, "last_run");
+        assert_eq!(caps.change_preview, "ready");
+    }
+
+    #[test]
+    fn get_workspace_review_capabilities_reports_a_git_workspace() {
+        let _home = init("cmd_review_caps_git");
+        let repo = git_repo("caps-git");
+        let ws = crate::store::create_workspace(CreateWorkspaceInput {
+            name: Some("git_ws".to_string()),
+            path: repo.display().to_string(),
+            description: None,
+            create_directory: None,
+        })
+        .expect("create git workspace");
+        let caps = get_workspace_review_capabilities(ws.id).expect("caps");
+        assert!(caps.is_git_workspace);
+        assert_eq!(
+            caps.views,
+            vec!["git_changes".to_string(), "last_run".to_string()]
+        );
+        assert_eq!(caps.default_view, "git_changes");
+    }
+
+    #[test]
+    fn get_last_run_review_is_none_without_a_changeset() {
+        let _home = init("cmd_review_last_run");
+        let ws = workspace("last_run_ws");
+        let thread = thread_in(&ws);
+        let review = get_last_run_review(thread.id).expect("review");
+        assert!(review.is_none());
+    }
+
+    #[test]
+    fn retry_run_review_errors_for_an_unknown_run() {
+        let _home = init("cmd_review_retry");
+        assert!(retry_run_review("ghost_run".into()).is_err());
+    }
+
+    #[test]
+    fn get_git_review_errors_for_unknown_workspace() {
+        let _home = init("cmd_review_git_ghost");
+        assert!(get_git_review("ghost".into(), None, None).is_err());
+    }
+
+    #[test]
+    fn get_git_review_reports_a_non_git_workspace() {
+        let _home = init("cmd_review_git_nongit");
+        let ws = workspace("nongit_ws");
+        let review = get_git_review(ws.id, None, None).expect("review");
+        let value = serde_json::to_value(&review).expect("serialize");
+        assert_eq!(value["isGitWorkspace"], serde_json::json!(false));
+        assert_eq!(value["files"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn get_git_review_reports_a_git_workspace() {
+        let _home = init("cmd_review_git_ok");
+        let repo = git_repo("git-ok");
+        let ws = crate::store::create_workspace(CreateWorkspaceInput {
+            name: Some("git_ok_ws".to_string()),
+            path: repo.display().to_string(),
+            description: None,
+            create_directory: None,
+        })
+        .expect("create git workspace");
+        let review = get_git_review(ws.id, None, None).expect("review");
+        let value = serde_json::to_value(&review).expect("serialize");
+        assert_eq!(value["isGitWorkspace"], serde_json::json!(true));
+        assert_eq!(value["branch"], serde_json::json!("main"));
+    }
+}

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -428,6 +428,76 @@ mod tests {
     }
 
     #[test]
+    fn async_command_wrappers_reject_malformed_bodies() {
+        crate::commands::ipc_harness::assert_all_reject_bad_body(
+            tauri::generate_handler![
+                fork_thread,
+                rename_thread,
+                update_thread_model,
+                update_thread_thinking_level,
+                delete_thread,
+                batch_delete_threads,
+                get_thread_agent_state,
+                get_session_entries,
+                clear_finished_runs,
+                attach_remote_stream
+            ],
+            &[
+                "fork_thread",
+                "rename_thread",
+                "update_thread_model",
+                "update_thread_thinking_level",
+                "delete_thread",
+                "batch_delete_threads",
+                "get_thread_agent_state",
+                "get_session_entries",
+                "clear_finished_runs",
+                "attach_remote_stream",
+            ],
+        );
+        // `fork_thread` takes three arguments, so the empty-body rejection only
+        // exercises its *first* argument's error arm (attributed to the signature
+        // line). Fail the *last* argument instead to hit the error arm attributed
+        // to the `#[tauri::command]` attribute line.
+        crate::commands::ipc_harness::assert_all_reject_bodies(
+            tauri::generate_handler![fork_thread],
+            &[(
+                "fork_thread",
+                serde_json::json!({ "threadId": "t", "userMessageContent": "c" }),
+            )],
+        );
+    }
+
+    #[test]
+    fn create_thread_command_creates_a_chat_thread() {
+        let _home = init("cmd_create_thread");
+        let thread = create_thread(store::CreateThreadInput {
+            mode: "chat".into(),
+            title: Some("New Chat".into()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: None,
+        })
+        .expect("create thread");
+        assert_eq!(thread.title, "New Chat");
+    }
+
+    #[tokio::test]
+    async fn fork_thread_errors_for_an_unknown_thread() {
+        let _home = init("cmd_fork_ghost");
+        assert!(fork_thread("no-such-thread".into(), "x".into(), 0)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn attach_remote_stream_errors_for_an_unknown_thread() {
+        let _home = init("cmd_attach_ghost");
+        assert!(attach_remote_stream("no-such-thread".into()).await.is_err());
+    }
+
+    #[test]
     fn thread_read_and_pin_commands_round_trip() {
         let _home = init("cmd_threads");
         assert!(list_threads().expect("list empty").is_empty());


### PR DESCRIPTION
## Summary

Third-round residual cleanup for the desktop/src-tauri per-line 100% goal (口径 A: lcov DA:0 = 0).

**Net: 713 → 648 DA:0** (-65 lines; 886 + 1 tests green, fmt + clippy clean).

### This PR

- **commands/review.rs** (45 → 5): all four sync commands were never called. Added a full test module covering `get_workspace_review_capabilities` (unknown-workspace error, non-git, git), `get_last_run_review` (no changeset), `retry_run_review` (unknown run), and `get_git_review` (unknown-workspace error, non-git, git) — with a local `git init -b main` repo fixture.
- **commands/threads.rs** (43 → 18): added `create_thread` direct-call test, `fork_thread` / `attach_remote_stream` error paths, and an `ipc_harness` test that rejects malformed bodies across all async commands (covers the tauri-macros attribute-line attribution artifacts).

### Remaining (648 lines, 16 files) — not in this PR

Mostly W7 shells (`AppHandle<Wry>` un-mockable → needs generic-Runtime refactor): lib.rs 171 / update.rs 89 / remote/commands.rs 78 / agent_supervisor.rs 68 / observer.rs 55 / menu.rs 48 / login.rs 33 / files.rs 18 / debug.rs 19 / skills_bootstrap.rs 14 / skills.rs 7, plus agent_bridge/review.rs 6, future_login.rs 3, and the tail of review.rs (5: too-large branch + changeset-success paths).