### PR TITLE
fix(agent): drop empty assistant messages from model context

### DIFF
--- a/agent/src/types/mod.rs
+++ b/agent/src/types/mod.rs
@@ -812,7 +812,17 @@ impl AgentMessage {
 }
 
 pub fn convert_to_llm(msgs: &[AgentMessage]) -> Vec<Message> {
-    msgs.iter().map(|m| m.to_llm()).collect()
+    msgs.iter()
+        // Drop empty assistant messages (no content and no tool_calls) before
+        // they reach the model. A crash/interrupt can leave a reasoning-only
+        // assistant entry in the journal; on resume the API rejects it with
+        // "content or tool_calls must be set". Filtering here — at the single
+        // AgentMessage → Message boundary every send path and every provider
+        // format (OpenAI, Anthropic, responses) flows through — keeps the
+        // model-bound context clean without touching display or the journal.
+        .filter(|m| !(m.role == "assistant" && m.content.is_empty() && m.tool_calls.is_empty()))
+        .map(|m| m.to_llm())
+        .collect()
 }
 
 pub fn convert_from_llm(msgs: Vec<Message>) -> Vec<AgentMessage> {
@@ -1512,6 +1522,28 @@ mod tests {
         assert_eq!(back.len(), 1);
         assert_eq!(back[0].role, "user");
         assert_eq!(back[0].text(), "test");
+    }
+
+    #[test]
+    fn convert_to_llm_skips_empty_assistant() {
+        // Regression: a crash mid-turn can leave a reasoning-only assistant
+        // entry (no content, no tool_calls). convert_to_llm must drop it so the
+        // API never sees "content or tool_calls must be set" on resume.
+        let msgs = vec![
+            AgentMessage {
+                role: "assistant".to_string(),
+                thinking: "thinking...".to_string(),
+                ..Default::default()
+            },
+            AgentMessage {
+                role: "user".to_string(),
+                content: vec![ContentBlock::text("hi")],
+                ..Default::default()
+            },
+        ];
+        let llm_msgs = convert_to_llm(&msgs);
+        assert_eq!(llm_msgs.len(), 1);
+        assert_eq!(llm_msgs[0].role, "user");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

After an unexpected exit mid-conversation, resuming the session fails with:

```
API request failed (HTTP 400): code=invalid_request_error,
message="Invalid assistant message: content or tool_calls must be set"
```

## Root cause

A crash/interrupt can land on a turn where the model emitted only reasoning
content (no body text, no tool calls). The run loop persists such a turn as a
`thinking`-only assistant entry so the GUI still shows the partial response.

On resume, that entry is reloaded into the message list and sent to the API as
`{"role":"assistant","reasoning_content":"..."}` — no `content`, no
`tool_calls`. DeepSeek (and other strict APIs) reject it because
`reasoning_content` does not satisfy the "content or tool_calls" requirement.

## Fix

Filter in `convert_to_llm` (`types/mod.rs`) — the single `AgentMessage → Message`
boundary every send path flows through — dropping any assistant message with
neither content nor tool_calls.

This sits one level *above* the per-provider format converters
(`convert_messages_to_openai` today, and any future Anthropic `/v1/messages`
or OpenAI `/v1/responses` converters), so the filtering lives in exactly one
place and covers every current and future provider format. `reasoning_content`
is intentionally NOT treated as content for this check.

Display is unaffected: the reasoning entry still lives in the journal and in
memory, so the GUI keeps showing the partial reply; only the model-bound copy
drops the invalid message.

## Test

- Added `convert_to_llm_skips_empty_assistant` (reasoning-only assistant is
  dropped, following user message survives).
- `cargo fmt --check` clean, `cargo check -p future-agent` clean,
  `cargo test -p future-agent --lib` passes (1373 tests; one pre-existing
  flaky `new_run_closes_a_prior_interrupted_run` timed out once but passes on
  rerun, unrelated to this change).
