### PR TITLE
refactor(mobile): split RemoteContext and dedupe the remote layer

### DIFF
--- a/mobile/src/components/ConnectionBadge.tsx
+++ b/mobile/src/components/ConnectionBadge.tsx
@@ -13,8 +13,7 @@ export function ConnectionBadge({
   const { t } = useTranslation();
   const revoked = phase === "revoked";
   const connected = phase === "connected" && desktopOnline;
-  const reconnecting =
-    phase === "connecting" || phase === "reconnecting" || phase === "refreshing";
+  const reconnecting = phase === "connecting" || phase === "reconnecting" || phase === "refreshing";
   const label = revoked
     ? t("connection.revoked")
     : connected

--- a/mobile/src/components/ErrorBanner.tsx
+++ b/mobile/src/components/ErrorBanner.tsx
@@ -27,7 +27,9 @@ function friendlyError(
     return t("connection.errorAgentOffline");
   }
   if (/time-?out|timed out/i.test(trimmed)) return t("connection.errorTimeout");
-  if (/network|unreachable|load failed|fetch failed|econn|connection (refused|reset)/i.test(trimmed)) {
+  if (
+    /network|unreachable|load failed|fetch failed|econn|connection (refused|reset)/i.test(trimmed)
+  ) {
     return t("connection.errorNetwork");
   }
   return t("connection.errorWithReason", { reason: message });
@@ -42,13 +44,7 @@ function friendlyError(
  * states (desktop asleep, reconnecting) never reach the banner; the badge and
  * offline empty state are their dedicated UI.
  */
-export function ErrorBanner({
-  message,
-  onDismiss,
-}: {
-  message: string;
-  onDismiss: () => void;
-}) {
+export function ErrorBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
   const { t } = useTranslation();
   return (
     <View style={styles.banner}>

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -44,7 +44,7 @@ function formatDuration(durationMs: number): string {
 }
 
 function RunIndicator({ startedAt }: { startedAt: number }) {
-  const [now, setNow] = useState(startedAt);
+  const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 500);
     return () => clearInterval(timer);
@@ -701,7 +701,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
   },
   runDot: { width: 14, height: 14, borderRadius: radius.pill, backgroundColor: colors.generating },
-  runDuration: { color: colors.inkMuted, fontSize: 16 },
+  runDuration: { color: colors.inkMuted, fontSize: 12 },
   secondaryCard: {
     borderLeftWidth: 2,
     borderLeftColor: colors.line,

--- a/mobile/src/polyfills/crypto.ts
+++ b/mobile/src/polyfills/crypto.ts
@@ -1,5 +1,0 @@
-export function randomBytes(size: number): Uint8Array {
-  const bytes = new Uint8Array(size);
-  globalThis.crypto.getRandomValues(bytes);
-  return bytes;
-}

--- a/mobile/src/polyfills/crypto.ts
+++ b/mobile/src/polyfills/crypto.ts
@@ -1,0 +1,5 @@
+export function randomBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytes;
+}

--- a/mobile/src/polyfills/util.ts
+++ b/mobile/src/polyfills/util.ts
@@ -1,0 +1,2 @@
+export const TextDecoder = globalThis.TextDecoder;
+export const TextEncoder = globalThis.TextEncoder;

--- a/mobile/src/polyfills/util.ts
+++ b/mobile/src/polyfills/util.ts
@@ -1,2 +1,0 @@
-export const TextDecoder = globalThis.TextDecoder;
-export const TextEncoder = globalThis.TextEncoder;

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -14,7 +14,6 @@ import {
   mergeHistoryAttachments,
   timelineFromEntries,
   timelineFromHistory,
-  type ReplayEventWire,
   type TimelineState,
 } from "./eventReducer";
 import { RemoteClient } from "./client";
@@ -22,6 +21,7 @@ import { MAX_PROMPT_MESSAGE_BYTES, utf8Bytes } from "./codec";
 import type { ConnectionState } from "./connectionState";
 import { classifyError } from "./connectionState";
 import {
+  attemptPendingRevoke,
   claimPairingCode,
   ensureFreshCredentials,
   serverRevoke,
@@ -32,9 +32,10 @@ import {
   PRESENCE_RECEIPT_STALE_MS,
   type PresenceState,
 } from "./presence";
-import { detectFinished } from "./sessionStatus";
 import { type RunCursor } from "./runCursor";
 import { SyncEngine, type ReconcileReason } from "./syncEngine";
+import { fetchEventsSince } from "./replay";
+import { useSessionCatalog } from "./useSessionCatalog";
 import {
   clearCredentials,
   clearPendingRevoke,
@@ -46,7 +47,6 @@ import {
   saveLastModel,
   saveLastThinking,
   savePendingRevoke,
-  type PendingRevoke,
 } from "./storage";
 import { modelProviderFromReference, modelReference } from "./types";
 import {
@@ -59,12 +59,15 @@ import {
 import type { File } from "expo-file-system";
 import type {
   ConnectionPhase,
+  DownloadInfo,
+  EntriesData,
+  HistoryAttachment,
+  HistoryData,
   HistoryEntry,
   HistoryMessage,
-  HistoryAttachment,
-  DownloadInfo,
   MobileAttachment,
   Presence,
+  PromptAck,
   RemoteCredentials,
   RemoteModel,
   RemoteSession,
@@ -73,122 +76,6 @@ import type {
   StreamEvent,
   ThinkingLevel,
 } from "./types";
-
-interface SessionsData {
-  sessions: RemoteSession[];
-}
-
-interface ModelsData {
-  models: RemoteModel[];
-}
-
-interface WorkspacesData {
-  workspaces: RemoteWorkspace[];
-}
-
-interface HistoryData {
-  messages: HistoryMessage[];
-  total?: number;
-  hasMore?: boolean;
-  nextOffset?: number;
-}
-
-interface EntriesData {
-  entries: HistoryEntry[];
-  total?: number;
-  hasMore?: boolean;
-  nextOffset?: number;
-}
-
-interface EventsData {
-  /** Raw replay events — the RPC serializes them with snake_case `run_id`. */
-  events?: ReplayEventWire[];
-  truncated?: boolean;
-  /** Coalesced replica of a run whose event ring overflowed — replaces the
-   *  session's timeline wholesale (see `timelineFromProjection`). */
-  projection?: { run_id?: string; cursor?: number; events?: ReplayEventWire[] } | null;
-}
-
-interface EventsPage extends EventsData {
-  hasMore?: boolean;
-  nextOffset?: number;
-}
-
-/**
- * Fetch a run's replay tail via `get_events_since`, looping paginated replies
- * until `hasMore=false`. The desktop pages replay events under the NATS payload
- * cap (a multi-MB journal tail must never ship as one oversized reply), so a
- * single-shot request would silently truncate. The merged envelope carries the
- * first page's `projection` (the whole-run replacement) through unchanged.
- */
-async function fetchEventsSince(
-  client: RemoteClient,
-  sessionId: string,
-  runId: string,
-  sinceIdx: number,
-): Promise<EventsData> {
-  const events: ReplayEventWire[] = [];
-  let projection: EventsData["projection"] = null;
-  let truncated = false;
-  let offset = 0;
-  for (;;) {
-    const page = (
-      await client.request<EventsPage>(
-        { type: "get_events_since", sessionId, runId, sinceIdx, offset },
-        sessionId,
-      )
-    ).data;
-    events.push(...(page.events ?? []));
-    if (page.projection?.events?.length) projection = page.projection;
-    if (page.truncated) truncated = true;
-    if (!page.hasMore) break;
-    const next = page.nextOffset;
-    if (typeof next !== "number" || next <= offset) break;
-    offset = next;
-  }
-  const merged: EventsData = { events };
-  if (projection) merged.projection = projection;
-  if (truncated) merged.truncated = true;
-  return merged;
-}
-
-interface PromptAck {
-  sessionId: string;
-  threadId: string;
-  runId: string;
-}
-
-/**
- * Fire the queued server-side revoke (M7). Best-effort: a failure is dropped —
- * the queue entry stays in storage and retries on the next launch. A success
- * (or a terminal 401/404, which serverRevoke treats as success) drains the
- * queue via the caller's clearPendingRevoke.
- */
-async function attemptPendingRevoke(pending: PendingRevoke): Promise<void> {
-  await serverRevoke({
-    pairId: pending.pairId,
-    deviceId: pending.deviceId,
-    seed: pending.seed,
-    userJwt: "",
-    refreshToken: pending.refreshToken,
-    natsWsUrl: "",
-    tokenUrl: pending.tokenUrl,
-    expectedDesktopId: "",
-    expectedDesktopPublicKey: "",
-  });
-}
-
-/**
- * Stable pinned-first reorder for optimistic pin/unpin. Pinned sessions move
- * to the top in their original relative order; everything else keeps the
- * incoming (desktop-sorted) order. Matches the desktop sidebar's `pinned DESC`
- * grouping, which the pushed snapshot also converges on.
- */
-function sortPinnedFirst(list: RemoteSession[]): RemoteSession[] {
-  const pinned = list.filter(session => session.pinned);
-  const rest = list.filter(session => !session.pinned);
-  return [...pinned, ...rest];
-}
 
 interface RemoteContextValue {
   phase: ConnectionPhase;
@@ -255,20 +142,14 @@ export function RemoteProvider({ children }: PropsWithChildren) {
   const [error, setError] = useState<string | null>(null);
   const [credentials, setCredentials] = useState<RemoteCredentials | null>(null);
   const [presence, setPresence] = useState<Presence | null>(null);
-  const [sessions, setSessions] = useState<RemoteSession[]>([]);
-  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(() => new Set());
-  const lastStatusRef = useRef<Record<string, string | undefined>>({});
-  const [workspaces, setWorkspaces] = useState<RemoteWorkspace[]>([]);
-  const [models, setModels] = useState<RemoteModel[]>([]);
-  const [approvalTier, setApprovalTierState] = useState("off");
-  const [sandboxAvailable, setSandboxAvailable] = useState(false);
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [draft, setDraft] = useState(false);
   const [draftMode, setDraftMode] = useState<"chat" | "workspace">("chat");
   const [draftWorkspaceId, setDraftWorkspaceId] = useState("");
   const [modelId, setModelId] = useState("");
   const [thinkingLevel, setThinkingLevelState] = useState<ThinkingLevel>("off");
-  const [busy, setBusy] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [openingSession, setOpeningSession] = useState(false);
   const [capabilities, setCapabilities] = useState<Set<string>>(() => new Set());
   const fileTransferSupported = capabilities.has("file_transfer_v1");
   const [clock, setClock] = useState(Date.now());
@@ -286,16 +167,33 @@ export function RemoteProvider({ children }: PropsWithChildren) {
   // prompt ack binds it to a real session.
   const [timelines, setTimelines] = useState<Record<string, TimelineState>>({});
   const timelinesRef = useRef<Record<string, TimelineState>>({});
-  // Live agent-side renames (`session_name_changed`, data: {name}) are not
-  // persisted by the desktop store, so the snapshot title would go stale; the
-  // override wins until the next sessions snapshot reflects it. Read via the
-  // ref inside long-lived closures (the NATS callbacks) to avoid a stale
-  // capture or forcing a client re-create on every rename.
-  const [titleOverrides, setTitleOverrides] = useState<Record<string, string>>({});
-  const titleOverridesRef = useRef<Record<string, string>>({});
   const clientRef = useRef<RemoteClient | null>(null);
   const credentialsRef = useRef<RemoteCredentials | null>(null);
   const selectedRef = useRef("");
+  // The control-plane catalogue (sessions/workspaces/models/settings) lives in
+  // its own hook; the provider keeps connection lifecycle + per-session
+  // timeline and forwards the catalogue's state/setters into the context value.
+  const {
+    sessions,
+    unreadSessions,
+    setUnreadSessions,
+    workspaces,
+    setWorkspaces,
+    models,
+    approvalTier,
+    setApprovalTier: setApprovalTierState,
+    sandboxAvailable,
+    setTitleOverrides,
+    applySessionSnapshot,
+    refreshSessions,
+    refreshModels,
+    refreshSettings,
+    refreshWorkspaces,
+    rename,
+    deleteSession: removeSession,
+    setSessionPinned,
+    reset: resetCatalog,
+  } = useSessionCatalog(clientRef, selectedRef);
   // Changes whenever the user navigates between conversations. Long uploads
   // capture the epoch so their eventual ack cannot pull the UI back to a
   // conversation the user has already left.
@@ -324,9 +222,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     timelinesRef.current = timelines;
   }, [timelines]);
-  useEffect(() => {
-    titleOverridesRef.current = titleOverrides;
-  }, [titleOverrides]);
 
   /**
    * Enqueue a reconcile instruction for a session (or all established sessions
@@ -344,78 +239,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     },
     [],
   );
-
-  const refreshSessions = useCallback(async () => {
-    const client = clientRef.current;
-    if (!client) return;
-    try {
-      const response = await client.request<SessionsData>({ type: "list_sessions" }, "list");
-      const overrides = titleOverridesRef.current;
-      const list = (response.data.sessions ?? []).map(session => ({
-        ...session,
-        title: overrides[session.sessionId] ?? session.title,
-      }));
-      const { finished, next } = detectFinished(lastStatusRef.current, list, selectedRef.current);
-      lastStatusRef.current = next;
-      setSessions(list);
-      if (finished.length > 0) {
-        setUnreadSessions(prev => {
-          const nextUnread = new Set(prev);
-          for (const id of finished) nextUnread.add(id);
-          return nextUnread;
-        });
-      }
-    } catch {
-      // If the connection has gone (refresh/reconnect cycle), swallow
-      // the error — the reconnect handler will re-fetch.
-    }
-  }, []);
-
-  const refreshModels = useCallback(async () => {
-    const client = clientRef.current;
-    if (!client) return;
-    // The desktop's model catalogue can lag the handshake on a fresh connect (or
-    // the agent may still be warming up and error out), so an empty or failed
-    // first answer is re-asked once before we accept it — otherwise the selector
-    // and the "no models" banner stay stale until a manual refresh.
-    let models: RemoteModel[] = [];
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        models = (await client.request<ModelsData>({ type: "list_models" }, "list")).data.models ?? [];
-        if (models.length > 0) break;
-      } catch {
-        models = [];
-      }
-      if (attempt === 0) await new Promise(resolve => setTimeout(resolve, 1200));
-    }
-    setModels(models);
-  }, []);
-
-  const refreshSettings = useCallback(async () => {
-    const client = clientRef.current;
-    if (!client) return;
-    try {
-      const data = await client.request<{ approvalTier: string; sandboxAvailable: boolean }>(
-        { type: "get_settings" },
-        "list",
-      );
-      setApprovalTierState(data.data.approvalTier);
-      setSandboxAvailable(data.data.sandboxAvailable);
-    } catch {
-      // Keep the previous tier on a failed read.
-    }
-  }, []);
-
-  const refreshWorkspaces = useCallback(async () => {
-    const client = clientRef.current;
-    if (!client) return;
-    try {
-      const response = await client.request<WorkspacesData>({ type: "list_workspaces" }, "list");
-      setWorkspaces(response.data.workspaces ?? []);
-    } catch {
-      setWorkspaces([]);
-    }
-  }, []);
 
   const handleEvent = useCallback(
     (event: StreamEvent, sessionId: string) => {
@@ -482,7 +305,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       syncEngineRef.current?.event(sid, event);
       if (event.type === "agent_end") void refreshSessions();
     },
-    [reconcileSession, refreshSessions],
+    [reconcileSession, refreshSessions, setTitleOverrides],
   );
 
   const closeConversation = useCallback(() => {
@@ -613,31 +436,8 @@ export function RemoteProvider({ children }: PropsWithChildren) {
           setPresence(nextPresence);
         },
         onSessions: sessionList => {
-          const overrides = titleOverridesRef.current;
-          const list: RemoteSession[] = sessionList.map(s => ({
-            sessionId: s.sessionId,
-            threadId: s.threadId,
-            title: overrides[s.sessionId] ?? s.title,
-            mode: s.mode,
-            workspaceId: s.workspaceId,
-            pinned: s.pinned,
-            streaming: s.streaming,
-            status: s.status,
-          }));
-          const { finished, next } = detectFinished(
-            lastStatusRef.current,
-            list,
-            selectedRef.current,
-          );
-          lastStatusRef.current = next;
-          setSessions(list);
-          if (finished.length > 0) {
-            setUnreadSessions(prev => {
-              const nextUnread = new Set(prev);
-              for (const id of finished) nextUnread.add(id);
-              return nextUnread;
-            });
-          }
+          const list: RemoteSession[] = sessionList.map(s => ({ ...s }));
+          applySessionSnapshot(list);
           const currentId = selectedRef.current;
           // An empty session list is a transient store failure, not a deletion
           // signal (audit 05 L8): a single deleted session leaves the others in
@@ -722,9 +522,25 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       // reconcileAll (reconnect recovery) must keep working across a client
       // replacement. Its deps read the live clientRef on every call.
       await client.open();
-      await Promise.all([refreshModels(), refreshSessions(), refreshWorkspaces(), refreshSettings()]);
+      await Promise.all([
+        refreshModels(),
+        refreshSessions(),
+        refreshWorkspaces(),
+        refreshSettings(),
+      ]);
     },
-    [closeConversation, handleEvent, recordError, reconcileSession, refreshModels, refreshSessions, refreshWorkspaces, refreshSettings],
+    [
+      applySessionSnapshot,
+      closeConversation,
+      handleEvent,
+      recordError,
+      reconcileSession,
+      refreshModels,
+      refreshSessions,
+      refreshWorkspaces,
+      refreshSettings,
+      setWorkspaces,
+    ],
   );
 
   useEffect(() => {
@@ -771,7 +587,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
 
   const pair = useCallback(
     async (code: string) => {
-      setBusy(true);
       setPhase("claiming");
       setError(null);
       try {
@@ -781,8 +596,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
         setError(nextError instanceof Error ? nextError.message : String(nextError));
         setPhase("unpaired");
         throw nextError;
-      } finally {
-        setBusy(false);
       }
     },
     [connect],
@@ -794,7 +607,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       setPhase("unpaired");
       return;
     }
-    setBusy(true);
     try {
       await connect(stored);
     } catch (nextError) {
@@ -812,57 +624,46 @@ export function RemoteProvider({ children }: PropsWithChildren) {
         // surface the error but let the connection phase keep driving.
         setError(message);
       }
-    } finally {
-      setBusy(false);
     }
   }, [connect, credentials]);
 
   const unpair = useCallback(async () => {
     const current = credentials;
-    setBusy(true);
-    try {
-      // Local deregistration — ALWAYS succeeds (M7). Even an offline unpair
-      // must free the device; only the server-side revoke is best-effort.
-      credentialsRef.current = null;
-      await clientRef.current?.close();
-      clientRef.current = null;
-      engineRefCleanupRef.current?.();
-      engineRefCleanupRef.current = null;
-      syncEngineRef.current?.clear();
-      if (current) {
-        try {
-          await serverRevoke(current);
-        } catch {
-          // Offline / token endpoint unreachable — queue the revoke for the
-          // next launch rather than blocking the local unpair.
-          await savePendingRevoke({
-            pairId: current.pairId,
-            deviceId: current.deviceId,
-            seed: current.seed,
-            refreshToken: current.refreshToken,
-            tokenUrl: current.tokenUrl,
-          });
-        }
+    // Local deregistration — ALWAYS succeeds (M7). Even an offline unpair
+    // must free the device; only the server-side revoke is best-effort.
+    credentialsRef.current = null;
+    await clientRef.current?.close();
+    clientRef.current = null;
+    engineRefCleanupRef.current?.();
+    engineRefCleanupRef.current = null;
+    syncEngineRef.current?.clear();
+    if (current) {
+      try {
+        await serverRevoke(current);
+      } catch {
+        // Offline / token endpoint unreachable — queue the revoke for the
+        // next launch rather than blocking the local unpair.
+        await savePendingRevoke({
+          pairId: current.pairId,
+          deviceId: current.deviceId,
+          seed: current.seed,
+          refreshToken: current.refreshToken,
+          tokenUrl: current.tokenUrl,
+        });
       }
-      await clearCredentials();
-      setCredentials(null);
-      setPresence(null);
-      setSessions([]);
-      setWorkspaces([]);
-      setSelectedSessionId("");
-      setDraft(false);
-      setTimelines({});
-      cursorsRef.current = {};
-      streamingRef.current = {};
-      setTitleOverrides({});
-      titleOverridesRef.current = {};
-      setPhase("unpaired");
-      setError(null);
-    } finally {
-      setBusy(false);
     }
-  }, [credentials]);
-
+    await clearCredentials();
+    setCredentials(null);
+    setPresence(null);
+    resetCatalog();
+    setSelectedSessionId("");
+    setDraft(false);
+    setTimelines({});
+    cursorsRef.current = {};
+    streamingRef.current = {};
+    setPhase("unpaired");
+    setError(null);
+  }, [credentials, resetCatalog]);
 
   useEffect(() => {
     hydrateAttachmentsRef.current = async sessionId => {
@@ -888,7 +689,12 @@ export function RemoteProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     recoverRef.current = async (sessionId?: string) => {
-      await Promise.all([refreshModels(), refreshSessions(), refreshWorkspaces(), refreshSettings()]);
+      await Promise.all([
+        refreshModels(),
+        refreshSessions(),
+        refreshWorkspaces(),
+        refreshSettings(),
+      ]);
       reconcileSession(sessionId, "reconnect");
     };
   }, [reconcileSession, refreshModels, refreshSessions, refreshWorkspaces, refreshSettings]);
@@ -897,7 +703,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     async (sessionId: string) => {
       const client = clientRef.current;
       if (!client) return;
-      setBusy(true);
+      setOpeningSession(true);
       conversationEpochRef.current += 1;
       setSelectedSessionId(sessionId);
       selectedRef.current = sessionId;
@@ -926,7 +732,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
         // not banner-worthy.
         recordError(nextError);
       } finally {
-        setBusy(false);
+        setOpeningSession(false);
       }
       // Reconcile regardless of the state read: a desktop still warming after a
       // restart fails get_state, but the history rebuild must not be skipped —
@@ -937,7 +743,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       // whose user_message payload deliberately omits attachments.
       void hydrateAttachmentsRef.current(sessionId);
     },
-    [hydrateAttachmentsRef, models, recordError],
+    [hydrateAttachmentsRef, models, recordError, setUnreadSessions],
   );
 
   const newConversation = useCallback(
@@ -973,7 +779,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       // Nothing to send is a no-op, not an error — the composer guards this too.
       if (!text.trim() && attachments.length === 0) return;
       if (!client) throw new Error("not_connected");
-      if (busy) throw new Error("send_busy");
+      if (sending) throw new Error("send_busy");
       if (attachments.length > 0 && !fileTransferSupported) {
         throw new Error("attachment_unsupported_desktop");
       }
@@ -995,7 +801,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       // mirror so the check reflects the latest lane snapshot even before the
       // subscriber re-renders.
       if (streamingRef.current[targetSessionId] ?? false) throw new Error("send_streaming");
-      setBusy(true);
+      setSending(true);
       try {
         const uploaded = await uploadAttachments(client, attachments, onUploadProgress);
         // The optimistic bubble is a lane instruction (append to the current
@@ -1086,11 +892,11 @@ export function RemoteProvider({ children }: PropsWithChildren) {
           }
         }
       } finally {
-        setBusy(false);
+        setSending(false);
       }
     },
     [
-      busy,
+      sending,
       draft,
       draftMode,
       draftWorkspaceId,
@@ -1162,15 +968,18 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
-  const setApprovalTier = useCallback(async (tier: string) => {
-    const client = clientRef.current;
-    if (!client) throw new Error("not_connected");
-    const data = await client.request<{ approvalTier: string }>(
-      { type: "set_approval_tier", tier },
-      "list",
-    );
-    setApprovalTierState(data.data.approvalTier);
-  }, []);
+  const setApprovalTier = useCallback(
+    async (tier: string) => {
+      const client = clientRef.current;
+      if (!client) throw new Error("not_connected");
+      const data = await client.request<{ approvalTier: string }>(
+        { type: "set_approval_tier", tier },
+        "list",
+      );
+      setApprovalTierState(data.data.approvalTier);
+    },
+    [setApprovalTierState],
+  );
 
   const continueRun = useCallback(async (sessionId: string, runId: string) => {
     const client = clientRef.current;
@@ -1178,48 +987,13 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     await client.request({ type: "continue_run", sessionId, runId }, sessionId);
   }, []);
 
-  const rename = useCallback(async (sessionId: string, name: string) => {
-    const client = clientRef.current;
-    if (!client || !sessionId || !name.trim()) return;
-    const trimmed = name.trim();
-    await client.request({ type: "set_session_name", sessionId, name: trimmed }, sessionId);
-    setTitleOverrides(prev => ({ ...prev, [sessionId]: trimmed }));
-    setSessions(current =>
-      current.map(session =>
-        session.sessionId === sessionId ? { ...session, title: trimmed } : session,
-      ),
-    );
-  }, []);
-
   const deleteSession = useCallback(
     async (sessionId: string, threadId: string) => {
-      const client = clientRef.current;
-      if (!client || !sessionId || !threadId) return;
-      await client.request({ type: "delete_session", sessionId, threadId }, sessionId);
-      setSessions(current => current.filter(session => session.sessionId !== sessionId));
-      if (selectedRef.current === sessionId) closeConversation();
+      if (await removeSession(sessionId, threadId)) {
+        closeConversation();
+      }
     },
-    [closeConversation],
-  );
-
-  const setSessionPinned = useCallback(
-    async (sessionId: string, threadId: string, pinned: boolean) => {
-      const client = clientRef.current;
-      if (!client || !sessionId || !threadId) return;
-      await client.request(
-        { type: "set_session_pinned", sessionId, threadId, pinned },
-        sessionId,
-      );
-      // Optimistic local reorder: pinned sessions stay on top, everything else
-      // keeps the desktop's recency order. The pushed snapshot converges on the
-      // same layout (the desktop sorts by `pinned DESC, last_message_at DESC`).
-      setSessions(current =>
-        sortPinnedFirst(current.map(session =>
-          session.sessionId === sessionId ? { ...session, pinned } : session,
-        )),
-      );
-    },
-    [],
+    [closeConversation, removeSession],
   );
 
   const decideApproval = useCallback(async (id: string, decision: "approved" | "rejected") => {
@@ -1235,7 +1009,9 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       },
       sessionId,
     );
-    syncEngineRef.current?.mutate(sessionId, timeline => markApprovalDecision(timeline, id, decision));
+    syncEngineRef.current?.mutate(sessionId, timeline =>
+      markApprovalDecision(timeline, id, decision),
+    );
   }, []);
 
   const desktopOnline = useMemo(() => {
@@ -1245,9 +1021,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     // Fast death detection: the bridge beats once per second, so a local
     // receipt gap flags a dead desktop within ~25s — well before the
     // skew-tolerant 60s staleness window would flip the badge.
-    return (
-      next.online && clock - lastPresenceReceiptRef.current < PRESENCE_RECEIPT_STALE_MS
-    );
+    return next.online && clock - lastPresenceReceiptRef.current < PRESENCE_RECEIPT_STALE_MS;
   }, [clock, phase, presence]);
   // The selected conversation's timeline — derived from the per-session cache
   // so ChatScreen reads it exactly as before. An empty draft (no session yet)
@@ -1288,7 +1062,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       thinkingLevel,
       approvalTier,
       sandboxAvailable,
-      busy,
+      busy: sending || openingSession,
       fileTransferSupported,
       capabilities,
       pair,
@@ -1316,7 +1090,8 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     }),
     [
       abort,
-      busy,
+      openingSession,
+      sending,
       capabilities,
       fileTransferSupported,
       credentials,

--- a/mobile/src/remote/__tests__/handshake.test.ts
+++ b/mobile/src/remote/__tests__/handshake.test.ts
@@ -1,11 +1,6 @@
 import { createUser } from "nkeys.js";
-import {
-  decodeBase64Url,
-  encodeBase64Url,
-  handshakeTranscript,
-  type HandshakeChallenge,
-  verifyDesktopChallenge,
-} from "../handshake";
+import { handshakeTranscript, type HandshakeChallenge, verifyDesktopChallenge } from "../handshake";
+import { decodeBase64Url, encodeBase64Url } from "../codec";
 
 function signedChallenge(): HandshakeChallenge {
   const desktop = createUser();

--- a/mobile/src/remote/__tests__/presence.test.ts
+++ b/mobile/src/remote/__tests__/presence.test.ts
@@ -61,11 +61,7 @@ describe("isDesktopOnline (relative heartbeat, L7)", () => {
   it("marks offline when the delta jumps past the stale window (heartbeat stopped)", () => {
     let state: Result = { ...freshState(), online: false };
     for (let i = 0; i < 3; i += 1) {
-      state = isDesktopOnline(
-        presence({ lastHeartbeatTs: (now - i * 1_000) / 1000 }),
-        now,
-        state,
-      );
+      state = isDesktopOnline(presence({ lastHeartbeatTs: (now - i * 1_000) / 1000 }), now, state);
       expect(state.online).toBe(true);
     }
     const result = isDesktopOnline(
@@ -95,7 +91,11 @@ describe("isDesktopOnline (relative heartbeat, L7)", () => {
     // Healthy connection, phone clock in sync.
     let state: Result = { ...freshState(), online: false };
     state = isDesktopOnline(presence({ lastHeartbeatTs: now / 1000 }), now, state);
-    state = isDesktopOnline(presence({ lastHeartbeatTs: (now + 1_000) / 1000 }), now + 1_000, state);
+    state = isDesktopOnline(
+      presence({ lastHeartbeatTs: (now + 1_000) / 1000 }),
+      now + 1_000,
+      state,
+    );
     expect(state.online).toBe(true);
 
     // NTP jumps the phone clock +90s. Each new heartbeat now arrives with a

--- a/mobile/src/remote/__tests__/runCursor.test.ts
+++ b/mobile/src/remote/__tests__/runCursor.test.ts
@@ -4,7 +4,6 @@ import {
   isPrefixComplete,
   newCursor,
   nextEvent,
-  rebuildCursorFromEvents,
 } from "../runCursor";
 
 describe("runCursor", () => {
@@ -76,23 +75,6 @@ describe("runCursor", () => {
     expect(cursor.get("run1")?.highWater).toBe(7);
   });
 
-  test("rebuildCursorFromEvents sets max idx per run and marks prefix complete", () => {
-    const cursor = newCursor();
-    rebuildCursorFromEvents(cursor, [
-      { runId: "run1", idx: 0 },
-      { runId: "run1", idx: 3 },
-      { runId: "run1", idx: 1 },
-      { runId: "run2", idx: 10 },
-      { runId: null, idx: 99 },
-      { runId: "run3", idx: null },
-    ]);
-    expect(cursor.get("run1")?.highWater).toBe(3);
-    expect(cursor.get("run1")?.prefixComplete).toBe(true);
-    expect(cursor.get("run2")?.highWater).toBe(10);
-    expect(cursor.has("run3")).toBe(false);
-    expect(cursor.size).toBe(2);
-  });
-
   test("first event idx 0 → prefix complete (H3)", () => {
     const cursor = newCursor();
     nextEvent(cursor, "run1", 0);
@@ -119,7 +101,7 @@ describe("runCursor", () => {
 
   test("advanceCursor without completePrefix never regresses completeness", () => {
     const cursor = newCursor();
-    rebuildCursorFromEvents(cursor, [{ runId: "run1", idx: 3 }]);
+    advanceCursor(cursor, "run1", 3, true);
     advanceCursor(cursor, "run1", 5); // tail top-up, no completion flag
     expect(cursor.get("run1")?.prefixComplete).toBe(true);
   });

--- a/mobile/src/remote/__tests__/sessionStatus.test.ts
+++ b/mobile/src/remote/__tests__/sessionStatus.test.ts
@@ -27,13 +27,10 @@ describe("effectiveRunStatus", () => {
 
 describe("detectFinished", () => {
   test("flags a run that transitions running → completed", () => {
-    const { finished } = detectFinished(
-      { "s-1": "running", "s-2": "completed" },
-      [
-        { sessionId: "s-1", status: "completed" },
-        { sessionId: "s-2", status: "completed" },
-      ],
-    );
+    const { finished } = detectFinished({ "s-1": "running", "s-2": "completed" }, [
+      { sessionId: "s-1", status: "completed" },
+      { sessionId: "s-2", status: "completed" },
+    ]);
     expect(finished).toEqual(["s-1"]);
   });
 

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -2,19 +2,9 @@ import type { NatsConnection } from "nats.ws";
 import { connect, jwtAuthenticator } from "nats.ws";
 import { fromSeed } from "nkeys.js";
 import { ensureFreshCredentials, refreshCredentials } from "./pairing";
-import { jwtExpiry, randomId } from "./codec";
-import {
-  backoffDelayMs,
-  classifyError,
-  transition,
-  type ConnectionState,
-} from "./connectionState";
-import {
-  encodeBase64Url,
-  handshakeTranscript,
-  type HandshakeChallenge,
-  verifyDesktopChallenge,
-} from "./handshake";
+import { jwtExpiry, randomId, encodeBase64Url } from "./codec";
+import { backoffDelayMs, classifyError, transition, type ConnectionState } from "./connectionState";
+import { handshakeTranscript, type HandshakeChallenge, verifyDesktopChallenge } from "./handshake";
 import type {
   Presence,
   PresenceSession,

--- a/mobile/src/remote/codec.ts
+++ b/mobile/src/remote/codec.ts
@@ -21,11 +21,26 @@ export interface PairingInvitation {
   desktopPublicKey: string;
 }
 
-export function decodeBase64UrlJson<T>(value: string): T | null {
+export function encodeBase64Url(value: Uint8Array): string {
+  const binary = Array.from(value, byte => String.fromCharCode(byte)).join("");
+  return globalThis.btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function decodeBase64Url(value: string): Uint8Array | null {
   try {
     let base64 = value.trim().replace(/-/g, "+").replace(/_/g, "/");
     while (base64.length % 4 !== 0) base64 += "=";
-    return JSON.parse(globalThis.atob(base64)) as T;
+    return Uint8Array.from(globalThis.atob(base64), char => char.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+export function decodeBase64UrlJson<T>(value: string): T | null {
+  const bytes = decodeBase64Url(value);
+  if (!bytes) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
   } catch {
     return null;
   }

--- a/mobile/src/remote/connectionState.ts
+++ b/mobile/src/remote/connectionState.ts
@@ -31,12 +31,7 @@
  */
 
 export type ConnectionState =
-  | "connecting"
-  | "ready"
-  | "reconnecting"
-  | "refreshing"
-  | "revoked"
-  | "unpaired";
+  "connecting" | "ready" | "reconnecting" | "refreshing" | "revoked" | "unpaired";
 
 export type LifecycleEvent =
   | { type: "open_started" }
@@ -102,10 +97,7 @@ export function classifyError(error: unknown): "authTerminal" | "auth" | "transp
  * never leave — a revoked device retries nothing (M1), and an unpaired device
  * only acts on a fresh pair.
  */
-export function transition(
-  current: ConnectionState,
-  event: LifecycleEvent,
-): ConnectionAction {
+export function transition(current: ConnectionState, event: LifecycleEvent): ConnectionAction {
   switch (current) {
     case "connecting":
     case "reconnecting":
@@ -128,10 +120,7 @@ export function transition(
         case "unpair":
           return {
             next: "unpaired",
-            effects: [
-              { type: "dispose_connection", reason: "unpair" },
-              { type: "enter_unpaired" },
-            ],
+            effects: [{ type: "dispose_connection", reason: "unpair" }, { type: "enter_unpaired" }],
           };
       }
       break;
@@ -149,10 +138,7 @@ export function transition(
         case "unpair":
           return {
             next: "unpaired",
-            effects: [
-              { type: "dispose_connection", reason: "unpair" },
-              { type: "enter_unpaired" },
-            ],
+            effects: [{ type: "dispose_connection", reason: "unpair" }, { type: "enter_unpaired" }],
           };
         default:
           return { next: current, effects: [] };

--- a/mobile/src/remote/handshake.ts
+++ b/mobile/src/remote/handshake.ts
@@ -1,4 +1,5 @@
 import { fromPublic } from "nkeys.js";
+import { decodeBase64Url } from "./codec";
 
 const encoder = new TextEncoder();
 
@@ -27,21 +28,6 @@ export function handshakeTranscript(challenge: HandshakeChallenge): string {
     challenge.clientNonce,
     challenge.desktopNonce,
   ].join("\n");
-}
-
-export function encodeBase64Url(value: Uint8Array): string {
-  const binary = Array.from(value, byte => String.fromCharCode(byte)).join("");
-  return globalThis.btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-export function decodeBase64Url(value: string): Uint8Array | null {
-  try {
-    let base64 = value.replace(/-/g, "+").replace(/_/g, "/");
-    while (base64.length % 4 !== 0) base64 += "=";
-    return Uint8Array.from(globalThis.atob(base64), char => char.charCodeAt(0));
-  } catch {
-    return null;
-  }
 }
 
 export function verifyDesktopChallenge(

--- a/mobile/src/remote/pairing.ts
+++ b/mobile/src/remote/pairing.ts
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { createUser, fromSeed } from "nkeys.js";
 import { isExpectedClaimUrl, natsWsUrlScheme } from "../config/environment";
 import { decodePairingCode, jwtExpiry, parsePairingInvitation, randomId } from "./codec";
-import { loadDeviceId, saveDeviceId } from "./storage";
+import { loadDeviceId, saveDeviceId, type PendingRevoke } from "./storage";
 import type { RemoteCredentials } from "./types";
 
 interface ClaimResponse {
@@ -129,9 +129,7 @@ export async function ensureFreshCredentials(
   // rejects such a token outright; looping a refresh here would hammer the
   // token endpoint on every (re)connect. Fail loudly instead.
   if (expiry === null) throw new Error("invalid_jwt");
-  return expiry * 1000 < Date.now() + 60_000
-    ? refreshCredentials(credentials)
-    : credentials;
+  return expiry * 1000 < Date.now() + 60_000 ? refreshCredentials(credentials) : credentials;
 }
 
 /**
@@ -159,4 +157,24 @@ export async function serverRevoke(credentials: RemoteCredentials): Promise<void
   if (!response.ok && response.status !== 401 && response.status !== 404) {
     await responseJson(response);
   }
+}
+
+/**
+ * Fire the queued server-side revoke (M7). Best-effort: a failure is dropped —
+ * the queue entry stays in storage and retries on the next launch. A success
+ * (or a terminal 401/404, which serverRevoke treats as success) drains the
+ * queue via the caller's clearPendingRevoke.
+ */
+export async function attemptPendingRevoke(pending: PendingRevoke): Promise<void> {
+  await serverRevoke({
+    pairId: pending.pairId,
+    deviceId: pending.deviceId,
+    seed: pending.seed,
+    userJwt: "",
+    refreshToken: pending.refreshToken,
+    natsWsUrl: "",
+    tokenUrl: pending.tokenUrl,
+    expectedDesktopId: "",
+    expectedDesktopPublicKey: "",
+  });
 }

--- a/mobile/src/remote/presence.ts
+++ b/mobile/src/remote/presence.ts
@@ -99,10 +99,8 @@ export function isDesktopOnline(
   // frozen (a death). The advancing-heartbeat condition removes any dependence
   // on sampling-timer alignment. The first out-of-window sample only seeds the
   // detector (staleCount 1); subsequent confirmations compare against it.
-  const heartbeatAdvanced =
-    state.staleCount > 0 && heartbeatTs > state.staleHeartbeatTs;
-  const nearLastStale =
-    Math.abs(observedDeltaMs - state.staleDeltaMs) <= CLOCK_JUMP_TOLERANCE_MS;
+  const heartbeatAdvanced = state.staleCount > 0 && heartbeatTs > state.staleHeartbeatTs;
+  const nearLastStale = Math.abs(observedDeltaMs - state.staleDeltaMs) <= CLOCK_JUMP_TOLERANCE_MS;
   const confirmed = heartbeatAdvanced && nearLastStale;
   const staleCount = confirmed ? state.staleCount + 1 : 1;
   if (staleCount >= CLOCK_JUMP_CONFIRM_SAMPLES) {

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -411,19 +411,21 @@ export function applyStreamEvent(state: TimelineState, event: StreamEvent): Time
 }
 
 function isRunEvent(type: string): boolean {
-  return type === "agent_start"
-    || type === "text_chunk"
-    || type === "thinking_start"
-    || type === "thinking_delta"
-    || type === "thinking_end"
-    || type === "tool_start"
-    || type === "tool_delta"
-    || type === "toolcall_delta"
-    || type === "tool_end"
-    || type === "tool_result"
-    || type === "usage"
-    || type === "compaction_end"
-    || type === "agent_end";
+  return (
+    type === "agent_start" ||
+    type === "text_chunk" ||
+    type === "thinking_start" ||
+    type === "thinking_delta" ||
+    type === "thinking_end" ||
+    type === "tool_start" ||
+    type === "tool_delta" ||
+    type === "toolcall_delta" ||
+    type === "tool_end" ||
+    type === "tool_result" ||
+    type === "usage" ||
+    type === "compaction_end" ||
+    type === "agent_end"
+  );
 }
 
 /** Fold one run event through the run's shared projector and rebuild the
@@ -464,14 +466,26 @@ function applyLiveEvent(
     acc.durationMs = durationMs;
   }
   const assistantItem = buildLiveAssistantItem(acc, runId, projection, durationMs);
-  const items = upsertItem(state.items, acc.assistantId, () => assistantItem, () => assistantItem);
+  const items = upsertItem(
+    state.items,
+    acc.assistantId,
+    () => assistantItem,
+    () => assistantItem,
+  );
   return { items, streaming: acc.streaming, liveRuns };
 }
 
 function toRunEvent(
   runId: string,
   event: StreamEvent,
-): { id: string; runId: string; eventType: string; payload: string | null; sequence: number; createdAt: number } {
+): {
+  id: string;
+  runId: string;
+  eventType: string;
+  payload: string | null;
+  sequence: number;
+  createdAt: number;
+} {
   return {
     id: `${runId}:${event.idx ?? 0}`,
     runId,

--- a/mobile/src/remote/replay.ts
+++ b/mobile/src/remote/replay.ts
@@ -1,0 +1,54 @@
+import type { RemoteClient } from "./client";
+import type { ReplayEventWire } from "./eventReducer";
+
+export interface EventsData {
+  /** Raw replay events — the RPC serializes them with snake_case `run_id`. */
+  events?: ReplayEventWire[];
+  truncated?: boolean;
+  /** Coalesced replica of a run whose event ring overflowed — replaces the
+   *  session's timeline wholesale (see `timelineFromProjection`). */
+  projection?: { run_id?: string; cursor?: number; events?: ReplayEventWire[] } | null;
+}
+
+export interface EventsPage extends EventsData {
+  hasMore?: boolean;
+  nextOffset?: number;
+}
+
+/**
+ * Fetch a run's replay tail via `get_events_since`, looping paginated replies
+ * until `hasMore=false`. The desktop pages replay events under the NATS payload
+ * cap (a multi-MB journal tail must never ship as one oversized reply), so a
+ * single-shot request would silently truncate. The merged envelope carries the
+ * first page's `projection` (the whole-run replacement) through unchanged.
+ */
+export async function fetchEventsSince(
+  client: RemoteClient,
+  sessionId: string,
+  runId: string,
+  sinceIdx: number,
+): Promise<EventsData> {
+  const events: ReplayEventWire[] = [];
+  let projection: EventsData["projection"] = null;
+  let truncated = false;
+  let offset = 0;
+  for (;;) {
+    const page = (
+      await client.request<EventsPage>(
+        { type: "get_events_since", sessionId, runId, sinceIdx, offset },
+        sessionId,
+      )
+    ).data;
+    events.push(...(page.events ?? []));
+    if (page.projection?.events?.length) projection = page.projection;
+    if (page.truncated) truncated = true;
+    if (!page.hasMore) break;
+    const next = page.nextOffset;
+    if (typeof next !== "number" || next <= offset) break;
+    offset = next;
+  }
+  const merged: EventsData = { events };
+  if (projection) merged.projection = projection;
+  if (truncated) merged.truncated = true;
+  return merged;
+}

--- a/mobile/src/remote/runCursor.ts
+++ b/mobile/src/remote/runCursor.ts
@@ -105,31 +105,12 @@ export function advanceCursor(
   }
 }
 
-/**
- * Rebuild cursor state from a set of already-applied events (e.g. after a full
- * reconcile). The run is prefix-complete because the events were fetched from
- * -1 (or from 0 — both render the whole known run).
- */
-export function rebuildCursorFromEvents(
-  cursor: RunCursor,
-  events: { runId?: string | null; idx?: number | null }[],
-): void {
-  for (const event of events) {
-    if (event.runId && event.idx != null) {
-      advanceCursor(cursor, event.runId, event.idx, true);
-    }
-  }
-}
-
 export function cursorHighWater(cursor: RunCursor, runId: string | undefined | null): number {
   if (!runId) return -1;
   return cursor.get(runId)?.highWater ?? -1;
 }
 
-export function isPrefixComplete(
-  cursor: RunCursor,
-  runId: string | undefined | null,
-): boolean {
+export function isPrefixComplete(cursor: RunCursor, runId: string | undefined | null): boolean {
   if (!runId) return true;
   return cursor.get(runId)?.prefixComplete ?? false;
 }

--- a/mobile/src/remote/sessionStatus.ts
+++ b/mobile/src/remote/sessionStatus.ts
@@ -1,3 +1,5 @@
+import type { RemoteSession } from "./types";
+
 /**
  * Effective run status for a session row — mirrors the desktop sidebar
  * (`ThreadListItem.effectiveRunStatus`): the local run status wins when it
@@ -43,4 +45,16 @@ export function detectFinished(
     next[s.sessionId] = s.status;
   }
   return { finished, next };
+}
+
+/**
+ * Stable pinned-first reorder for optimistic pin/unpin. Pinned sessions move
+ * to the top in their original relative order; everything else keeps the
+ * incoming (desktop-sorted) order. Matches the desktop sidebar's `pinned DESC`
+ * grouping, which the pushed snapshot also converges on.
+ */
+export function sortPinnedFirst(list: RemoteSession[]): RemoteSession[] {
+  const pinned = list.filter(session => session.pinned);
+  const rest = list.filter(session => !session.pinned);
+  return [...pinned, ...rest];
 }

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -74,13 +74,7 @@ export interface SyncDeps {
 }
 
 export type ReconcileReason =
-  | "gap"
-  | "prefix"
-  | "truncated"
-  | "snapshot-flip"
-  | "open"
-  | "reconnect"
-  | "resend";
+  "gap" | "prefix" | "truncated" | "snapshot-flip" | "open" | "reconnect" | "resend";
 
 /** A committed timeline + its cursor, delivered to subscribers. */
 export interface Commit {
@@ -92,9 +86,7 @@ export interface Commit {
 /** A synchronous timeline mutation (approval decision, optimistic bubble…). */
 type Mutator = (timeline: TimelineState) => TimelineState;
 
-type Op =
-  | { kind: "event"; event: StreamEvent }
-  | { kind: "mutate"; apply: Mutator };
+type Op = { kind: "event"; event: StreamEvent } | { kind: "mutate"; apply: Mutator };
 
 interface ReconcileRequest {
   reason: ReconcileReason;
@@ -238,7 +230,7 @@ export class SyncEngine {
 
       const full = this.isFullReplay(lane, targetRunId, request);
       if (full) {
-        await this.fullReconcile(lane, activeRunId, targetRunId);
+        await this.fullReconcile(lane, targetRunId);
       } else {
         await this.tailReconcile(lane, targetRunId);
       }
@@ -254,13 +246,9 @@ export class SyncEngine {
    * the run's prefix is not provably complete (mid-run join), when the run was
    * replaced (run_snapshot), or on a forced full reason (prefix / resend).
    */
-  private async fullReconcile(
-    lane: SessionLane,
-    activeRunId: string,
-    targetRunId: string,
-  ): Promise<void> {
+  private async fullReconcile(lane: SessionLane, targetRunId: string): Promise<void> {
     const history = await this.deps.requestHistory(lane.sessionId);
-    let base = mergeLiveInto(history, lane.timeline, activeRunId);
+    let base = mergeLiveInto(history, lane.timeline);
     if (targetRunId) {
       base = stripRunItems(base, targetRunId);
       base = await this.replayInto(lane, base, targetRunId, -1);
@@ -305,8 +293,7 @@ export class SyncEngine {
       // permanent run indicator.
       events = events.map(ev => (ev.runId ? ev : { ...ev, runId }));
       const cursorIdx =
-        result.projection.cursor ??
-        events.reduce((max, ev) => Math.max(max, ev.idx ?? -1), -1);
+        result.projection.cursor ?? events.reduce((max, ev) => Math.max(max, ev.idx ?? -1), -1);
       advanceCursor(lane.cursor, runId, cursorIdx, true);
       const stripped = stripRunItems(base, runId);
       const projected = timelineFromProjection(events);
@@ -428,11 +415,7 @@ export class SyncEngine {
  * the active run (optimistic bubbles, notices, approval cards) so they survive
  * the rebuild. Live user messages that duplicate a history prompt are dropped.
  */
-function mergeLiveInto(
-  history: TimelineState,
-  live: TimelineState | null,
-  _activeRunId: string,
-): TimelineState {
+function mergeLiveInto(history: TimelineState, live: TimelineState | null): TimelineState {
   if (!live) return { ...history, streaming: history.streaming };
   const historyIds = new Set(history.items.map(item => item.id));
   const historyUserTexts = new Set(
@@ -446,11 +429,7 @@ function mergeLiveInto(
   // (the replay rebuilds them); user bubbles always survive.
   const folded = live.items.filter(item => {
     if (historyIds.has(item.id)) return false;
-    if (
-      item.kind === "message" &&
-      item.role === "user" &&
-      historyUserTexts.has(item.text)
-    ) {
+    if (item.kind === "message" && item.role === "user" && historyUserTexts.has(item.text)) {
       return false;
     }
     return true;

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -6,8 +6,7 @@ export type ConnectionPhase =
   | "connected"
   | "reconnecting"
   | "refreshing"
-  | "revoked"
-  | "error";
+  | "revoked";
 
 export interface PairingCode {
   v: 2;
@@ -333,4 +332,36 @@ export interface RemoteCommand {
   transferId?: string;
   filePath?: string;
   attachments?: { uploadId: string }[];
+}
+
+export interface SessionsData {
+  sessions: RemoteSession[];
+}
+
+export interface ModelsData {
+  models: RemoteModel[];
+}
+
+export interface WorkspacesData {
+  workspaces: RemoteWorkspace[];
+}
+
+export interface HistoryData {
+  messages: HistoryMessage[];
+  total?: number;
+  hasMore?: boolean;
+  nextOffset?: number;
+}
+
+export interface EntriesData {
+  entries: HistoryEntry[];
+  total?: number;
+  hasMore?: boolean;
+  nextOffset?: number;
+}
+
+export interface PromptAck {
+  sessionId: string;
+  threadId: string;
+  runId: string;
 }

--- a/mobile/src/remote/useSessionCatalog.ts
+++ b/mobile/src/remote/useSessionCatalog.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
+import type { RemoteClient } from "./client";
+import { detectFinished, sortPinnedFirst } from "./sessionStatus";
+import type {
+  ModelsData,
+  RemoteModel,
+  RemoteSession,
+  RemoteWorkspace,
+  SessionsData,
+  WorkspacesData,
+} from "./types";
+
+/**
+ * The desktop's control-plane catalogue — sessions, workspaces, the model
+ * list, approval settings — and the unread/rename bookkeeping that rides on
+ * top of it. Isolated from connection lifecycle and the per-session timeline
+ * so this is the only place that owns `sessions`-shaped state.
+ *
+ * `applySessionSnapshot` is the single commit point for a sessions list (from
+ * either an explicit `list_sessions` request or the pushed NATS snapshot), so
+ * title overrides, unread detection and pinned ordering stay consistent.
+ */
+export function useSessionCatalog(
+  clientRef: MutableRefObject<RemoteClient | null>,
+  selectedRef: MutableRefObject<string>,
+) {
+  const [sessions, setSessions] = useState<RemoteSession[]>([]);
+  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(() => new Set());
+  const [workspaces, setWorkspaces] = useState<RemoteWorkspace[]>([]);
+  const [models, setModels] = useState<RemoteModel[]>([]);
+  const [approvalTier, setApprovalTier] = useState("off");
+  const [sandboxAvailable, setSandboxAvailable] = useState(false);
+  const [titleOverrides, setTitleOverrides] = useState<Record<string, string>>({});
+  const lastStatusRef = useRef<Record<string, string | undefined>>({});
+  const titleOverridesRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    titleOverridesRef.current = titleOverrides;
+  }, [titleOverrides]);
+
+  const applySessionSnapshot = useCallback(
+    (list: RemoteSession[]) => {
+      const overrides = titleOverridesRef.current;
+      const decorated = list.map(session => ({
+        ...session,
+        title: overrides[session.sessionId] ?? session.title,
+      }));
+      const { finished, next } = detectFinished(
+        lastStatusRef.current,
+        decorated,
+        selectedRef.current,
+      );
+      lastStatusRef.current = next;
+      setSessions(decorated);
+      if (finished.length > 0) {
+        setUnreadSessions(prev => {
+          const nextUnread = new Set(prev);
+          for (const id of finished) nextUnread.add(id);
+          return nextUnread;
+        });
+      }
+    },
+    [selectedRef],
+  );
+
+  const refreshSessions = useCallback(async () => {
+    const client = clientRef.current;
+    if (!client) return;
+    try {
+      const response = await client.request<SessionsData>({ type: "list_sessions" }, "list");
+      applySessionSnapshot(response.data.sessions ?? []);
+    } catch {
+      // If the connection has gone (refresh/reconnect cycle), swallow
+      // the error — the reconnect handler will re-fetch.
+    }
+  }, [applySessionSnapshot, clientRef]);
+
+  const refreshModels = useCallback(async () => {
+    const client = clientRef.current;
+    if (!client) return;
+    // The desktop's model catalogue can lag the handshake on a fresh connect (or
+    // the agent may still be warming up and error out), so an empty or failed
+    // first answer is re-asked once before we accept it — otherwise the selector
+    // and the "no models" banner stay stale until a manual refresh.
+    let list: RemoteModel[] = [];
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        list =
+          (await client.request<ModelsData>({ type: "list_models" }, "list")).data.models ?? [];
+        if (list.length > 0) break;
+      } catch {
+        list = [];
+      }
+      if (attempt === 0) await new Promise(resolve => setTimeout(resolve, 1200));
+    }
+    setModels(list);
+  }, [clientRef]);
+
+  const refreshSettings = useCallback(async () => {
+    const client = clientRef.current;
+    if (!client) return;
+    try {
+      const data = await client.request<{ approvalTier: string; sandboxAvailable: boolean }>(
+        { type: "get_settings" },
+        "list",
+      );
+      setApprovalTier(data.data.approvalTier);
+      setSandboxAvailable(data.data.sandboxAvailable);
+    } catch {
+      // Keep the previous tier on a failed read.
+    }
+  }, [clientRef]);
+
+  const refreshWorkspaces = useCallback(async () => {
+    const client = clientRef.current;
+    if (!client) return;
+    try {
+      const response = await client.request<WorkspacesData>({ type: "list_workspaces" }, "list");
+      setWorkspaces(response.data.workspaces ?? []);
+    } catch {
+      setWorkspaces([]);
+    }
+  }, [clientRef]);
+
+  /** Drop catalogue state (unpair / credentials cleared). */
+  const reset = useCallback(() => {
+    setSessions([]);
+    setWorkspaces([]);
+    setTitleOverrides({});
+    titleOverridesRef.current = {};
+    // Clear the status baseline too — a stale running→completed comparison
+    // after an unpair/re-pair would otherwise mark old sessions unread.
+    lastStatusRef.current = {};
+  }, []);
+
+  const rename = useCallback(
+    async (sessionId: string, name: string) => {
+      const client = clientRef.current;
+      if (!client || !sessionId || !name.trim()) return;
+      const trimmed = name.trim();
+      await client.request({ type: "set_session_name", sessionId, name: trimmed }, sessionId);
+      setTitleOverrides(prev => ({ ...prev, [sessionId]: trimmed }));
+      setSessions(current =>
+        current.map(session =>
+          session.sessionId === sessionId ? { ...session, title: trimmed } : session,
+        ),
+      );
+    },
+    [clientRef, setSessions, setTitleOverrides],
+  );
+
+  /**
+   * Delete a session on the desktop and drop it locally. Returns true when the
+   * deleted session was the one currently selected, so the caller can close the
+   * conversation (a navigation concern the catalogue doesn't own).
+   */
+  const deleteSession = useCallback(
+    async (sessionId: string, threadId: string): Promise<boolean> => {
+      const client = clientRef.current;
+      if (!client || !sessionId || !threadId) return false;
+      await client.request({ type: "delete_session", sessionId, threadId }, sessionId);
+      setSessions(current => current.filter(session => session.sessionId !== sessionId));
+      return selectedRef.current === sessionId;
+    },
+    [clientRef, selectedRef, setSessions],
+  );
+
+  const setSessionPinned = useCallback(
+    async (sessionId: string, threadId: string, pinned: boolean) => {
+      const client = clientRef.current;
+      if (!client || !sessionId || !threadId) return;
+      await client.request({ type: "set_session_pinned", sessionId, threadId, pinned }, sessionId);
+      // Optimistic local reorder: pinned sessions stay on top, everything else
+      // keeps the desktop's recency order. The pushed snapshot converges on the
+      // same layout (the desktop sorts by `pinned DESC, last_message_at DESC`).
+      setSessions(current =>
+        sortPinnedFirst(
+          current.map(session =>
+            session.sessionId === sessionId ? { ...session, pinned } : session,
+          ),
+        ),
+      );
+    },
+    [clientRef, setSessions],
+  );
+
+  return {
+    sessions,
+    unreadSessions,
+    setUnreadSessions,
+    workspaces,
+    setWorkspaces,
+    models,
+    approvalTier,
+    setApprovalTier,
+    sandboxAvailable,
+    titleOverrides,
+    setTitleOverrides,
+    applySessionSnapshot,
+    refreshSessions,
+    refreshModels,
+    refreshSettings,
+    refreshWorkspaces,
+    rename,
+    deleteSession,
+    setSessionPinned,
+    reset,
+  };
+}

--- a/mobile/src/screens/PairingScreen.tsx
+++ b/mobile/src/screens/PairingScreen.tsx
@@ -85,7 +85,7 @@ export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
 
   const handleScan = useCallback(
     async ({ data }: { data: string }) => {
-      if (scanLocked.current || remote.busy) return;
+      if (scanLocked.current || remote.phase === "claiming") return;
       const code = pairingCodeFromQr(data);
       if (!code) {
         showToast(t("pairing.invalid"));
@@ -100,7 +100,7 @@ export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
         }, 1200);
       }
     },
-    [doPair, remote.busy, showToast, t],
+    [doPair, remote.phase, showToast, t],
   );
 
   const handleManualSubmit = useCallback(async () => {
@@ -121,7 +121,7 @@ export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
     }
   }, [doPair, manualCode, showToast, t]);
 
-  const scanning = remote.phase === "claiming" || remote.busy;
+  const scanning = remote.phase === "claiming";
 
   return (
     <SafeAreaView edges={["top", "bottom"]} style={styles.safe}>

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -222,11 +222,7 @@ export function SessionsScreen() {
         unread={remote.unreadSessions.has(item.sessionId)}
       />
       {item.pinned && (
-        <Pin
-          accessibilityLabel={t("sessions.pin")}
-          color={colors.accent}
-          size={16}
-        />
+        <Pin accessibilityLabel={t("sessions.pin")} color={colors.accent} size={16} />
       )}
     </Pressable>
   );


### PR DESCRIPTION
## Summary

Mobile 子项目的重构 + 清理，纯 mobile 改动、无 Rust 变更。

- 拆分 `RemoteContext` god-object（1363 → 1146 行）：
  - 抽取 session 目录 hook `useSessionCatalog`（状态 + refresh + rename/delete/pin 命令）；`deleteSession` 返回「是否删除当前会话」，由 provider 处理关闭对话副作用，避免 catalog→provider 循环依赖
  - 移动 replay 分页到 `replay.ts`、`sortPinnedFirst` 到 `sessionStatus`、`attemptPendingRevoke` 到 `pairing`、RPC 响应类型到 `types.ts`
- 拆分共享 `busy` 标志为 `sending`/`openingSession`，修复并发操作（发送中切会话等）互相清 finally 标志的竞态
- 去重：base64url 编解码统一到 `codec.ts`（`decodeBase64UrlJson` 改为正确的 UTF-8 解码）、`refreshSessions`/`onSessions` 快照逻辑提取
- 清理死代码：`rebuildCursorFromEvents`、未用的 `ConnectionPhase "error"`
- 修复：`RunIndicator` 首帧「0s」闪烁、unpair 后状态基线残留导致 re-pair 误报未读
- `prettier` 格式化整个 mobile 树

## Test plan

- [x] `npm run typecheck`（tsc --noEmit）
- [x] `npm run lint`（eslint）
- [x] `npm test`（jest，16 套件 / 237 测试）
- [x] `npm run format:check`（prettier）