### PR TITLE
test(desktop): review upsert + skills bootstrap command arms (cov100 finish)

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/review.rs
+++ b/desktop/src-tauri/src/agent_bridge/review.rs
@@ -897,14 +897,15 @@ mod tests {
         assert_eq!(changeset.completeness, "partial");
     }
 
-    /// With both snapshots resolved, the changeset upsert itself fails when the
-    /// changeset table is gone (exercises the `?` error arm on the upsert).
+    /// When the changeset store vanishes (raw table drop on the app db),
+    /// materialize fails at the changeset upsert — exercising the `?` error
+    /// arm on the upsert call itself (not the earlier snapshot reads).
     #[test]
-    fn materialize_errors_when_changeset_upsert_fails() {
+    fn materialize_fails_when_the_changeset_store_is_gone() {
         let _lock = crate::TEST_HOME_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        let (_fx, thread, run) = fixture("upsert-gone");
+        let (_fx, thread, run) = fixture("changeset-gone");
         let ws_id = store::get_thread(&thread.id).unwrap().unwrap().workspace_id;
 
         for (phase, status) in [("before", "complete"), ("after", "complete")] {
@@ -925,6 +926,8 @@ mod tests {
             .unwrap();
         }
 
+        // Drop the changeset table so the upsert fails deterministically (raw
+        // table drop; rusqlite does not enforce FKs by default).
         let conn =
             rusqlite::Connection::open(_fx.base.join("home/.future/app/app.db")).expect("open db");
         conn.execute_batch("DROP TABLE review_changesets;").unwrap();

--- a/desktop/src-tauri/src/commands/review.rs
+++ b/desktop/src-tauri/src/commands/review.rs
@@ -210,6 +210,28 @@ mod tests {
     }
 
     #[test]
+    fn get_last_run_review_returns_the_changeset_after_a_capture() {
+        let _home = init("cmd_review_last_run_ok");
+        let ws = workspace("last_run_ok_ws");
+        let thread = thread_in(&ws);
+        let run = crate::store::create_run(crate::store::CreateRunInput {
+            id: None,
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .expect("run");
+        // Real captures produce real shadow commits + a materialized changeset,
+        // so the Some arm of get_last_run_review runs.
+        std::fs::write(std::path::Path::new(&ws.path).join("a.txt"), b"hello").unwrap();
+        crate::agent_bridge::capture_before(&thread.id, &run.id);
+        crate::agent_bridge::finalize_after(&thread.id, &run.id);
+        let review = get_last_run_review(thread.id).expect("review");
+        assert!(review.is_some());
+    }
+
+    #[test]
     fn retry_run_review_errors_for_an_unknown_run() {
         let _home = init("cmd_review_retry");
         assert!(retry_run_review("ghost_run".into()).is_err());

--- a/desktop/src-tauri/src/commands/skills.rs
+++ b/desktop/src-tauri/src/commands/skills.rs
@@ -50,8 +50,8 @@ pub async fn uninstall_skill(id: String) -> Result<bool, crate::AppError> {
 /// skills. Used by the post-login onboarding flow; runs on a background thread
 /// since it blocks on the CLI child process.
 /// Spawn the builtin skill bootstrap on a background thread. Extracted so the
-/// thread body can run against a mock handle (the command wrapper itself needs
-/// a real Wry handle).
+/// thread body can run against a mock handle. The command wrapper is generic
+/// over `Runtime` for the same reason.
 fn spawn_builtin_skills<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
     std::thread::spawn(move || skills_bootstrap::run_builtin_skills(&app));
 }
@@ -79,11 +79,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bootstrap_builtin_skills_command_runs_against_a_mock_handle() {
+    async fn bootstrap_builtin_skills_spawns_against_a_mock_handle() {
         let app = tauri::test::mock_builder()
             .plugin(tauri_plugin_shell::init())
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("build mock app");
+        // The command wrapper is generic over Runtime so its body (which just
+        // delegates to spawn_builtin_skills) can run against a mock handle.
         bootstrap_builtin_skills(app.handle().clone()).await;
     }
 


### PR DESCRIPTION
Worker in-flight edits recovered from the main worktree: materialize-fails-on-missing-changeset-table test + bootstrap command wrapper mock test. Goal goal_c86c1a0aa7b8.