### PR TITLE
docs: sharpen hero tagline — one AI agent, everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # FutureOS
 
-> A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one gRPC backend.
+> One AI agent, everywhere you work — terminal, desktop, and your chat apps.
 
 FutureOS gives you a unified AI agent experience across a terminal UI (TUI),
 desktop app (GUI), CLI, and IM bots — on macOS, Linux, and Windows.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 # FutureOS
 
-> 本地优先的 AI Agent 工作台——终端、桌面、消息平台，一个 gRPC 后端全搞定。
+> 同一个 AI Agent，处处随你——终端、桌面、飞书与钉钉。
 
 FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、命令行 (CLI) 和 IM 机器人——支持 macOS、Linux、Windows。写代码、做调研、管理文件——从终端、聊天软件或原生桌面窗口，无缝切换。
 


### PR DESCRIPTION
## 改动

README 与 README.zh-CN 的 hero slogan 重写：

- EN: `A local-first AI agent workspace — terminal, desktop, messaging platforms, all through one gRPC backend.` → `One AI agent, everywhere you work — terminal, desktop, and your chat apps.`
- ZH: `本地优先的 AI Agent 工作台……一个 gRPC 后端全搞定` → `同一个 AI Agent，处处随你——终端、桌面、飞书与钉钉。`

## 理由

把架构事实（one backend / gRPC）翻译成用户价值（one agent, everywhere）；gRPC 架构说明保留在 Features 表。中文版点名飞书/钉钉，对齐中文市场差异化。

纯文档改动，无代码影响。