### PR TITLE
test(desktop): drain root shell residual via testable seams (cov100 final-tauri)

### DIFF
--- a/desktop/src-tauri/src/agent_supervisor.rs
+++ b/desktop/src-tauri/src/agent_supervisor.rs
@@ -65,14 +65,30 @@ fn agent_reachable(addr: &str) -> bool {
 /// which embeds the same code as the retired standalone future-agent binary —
 /// so only `future` is bundled (tauri.conf.json externalBin).
 pub fn ensure_agent_running<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    ensure_agent_running_with(app, agent_reachable);
+}
+
+/// [`ensure_agent_running`] with an injectable reachability probe, so the
+/// "already reachable" early-return is testable without a live agent.
+fn ensure_agent_running_with<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    reachable: impl Fn(&str) -> bool,
+) {
     let addr = bare_addr();
-    if agent_reachable(&addr) {
+    if reachable(&addr) {
         eprintln!("FutureOS: agent already reachable at {addr}; not spawning bundled agent");
         return;
     }
 
+    spawn_bundled_agent(app, &addr);
+}
+
+/// Resolve the `future` sidecar and spawn it (or log why we can't). Extracted so
+/// the sidecar-unavailable / spawn-failure arms are testable with a mock app
+/// handle instead of the real `AppHandle` + bundled sidecar binary.
+fn spawn_bundled_agent<R: tauri::Runtime>(app: &tauri::AppHandle<R>, addr: &str) {
     let command = match app.shell().sidecar("future") {
-        Ok(command) => command.args(["agent", "--grpc-addr", &addr]),
+        Ok(command) => command.args(["agent", "--grpc-addr", addr]),
         Err(error) => {
             eprintln!(
                 "FutureOS: bundled CLI sidecar unavailable ({error}); run it manually in dev"
@@ -326,6 +342,42 @@ mod tests {
         .unwrap();
         drop(tx);
         drain_agent_events(rx);
+    }
+
+    #[test]
+    fn shutdown_agent_noops_without_child() {
+        // `AGENT_CHILD` is `None` by default in tests (no real sidecar spawn),
+        // so this exercises the idempotent no-op path.
+        shutdown_agent();
+    }
+
+    #[test]
+    fn ensure_agent_running_skips_when_reachable() {
+        // A reachable probe short-circuits before any sidecar resolution.
+        ensure_agent_running_with(&mock_handle(), |_| true);
+    }
+
+    #[test]
+    fn ensure_agent_running_logs_sidecar_unavailable() {
+        // Unreachable probe + no bundled sidecar binary → the spawn fails and is
+        // logged, without spawning anything.
+        ensure_agent_running_with(&mock_handle(), |_| false);
+    }
+
+    #[test]
+    fn ensure_agent_running_wrapper_probes_and_delegates() {
+        // The public entry wires `agent_reachable` into the injectable core. With
+        // a mock handle the spawn always fails (no bundled sidecar), so this is a
+        // benign no-op regardless of whether the bare addr happens to be reachable.
+        ensure_agent_running(&mock_handle());
+    }
+
+    fn mock_handle() -> tauri::AppHandle<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        app.handle().clone()
     }
 
     #[test]

--- a/desktop/src-tauri/src/future_login.rs
+++ b/desktop/src-tauri/src/future_login.rs
@@ -267,10 +267,7 @@ pub async fn poll(device_code: &str) -> Result<FutureLoginPoll, AppError> {
         // boot anyway).
         let base_url = format!("{platform}/api");
         let registered = crate::agent_bridge::config::future_login(key.trim(), &base_url).await?;
-        if !registered {
-            crate::auth_store::set_future_login(key.trim(), &base_url)?;
-            let _ = crate::agent_bridge::reload_agent_credentials().await;
-        }
+        persist_future_login_if_needed(registered, key.trim(), &base_url).await?;
         return Ok(FutureLoginPoll::of("authorized"));
     }
 
@@ -365,19 +362,39 @@ fn validate_browser_url(target: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Write the login key to `auth.json` and reload agent credentials when the
+/// RPC-first write did not already persist it (agent unreachable, or a legacy
+/// agent without `set_auth`). Extracted so the already-registered no-op path is
+/// testable without a live mock agent.
+async fn persist_future_login_if_needed(
+    registered: bool,
+    key: &str,
+    base_url: &str,
+) -> Result<(), AppError> {
+    if !registered {
+        crate::auth_store::set_future_login(key, base_url)?;
+        let _ = crate::agent_bridge::reload_agent_credentials().await;
+    }
+    Ok(())
+}
+
 /// Open a URL in the default browser, detached and best-effort (mirrors the
 /// CLI). Caller must validate the URL first (see [`validate_browser_url`]).
 /// Uses the `open` crate (ShellExecuteW on Windows) — never `cmd /c start`,
 /// which re-parses the URL so a `&` truncates it and `&cmd`-style payloads
 /// from a hostile platform host would execute.
 fn open_browser(url: &str) {
-    // Best-effort launch of the default browser. In tests this is a no-op so a
-    // `start()` success test doesn't spawn the real browser; the side effect is
-    // irrelevant to the code paths under test.
-    if !cfg!(test) {
-        let _ = open::that_detached(url);
-    }
+    // The opener is swappable so tests can assert the URL is passed through
+    // without launching a real browser (`open::that_detached` is a real side
+    // effect that would escape the test process).
+    let opener = BROWSER_OPENER.get_or_init(|| |url: &str| open::that_detached(url));
+    let _ = opener(url);
 }
+
+/// Swappable default-browser opener; production uses the default `open` crate
+/// launcher, tests install a no-op.
+static BROWSER_OPENER: std::sync::OnceLock<fn(&str) -> std::io::Result<()>> =
+    std::sync::OnceLock::new();
 
 #[cfg(target_os = "macos")]
 const LOGIN_PLATFORM: &str = "macOS";
@@ -498,6 +515,28 @@ mod tests {
         assert_eq!(future_api_key().unwrap(), "sekret");
     }
 
+    #[test]
+    fn open_browser_uses_injected_opener() {
+        let _ = BROWSER_OPENER.set(|_| Ok(()));
+        open_browser("https://example.com/device");
+    }
+
+    #[tokio::test]
+    async fn persist_future_login_skips_when_already_registered() {
+        // RPC-first path already persisted the key → the local fallback no-ops.
+        persist_future_login_if_needed(true, "key", "https://future-os.cn/api")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn broken_agent_endpoint_restores_unset_env() {
+        std::env::remove_var("FUTURE_AGENT_GRPC_ADDR");
+        let value = with_broken_agent_endpoint(|| async { 42 }).await;
+        assert_eq!(value, 42);
+        assert!(std::env::var("FUTURE_AGENT_GRPC_ADDR").is_err());
+    }
+
     // ─── async OAuth + account calls against a mock HTTP server ───────────
 
     fn mock_http_server(responses: Vec<(u16, &'static str, Vec<u8>)>) -> String {
@@ -527,6 +566,24 @@ mod tests {
 
     fn point_auth_with_key(url: &str) {
         crate::auth_store::set_future_login("sekret", &format!("{url}/api")).unwrap();
+    }
+
+    /// Run a closure with `FUTURE_AGENT_GRPC_ADDR` pointed at an unparseable
+    /// endpoint so `connect_agent` fails deterministically, then restore the
+    /// previous value (or remove it when it was unset).
+    async fn with_broken_agent_endpoint<F, Fut, T>(f: F) -> T
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let previous = std::env::var("FUTURE_AGENT_GRPC_ADDR").ok();
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
+        let result = f().await;
+        match previous {
+            Some(value) => std::env::set_var("FUTURE_AGENT_GRPC_ADDR", value),
+            None => std::env::remove_var("FUTURE_AGENT_GRPC_ADDR"),
+        }
+        result
     }
 
     #[tokio::test]
@@ -635,6 +692,9 @@ mod tests {
     #[tokio::test]
     async fn start_returns_device_codes() {
         let _home = crate::auth_store::test_support::HomeGuard::new("fl-start");
+        // The success path reaches `open_browser`; install a no-op opener so it
+        // doesn't launch a real browser.
+        let _ = BROWSER_OPENER.set(|_| Ok(()));
         let body = r#"{"device_code":"dc-123","user_code":"uc-456","verification_uri":"https://example.com/device","verification_uri_complete":"https://example.com/device?code=uc-456","expires_in":300,"interval":5}"#;
         let url = mock_http_server(vec![(200, "application/json", body.as_bytes().to_vec())]);
         point_auth(&url);
@@ -847,13 +907,7 @@ mod tests {
         )]);
         point_auth(&url);
 
-        let previous = std::env::var("FUTURE_AGENT_GRPC_ADDR").ok();
-        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
-        let out = poll("dc").await.unwrap();
-        match previous {
-            Some(value) => std::env::set_var("FUTURE_AGENT_GRPC_ADDR", value),
-            None => std::env::remove_var("FUTURE_AGENT_GRPC_ADDR"),
-        }
+        let out = with_broken_agent_endpoint(|| poll("dc")).await.unwrap();
 
         assert_eq!(out.status, "authorized");
         assert_eq!(

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -48,7 +48,7 @@ static APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::
 /// excludes the taskbar/dock/menubar) and center it there — near-fullscreen but
 /// not maximized, correct on every OS. Best effort: any failure leaves the
 /// config default (1440x960).
-fn size_main_window_to_screen(app: &tauri::App) {
+fn size_main_window_to_screen<R: tauri::Runtime>(app: &tauri::App<R>) {
     use tauri::Manager;
     let Some(window) = app.get_webview_window("main") else {
         return;
@@ -58,19 +58,39 @@ fn size_main_window_to_screen(app: &tauri::App) {
     };
     let scale = monitor.scale_factor();
     let area = monitor.work_area();
-    let area_w = area.size.width as f64 / scale;
-    let area_h = area.size.height as f64 / scale;
-    let area_x = area.position.x as f64 / scale;
-    let area_y = area.position.y as f64 / scale;
+    let (width, height, x, y) = main_window_geometry(
+        scale,
+        area.size.width as f64,
+        area.size.height as f64,
+        area.position.x as f64,
+        area.position.y as f64,
+    );
+    let _ = window.set_size(tauri::LogicalSize::new(width, height));
+    // Center horizontally; sit a bit above vertical center (smaller top gap).
+    let _ = window.set_position(tauri::LogicalPosition::new(x, y));
+}
+
+/// Compute the main-window size (near-fullscreen, clamped) and centered position
+/// — both in logical units — from a monitor's scale factor and physical work
+/// area. Extracted so the geometry is unit-testable without a live
+/// window/monitor.
+fn main_window_geometry(
+    scale: f64,
+    area_w: f64,
+    area_h: f64,
+    area_x: f64,
+    area_y: f64,
+) -> (f64, f64, f64, f64) {
+    let area_w = area_w / scale;
+    let area_h = area_h / scale;
+    let area_x = area_x / scale;
+    let area_y = area_y / scale;
 
     let width = (area_w * 0.94).clamp(1024.0, area_w);
     let height = (area_h * 0.94).clamp(720.0, area_h);
-    let _ = window.set_size(tauri::LogicalSize::new(width, height));
-    // Center horizontally; sit a bit above vertical center (smaller top gap).
-    let _ = window.set_position(tauri::LogicalPosition::new(
-        area_x + (area_w - width) / 2.0,
-        area_y + (area_h - height) * 0.35,
-    ));
+    let x = area_x + (area_w - width) / 2.0;
+    let y = area_y + (area_h - height) * 0.35;
+    (width, height, x, y)
 }
 
 /// Set a crisp taskbar icon on Windows by loading the multi-size ICO directly.
@@ -212,18 +232,31 @@ fn icon_ico_bytes() -> &'static [u8] {
 /// frontend bridges this to its typed event bus (§6.1, C1).
 pub(crate) fn emit_review_updated(thread_id: &str) {
     if let Some(handle) = APP_HANDLE.get() {
-        use tauri::Emitter;
-        let _ = handle.emit("review-updated", thread_id.to_string());
+        emit_review_updated_on(handle, thread_id);
     }
+}
+
+/// Emit the "review-updated" event on a caller-supplied handle. Extracted so the
+/// `.emit()` body is testable with a mock handle (the process-global
+/// `APP_HANDLE` is only populated when the real app runs).
+fn emit_review_updated_on<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, thread_id: &str) {
+    use tauri::Emitter;
+    let _ = handle.emit("review-updated", thread_id.to_string());
 }
 
 /// Notify the frontend that a remote (phone) client created/drove a thread, so
 /// the thread list + runs refresh and the conversation shows up live.
 pub(crate) fn emit_remote_activity(thread_id: &str) {
     if let Some(handle) = APP_HANDLE.get() {
-        use tauri::Emitter;
-        let _ = handle.emit("remote-activity", thread_id.to_string());
+        emit_remote_activity_on(handle, thread_id);
     }
+}
+
+/// Emit the "remote-activity" event on a caller-supplied handle (see
+/// [`emit_review_updated_on`]).
+fn emit_remote_activity_on<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, thread_id: &str) {
+    use tauri::Emitter;
+    let _ = handle.emit("remote-activity", thread_id.to_string());
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
@@ -330,10 +363,7 @@ pub(crate) fn emit_thread_runtime_updated(
                         }
                     }
                     if let Some(handle) = APP_HANDLE.get() {
-                        use tauri::Emitter;
-                        for update in coalesce_runtime_updates(first, rest) {
-                            let _ = handle.emit("thread-runtime-updated", update);
-                        }
+                        emit_runtime_updates_on(handle, coalesce_runtime_updates(first, rest));
                     }
                 }
             })
@@ -373,6 +403,16 @@ pub(crate) fn emit_approvals_updated(thread_id: &str, approval_request_id: &str)
     let Some(handle) = APP_HANDLE.get() else {
         return;
     };
+    emit_approvals_updated_on(handle, thread_id, approval_request_id);
+}
+
+/// Emit the "approvals-updated" event on a caller-supplied handle (see
+/// [`emit_review_updated_on`]).
+fn emit_approvals_updated_on<R: tauri::Runtime>(
+    handle: &tauri::AppHandle<R>,
+    thread_id: &str,
+    approval_request_id: &str,
+) {
     use tauri::Emitter;
     let _ = handle.emit(
         "approvals-updated",
@@ -381,6 +421,18 @@ pub(crate) fn emit_approvals_updated(thread_id: &str, approval_request_id: &str)
             approval_request_id: approval_request_id.to_string(),
         },
     );
+}
+
+/// Emit the coalesced "thread-runtime-updated" updates on a caller-supplied
+/// handle (see [`emit_review_updated_on`]).
+fn emit_runtime_updates_on<R: tauri::Runtime>(
+    handle: &tauri::AppHandle<R>,
+    updates: Vec<ThreadRuntimeUpdate>,
+) {
+    use tauri::Emitter;
+    for update in updates {
+        let _ = handle.emit("thread-runtime-updated", update);
+    }
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -403,25 +455,52 @@ fn start_thread_streaming_monitor() {
     tauri::async_runtime::spawn(async move {
         let mut previous: Option<Vec<String>> = None;
         loop {
-            let mut thread_ids = list_streaming_thread_ids().await.unwrap_or_default();
-            thread_ids.sort_unstable();
-            thread_ids.dedup();
-            if previous.as_ref() != Some(&thread_ids) {
-                previous = Some(thread_ids.clone());
-                if let Some(handle) = APP_HANDLE.get() {
-                    use tauri::Emitter;
-                    let _ = handle.emit(
-                        "thread-streaming-updated",
-                        ThreadStreamingUpdate {
-                            revision: next_runtime_revision(),
-                            thread_ids,
-                        },
-                    );
-                }
+            if let Some(handle) = APP_HANDLE.get() {
+                sample_thread_streaming(handle, &mut previous).await;
             }
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
+}
+
+/// Sample the agent's streaming thread ids once and, if the set changed, emit a
+/// "thread-streaming-updated" notification on the given handle. Extracted so the
+/// change-detection + emit body is testable without the process-global
+/// `APP_HANDLE` or a real agent.
+async fn sample_thread_streaming<R: tauri::Runtime>(
+    handle: &tauri::AppHandle<R>,
+    previous: &mut Option<Vec<String>>,
+) {
+    sample_thread_streaming_with(handle, previous, list_streaming_thread_ids).await;
+}
+
+/// The injectable core of [`sample_thread_streaming`]: fetch the current
+/// streaming thread ids, then — if the set changed — emit a
+/// "thread-streaming-updated" notification on the given handle. Extracted so the
+/// change-detection + emit body is testable with a deterministic id source.
+async fn sample_thread_streaming_with<R, F, Fut>(
+    handle: &tauri::AppHandle<R>,
+    previous: &mut Option<Vec<String>>,
+    fetch: F,
+) where
+    R: tauri::Runtime,
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<String>, crate::AppError>>,
+{
+    let mut thread_ids = fetch().await.unwrap_or_default();
+    thread_ids.sort_unstable();
+    thread_ids.dedup();
+    if previous.as_ref() != Some(&thread_ids) {
+        *previous = Some(thread_ids.clone());
+        use tauri::Emitter;
+        let _ = handle.emit(
+            "thread-streaming-updated",
+            ThreadStreamingUpdate {
+                revision: next_runtime_revision(),
+                thread_ids,
+            },
+        );
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -752,7 +831,11 @@ pub fn run() {
 
 #[cfg(test)]
 mod runtime_update_tests {
-    use super::{coalesce_runtime_updates, ThreadRuntimeUpdate};
+    use super::{
+        coalesce_runtime_updates, emit_approvals_updated_on, emit_remote_activity_on,
+        emit_review_updated_on, emit_runtime_updates_on, main_window_geometry,
+        sample_thread_streaming_with, size_main_window_to_screen, ThreadRuntimeUpdate,
+    };
 
     fn update(run_id: &str, revision: i64, status: &str, reset: bool) -> ThreadRuntimeUpdate {
         ThreadRuntimeUpdate {
@@ -807,5 +890,84 @@ mod runtime_update_tests {
         );
 
         assert_eq!(updates, vec![update("run-1", 2, "finalizing", false)]);
+    }
+
+    #[test]
+    fn main_window_geometry_scales_clamps_and_centers() {
+        // 2x scale → logical work area is 2000x1000 at (50, 25).
+        let (width, height, x, y) = main_window_geometry(2.0, 4000.0, 2000.0, 100.0, 50.0);
+        assert_eq!(width, 1880.0);
+        assert_eq!(height, 940.0);
+        assert_eq!(x, 50.0 + (2000.0 - 1880.0) / 2.0);
+        assert_eq!(y, 25.0 + (1000.0 - 940.0) * 0.35);
+    }
+
+    #[test]
+    fn main_window_geometry_clamps_to_minimums() {
+        // 0.94×1050 = 987 < 1024 → clamps to the 1024 floor; same for height.
+        let (width, height, _, _) = main_window_geometry(1.0, 1050.0, 730.0, 0.0, 0.0);
+        assert_eq!(width, 1024.0);
+        assert_eq!(height, 720.0);
+    }
+
+    #[test]
+    fn size_main_window_returns_without_main_window() {
+        // `mock_app` has no "main" window, so this takes the early-return path.
+        let app = tauri::test::mock_app();
+        size_main_window_to_screen(&app);
+    }
+
+    #[test]
+    fn size_main_window_returns_without_monitor() {
+        // A mock "main" window has no monitor, so the monitor lookup fails and
+        // the function returns before sizing/positioning.
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let _window = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("build webview");
+        size_main_window_to_screen(&app);
+    }
+
+    #[test]
+    fn emit_helpers_emit_on_mock_handle() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        emit_review_updated_on(handle, "thread-1");
+        emit_remote_activity_on(handle, "thread-1");
+        emit_approvals_updated_on(handle, "thread-1", "approval-1");
+        emit_runtime_updates_on(
+            handle,
+            vec![
+                update("run-1", 1, "running", false),
+                update("run-1", 2, "completed", false),
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn sample_thread_streaming_emits_only_on_change() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let mut previous: Option<Vec<String>> = None;
+        // First sample emits and records the new set.
+        sample_thread_streaming_with(handle, &mut previous, || async {
+            Ok(vec!["a".to_string(), "a".to_string(), "b".to_string()])
+        })
+        .await;
+        assert_eq!(previous, Some(vec!["a".to_string(), "b".to_string()]));
+        // Unchanged sample → no emit, `previous` keeps the same value.
+        sample_thread_streaming_with(handle, &mut previous, || async {
+            Ok(vec!["b".to_string(), "a".to_string()])
+        })
+        .await;
+        assert_eq!(previous, Some(vec!["a".to_string(), "b".to_string()]));
+        // Changed sample → emit + record the new set.
+        sample_thread_streaming_with(handle, &mut previous, || async {
+            Ok(vec!["c".to_string()])
+        })
+        .await;
+        assert_eq!(previous, Some(vec!["c".to_string()]));
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -834,7 +834,8 @@ mod runtime_update_tests {
     use super::{
         coalesce_runtime_updates, emit_approvals_updated_on, emit_remote_activity_on,
         emit_review_updated_on, emit_runtime_updates_on, main_window_geometry,
-        sample_thread_streaming_with, size_main_window_to_screen, ThreadRuntimeUpdate,
+        sample_thread_streaming, sample_thread_streaming_with, size_main_window_to_screen,
+        ThreadRuntimeUpdate,
     };
 
     fn update(run_id: &str, revision: i64, status: &str, reset: bool) -> ThreadRuntimeUpdate {
@@ -969,5 +970,27 @@ mod runtime_update_tests {
         })
         .await;
         assert_eq!(previous, Some(vec!["c".to_string()]));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn sample_thread_streaming_wrapper_delegates_to_real_id_source() {
+        // The thin wrapper feeds the real `list_streaming_thread_ids` (which
+        // hits the agent) into `sample_thread_streaming_with`. With the mock
+        // agent down (health check still up, streaming list empty) it records
+        // an empty sample without panicking — exercising the wrapper's own
+        // delegation line rather than the injectable core.
+        let _lock = crate::commands::agent_mock::mock_agent_lock();
+        crate::commands::agent_mock::ensure_mock_agent();
+        crate::commands::agent_mock::script_mock_agent(crate::commands::agent_mock::MockScript {
+            down: true,
+            ..Default::default()
+        });
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let mut previous: Option<Vec<String>> = None;
+        sample_thread_streaming(handle, &mut previous).await;
+        assert_eq!(previous, Some(Vec::new()));
+        crate::commands::agent_mock::script_mock_agent(Default::default());
     }
 }

--- a/desktop/src-tauri/src/skills_bootstrap.rs
+++ b/desktop/src-tauri/src/skills_bootstrap.rs
@@ -6,7 +6,6 @@
 //! endpoints are unauthenticated). Used by the post-login onboarding flow; runs
 //! on a background thread since it blocks on the CLI child process.
 
-use tauri::AppHandle;
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 
@@ -14,7 +13,7 @@ const INIT_ARGS: [&str; 1] = ["init"];
 
 /// Force-run the skill bootstrap. Idempotent — the CLI itself skips
 /// already-installed skills. Used by the post-login onboarding flow.
-pub fn run_builtin_skills(app: &AppHandle) {
+pub fn run_builtin_skills<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     let command = match app.shell().sidecar("future") {
         Ok(command) => command.args(INIT_ARGS),
         Err(error) => {
@@ -118,5 +117,16 @@ mod tests {
         .unwrap();
         drop(tx);
         assert_eq!(drain_skill_events(rx), Some(2));
+    }
+
+    #[test]
+    fn run_builtin_skills_logs_spawn_failure() {
+        // No bundled `future` sidecar binary in a mock app → the spawn fails and
+        // is logged, without draining anything.
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        run_builtin_skills(app.handle());
     }
 }

--- a/measure-tauri.sh
+++ b/measure-tauri.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Measure desktop/src-tauri per-line coverage (lcov DA:0) for the final-tauri residual.
+set -uo pipefail
+cd "$(dirname "$0")"
+REALHOME="$HOME"
+
+while IFS='=' read -r k _; do case "$k" in CARGO*) unset "$k";; esac; done < <(env)
+export PATH="/Users/geilige/.rustup/toolchains/1.97.0-aarch64-apple-darwin/bin:$PATH"
+export CARGO_HOME="$REALHOME/.cargo"
+export RUSTUP_HOME="$REALHOME/.rustup"
+
+mkdir -p coverage/final-100 target/test-home
+triple=$(rustc -Vv | sed -n 's/^host: //p')
+mkdir -p desktop/src-tauri/binaries
+[ -f "desktop/src-tauri/binaries/future-$triple" ] || : > "desktop/src-tauri/binaries/future-$triple"
+
+export HOME="$PWD/target/test-home"
+cargo llvm-cov --manifest-path desktop/src-tauri/Cargo.toml --no-report > coverage/final-100/tauri-run.log 2>&1
+echo "tauri run exit=$?"
+cargo llvm-cov report --manifest-path desktop/src-tauri/Cargo.toml --lcov --output-path coverage/final-100/tauri-lcov.info >> coverage/final-100/tauri-run.log 2>&1
+cargo llvm-cov report --manifest-path desktop/src-tauri/Cargo.toml --summary-only >> coverage/final-100/tauri-run.log 2>&1
+export HOME="$REALHOME"
+
+python3 coverage/baseline-100/parse_lcov.py coverage/final-100/tauri-lcov.info coverage/final-100/desktop-tauri-missed.txt
+echo "=== done ==="


### PR DESCRIPTION
## Summary

Refactors the tauri **root shell** files so their logic is unit-testable without a live `App<Wry>`/display/main-thread/sidecar, and adds tests that clear the reachable per-line DA:0 lines.

Measured (lcov DA:0, macOS, env-sanitized): root five files **304 → 256** missed lines; **future_login.rs → 0**.

## Changes

- **lib.rs**: extract pure `main_window_geometry`; generic `emit_*_on` helpers + injectable `sample_thread_streaming_with` (driven by `tauri::test::mock_app()`); make `size_main_window_to_screen` generic over Runtime and cover its no-window/no-monitor early returns.
- **agent_supervisor.rs**: make `ensure_agent_running` generic + split the reachability probe and sidecar spawn into injectable helpers; cover reachable/sidecar-unavailable arms + shutdown no-op.
- **skills_bootstrap.rs**: make `run_builtin_skills` generic; cover the spawn-failure path.
- **future_login.rs**: replace the `cfg!(test)` split in `open_browser` with an injectable opener; extract `persist_future_login_if_needed` (covers the already-registered arm); factor the broken-agent-endpoint env save/restore into a helper (covers the env-was-unset arm).

## Remaining DA:0 (not cleared — genuine W5/W7 seams)

- **menu.rs (48)**: muda menu construction asserts macOS main-thread; libtest runs worker threads. Already tried generic `R: Runtime` + `mock_app()` — panics.
- **lib.rs (149)**: `run()` Builder chain + closures need a real `App<Wry>` + display; 4 `emit_*_on` delegation lines need `APP_HANDLE` (Wry `OnceLock`) populated; `size_main_window_to_screen` set_size/set_position need a live monitor; streaming-monitor spawn loop.
- **agent_supervisor.rs (53)**: sidecar-spawn `Ok` branch (needs bundled `future` binary), `shutdown_agent` kill-Err (needs `CommandChild`), `confirm_quit` native dialog + callback, `CommandEvent` `#[non_exhaustive]` `_ => {}`.
- **skills_bootstrap.rs (6)**: sidecar-spawn `Ok` + drain call, `_ => {}`.

These are non-testable seams / non-dead defensive code; deleting them would remove meaningful logic.