### PR TITLE
docs: revamp README feature highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # FutureOS
 
-> A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one backend.
+> A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one gRPC backend.
 
 FutureOS gives you a unified AI agent experience across a terminal UI (TUI),
 desktop app (GUI), CLI, and IM bots — on macOS, Linux, and Windows.
@@ -24,12 +24,11 @@ or from a native desktop window.
 |---|---|
 | **Multi-Interface** | Terminal UI (TUI), desktop app (GUI), CLI, IM bots — one agent, everywhere |
 | **Model Flexibility** | 3800+ built-in models across 140+ providers ([catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
-| **Streaming & Thinking** | Real-time token streaming with collapsible reasoning-content blocks; configurable thinking levels (off ↔ xhigh) |
-| **Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt) |
-| **Session Persistence** | JSONL-based sessions with fork, clone, tree navigation, and query-count tracking ([using](docs/wiki/en/Using-FutureOS.md)) |
-| **Skills System** | Pluggable YAML-defined skill bundles discovered from multiple directories ([guide](docs/wiki/en/Skills.md)) |
-| **Compaction & Retry** | Automatic context compaction; exponential-backoff retry on context-length errors |
-| **Loop Control Plane** | `future-loop`: durable goals/todos/gates/monitors, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
+| **Agent Service** | The agent runs as a standalone gRPC service — the runtime is decoupled from the TUI, desktop app, channel bridge, and loop control plane, leaving room for new clients and extensions |
+| **Minimalist Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt) — Pi-style minimalism: a lean tool set, no prompt bloat |
+| **Forkable Sessions** | Branch any conversation like a repo — fork, clone, and tree navigation over JSONL session history |
+| **Powerful Built-in Skills** | 14+ skills out of the box for everyday agent work — image read & generation, PDF/Word parsing, web search, browser control, slides, and software install ([builtin](https://github.com/futuregene/future-skills/tree/main/builtin)) |
+| **Loop Engineering** | Durable goals/todos/gates/monitors for long-horizon runs of 24+ hours, quota should-run kernel, event-sourced state, validators, extensions & multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
 | **Rust Core** | Agent, IM channel bridge, loop control plane, CLI, and TUI are all written in Rust — high performance with memory safety |
 
 ## Quick Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 # FutureOS
 
-> 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个后端全搞定。
+> 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个 gRPC 后端全搞定。
 
 FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI) 和 IM 机器人——支持 macOS、Linux、Windows。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
 
@@ -21,12 +21,11 @@ FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应�
 |---|---|
 | **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI)、IM 机器人——一个 Agent，无处不在 |
 | **模型灵活** | 内置 3800+ 模型，覆盖 140+ Provider（[目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
-| **流式输出与思考链** | 实时 token 流式传输，可折叠的思考链展示；可配置思考深度（off ↔ xhigh） |
-| **工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt） |
-| **会话持久化** | JSONL 格式存储，支持 fork、clone、树形导航和问答计数（[使用](docs/wiki/zh/Using-FutureOS.md)） |
-| **技能系统** | 可插拔的 YAML 定义 Skill 包，从多目录自动发现（[指南](docs/wiki/zh/Skills.md)） |
-| **自动压缩与重试** | 上下文自动压缩；上下文超长时指数退避自动重试 |
-| **Loop 控制面** | `future-loop`：持久化目标/todos/门禁/监控、quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
+| **Agent 服务** | Agent 以独立 gRPC 服务运行——运行时与 TUI、桌面端、IM 渠道桥、loop 控制面解耦，为新的客户端与扩展留足空间 |
+| **极简工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt）——Pi 式极简主义：工具集精简，杜绝 prompt 膨胀 |
+| **可分支会话** | 像仓库一样为对话开分支——fork、clone、树形导航，JSONL 存储 |
+| **强大的预设技能** | 内置 14+ 技能开箱即用，覆盖日常 Agent 场景——图片读取与生成、PDF/Word 解析、网页搜索、浏览器控制、幻灯片与软件安装（[builtin](https://github.com/futuregene/future-skills/tree/main/builtin)） |
+| **Loop 工程** | 持久化目标/todos/门禁/监控，支撑 24+ 小时长程任务连续执行——quota should-run 内核、事件溯源状态、验证器、扩展与多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
 | **Rust 核心** | Agent、IM 渠道桥、loop 控制面、CLI 与 TUI 均用 Rust 编写——高性能、内存安全 |
 
 ## 快速开始


### PR DESCRIPTION
Reworks the Features table in README.md and README.zh-CN.md:

- Remove generic rows (streaming & thinking, compaction & retry)
- Add **Agent Service**: standalone gRPC service, runtime decoupled from clients, room for extension
- **Minimalist Tool Execution**: Pi-style minimalism, lean tools, no prompt bloat
- Rename Loop Control Plane \u2192 **Loop Engineering** (24+ hour long-horizon runs)
- Session Persistence \u2192 **Forkable Sessions** (fork/clone/tree)
- Skills \u2192 **Powerful Built-in Skills** (image read/generation, PDF/Word parsing, web search, etc.)

Docs only — no code changes.