### PR TITLE
test(mobile): cover replay/useSessionCatalog/pairing/sessionStatus to per-line 100% (cov100 finish)

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -37,10 +37,12 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^26.1.1",
     "@types/react": "~19.2.17",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^9.0.0",
     "eslint-config-expo": "^57.0.0",
     "jest-expo": "^57.0.2",
     "prettier": "^3.9.6",
+    "react-test-renderer": "^19.2.3",
     "typescript": "~5.8.0"
   },
   "scripts": {

--- a/mobile/src/remote/__tests__/pairing.test.ts
+++ b/mobile/src/remote/__tests__/pairing.test.ts
@@ -1,6 +1,7 @@
 import * as Device from "expo-device";
 import { createUser, fromSeed } from "nkeys.js";
 import {
+  attemptPendingRevoke,
   claimPairingCode,
   ensureFreshCredentials,
   refreshCredentials,
@@ -238,5 +239,28 @@ describe("serverRevoke", () => {
   test("rethrows the server error on a non-terminal failure", async () => {
     globalThis.fetch = jest.fn().mockResolvedValue(jsonResponse({ message: "boom" }, 500));
     await expect(serverRevoke(makeCredentials())).rejects.toThrow("boom");
+  });
+});
+
+describe("attemptPendingRevoke", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("fires the queued revoke and resolves", async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue(jsonResponse({}, 200));
+    const credentials = makeCredentials();
+    const pending = {
+      pairId: credentials.pairId,
+      deviceId: credentials.deviceId,
+      seed: credentials.seed,
+      refreshToken: credentials.refreshToken,
+      tokenUrl: credentials.tokenUrl,
+    };
+    await expect(attemptPendingRevoke(pending)).resolves.toBeUndefined();
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://example.com/pair/revoke",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 });

--- a/mobile/src/remote/__tests__/replay.test.ts
+++ b/mobile/src/remote/__tests__/replay.test.ts
@@ -1,0 +1,83 @@
+import { fetchEventsSince, type EventsPage } from "../replay";
+import type { RemoteClient } from "../client";
+import type { ReplayEventWire } from "../eventReducer";
+
+/** Build a fake client that returns a scripted sequence of pages. */
+function clientReturning(pages: EventsPage[]): { client: RemoteClient; request: jest.Mock } {
+  const request = jest.fn();
+  for (const page of pages) request.mockResolvedValueOnce({ data: page });
+  return { client: { request } as unknown as RemoteClient, request };
+}
+
+function event(type: string, idx: number): ReplayEventWire {
+  return { type, idx };
+}
+
+describe("fetchEventsSince", () => {
+  test("merges a single page and returns its events", async () => {
+    const { client, request } = clientReturning([
+      { events: [event("agent_start", 0), event("agent_end", 1)] },
+    ]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.events).toEqual([event("agent_start", 0), event("agent_end", 1)]);
+    expect(result.projection).toBeUndefined();
+    expect(result.truncated).toBeUndefined();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      { type: "get_events_since", sessionId: "s1", runId: "r1", sinceIdx: 0, offset: 0 },
+      "s1",
+    );
+  });
+
+  test("loops paginated pages until hasMore is false", async () => {
+    const { client, request } = clientReturning([
+      { events: [event("a", 0)], hasMore: true, nextOffset: 1 },
+      { events: [event("b", 1)], hasMore: true, nextOffset: 2 },
+      { events: [event("c", 2)] },
+    ]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect((result.events ?? []).map(e => e.idx)).toEqual([0, 1, 2]);
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls[1][0]).toMatchObject({ offset: 1 });
+    expect(request.mock.calls[2][0]).toMatchObject({ offset: 2 });
+  });
+
+  test("carries the first page's projection through unchanged", async () => {
+    const projection = { run_id: "r1", cursor: 3, events: [event("agent_end", 3)] };
+    const { client } = clientReturning([{ events: [], projection }]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.projection).toBe(projection);
+  });
+
+  test("marks the envelope truncated when any page is truncated", async () => {
+    const { client } = clientReturning([
+      { events: [event("a", 0)], hasMore: true, nextOffset: 1, truncated: true },
+      { events: [event("b", 1)] },
+    ]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.truncated).toBe(true);
+  });
+
+  test("stops looping when nextOffset is not a number", async () => {
+    const { client, request } = clientReturning([{ events: [event("a", 0)], hasMore: true }]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.events).toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops looping when nextOffset does not advance", async () => {
+    const { client, request } = clientReturning([
+      { events: [event("a", 0)], hasMore: true, nextOffset: 0 },
+    ]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.events).toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles a page with no events array", async () => {
+    const { client, request } = clientReturning([{}]);
+    const result = await fetchEventsSince(client, "s1", "r1", 0);
+    expect(result.events).toEqual([]);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/remote/__tests__/sessionStatus.test.ts
+++ b/mobile/src/remote/__tests__/sessionStatus.test.ts
@@ -1,4 +1,5 @@
-import { detectFinished, effectiveRunStatus } from "../sessionStatus";
+import { detectFinished, effectiveRunStatus, sortPinnedFirst } from "../sessionStatus";
+import type { RemoteSession } from "../types";
 
 describe("effectiveRunStatus", () => {
   test("local running/queued status wins", () => {
@@ -50,5 +51,26 @@ describe("detectFinished", () => {
       "s-1",
     );
     expect(finished).toEqual(["s-2"]);
+  });
+});
+
+describe("sortPinnedFirst", () => {
+  function session(id: string, pinned: boolean): RemoteSession {
+    return { sessionId: id, threadId: `thread-${id}`, title: id, streaming: false, pinned };
+  }
+
+  test("moves pinned sessions to the top in their original relative order", () => {
+    const list = [session("a", false), session("b", true), session("c", false), session("d", true)];
+    expect(sortPinnedFirst(list).map(s => s.sessionId)).toEqual(["b", "d", "a", "c"]);
+  });
+
+  test("keeps the incoming order when nothing is pinned", () => {
+    const list = [session("a", false), session("b", false), session("c", false)];
+    expect(sortPinnedFirst(list).map(s => s.sessionId)).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns the same order when everything is pinned", () => {
+    const list = [session("a", true), session("b", true)];
+    expect(sortPinnedFirst(list).map(s => s.sessionId)).toEqual(["a", "b"]);
   });
 });

--- a/mobile/src/remote/__tests__/useSessionCatalog.test.ts
+++ b/mobile/src/remote/__tests__/useSessionCatalog.test.ts
@@ -1,0 +1,306 @@
+import React from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { useSessionCatalog } from "../useSessionCatalog";
+import type { RemoteClient } from "../client";
+import type { RemoteSession } from "../types";
+
+type Catalog = ReturnType<typeof useSessionCatalog>;
+
+function session(id: string, status?: string): RemoteSession {
+  return {
+    sessionId: id,
+    threadId: `thread-${id}`,
+    title: `Title ${id}`,
+    streaming: false,
+    status,
+  };
+}
+
+describe("useSessionCatalog", () => {
+  let clientRef: { current: RemoteClient | null };
+  let selectedRef: { current: string };
+  let request: jest.Mock;
+  let result: { current: Catalog };
+  let renderer: ReactTestRenderer | null;
+
+  function TestComponent(): null {
+    result.current = useSessionCatalog(
+      clientRef as React.MutableRefObject<RemoteClient | null>,
+      selectedRef as React.MutableRefObject<string>,
+    );
+    return null;
+  }
+
+  function render(): void {
+    act(() => {
+      renderer = create(React.createElement(TestComponent));
+    });
+  }
+
+  beforeEach(() => {
+    request = jest.fn();
+    clientRef = { current: { request } as unknown as RemoteClient };
+    selectedRef = { current: "s1" };
+    result = { current: undefined as unknown as Catalog };
+    renderer = null;
+  });
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer!.unmount());
+      renderer = null;
+    }
+  });
+
+  test("returns the full catalogue surface on mount", () => {
+    render();
+    expect(result.current.sessions).toEqual([]);
+    expect(result.current.unreadSessions).toEqual(new Set());
+    expect(result.current.workspaces).toEqual([]);
+    expect(result.current.models).toEqual([]);
+    expect(result.current.approvalTier).toBe("off");
+    expect(result.current.sandboxAvailable).toBe(false);
+    expect(result.current.titleOverrides).toEqual({});
+    expect(typeof result.current.applySessionSnapshot).toBe("function");
+  });
+
+  test("applySessionSnapshot decorates titles and detects a finished transition", async () => {
+    render();
+    // Baseline: s2 is running (establishes lastStatusRef).
+    act(() => result.current.applySessionSnapshot([session("s2", "running")]));
+    expect(result.current.sessions[0]?.title).toBe("Title s2");
+
+    // Rename s2 to install a title override (synced to titleOverridesRef via effect).
+    request.mockResolvedValueOnce({ data: {} });
+    await act(async () => {
+      await result.current.rename("s2", "Custom Title");
+    });
+
+    // Second snapshot: s2 completed — uses the override and flags unread.
+    act(() => result.current.applySessionSnapshot([session("s2", "completed")]));
+    expect(result.current.sessions[0]).toMatchObject({ sessionId: "s2", title: "Custom Title" });
+    expect(result.current.unreadSessions.has("s2")).toBe(true);
+  });
+
+  test("applySessionSnapshot leaves the selected session out of unread", () => {
+    render();
+    act(() => result.current.applySessionSnapshot([session("s1", "running")]));
+    act(() => result.current.applySessionSnapshot([session("s1", "completed")]));
+    expect(result.current.unreadSessions.has("s1")).toBe(false);
+  });
+
+  test("refreshSessions applies the pushed snapshot", async () => {
+    render();
+    request.mockResolvedValueOnce({ data: { sessions: [session("s2", "running")] } });
+    await act(async () => {
+      await result.current.refreshSessions();
+    });
+    expect(result.current.sessions).toHaveLength(1);
+    expect(request).toHaveBeenCalledWith({ type: "list_sessions" }, "list");
+  });
+
+  test("refreshSessions tolerates a missing sessions array", async () => {
+    render();
+    request.mockResolvedValueOnce({ data: {} });
+    await act(async () => {
+      await result.current.refreshSessions();
+    });
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  test("refreshSessions swallows a dropped connection", async () => {
+    render();
+    request.mockRejectedValueOnce(new Error("not_connected"));
+    await act(async () => {
+      await result.current.refreshSessions();
+    });
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  test("refreshModels returns models on the first attempt", async () => {
+    render();
+    request.mockResolvedValueOnce({ data: { models: [{ id: "m1", label: "M1" }] } });
+    await act(async () => {
+      await result.current.refreshModels();
+    });
+    expect(result.current.models).toEqual([{ id: "m1", label: "M1" }]);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshModels retries once after an empty first answer", async () => {
+    jest.useFakeTimers();
+    try {
+      render();
+      request
+        .mockResolvedValueOnce({ data: { models: [] } })
+        .mockResolvedValueOnce({ data: { models: [{ id: "m1" }] } });
+      let pending: Promise<void> | undefined;
+      act(() => {
+        pending = result.current.refreshModels();
+      });
+      await act(async () => {
+        await jest.runAllTimersAsync();
+      });
+      await act(async () => {
+        await pending;
+      });
+      expect(result.current.models).toEqual([{ id: "m1" }]);
+      expect(request).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("refreshModels retries once after a failed first attempt", async () => {
+    jest.useFakeTimers();
+    try {
+      render();
+      request
+        .mockRejectedValueOnce(new Error("warming up"))
+        .mockResolvedValueOnce({ data: { models: [{ id: "m2" }] } });
+      let pending: Promise<void> | undefined;
+      act(() => {
+        pending = result.current.refreshModels();
+      });
+      await act(async () => {
+        await jest.runAllTimersAsync();
+      });
+      await act(async () => {
+        await pending;
+      });
+      expect(result.current.models).toEqual([{ id: "m2" }]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("refreshSettings updates approval tier and sandbox availability", async () => {
+    render();
+    request.mockResolvedValueOnce({
+      data: { approvalTier: "high", sandboxAvailable: true },
+    });
+    await act(async () => {
+      await result.current.refreshSettings();
+    });
+    expect(result.current.approvalTier).toBe("high");
+    expect(result.current.sandboxAvailable).toBe(true);
+  });
+
+  test("refreshWorkspaces updates the workspace list", async () => {
+    render();
+    request.mockResolvedValueOnce({
+      data: { workspaces: [{ id: "w1", name: "W", path: "/w" }] },
+    });
+    await act(async () => {
+      await result.current.refreshWorkspaces();
+    });
+    expect(result.current.workspaces).toEqual([{ id: "w1", name: "W", path: "/w" }]);
+  });
+
+  test("refreshWorkspaces clears the list on error", async () => {
+    render();
+    request.mockRejectedValueOnce(new Error("gone"));
+    await act(async () => {
+      await result.current.refreshWorkspaces();
+    });
+    expect(result.current.workspaces).toEqual([]);
+  });
+
+  test("reset clears catalogue state", async () => {
+    render();
+    request.mockResolvedValueOnce({ data: { sessions: [session("s2", "running")] } });
+    await act(async () => {
+      await result.current.refreshSessions();
+    });
+    expect(result.current.sessions).toHaveLength(1);
+    act(() => result.current.reset());
+    expect(result.current.sessions).toEqual([]);
+    expect(result.current.workspaces).toEqual([]);
+    expect(result.current.titleOverrides).toEqual({});
+  });
+
+  test("rename trims the name and updates both the override and the session", async () => {
+    render();
+    act(() =>
+      result.current.applySessionSnapshot([session("s1", "running"), session("s2", "running")]),
+    );
+    request.mockResolvedValueOnce({ data: {} });
+    await act(async () => {
+      await result.current.rename("s2", "  New Name  ");
+    });
+    expect(request).toHaveBeenCalledWith(
+      { type: "set_session_name", sessionId: "s2", name: "New Name" },
+      "s2",
+    );
+    expect(result.current.titleOverrides["s2"]).toBe("New Name");
+    expect(
+      result.current.sessions.map(s => (s.sessionId === "s2" ? s.title : s.sessionId)),
+    ).toEqual(["s1", "New Name"]);
+  });
+
+  test("rename ignores an empty session id or a blank name", async () => {
+    render();
+    await act(async () => {
+      await result.current.rename("", "name");
+    });
+    await act(async () => {
+      await result.current.rename("s2", "   ");
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test("deleteSession drops the session and reports the selected one", async () => {
+    render();
+    act(() =>
+      result.current.applySessionSnapshot([session("s1", "running"), session("s2", "running")]),
+    );
+    request.mockResolvedValueOnce({ data: {} });
+    let selected = false;
+    await act(async () => {
+      selected = await result.current.deleteSession("s1", "thread-s1");
+    });
+    expect(selected).toBe(true);
+    expect(result.current.sessions.map(s => s.sessionId)).toEqual(["s2"]);
+  });
+
+  test("deleteSession returns false for a non-selected session", async () => {
+    render();
+    act(() => result.current.applySessionSnapshot([session("s2", "running")]));
+    request.mockResolvedValueOnce({ data: {} });
+    let selected = false;
+    await act(async () => {
+      selected = await result.current.deleteSession("s2", "thread-s2");
+    });
+    expect(selected).toBe(false);
+  });
+
+  test("deleteSession ignores empty ids", async () => {
+    render();
+    let selected = false;
+    await act(async () => {
+      selected = await result.current.deleteSession("", "");
+    });
+    expect(selected).toBe(false);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test("setSessionPinned reorders pinned sessions to the top", async () => {
+    render();
+    act(() =>
+      result.current.applySessionSnapshot([session("a", "running"), session("b", "running")]),
+    );
+    request.mockResolvedValueOnce({ data: {} });
+    await act(async () => {
+      await result.current.setSessionPinned("b", "thread-b", true);
+    });
+    expect(result.current.sessions.map(s => s.sessionId)).toEqual(["b", "a"]);
+  });
+
+  test("setSessionPinned ignores empty ids", async () => {
+    render();
+    await act(async () => {
+      await result.current.setSessionPinned("", "", true);
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,10 +94,12 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^26.1.1",
         "@types/react": "~19.2.17",
+        "@types/react-test-renderer": "^19.1.0",
         "eslint": "^9.0.0",
         "eslint-config-expo": "^57.0.0",
         "jest-expo": "^57.0.2",
         "prettier": "^3.9.6",
+        "react-test-renderer": "^19.2.3",
         "typescript": "~5.8.0"
       }
     },
@@ -6085,6 +6087,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -19499,7 +19511,7 @@
     },
     "node_modules/react-test-renderer": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmmirror.com/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
       "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

Finishes the mobile jest coverage leg of the cov100 goal — `src/remote/**/*.ts` (excluding `client.ts`) reaches **per-line 100% (lcov `DA:0` = 0)**.

Closes the final `mobile-final-missed.txt` residual (404 lines reported against the pre-#220 refactor baseline). After the npm-workspaces migration (#231) the shared `@future-os/thread-projection` source is a workspace package; `projection.ts` + `syncEngine.ts` are already fully line-covered by the existing `eventReducer`/`syncEngine` suites, so the real residual was:

- `replay.ts` (17) — new `fetchEventsSince` pagination suite
- `useSessionCatalog.ts` (82) — new react-test-renderer hook suite (snapshot decoration, unread detection, all four refresh paths incl. retry/error arms, rename/delete/pin/reset)
- `sessionStatus.ts` (3) — `sortPinnedFirst`
- `pairing.ts` (1) — `attemptPendingRevoke`

## Changes

- `mobile/src/remote/__tests__/replay.test.ts` (new): pagination loop, projection/truncated carry-through, non-advancing offset guards, missing events array.
- `mobile/src/remote/__tests__/useSessionCatalog.test.ts` (new): full hook surface via `react-test-renderer`.
- `mobile/src/remote/__tests__/sessionStatus.test.ts`: `sortPinnedFirst` ordering.
- `mobile/src/remote/__tests__/pairing.test.ts`: queued server-side revoke fires and resolves.
- `mobile/package.json` / `package-lock.json`: add `react-test-renderer` + `@types/react-test-renderer` devDeps for the hook suite.

## Verification

- `npx jest --coverage` → lcov `DA:0` count = **0** (912 instrumented lines, 17 source files).
- `npm run check` (typecheck + lint + format:check + test) → green, 19 suites / 279 tests pass.