### PR TITLE
fix(loop): leased-work quiet wait — never terminal when peers hold leases

### DIFF
--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -360,6 +360,29 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         );
     }
 
+    // ── 5c. Open advancement work exists but none of it is runnable for
+    //        THIS agent (leased to peers). Quiet wait — never terminal: a
+    //        leased todo is not a closed goal, and falling through to
+    //        closure here parks every subsequent run in a skip loop until
+    //        the lease expires. (Learned from goal_c86c1a0aa7b8.) ────────
+    if goal.todos.iter().any(|t| {
+        t.class == TaskClass::Advancement
+            && (t.status == TodoStatus::Open
+                || (t.status == TodoStatus::Deferred && t.is_due_deferred(now)))
+    }) {
+        return packet(
+            goal,
+            DecisionReasonCode::WorkLeasedToOthers,
+            "wait",
+            false,
+            "quiet_wait",
+            TurnMode::WaitMonitor,
+            "open advancement(s) leased to other agents — quiet wait, goal is not closed",
+            UserChannel::none(),
+            agent_channel(None, None, None, false, false, true),
+        );
+    }
+
     // ── 6. Validated closure. ───────────────────────────────────────────
     let mut p = packet(
         goal,

--- a/orchestration/loop/src/quota/error_codes.rs
+++ b/orchestration/loop/src/quota/error_codes.rs
@@ -106,6 +106,9 @@ pub enum DecisionReasonCode {
     AcceptanceGapOpen,
     /// Deferred todo(s) not yet due — quiet wait.
     DeferredNotDue,
+    /// Open advancement work exists but is leased to other agents — quiet
+    /// wait, NEVER terminal (a leased todo ≠ a closed goal).
+    WorkLeasedToOthers,
     /// Validated closure — todos done, gaps closed, closure intent declared.
     ValidatedClosure,
     /// A↔V oscillation signature detected (main #163) — force a
@@ -131,6 +134,7 @@ impl DecisionReasonCode {
             Self::MonitorBackoff => "monitor_backoff",
             Self::AcceptanceGapOpen => "acceptance_gap_open",
             Self::DeferredNotDue => "deferred_not_due",
+            Self::WorkLeasedToOthers => "work_leased_to_others",
             Self::ValidatedClosure => "validated_closure",
             Self::OscillationDetected => "oscillation_detected",
         }

--- a/orchestration/loop/tests/decision_contract.rs
+++ b/orchestration/loop/tests/decision_contract.rs
@@ -96,6 +96,27 @@ fn runnable_advancement_is_bounded_delivery() {
     );
 }
 
+// ── Contract: work leased to other agents is quiet wait, NOT terminal ────
+// An agent whose runnable frontier is empty because every open advancement
+// is leased to peers must get a quiet wait — never the validated-closure
+// terminal stop, which parks the goal in a skip loop until leases expire.
+#[test]
+fn work_leased_to_peers_is_quiet_wait_not_terminal() {
+    let mut goal = Goal::new("g", "objective", "/tmp");
+    goal.register_agent("worker-2", vec![]);
+    goal.add(Todo::advancement("T1", "Open work"));
+    goal.todo_mut("T1")
+        .unwrap()
+        .claim("worker-1", 3600, future_loop::state::now_epoch());
+    let p = future_loop::decision::decide_for(&goal, now(), Some("worker-2"));
+    assert_eq!(p.interaction_contract.mode, TurnMode::WaitMonitor);
+    assert!(p.reason.contains("leased to other agents"));
+    // And once the lease holder completes it, the same goal is terminal.
+    goal.todo_mut("T1").unwrap().complete(true, vec![]);
+    let p = future_loop::decision::decide_for(&goal, now(), Some("worker-2"));
+    assert_eq!(p.interaction_contract.mode, TurnMode::Terminal);
+}
+
 // ── Contract: terminal closure is NOT "open_count == 0" ────────────────────
 #[test]
 fn open_todos_alone_is_not_terminal() {


### PR DESCRIPTION
decide_for treated an empty own-runnable frontier as validated closure when every open advancement was leased to another agent. Terminal stop parked runs in a skip loop (watchdog relaunch churn on goal_c86c1a0aa7b8). New WorkLeasedToOthers disposition: quiet wait. Contract test added.