### PR TITLE
test(desktop): de-flake remote/agent_bridge retry tests (cov100 final-tauri)

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -2155,7 +2155,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn run_observer_retries_connect_failures() {
+        // Serialize with the remote mock family too: breaking
+        // `FUTURE_AGENT_GRPC_ADDR` must not race a bridge/commands test's
+        // `connect_agent`. Acquire MOCK_SER before MOCK_LOCK so the lock
+        // ordering stays acyclic (bridge: MOCK_SER→TEST_HOME_LOCK; TestHome
+        // observer: TEST_HOME_LOCK→MOCK_LOCK; here: MOCK_SER→MOCK_LOCK).
+        let _remote = crate::remote::test_support::mock_agent_lock();
         let _mock = mock_agent();
         std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "40");
         let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -2703,6 +2703,7 @@ mod bridge_tests {
     async fn continue_run_resumes_a_failed_run_and_rejects_busy_sessions() {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-continue").await;
+        let agent = ensure_mock_agent();
         let session = unique("sess");
 
         // A thread bound to the session + a failed run with terminal events.
@@ -2739,12 +2740,12 @@ mod bridge_tests {
         })
         .unwrap();
 
-        // Break the agent endpoint so the Ok arm's spawned `run_prepared_prompt`
-        // fails at `connect_agent` BEFORE it can spawn a session observer — the
-        // ack path (prepare_remote_prompt) is store-only and unaffected. This
-        // keeps the shared mock script clean for later tests (no zombie).
-        let prev_addr = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
-        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
+        // Reject the Ok arm's spawned `run_prepared_prompt` at session
+        // provisioning (new_session) so it fails BEFORE spawning a session
+        // observer — the ack path (prepare_remote_prompt) is store-only and
+        // unaffected. This keeps the shared mock script clean for later tests
+        // (no zombie) without touching the process-global agent endpoint.
+        agent.script("new_session", false, json!(null), "rejected");
 
         // Ok arm: continue the failed run → ack carries the fresh run ids.
         let reply = bridge
@@ -2754,8 +2755,8 @@ mod bridge_tests {
         assert_eq!(reply["data"]["sessionId"], json!(session));
         assert_eq!(reply["data"]["threadId"], json!(thread.id));
 
-        // The spawned pipeline settles the new run as failed (its connect_agent
-        // fails) — poll until the run leaves the running state.
+        // The spawned pipeline settles the new run as failed (its session
+        // provisioning is rejected) — poll until the run leaves the running state.
         let continued_run = reply["data"]["runId"].as_str().unwrap().to_string();
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
@@ -2773,7 +2774,6 @@ mod bridge_tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev_addr);
         bridge.stop();
     }
 


### PR DESCRIPTION
Follow-up to #219 (which landed the DA:0 work for remote/ + agent_bridge). Two small de-flaking fixes:

- **observer**: `run_observer_retries_connect_failures` breaks `FUTURE_AGENT_GRPC_ADDR` for its retry window — serialize it with the remote mock family (`MOCK_SER` before `MOCK_LOCK`) so it can't race a bridge/commands test's `connect_agent`.
- **commands**: `continue_run`'s Ok arm now rejects the spawned pipeline at `new_session` (scripted) instead of breaking `FUTURE_AGENT_GRPC_ADDR`, exercising the ack path without a zombie session observer or an endpoint race.

No coverage change — remote/ + agent_bridge stay at 0 DA:0 lines.