### PR TITLE
test(desktop): remote/agent_bridge residuals + review flake fixes (cov100 final)

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -62,6 +62,38 @@ const OBSERVER_IDLE_SLEEP: Duration = Duration::from_secs(15 * 60);
 /// How often a quiet stream is checked for the idle-sleep condition.
 const IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Initial attach backoff. Tests shrink it so the self-heal retry loop runs
+/// without real waits (the doubling stays, capped at 10s); the env override
+/// lets individual tests pick a long window to cancel mid-backoff.
+fn observer_backoff() -> Duration {
+    #[cfg(test)]
+    if let Some(ms) = std::env::var("FUTURE_TEST_OBSERVER_BACKOFF_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+    {
+        return Duration::from_millis(ms);
+    }
+    #[cfg(test)]
+    const INITIAL: Duration = Duration::from_millis(5);
+    #[cfg(not(test))]
+    const INITIAL: Duration = Duration::from_millis(500);
+    INITIAL
+}
+
+/// How often a quiet stream is checked for the idle-sleep condition. Tests
+/// shrink it via env so the quiet-window branch can be exercised without a
+/// 30-second wait.
+fn idle_check_interval() -> Duration {
+    #[cfg(test)]
+    if let Some(ms) = std::env::var("FUTURE_TEST_IDLE_CHECK_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+    {
+        return Duration::from_millis(ms);
+    }
+    IDLE_CHECK_INTERVAL
+}
+
 /// Event types forwarded to the webview as `agent-event`. Same whitelist as
 /// the retired single-slot observer: settings changes applied by
 /// `agentStateCache`, plus `user_message` (zero-latency user bubble in the
@@ -467,7 +499,7 @@ async fn run_observer(
     mut cancel: oneshot::Receiver<()>,
 ) {
     let mut state = ObserverState::default();
-    let mut backoff = Duration::from_millis(500);
+    let mut backoff = observer_backoff();
 
     'attach: loop {
         let mut client = match connect_agent().await {
@@ -557,13 +589,13 @@ async fn run_observer(
                 }
             }
         };
-        backoff = Duration::from_millis(500);
+        backoff = observer_backoff();
 
         // ── Streaming ──────────────────────────────────────────────
         loop {
             let message = tokio::select! {
                 _ = &mut cancel => return,
-                result = tokio::time::timeout(IDLE_CHECK_INTERVAL, stream.message()) => result,
+                result = tokio::time::timeout(idle_check_interval(), stream.message()) => result,
             };
             let event = match message {
                 Ok(Ok(Some(event))) => event,
@@ -579,9 +611,6 @@ async fn run_observer(
             shared.touch();
             if !handle_event(session_id, shared, &mut state, event).await {
                 break; // idx gap — reattach for replay/snapshot healing
-            }
-            if shared.should_sleep() {
-                return;
             }
         }
 
@@ -667,7 +696,13 @@ async fn handle_event(
         }
         let event_data = future_rpc::decode::event_data_json(&event);
         if FORWARDED_EVENTS.contains(&event_type) {
-            forward_settings_event(session_id, &shared.thread_id, event_type, &event_data);
+            forward_settings_event(
+                crate::APP_HANDLE.get(),
+                session_id,
+                &shared.thread_id,
+                event_type,
+                &event_data,
+            );
         }
         crate::remote::publish_event(
             session_id,
@@ -762,6 +797,7 @@ async fn handle_event(
                     let event_data = future_rpc::decode::event_data_json(&event);
                     if FORWARDED_EVENTS.contains(&event_type) {
                         forward_settings_event(
+                            crate::APP_HANDLE.get(),
                             session_id,
                             &shared.thread_id,
                             event_type,
@@ -835,7 +871,13 @@ async fn handle_event(
     }
 
     if FORWARDED_EVENTS.contains(&event_type) {
-        forward_settings_event(session_id, &shared.thread_id, event_type, &event_data);
+        forward_settings_event(
+            crate::APP_HANDLE.get(),
+            session_id,
+            &shared.thread_id,
+            event_type,
+            &event_data,
+        );
     }
     crate::remote::publish_event(
         session_id,
@@ -954,10 +996,28 @@ async fn observer_run(
 /// Forward a whitelisted event to the webview as `agent-event`. Both owner
 /// identities are injected so the frontend can reject stale listeners during
 /// a thread switch instead of trusting session identity alone.
-fn forward_settings_event(session_id: &str, thread_id: &str, event_type: &str, data: &str) {
-    let Some(app_handle) = crate::APP_HANDLE.get() else {
-        return;
-    };
+fn forward_settings_event<R: tauri::Runtime>(
+    app_handle: Option<&tauri::AppHandle<R>>,
+    session_id: &str,
+    thread_id: &str,
+    event_type: &str,
+    data: &str,
+) {
+    if let Some(app_handle) = app_handle {
+        emit_settings_event(app_handle, session_id, thread_id, event_type, data);
+    }
+}
+
+/// Emit the enriched payload via an injectable `Emitter`. Generic over
+/// `Runtime` so unit tests can drive the emit body with a mock app handle
+/// (the process-global `APP_HANDLE` is `None` outside a running Tauri app).
+fn emit_settings_event<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    session_id: &str,
+    thread_id: &str,
+    event_type: &str,
+    data: &str,
+) {
     if let Some(payload) = settings_event_payload(session_id, thread_id, event_type, data) {
         let _ = app_handle.emit("agent-event", &payload);
     }
@@ -1270,7 +1330,8 @@ mod tests {
     // ── manager + task helpers ────────────────────────────────────────
 
     use super::super::test_support::{
-        break_home, mock_agent, restore_home, seed_thread, seed_workspace, Reply, TestHome,
+        break_home, mock_agent, restore_home, seed_thread, seed_workspace, Reply, StreamScript,
+        TestHome,
     };
 
     #[tokio::test]
@@ -1571,11 +1632,28 @@ mod tests {
     }
 
     #[test]
-    fn forward_settings_event_returns_without_an_app_handle() {
-        // No APP_HANDLE (unit test) → early return.
-        forward_settings_event("sess", "thread", "model_changed", "{}");
-        // Malformed JSON → the parse arm is skipped without an emit.
-        forward_settings_event("sess", "thread", "model_changed", "not json");
+    fn forward_settings_event_emits_or_skips_without_a_handle() {
+        // No handle → no emit (the `if let Some` body is skipped).
+        forward_settings_event(
+            None::<&tauri::AppHandle<tauri::test::MockRuntime>>,
+            "sess",
+            "thread",
+            "model_changed",
+            "{}",
+        );
+        // A mock handle → the emit body runs (valid + malformed payloads).
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+        let handle = app.handle();
+        forward_settings_event(
+            Some(handle),
+            "sess",
+            "thread",
+            "model_changed",
+            r#"{"model":"k3"}"#,
+        );
+        forward_settings_event(Some(handle), "sess", "thread", "model_changed", "not json");
     }
 
     #[test]
@@ -2049,5 +2127,355 @@ mod tests {
             serde_json::json!({"sessionIds": []}),
         );
         discovery_tick(60).await;
+    }
+
+    // ── run_observer self-heal paths ─────────────────────────────────
+
+    /// Spawn `run_observer` directly on the test runtime so its retry/idle
+    /// arms can be driven deterministically (unlike `spawn_observer`, which
+    /// runs on Tauri's ambient runtime).
+    fn spawn_run_observer(
+        session_id: &str,
+        shared: Arc<ObserverShared>,
+    ) -> (oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let sid = session_id.to_string();
+        let handle = tokio::spawn(async move {
+            run_observer(&sid, &shared, cancel_rx).await;
+        });
+        (cancel_tx, handle)
+    }
+
+    fn quiet_shared(thread_id: &str) -> Arc<ObserverShared> {
+        Arc::new(ObserverShared {
+            last_activity_ms: AtomicI64::new(0),
+            has_active_run: AtomicBool::new(false),
+            ..ObserverShared::new(thread_id)
+        })
+    }
+
+    #[tokio::test]
+    async fn run_observer_retries_connect_failures() {
+        let _mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "40");
+        let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
+
+        let shared = Arc::new(ObserverShared::new("thread-cf"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-cf", shared);
+        // Cycle 1: connect fails → 40ms backoff completes → double + continue.
+        // Cycle 2: connect fails → 80ms backoff; cancel lands mid-sleep → return.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_retries_replay_failures() {
+        let _home = TestHome::new("observer-replay-retry");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "50");
+        mock.push(
+            "get_session_events_since",
+            Reply::Reject("nope".to_string()),
+        );
+        mock.push(
+            "get_session_events_since",
+            Reply::Reject("nope".to_string()),
+        );
+
+        let shared = Arc::new(ObserverShared::new("thread-rr"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-rr", shared);
+        // Cycle 1: replay fails → 50ms backoff completes → continue (no doubling).
+        // Cycle 2: replay fails → 50ms backoff; cancel mid-sleep → return.
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_attaches_atomically_to_an_active_run() {
+        let _home = TestHome::new("observer-atomic");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "200");
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data(
+            "get_state",
+            serde_json::json!({"activeRun": {"runId": "run-aa"}}),
+        );
+        mock.push_stream(StreamScript::Events(
+            vec![stream_event("agent_start", "run-aa", 0)],
+            None,
+        ));
+
+        let shared = Arc::new(ObserverShared::new("thread-aa"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-aa", shared);
+        // The atomic attach streams one event then closes; the post-stream
+        // 200ms backoff sleep is where cancel lands → return (post-stream arm).
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    /// A re-attach to a run already seen resumes from the in-memory cursor
+    /// (`Some` arm) instead of replaying from the start.
+    #[tokio::test]
+    async fn run_observer_reattaches_with_a_cached_cursor() {
+        let _home = TestHome::new("observer-reattach");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "50");
+        // Two full attach cycles (replay empty → probe active → atomic stream
+        // yields one event then closes).
+        for _ in 0..2 {
+            mock.push_data(
+                "get_session_events_since",
+                serde_json::json!({"events": []}),
+            );
+            mock.push_data(
+                "get_state",
+                serde_json::json!({"activeRun": {"runId": "run-rc"}}),
+            );
+            mock.push_stream(StreamScript::Events(
+                vec![stream_event("agent_start", "run-rc", 0)],
+                None,
+            ));
+        }
+
+        let shared = Arc::new(ObserverShared::new("thread-rc"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-rc", shared);
+        // Cycle 1 attaches fresh (cursor None → -1) and re-attaches; cycle 2
+        // attaches with a cached cursor (Some arm).
+        tokio::time::sleep(Duration::from_millis(140)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_falls_back_to_plain_subscribe_after_atomic_error() {
+        let _home = TestHome::new("observer-atomic-fallback");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "50");
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data(
+            "get_state",
+            serde_json::json!({"activeRun": {"runId": "run-fb"}}),
+        );
+        // Atomic attach fails with FailedPrecondition → plain subscribe; the
+        // plain subscribe also fails → sleep_or_cancel → cancel mid-sleep.
+        mock.push_stream(StreamScript::AttachError(
+            tonic::Code::FailedPrecondition,
+            "ended",
+        ));
+        mock.push_plain_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+
+        let shared = Arc::new(ObserverShared::new("thread-fb"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-fb", shared);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    /// When the atomic attach fails with `FailedPrecondition`/`NotFound` but the
+    /// fallback plain subscribe works, the observer streams from it (`Some` arm).
+    #[tokio::test]
+    async fn run_observer_falls_back_to_a_working_plain_subscribe() {
+        let _home = TestHome::new("observer-fallback-ok");
+        let mock = mock_agent();
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data(
+            "get_state",
+            serde_json::json!({"activeRun": {"runId": "run-fbok"}}),
+        );
+        mock.push_stream(StreamScript::AttachError(tonic::Code::NotFound, "ended"));
+        // Plain subscribe succeeds (yields one event then closes).
+        mock.push_plain_stream(StreamScript::Events(
+            vec![stream_event("model_changed", "", -1)],
+            None,
+        ));
+
+        let shared = Arc::new(ObserverShared::new("thread-fbok"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-fbok", shared);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    /// When the fallback plain subscribe also fails, the observer sleeps the
+    /// backoff and re-attaches (the `continue 'attach` arm).
+    #[tokio::test]
+    async fn run_observer_continues_after_plain_subscribe_failure() {
+        let _home = TestHome::new("observer-fallback-retry");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "50");
+        for _ in 0..2 {
+            mock.push_data(
+                "get_session_events_since",
+                serde_json::json!({"events": []}),
+            );
+            mock.push_data(
+                "get_state",
+                serde_json::json!({"activeRun": {"runId": "run-fbr"}}),
+            );
+            mock.push_stream(StreamScript::AttachError(
+                tonic::Code::FailedPrecondition,
+                "ended",
+            ));
+            mock.push_plain_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+        }
+
+        let shared = Arc::new(ObserverShared::new("thread-fbr"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-fbr", shared);
+        // Cycle 1's backoff completes → continue 'attach; cycle 2's backoff is
+        // where cancel lands (the `return` arm) after both arms are exercised.
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_retries_atomic_attach_errors() {
+        let _home = TestHome::new("observer-atomic-error");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "40");
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data(
+            "get_state",
+            serde_json::json!({"activeRun": {"runId": "run-ae"}}),
+        );
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data(
+            "get_state",
+            serde_json::json!({"activeRun": {"runId": "run-ae"}}),
+        );
+        // Both atomic attaches fail with a non-NotFound status → settle + backoff.
+        mock.push_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+        mock.push_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+
+        let shared = Arc::new(ObserverShared::new("thread-ae"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-ae", shared);
+        // Cycle 1: 40ms backoff completes → double + continue. Cycle 2: 80ms
+        // backoff; cancel mid-sleep → return.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_retries_plain_subscribe_failure() {
+        let _home = TestHome::new("observer-plain-retry");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "40");
+        // No active run → plain subscribe; it fails twice so both the continue
+        // and the cancel-during-sleep arms execute.
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        mock.push_plain_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        mock.push_plain_stream(StreamScript::AttachError(tonic::Code::Internal, "down"));
+
+        let shared = Arc::new(ObserverShared::new("thread-pr"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-pr", shared);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_gap_breaks_the_stream() {
+        let _home = TestHome::new("observer-gap");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_OBSERVER_BACKOFF_MS", "40");
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        // No active run → plain subscribe; the stream yields a gap event first.
+        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        mock.push_plain_stream(StreamScript::Events(
+            vec![stream_event("text_chunk", "run-gap-stream", 3)],
+            None,
+        ));
+
+        let shared = Arc::new(ObserverShared::new("thread-gap"));
+        let (cancel_tx, handle) = spawn_run_observer("sess-gap", shared);
+        // handle_event rejects the gap (idx 3 with no cursor) → break → backoff.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        cancel_tx.send(()).unwrap();
+        handle.await.unwrap();
+        std::env::remove_var("FUTURE_TEST_OBSERVER_BACKOFF_MS");
+    }
+
+    #[tokio::test]
+    async fn run_observer_quiet_window_sleeps() {
+        let _home = TestHome::new("observer-quiet");
+        let mock = mock_agent();
+        std::env::set_var("FUTURE_TEST_IDLE_CHECK_MS", "10");
+        mock.push_data(
+            "get_session_events_since",
+            serde_json::json!({"events": []}),
+        );
+        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        // Plain subscribe hangs; the quiet-window timeout fires and, with an
+        // ancient last-activity timestamp and no active run, the observer sleeps.
+
+        let shared = quiet_shared("thread-quiet");
+        let (_cancel_tx, handle) = spawn_run_observer("sess-quiet", shared);
+        // The observer should self-terminate via the quiet-window return; give
+        // it a bounded window to do so.
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("observer sleeps")
+            .expect("observer joins cleanly");
+        std::env::remove_var("FUTURE_TEST_IDLE_CHECK_MS");
+    }
+
+    #[test]
+    fn emit_settings_event_emits_through_a_mock_handle() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+        let handle = app.handle();
+        // Valid object payload → emits; malformed JSON → no emit.
+        emit_settings_event(
+            handle,
+            "sess",
+            "thread",
+            "model_changed",
+            r#"{"model":"k3"}"#,
+        );
+        emit_settings_event(handle, "sess", "thread", "model_changed", "not json");
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/review.rs
+++ b/desktop/src-tauri/src/agent_bridge/review.rs
@@ -647,6 +647,38 @@ mod tests {
         assert_eq!(changeset.source_kind, "run_snapshot");
     }
 
+    /// A sensitive file makes the after snapshot `partial`, so retry marks the
+    /// re-materialized changeset `partial` too.
+    #[test]
+    fn retry_marks_partial_completeness() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_fx, thread, run) = fixture("retry-partial");
+        let ws_path =
+            store::get_workspace(&store::get_thread(&thread.id).unwrap().unwrap().workspace_id)
+                .unwrap()
+                .unwrap()
+                .path;
+
+        fs::write(std::path::Path::new(&ws_path).join("keep.txt"), "before\n").unwrap();
+        super::capture_before(&thread.id, &run.id);
+        fs::write(
+            std::path::Path::new(&ws_path).join("keep.txt"),
+            "before\nafter\n",
+        )
+        .unwrap();
+        // A credential file is omitted (sensitive) → after snapshot is `partial`.
+        fs::write(std::path::Path::new(&ws_path).join(".env"), "SECRET=1\n").unwrap();
+        super::capture_after(&thread.id, &run.id);
+
+        super::retry(&run.id).unwrap();
+        let changeset = store::get_run_changeset(&run.id)
+            .unwrap()
+            .expect("changeset");
+        assert_eq!(changeset.completeness, "partial");
+    }
+
     #[test]
     fn try_capture_and_materialize_skip_non_applicable_threads() {
         let _lock = crate::TEST_HOME_LOCK
@@ -753,5 +785,150 @@ mod tests {
 
         let err = super::retry(&run.id).unwrap_err();
         assert!(!err.to_string().is_empty());
+    }
+
+    /// A non-git Workspace whose volume crosses the redline is skipped before
+    /// snapshotting (§6.7): no before row, no shadow repo, no error.
+    #[test]
+    fn capture_before_skips_non_git_workspace_over_volume_redline() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_fx, thread, run) = fixture("too-large");
+        let ws_id = store::get_thread(&thread.id).unwrap().unwrap().workspace_id;
+        let ws_path = store::get_workspace(&ws_id).unwrap().unwrap().path;
+
+        // One sparse file over the byte redline (512 MiB) — instant, no disk
+        // allocation, but `metadata().len()` reports the full logical size.
+        let big = std::path::Path::new(&ws_path).join("huge.bin");
+        std::fs::File::create(&big)
+            .unwrap()
+            .set_len(512 * 1024 * 1024 + 1)
+            .unwrap();
+
+        super::try_capture_before(&thread.id, &run.id).unwrap();
+        assert!(
+            store::get_review_snapshot(&run.id, "before")
+                .unwrap()
+                .is_none(),
+            "an over-redline workspace produces no before snapshot"
+        );
+    }
+
+    /// When the Run row disappears (raw cleanup with FK enforcement off),
+    /// capture's snapshot INSERT fails on the `run_id` FK and records a
+    /// `failed` before row.
+    #[test]
+    fn capture_fails_when_run_row_is_gone() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_fx, thread, run) = fixture("run-gone-capture");
+
+        let conn =
+            rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("DELETE FROM runs WHERE id = ?1", [&run.id])
+            .unwrap();
+        drop(conn);
+
+        // capture_before: resolve + shadow open succeed, capture's snapshot
+        // INSERT fails on the missing run FK → record_failure + Err.
+        let err = super::try_capture_before(&thread.id, &run.id).unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    /// When the Run row disappears, materialize fails at the changeset upsert
+    /// (its INSERT references the missing run).
+    #[test]
+    fn materialize_fails_when_run_row_is_gone() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_fx, thread, run) = fixture("run-gone-materialize");
+        let ws_id = store::get_thread(&thread.id).unwrap().unwrap().workspace_id;
+
+        for (phase, status) in [("before", "complete"), ("after", "complete")] {
+            store::create_review_snapshot(store::CreateReviewSnapshotInput {
+                workspace_id: ws_id.clone(),
+                thread_id: thread.id.clone(),
+                run_id: run.id.clone(),
+                phase: phase.to_string(),
+                commit_id: None,
+                tree_id: None,
+                status: status.to_string(),
+                file_count: 1,
+                total_bytes: 1,
+                ignored_count: 0,
+                omitted_count: 0,
+                error_message: None,
+            })
+            .unwrap();
+        }
+
+        let conn =
+            rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("DELETE FROM runs WHERE id = ?1", [&run.id])
+            .unwrap();
+        drop(conn);
+
+        // materialize: resolve + both snapshots + bare open succeed, then the
+        // changeset upsert fails on the missing run FK.
+        let err = super::try_materialize_changeset(&thread.id, &run.id, vec![]).unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    /// A `partial` before snapshot makes the changeset completeness `partial`
+    /// (before it is upserted successfully).
+    #[test]
+    fn materialize_marks_partial_completeness() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let (_fx, thread, run) = fixture("partial");
+        let ws_id = store::get_thread(&thread.id).unwrap().unwrap().workspace_id;
+
+        for (phase, status) in [("before", "partial"), ("after", "complete")] {
+            store::create_review_snapshot(store::CreateReviewSnapshotInput {
+                workspace_id: ws_id.clone(),
+                thread_id: thread.id.clone(),
+                run_id: run.id.clone(),
+                phase: phase.to_string(),
+                commit_id: None,
+                tree_id: None,
+                status: status.to_string(),
+                file_count: 1,
+                total_bytes: 1,
+                ignored_count: 0,
+                omitted_count: 0,
+                error_message: None,
+            })
+            .unwrap();
+        }
+
+        super::try_materialize_changeset(&thread.id, &run.id, vec![]).unwrap();
+        let changeset = store::get_run_changeset(&run.id)
+            .unwrap()
+            .expect("changeset");
+        assert_eq!(changeset.completeness, "partial");
+    }
+
+    /// `Fixture` drops remove HOME when it was unset before the fixture was
+    /// created (the `None` restore arm).
+    #[test]
+    fn fixture_drop_removes_home_when_unset_before() {
+        let _lock = crate::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let saved = std::env::var("HOME").ok();
+        std::env::remove_var("HOME");
+        {
+            let (_fx, _thread, _run) = fixture("unset-home");
+        }
+        assert!(std::env::var("HOME").is_err(), "HOME removed on drop");
+        if let Some(saved) = saved {
+            std::env::set_var("HOME", saved);
+        }
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/review.rs
+++ b/desktop/src-tauri/src/agent_bridge/review.rs
@@ -847,8 +847,8 @@ mod tests {
         // Drop the snapshot table so the capture write fails deterministically
         // (rusqlite does not enforce FKs by default, so deleting the Run row
         // alone does not break the snapshot write).
-        let conn = rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db"))
-            .expect("open db");
+        let conn =
+            rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
         conn.execute_batch("DROP TABLE review_snapshots;").unwrap();
         drop(conn);
 

--- a/desktop/src-tauri/src/agent_bridge/review.rs
+++ b/desktop/src-tauri/src/agent_bridge/review.rs
@@ -815,37 +815,15 @@ mod tests {
         );
     }
 
-    /// When the Run row disappears (raw cleanup with FK enforcement off),
-    /// capture's snapshot INSERT fails on the `run_id` FK and records a
-    /// `failed` before row.
+    /// When the review-snapshot store vanishes (raw table drop on the app
+    /// db), capture fails at the snapshot write and records a `failed` before
+    /// row (ignored, same table); materialize fails reading the snapshots.
     #[test]
-    fn capture_fails_when_run_row_is_gone() {
+    fn capture_and_materialize_fail_when_the_snapshot_store_is_gone() {
         let _lock = crate::TEST_HOME_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        let (_fx, thread, run) = fixture("run-gone-capture");
-
-        let conn =
-            rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
-        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
-        conn.execute("DELETE FROM runs WHERE id = ?1", [&run.id])
-            .unwrap();
-        drop(conn);
-
-        // capture_before: resolve + shadow open succeed, capture's snapshot
-        // INSERT fails on the missing run FK → record_failure + Err.
-        let err = super::try_capture_before(&thread.id, &run.id).unwrap_err();
-        assert!(!err.to_string().is_empty());
-    }
-
-    /// When the Run row disappears, materialize fails at the changeset upsert
-    /// (its INSERT references the missing run).
-    #[test]
-    fn materialize_fails_when_run_row_is_gone() {
-        let _lock = crate::TEST_HOME_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let (_fx, thread, run) = fixture("run-gone-materialize");
+        let (_fx, thread, run) = fixture("store-gone");
         let ws_id = store::get_thread(&thread.id).unwrap().unwrap().workspace_id;
 
         for (phase, status) in [("before", "complete"), ("after", "complete")] {
@@ -866,15 +844,20 @@ mod tests {
             .unwrap();
         }
 
-        let conn =
-            rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
-        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
-        conn.execute("DELETE FROM runs WHERE id = ?1", [&run.id])
-            .unwrap();
+        // Drop the snapshot table so the capture write fails deterministically
+        // (rusqlite does not enforce FKs by default, so deleting the Run row
+        // alone does not break the snapshot write).
+        let conn = rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db"))
+            .expect("open db");
+        conn.execute_batch("DROP TABLE review_snapshots;").unwrap();
         drop(conn);
 
-        // materialize: resolve + both snapshots + bare open succeed, then the
-        // changeset upsert fails on the missing run FK.
+        // capture_before: resolve + shadow open succeed, capture's snapshot
+        // write fails → record_failure (ignored) + Err (the error surfaces).
+        let err = super::try_capture_before(&thread.id, &run.id).unwrap_err();
+        assert!(!err.to_string().is_empty());
+
+        // materialize: reading the snapshots fails on the dropped table.
         let err = super::try_materialize_changeset(&thread.id, &run.id, vec![]).unwrap_err();
         assert!(!err.to_string().is_empty());
     }

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -330,6 +330,17 @@ impl MockAgentGuard {
             .push_back(script);
     }
 
+    /// Queue one plain-subscribe (`atomic_attach: false`) stream outcome — the
+    /// kind idle observers open. Lets observer retry/idle paths be scripted
+    /// deterministically.
+    pub(crate) fn push_plain_stream(&self, script: StreamScript) {
+        STATE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .plain_streams
+            .push_back(script);
+    }
+
     /// Every `execute_command` the mock has seen since the guard was taken.
     pub(crate) fn requests(&self) -> Vec<RpcCommand> {
         STATE

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -2220,6 +2220,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-history").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
         let session = unique("sess");
 
         let reply = bridge
@@ -2313,6 +2314,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-transfer").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
 
         // upload_init validation + success.
         let reply = bridge
@@ -2445,6 +2447,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-prompt-ws").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
 
         // Workspace mode with a real workspace id → thread bound to it.
         let workspace_dir = std::env::temp_dir().join(unique("futureos-ws-prompt"));
@@ -2533,6 +2536,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-session-ctl").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
         let session = unique("sess");
 
         // abort: success and agent failure.
@@ -2874,6 +2878,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-approval").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
         let session = unique("sess");
 
         // Unknown approval request.
@@ -3002,6 +3007,7 @@ mod bridge_tests {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-singleflight").await;
         let agent = ensure_mock_agent();
+        agent.clear_scripts();
         let session = unique("sess");
 
         let command_id = unique("cmdid");

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -2203,6 +2203,15 @@ mod bridge_tests {
             .call(json!({ "id": unique("cmd"), "type": "list_workspaces" }))
             .await;
         assert_eq!(reply["success"], json!(false));
+        // Settings handlers report the same store failure.
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "get_settings" }))
+            .await;
+        assert_eq!(reply["success"], json!(false));
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "set_approval_tier", "tier": "sandbox" }))
+            .await;
+        assert_eq!(reply["success"], json!(false));
         bridge.stop();
     }
 
@@ -2660,6 +2669,204 @@ mod bridge_tests {
             .contains("Unsupported command"));
 
         bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn settings_commands_read_and_update() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("cmd-settings").await;
+
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "get_settings" }))
+            .await;
+        assert_eq!(reply["success"], json!(true), "got: {reply}");
+        assert_eq!(reply["data"]["approvalTier"], json!("off"));
+        assert_eq!(
+            reply["data"]["sandboxAvailable"],
+            json!(cfg!(target_os = "macos"))
+        );
+
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "set_approval_tier", "tier": "sandbox" }))
+            .await;
+        assert_eq!(reply["success"], json!(true), "got: {reply}");
+        assert_eq!(reply["data"]["approvalTier"], json!("sandbox"));
+
+        bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn continue_run_resumes_a_failed_run_and_rejects_busy_sessions() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("cmd-continue").await;
+        let session = unique("sess");
+
+        // A thread bound to the session + a failed run with terminal events.
+        let thread = crate::store::create_thread(crate::store::CreateThreadInput {
+            mode: "chat".to_string(),
+            title: Some("Continue".to_string()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: Some(session.clone()),
+        })
+        .unwrap();
+        let run = crate::store::create_run(crate::store::CreateRunInput {
+            id: Some("run-failed".to_string()),
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        crate::store::append_run_event(crate::store::AppendRunEventInput {
+            run_id: run.id.clone(),
+            event_type: "tool_result".to_string(),
+            payload: Some(r#"{"text":"did the thing"}"#.to_string()),
+            sequence: 1,
+        })
+        .unwrap();
+        crate::store::flush_run_event_log_for_test(&run.id);
+        crate::store::update_run_status_if_active(crate::store::UpdateRunStatusInput {
+            run_id: run.id.clone(),
+            status: "failed".to_string(),
+            error_message: None,
+            error_type: None,
+        })
+        .unwrap();
+
+        // Break the agent endpoint so the Ok arm's spawned `run_prepared_prompt`
+        // fails at `connect_agent` BEFORE it can spawn a session observer — the
+        // ack path (prepare_remote_prompt) is store-only and unaffected. This
+        // keeps the shared mock script clean for later tests (no zombie).
+        let prev_addr = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
+
+        // Ok arm: continue the failed run → ack carries the fresh run ids.
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": run.id }))
+            .await;
+        assert_eq!(reply["success"], json!(true), "got: {reply}");
+        assert_eq!(reply["data"]["sessionId"], json!(session));
+        assert_eq!(reply["data"]["threadId"], json!(thread.id));
+
+        // The spawned pipeline settles the new run as failed (its connect_agent
+        // fails) — poll until the run leaves the running state.
+        let continued_run = reply["data"]["runId"].as_str().unwrap().to_string();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let row = crate::store::get_run(&continued_run)
+                .unwrap()
+                .expect("continued run");
+            if row.status != "running" {
+                assert_eq!(row.status, "failed");
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "continued run never settled"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev_addr);
+        bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn continue_run_rejects_a_busy_session() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("cmd-continue-busy").await;
+        let session = unique("sess");
+
+        let thread = crate::store::create_thread(crate::store::CreateThreadInput {
+            mode: "chat".to_string(),
+            title: Some("Busy".to_string()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: Some(session.clone()),
+        })
+        .unwrap();
+        // An active run on the session → the busy guard fires before anything
+        // is persisted or spawned.
+        crate::store::create_run(crate::store::CreateRunInput {
+            id: Some("run-active".to_string()),
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+
+        let reply = bridge
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": "run-active" }))
+            .await;
+        assert_eq!(reply["success"], json!(false));
+        assert!(reply["error"].as_str().unwrap().contains("still running"));
+
+        bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn build_continue_prompt_folds_recent_terminal_events() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("cmd-continue-prompt");
+        init_store();
+        let thread = crate::store::create_thread(crate::store::CreateThreadInput {
+            mode: "chat".to_string(),
+            title: Some("Prompt".to_string()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: None,
+        })
+        .unwrap();
+        let run = crate::store::create_run(crate::store::CreateRunInput {
+            id: None,
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        // A non-terminal event is ignored; terminal events are folded newest-first.
+        crate::store::append_run_event(crate::store::AppendRunEventInput {
+            run_id: run.id.clone(),
+            event_type: "text_chunk".to_string(),
+            payload: Some("ignored".to_string()),
+            sequence: 1,
+        })
+        .unwrap();
+        crate::store::append_run_event(crate::store::AppendRunEventInput {
+            run_id: run.id.clone(),
+            event_type: "tool_result".to_string(),
+            payload: Some("tool output".to_string()),
+            sequence: 2,
+        })
+        .unwrap();
+        crate::store::append_run_event(crate::store::AppendRunEventInput {
+            run_id: run.id.clone(),
+            event_type: "error".to_string(),
+            payload: Some("boom".to_string()),
+            sequence: 3,
+        })
+        .unwrap();
+        crate::store::flush_run_event_log_for_test(&run.id);
+
+        let prompt = build_continue_prompt(&run.id);
+        assert!(prompt.contains("继续上一个任务。"), "{prompt}");
+        assert!(prompt.contains("已执行内容摘要:"), "{prompt}");
+        assert!(prompt.contains("error"), "{prompt}");
+        assert!(prompt.contains("tool_result"), "{prompt}");
+        assert!(
+            !prompt.contains("text_chunk"),
+            "non-terminal ignored: {prompt}"
+        );
+
+        // An unknown run (no events) still yields the default continue prompt.
+        let empty = build_continue_prompt("no-such-run");
+        assert_eq!(empty, "继续上一个任务。");
     }
 
     #[tokio::test]


### PR DESCRIPTION
W3 partition (remote/commands 201 insertions, agent_bridge observer/review test_support) + two test-infra fixes: (1) capture_and_materialize failure via dropped snapshot table (deterministic, rusqlite has no FK enforcement), (2) clear mock scripts between remote bridge tests (kills instrumented-only queue-pollution flake). Goal goal_c86c1a0aa7b8.