### PR TITLE
test(desktop): cover commands/login + remote + skills + debug residuals (cov100 final-tauri2)

### DIFF
--- a/desktop/src-tauri/src/agent_supervisor.rs
+++ b/desktop/src-tauri/src/agent_supervisor.rs
@@ -64,7 +64,7 @@ fn agent_reachable(addr: &str) -> bool {
 /// The agent runs through the unified `future` CLI sidecar (`future agent`),
 /// which embeds the same code as the retired standalone future-agent binary —
 /// so only `future` is bundled (tauri.conf.json externalBin).
-pub fn ensure_agent_running(app: &AppHandle) {
+pub fn ensure_agent_running<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     let addr = bare_addr();
     if agent_reachable(&addr) {
         eprintln!("FutureOS: agent already reachable at {addr}; not spawning bundled agent");

--- a/desktop/src-tauri/src/commands/debug.rs
+++ b/desktop/src-tauri/src/commands/debug.rs
@@ -50,6 +50,26 @@ pub fn get_future_environment() -> Result<FutureEnvironment, AppError> {
     })
 }
 
+/// Resolve an environment selector (`production` | `test` | anything else) to
+/// the platform root it names. Extracted from [`set_future_environment`] so the
+/// selector validation and the release-build guard are testable without a real
+/// `AppHandle` — the command itself ends in `app.restart()`, which re-execs the
+/// process and never returns.
+fn resolve_environment(environment: &str) -> Result<&'static str, AppError> {
+    // Release builds are production-locked (the UI hides the switcher; this is
+    // the backend guard behind it). Only dev builds may switch environments.
+    if crate::build_info::is_release() && environment != ENV_PRODUCTION {
+        return Err(AppError::Message(
+            "Production builds only support the production environment; cannot switch.".to_string(),
+        ));
+    }
+    match environment {
+        ENV_PRODUCTION => Ok(PRODUCTION_PLATFORM_URL),
+        ENV_TEST => Ok(TEST_PLATFORM_URL),
+        other => Err(AppError::Message(format!("Unknown environment: {other}"))),
+    }
+}
+
 /// Switch the FutureGene environment and relaunch so the change takes effect.
 /// Pins `auth.json`'s `future.base_url` to `{platform}/api` (mirroring the CLI's
 /// `auth login --url`) and drops the stale key; both the agent and the GUI
@@ -76,18 +96,7 @@ pub fn get_future_environment() -> Result<FutureEnvironment, AppError> {
 /// forces the relaunched GUI to spawn a new agent that reads the new `base_url`.
 #[tauri::command]
 pub fn set_future_environment(app: tauri::AppHandle, environment: String) -> Result<(), AppError> {
-    // Release builds are production-locked (the UI hides the switcher; this is
-    // the backend guard behind it). Only dev builds may switch environments.
-    if crate::build_info::is_release() && environment != ENV_PRODUCTION {
-        return Err(AppError::Message(
-            "Production builds only support the production environment; cannot switch.".to_string(),
-        ));
-    }
-    let platform_url = match environment.as_str() {
-        ENV_PRODUCTION => PRODUCTION_PLATFORM_URL,
-        ENV_TEST => TEST_PLATFORM_URL,
-        other => return Err(AppError::Message(format!("Unknown environment: {other}"))),
-    };
+    let platform_url = resolve_environment(&environment)?;
     // Deliberately a direct `auth_store` write (not the RPC-first path of audit
     // item 2): this is a sync command that immediately kills and restarts the
     // agent, so there is nothing to RPC — the relaunched agent reads the new
@@ -119,5 +128,19 @@ mod tests {
         let env = get_future_environment().expect("custom env");
         assert_eq!(env.environment, "custom");
         assert_eq!(env.platform_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn resolve_environment_maps_known_selectors_and_rejects_unknown() {
+        assert_eq!(
+            resolve_environment("production").unwrap(),
+            "https://future-os.cn"
+        );
+        assert_eq!(
+            resolve_environment("test").unwrap(),
+            "https://test.future-os.cn"
+        );
+        assert!(resolve_environment("custom").is_err());
+        assert!(resolve_environment("nonsense").is_err());
     }
 }

--- a/desktop/src-tauri/src/commands/files.rs
+++ b/desktop/src-tauri/src/commands/files.rs
@@ -754,6 +754,26 @@ mod tests {
     }
 
     #[test]
+    fn ensure_path_allowed_is_a_noop_without_a_home_dir() {
+        let lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        // The test harness always has HOME set; `USERPROFILE` is a Windows-only
+        // fallback absent on macOS/Linux, so removing both and restoring HOME
+        // verbatim leaves the process-global state unchanged.
+        let old_home = std::env::var("HOME").unwrap();
+        std::env::remove_var("HOME");
+        std::env::remove_var("USERPROFILE");
+
+        let file = write_under(&future_root("no_home"), "ok.txt");
+        assert!(ensure_path_allowed(&file).is_ok());
+
+        std::env::set_var("HOME", old_home);
+        std::env::remove_var("USERPROFILE");
+        drop(lock);
+    }
+
+    #[test]
     fn inspect_attachment_classifies_dir_text_and_binary() {
         let root = future_root("inspect");
         assert!(inspect_attachment("   ".into()).is_err());

--- a/desktop/src-tauri/src/commands/login.rs
+++ b/desktop/src-tauri/src/commands/login.rs
@@ -10,8 +10,8 @@ pub async fn start_future_login() -> Result<FutureLoginStart, crate::AppError> {
 }
 
 #[tauri::command]
-pub async fn poll_future_login(
-    app: tauri::AppHandle,
+pub async fn poll_future_login<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
     device_code: String,
 ) -> Result<FutureLoginPoll, crate::AppError> {
     let result = future_login::poll(&device_code).await?;
@@ -62,4 +62,177 @@ pub async fn get_future_profile() -> Result<FutureProfile, crate::AppError> {
 #[tauri::command]
 pub async fn get_future_balance() -> Result<FutureBalance, crate::AppError> {
     future_login::fetch_balance().await
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::await_holding_lock)]
+    use super::*;
+    use crate::auth_store::test_support::HomeGuard;
+    use crate::commands::agent_mock::{mock_agent_lock, script_mock_agent, MockScript};
+    use std::collections::HashMap;
+
+    /// A one-shot mock HTTP server: each `(status, content-type, body)` tuple
+    /// answers one request.
+    fn mock_http_server(responses: Vec<(u16, &'static str, Vec<u8>)>) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            for (status, content_type, body) in responses {
+                let (mut stream, _) = listener.accept().expect("mock accept");
+                let mut sink = [0u8; 8192];
+                let _ = stream.read(&mut sink);
+                let header = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+            }
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    fn point_auth(url: &str) {
+        crate::auth_store::set_future_base_url(&format!("{url}/api")).unwrap();
+    }
+
+    fn point_auth_with_key(url: &str) {
+        crate::auth_store::set_future_login("sekret", &format!("{url}/api")).unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_future_login_returns_the_device_code() {
+        let _home = HomeGuard::new("cmd-login-start");
+        let url = mock_http_server(vec![(
+            200,
+            "application/json",
+            b"{\"device_code\":\"dc-1\",\"user_code\":\"UC-1\",\"verification_uri_complete\":\"https://future-os.cn/oauth/device?user_code=UC-1\",\"expires_in\":1800,\"interval\":5}".to_vec(),
+        )]);
+        point_auth(&url);
+        let start = start_future_login().await.expect("start");
+        assert_eq!(start.user_code, "UC-1");
+        assert_eq!(start.device_code, "dc-1");
+    }
+
+    #[tokio::test]
+    async fn logout_future_provider_delegates_to_the_agent() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("cmd-login-logout");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            data: HashMap::from([("set_auth".to_string(), "{}".to_string())]),
+            ..Default::default()
+        });
+        let view = logout_future_provider().await.expect("logout");
+        assert!(!view.builtin.is_empty());
+        script_mock_agent(MockScript::default());
+    }
+
+    #[tokio::test]
+    async fn logout_future_provider_falls_back_when_the_agent_is_down() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("cmd-login-logout-fb");
+        crate::auth_store::set_future_login("sekret", "https://future-os.cn/api").unwrap();
+        let view = crate::commands::agent_mock::with_broken_endpoint(logout_future_provider)
+            .await
+            .expect("logout fallback");
+        assert!(!view.builtin.is_empty());
+        // The local fallback cleared the stored key.
+        assert!(crate::future_login::future_api_key().is_err());
+    }
+
+    #[tokio::test]
+    async fn get_future_profile_fetches_the_account() {
+        let _home = HomeGuard::new("cmd-login-profile");
+        let url = mock_http_server(vec![(
+            200,
+            "application/json",
+            b"{\"email\":\"a@b.c\",\"user_id\":\"u1\"}".to_vec(),
+        )]);
+        point_auth_with_key(&url);
+        let profile = get_future_profile().await.expect("profile");
+        assert_eq!(profile.email, "a@b.c");
+    }
+
+    #[tokio::test]
+    async fn get_future_balance_fetches_credits() {
+        let _home = HomeGuard::new("cmd-login-balance");
+        let url = mock_http_server(vec![(
+            200,
+            "application/json",
+            b"{\"balance_credits\":10000000000}".to_vec(),
+        )]);
+        point_auth_with_key(&url);
+        let balance = get_future_balance().await.expect("balance");
+        assert_eq!(balance.credits, 1.0);
+    }
+
+    fn mock_app_with_main_window() -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+        tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("main webview");
+        app
+    }
+
+    #[test]
+    fn poll_future_login_wrapper_rejects_malformed_bodies() {
+        crate::commands::ipc_harness::assert_all_reject_bad_body(
+            tauri::generate_handler![poll_future_login],
+            &["poll_future_login"],
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_future_login_reports_pending_without_authorization() {
+        let _home = HomeGuard::new("cmd-login-poll-pending");
+        let app = mock_app_with_main_window();
+        // A non-2xx `authorization_pending` body exercises the poll call and
+        // the `status != authorized` (no window/spawn) branch.
+        let url = mock_http_server(vec![(
+            400,
+            "application/json",
+            b"{\"error\":\"authorization_pending\"}".to_vec(),
+        )]);
+        point_auth(&url);
+
+        let result = poll_future_login(app.handle().clone(), "dc-1".into())
+            .await
+            .expect("poll");
+        assert_eq!(result.status, "pending");
+    }
+
+    #[tokio::test]
+    async fn poll_future_login_refreshes_the_window_on_authorization() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("cmd-login-poll-auth");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            data: HashMap::from([("set_auth".to_string(), "{}".to_string())]),
+            ..Default::default()
+        });
+
+        let app = mock_app_with_main_window();
+        let url = mock_http_server(vec![(
+            200,
+            "application/json",
+            b"{\"api_key\":\"sk-test\",\"token_type\":\"api_key\"}".to_vec(),
+        )]);
+        point_auth(&url);
+
+        let result = poll_future_login(app.handle().clone(), "dc-1".into())
+            .await
+            .expect("poll");
+        assert_eq!(result.status, "authorized");
+
+        // The detached ensure_agent_running thread probes the (reachable) mock
+        // agent and returns — give it a beat to run so its line is attributed.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        script_mock_agent(MockScript::default());
+    }
 }

--- a/desktop/src-tauri/src/commands/remote.rs
+++ b/desktop/src-tauri/src/commands/remote.rs
@@ -121,4 +121,48 @@ mod tests {
         let status = remote_unpair().await.expect("unpair");
         assert!(!status.connected);
     }
+
+    #[tokio::test]
+    async fn remote_start_surfaces_a_degraded_status() {
+        let _home = HomeGuard::new("remote_start_deg");
+        // Point the platform at an unreachable host so `establish()` fails with
+        // a categorized "network" status — `remote::start` returns an Ok
+        // not-running status with `error_code` set, exercising the command's
+        // degraded-status eprintln arm (and the Ok branch of the match).
+        crate::remote::test_support::sign_in("http://127.0.0.1:9");
+        let status = remote_start(remote::RemoteStartInput {})
+            .await
+            .expect("start");
+        assert!(!status.running);
+        assert_eq!(status.error_code.as_deref(), Some("network"));
+    }
+
+    #[tokio::test]
+    async fn remote_start_propagates_a_local_failure() {
+        let _home = HomeGuard::new("remote_start_err");
+        // A legacy pairing credential + a read-only `.future` dir makes clearing
+        // it fail as an uncategorized *local* fault — `remote::start` then
+        // propagates `Err`, exercising the command's error arm.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            crate::remote::pairing::save_creds(&crate::remote::pairing::PairingCreds {
+                handshake_version: 0,
+                pair_id: "pair_err".into(),
+                desktop_id: "desk_err".into(),
+                nkey_seed: String::new(),
+                user_jwt: "jwt".into(),
+                nats_url: "nats://127.0.0.1:9".into(),
+                nats_ws_url: "ws://127.0.0.1:9".into(),
+                jwt_expires_at: 3600,
+            })
+            .unwrap();
+            let config_dir = std::path::Path::new(&std::env::var("HOME").unwrap()).join(".future");
+            let permissions = std::fs::metadata(&config_dir).unwrap().permissions();
+            std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+            let result = remote_start(remote::RemoteStartInput {}).await;
+            std::fs::set_permissions(&config_dir, permissions).unwrap();
+            assert!(result.is_err());
+        }
+    }
 }

--- a/desktop/src-tauri/src/commands/skills.rs
+++ b/desktop/src-tauri/src/commands/skills.rs
@@ -129,4 +129,82 @@ mod tests {
         let _home = crate::auth_store::test_support::HomeGuard::new("cmd-skills-install");
         assert!(install_skill("../evil".into(), "1.0".into()).await.is_err());
     }
+
+    /// A one-shot mock HTTP server: each `(status, content-type, body)` tuple
+    /// answers one request. `Connection: close` so the client reads the body
+    /// and moves on without keep-alive stalls.
+    fn mock_http_server(responses: Vec<(u16, &'static str, Vec<u8>)>) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            for (status, content_type, body) in responses {
+                let (mut stream, _) = listener.accept().expect("mock accept");
+                let mut sink = [0u8; 8192];
+                let _ = stream.read(&mut sink);
+                let header = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+            }
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    fn skill_zip() -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut cursor);
+            let options = zip::write::SimpleFileOptions::default();
+            writer.start_file("SKILL.md", options).unwrap();
+            std::io::Write::write_all(&mut writer, b"# acme\n").unwrap();
+            writer.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    #[tokio::test]
+    async fn install_skill_success_refreshes_the_agent() {
+        let _lock = mock_agent_lock();
+        let _home = crate::auth_store::test_support::HomeGuard::new("cmd-skills-install-ok");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            data: HashMap::from([("refresh_skills".to_string(), "{}".to_string())]),
+            ..Default::default()
+        });
+
+        // Point the platform at a mock that serves a valid skill zip, so the
+        // download + extract path succeeds and the command reaches its
+        // post-install agent refresh.
+        let url = mock_http_server(vec![(200, "application/zip", skill_zip())]);
+        crate::auth_store::set_future_base_url(&format!("{url}/api")).unwrap();
+
+        install_skill("acme".into(), "1.0".into())
+            .await
+            .expect("install");
+        script_mock_agent(MockScript::default());
+    }
+
+    #[tokio::test]
+    async fn uninstall_skill_removed_true_refreshes_the_agent() {
+        let _lock = mock_agent_lock();
+        let _home = crate::auth_store::test_support::HomeGuard::new("cmd-skills-uninstall-ok");
+        crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript {
+            data: HashMap::from([("refresh_skills".to_string(), "{}".to_string())]),
+            ..Default::default()
+        });
+
+        // Lay down an installed skill dir manually (no download needed) so the
+        // command's `if removed` branch fires and refreshes the agent.
+        let dest = crate::auth_store::agent_dir().unwrap().join("skills/acme");
+        std::fs::create_dir_all(&dest).unwrap();
+
+        let removed = uninstall_skill("acme".into()).await.expect("uninstall");
+        assert!(removed);
+        script_mock_agent(MockScript::default());
+    }
 }


### PR DESCRIPTION
Round 4 worker 2 (todo_ad88a93bfc80): cover the remaining `commands/` residuals outside update/threads/review.

## Result: tauri DA:0 648 → 586; commands/ 205 → 150 (W2 scope 93 → 38)

| file | before | after | covered |
|---|---|---|---|
| login.rs | 33 | **0** | start/logout(+fallback)/profile/balance direct calls against a mock HTTP platform; `poll_future_login` made generic over `Runtime` + mock_app pending/authorized paths (window focus + detached `ensure_agent_running`) |
| remote.rs | 16 | 3 | `remote_start` Ok (degraded "network") + Err (read-only config-dir local fault); only `open_url` (OS side effect) left |
| skills.rs | 7 | 4 | install_skill success (mock zip) + uninstall removed=true; only `bootstrap_builtin_skills` (sidecar) left |
| debug.rs | 19 | 14 | extracted `resolve_environment` (selector + release guard) for direct testing |
| files.rs | 18 | 17 | `home_dir()==None` no-op arm of `ensure_path_allowed` |
| **W2 total** | **93** | **38** | |

## Remaining 38 commands/ lines are W7/W1 (not unit-testable)

- **W7 OS side effects** (`open::that` / `open::that_detached`): files.rs `open_path`/`open_external_url`/`open_path_with_system` (17) + remote.rs `open_url` (3). Real `open` command dispatch — no deterministic in-test trigger without launching real apps/URLs.
- **W7 AppHandle shell entry**: debug.rs `clear_app_data`/`set_future_environment` bodies end in `app.restart()` (returns `!`, re-execs the process — can't run in a unit test) + skills.rs `bootstrap_builtin_skills` (sidecar `run_builtin_skills` spawn).
- **W1 release-build guard**: debug.rs `resolve_environment`'s `is_release() && env != production` arm (dev builds always have `is_release() == false`).

## Supporting refactor

- `agent_supervisor::ensure_agent_running` made generic over `Runtime` (previously `AppHandle<Wry>`) so the `poll_future_login` test can pass a `MockRuntime` handle — it early-returns on the reachable mock agent before touching `app.shell()`.

## Checks

- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.
- `cargo llvm-cov` (src-tauri) 859+ tests green; measured via `measure-tauri.sh`.