### PR TITLE
chore(scripts): move measure-tauri.sh into scripts/

### DIFF
--- a/scripts/measure-tauri.sh
+++ b/scripts/measure-tauri.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Measure desktop/src-tauri per-line coverage (lcov DA:0) for the final-tauri residual.
 set -uo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 REALHOME="$HOME"
 
 while IFS='=' read -r k _; do case "$k" in CARGO*) unset "$k";; esac; done < <(env)


### PR DESCRIPTION
将 measure-tauri.sh 从仓库根移动到 scripts/ 目录（与 build-desktop、start-desktop 等桌面端脚本放在一起）。

- 脚本内部 `cd "$(dirname "$0")"` 改为 `cd "$(dirname "$0")/.."`，保证从 scripts/ 运行时仍回到仓库根，`coverage/`、`desktop/src-tauri` 等相对路径引用不受影响
- 已通过 `bash -n` 语法检查