### PR TITLE
fix(loop): O1 unknown-kind tolerant ledger reads — skip+warn, hard-fail only structural errors

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1872,6 +1872,7 @@ fn cmd_status(store: &Store, args: &[String]) -> Result<()> {
             .replay(&g)?
             .ok_or_else(|| anyhow::anyhow!("goal {g} not found"))?;
         print_goal_status(&goal);
+        print_ledger_read_note(store, &g);
         return Ok(());
     }
     if store.registry().is_empty() {
@@ -1881,10 +1882,23 @@ fn cmd_status(store: &Store, args: &[String]) -> Result<()> {
     for entry in store.registry() {
         if let Ok(Some(goal)) = store.replay(&entry.goal_id) {
             print_goal_status(&goal);
+            print_ledger_read_note(store, &entry.goal_id);
             println!();
         }
     }
     Ok(())
+}
+
+/// O1: surface the ledger read diagnostics note (unknown-kind lines skipped
+/// because this binary is older than the ledger) below a goal's status.
+fn print_ledger_read_note(store: &Store, goal_id: &str) {
+    if let Some(note) = store.ledger_read_diagnostics(goal_id).and_then(|d| {
+        d.get("note")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string())
+    }) {
+        println!("note      : {note}");
+    }
 }
 
 /// `loop status --format json` — machine-readable projection (goal, todos
@@ -1904,6 +1918,7 @@ fn print_status_json(store: &Store, goal_filter: Option<String>) -> Result<()> {
             "goal_id": goal.goal_id,
             "objective": goal.objective,
             "status": goal.status,
+            "ledger_read_diagnostics": store.ledger_read_diagnostics(&gid),
             "todos": goal.todos.iter().map(|t| serde_json::json!({
                 "id": t.id,
                 "text": t.text,
@@ -3470,15 +3485,23 @@ fn cmd_store(store: &mut Store, args: &[String]) -> Result<()> {
                 return Ok(());
             }
             println!(
-                "ledger {goal_id}: schema={} events={} unique={} idempotent_dups={} legacy_without_id={} conflicts={:?} → {}",
+                "ledger {goal_id}: schema={} events={} unique={} idempotent_dups={} legacy_without_id={} skipped_unknown_kinds={} conflicts={:?} → {}",
                 report.schema_version,
                 report.total_events,
                 report.unique_events,
                 report.idempotent_duplicates,
                 report.legacy_lines_without_id,
+                report.skipped_unknown_kinds,
                 report.conflicts,
                 if report.ok { "ok" } else { "CONFLICT" }
             );
+            if report.skipped_unknown_kinds > 0 {
+                println!(
+                    "note: {} unknown-kind event(s) [{}] skipped by the read path — binary older than ledger, please upgrade",
+                    report.skipped_unknown_kinds,
+                    report.unknown_kinds.join(", ")
+                );
+            }
             println!(
                 "run_index {goal_id}: rows={} files={} missing={} stale={} duplicates={} → {}",
                 drift.index_rows,
@@ -7031,6 +7054,7 @@ fn cmd_diagnose(store: &Store, args: &[String]) -> Result<()> {
             "projection_gap": crate::store::projection_gap(&goal),
             "terminal": goal.terminal_closure().is_some(),
             "runs": goal.history.len(),
+            "ledger_read_diagnostics": store.ledger_read_diagnostics(&goal_id),
             "recent_evidence": goal.history.iter().rev().take(3).map(|r| serde_json::json!({
                 "turn": r.turn, "todo": r.todo_id, "state": r.terminal_state,
                 "tools": r.tools, "cost": r.cost_delta, "evidence": crate::decision::truncate(&r.evidence, 200),
@@ -7062,6 +7086,13 @@ fn cmd_diagnose(store: &Store, args: &[String]) -> Result<()> {
     );
     if let Some(gap) = crate::store::projection_gap(&goal) {
         println!("gap       : {gap}");
+    }
+    if let Some(note) = store.ledger_read_diagnostics(&goal_id).and_then(|d| {
+        d.get("note")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string())
+    }) {
+        println!("note      : {note}");
     }
     for r in goal.history.iter().rev().take(3) {
         println!(

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -26,6 +26,10 @@ const RUNS_FILE: &str = "runs.jsonl";
 const NEXT_ACTION_FILE: &str = "next_action.txt";
 const BACKUPS_DIR: &str = "backups";
 const SCHEMA_FILE: &str = "schema.json";
+/// Per-goal ledger read diagnostics (O1): written when the read path skips
+/// lines carrying event kinds this binary does not know (a newer binary
+/// wrote the ledger). Surfaced by `status` / `diagnose` / `store verify`.
+const READ_DIAGNOSTICS_FILE: &str = "read_diagnostics.json";
 
 // ── Event ledger ───────────────────────────────────────────────────────────
 
@@ -817,6 +821,13 @@ impl Store {
         read_ledger(&dir, &from)
     }
 
+    /// Ledger read diagnostics (O1): the sidecar written by the last ledger
+    /// read when unknown-kind lines were skipped, or `None` when the ledger
+    /// read clean. Surfaced by `status` / `diagnose` / `store verify`.
+    pub fn ledger_read_diagnostics(&self, goal_id: &str) -> Option<serde_json::Value> {
+        read_diagnostics(&self.goal_dir(goal_id))
+    }
+
     /// Verify the ledger for id/conflict integrity (G-3): duplicate event
     /// ids with identical content are counted (idempotent duplicates); a
     /// duplicate id with DIFFERENT content is a conflict (fail closed).
@@ -1072,25 +1083,92 @@ fn append_event_locked(path: PathBuf, line: &str, event_id: &str) -> Result<()> 
     result
 }
 
+/// Classify a [`StoredEvent`] deserialization failure as an unknown `kind`
+/// variant (O1). Relies purely on serde's error text plus a non-empty `kind`
+/// string present in the line — no hand-maintained kind list, so a kind added
+/// by a newer binary is tolerated without shipping a new enum here.
+fn is_unknown_kind_error(value: &serde_json::Value, err: &serde_json::Error) -> Option<String> {
+    let kind = value.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if kind.is_empty() {
+        return None;
+    }
+    err.to_string()
+        .contains("unknown variant")
+        .then(|| kind.to_string())
+}
+
+/// Persist (or clear) the ledger read diagnostics sidecar (O1). Best-effort:
+/// a failed write must never take down the read path. `skipped` holds
+/// (1-based line number, kind) pairs for lines skipped as unknown-kind.
+fn write_read_diagnostics(dir: &Path, skipped: &[(usize, String)]) {
+    let path = dir.join(READ_DIAGNOSTICS_FILE);
+    if skipped.is_empty() {
+        let _ = fs::remove_file(&path);
+        return;
+    }
+    let mut kinds: Vec<&str> = skipped.iter().map(|(_, k)| k.as_str()).collect();
+    kinds.sort_unstable();
+    kinds.dedup();
+    let note = format!(
+        "{} unknown-kind event(s) skipped — binary older than ledger, please upgrade",
+        skipped.len()
+    );
+    let payload = serde_json::json!({
+        "skipped_unknown_kinds": skipped.len(),
+        "skipped_lines": skipped.iter().map(|(l, _)| *l).collect::<Vec<_>>(),
+        "unknown_kinds": kinds,
+        "note": note,
+    });
+    let _ = fs::write(
+        path,
+        serde_json::to_string_pretty(&payload).unwrap_or_default(),
+    );
+}
+
+/// Read the ledger read diagnostics sidecar, if present.
+pub fn read_diagnostics(dir: &Path) -> Option<serde_json::Value> {
+    let text = fs::read_to_string(dir.join(READ_DIAGNOSTICS_FILE)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
 /// Read + parse the ledger, migrating legacy lines in-memory to the current
 /// schema (G-6 read path) and backfilling content-derived ids for lines that
 /// predate G-3. Identical duplicate ids are collapsed to the first occurrence
 /// (idempotent dedupe); conflicting duplicates fail closed.
+///
+/// O1: lines carrying an event `kind` this binary does not know (written by
+/// a newer binary) are SKIPPED with a warning recorded to
+/// [`READ_DIAGNOSTICS_FILE`] instead of hard-failing the whole ledger read;
+/// structural errors (missing fields / wrong types on a known kind) still
+/// fail closed.
 fn read_ledger(dir: &Path, from_schema: &str) -> Result<Vec<StoredEvent>> {
     let path = dir.join(EVENTS_FILE);
     if !path.exists() {
+        write_read_diagnostics(dir, &[]);
         return Ok(vec![]);
     }
     let text = fs::read_to_string(&path).unwrap_or_default();
     let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     let mut out: Vec<StoredEvent> = vec![];
+    let mut skipped: Vec<(usize, String)> = vec![];
     for (line_number, line) in text.lines().filter(|l| !l.trim().is_empty()).enumerate() {
         let mut value: serde_json::Value =
             serde_json::from_str(line).context(format!("parse event line {}", line_number + 1))?;
         crate::migration::migrate_event_line(&mut value, from_schema, EVENT_STORE_SCHEMA_VERSION)
             .context(format!("migrate event line {}", line_number + 1))?;
-        let stored: StoredEvent = serde_json::from_value(value)
-            .context(format!("parse event line {}", line_number + 1))?;
+        let stored: StoredEvent = match serde_json::from_value(value.clone()) {
+            Ok(stored) => stored,
+            Err(err) => {
+                if let Some(kind) = is_unknown_kind_error(&value, &err) {
+                    skipped.push((line_number + 1, kind));
+                    continue;
+                }
+                return Err(anyhow::anyhow!(
+                    "parse event line {}: {err}",
+                    line_number + 1
+                ));
+            }
+        };
         let id = stored.effective_id();
         let fingerprint = event_fingerprint(
             &serde_json::to_value(&stored.event).unwrap_or(serde_json::Value::Null),
@@ -1107,6 +1185,7 @@ fn read_ledger(dir: &Path, from_schema: &str) -> Result<Vec<StoredEvent>> {
         seen.insert(id, fingerprint);
         out.push(stored);
     }
+    write_read_diagnostics(dir, &skipped);
     Ok(out)
 }
 
@@ -1119,6 +1198,10 @@ pub struct LedgerReport {
     pub unique_events: usize,
     pub idempotent_duplicates: usize,
     pub legacy_lines_without_id: usize,
+    /// O1: lines whose `kind` this binary does not know (skipped by the read
+    /// path, kept here so verify surfaces the tolerance surface).
+    pub skipped_unknown_kinds: usize,
+    pub unknown_kinds: Vec<String>,
     pub conflicts: Vec<String>,
     pub ok: bool,
 }
@@ -1135,6 +1218,8 @@ pub fn verify_ledger(dir: &Path, goal_id: &str, schema: &str) -> Result<LedgerRe
             unique_events: 0,
             idempotent_duplicates: 0,
             legacy_lines_without_id: 0,
+            skipped_unknown_kinds: 0,
+            unknown_kinds: vec![],
             conflicts: vec![],
             ok: true,
         });
@@ -1145,12 +1230,23 @@ pub fn verify_ledger(dir: &Path, goal_id: &str, schema: &str) -> Result<LedgerRe
     let mut legacy_lines_without_id = 0usize;
     let mut conflicts: Vec<String> = vec![];
     let mut total = 0usize;
+    let mut skipped_unknown_kinds = 0usize;
+    let mut unknown_kinds: Vec<String> = vec![];
     for line in text.lines().filter(|l| !l.trim().is_empty()) {
         total += 1;
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
             conflicts.push("unparsable line".to_string());
             continue;
         };
+        // O1: count the lines the read path would tolerate-and-skip.
+        if let Err(err) = serde_json::from_value::<StoredEvent>(value.clone()) {
+            if let Some(kind) = is_unknown_kind_error(&value, &err) {
+                skipped_unknown_kinds += 1;
+                if !unknown_kinds.contains(&kind) {
+                    unknown_kinds.push(kind);
+                }
+            }
+        }
         let raw_id = value
             .get("event_id")
             .and_then(|v| v.as_str())
@@ -1176,6 +1272,7 @@ pub fn verify_ledger(dir: &Path, goal_id: &str, schema: &str) -> Result<LedgerRe
         }
     }
     let ok = conflicts.is_empty();
+    unknown_kinds.sort();
     Ok(LedgerReport {
         goal_id: goal_id.to_string(),
         schema_version: schema.to_string(),
@@ -1183,6 +1280,8 @@ pub fn verify_ledger(dir: &Path, goal_id: &str, schema: &str) -> Result<LedgerRe
         unique_events: by_id.len(),
         idempotent_duplicates,
         legacy_lines_without_id,
+        skipped_unknown_kinds,
+        unknown_kinds,
         conflicts,
         ok,
     })

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -784,3 +784,145 @@ fn apply_matrix() {
     assert_eq!(goal.todo("t_preset").unwrap().index, 7);
     assert_eq!(goal.todo("m1").unwrap().status, TodoStatus::Done);
 }
+
+// ── O1: unknown-kind tolerant ledger reads ─────────────────────────────────
+
+/// Kind string of a stored event (the externally-tagged `kind` field).
+fn kind_of(event: &future_loop::store::StoredEvent) -> String {
+    serde_json::to_value(&event.event)
+        .unwrap()
+        .get("kind")
+        .and_then(|k| k.as_str())
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn read_ledger_tolerates_unknown_kind_lines() {
+    let (_d, root) = fresh_store("s-o1-unknown");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1"); // goal_started
+    add(&mut store, "g1", "t1"); // todo_added
+                                 // Clean ledger → no diagnostics sidecar.
+    assert!(store.ledger_read_diagnostics("g1").is_none());
+
+    // A newer binary wrote two lines with a kind this binary does not know,
+    // plus one ordinary known line, after our writes.
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap();
+    for line in [
+        serde_json::json!({"event_id":"u1","kind":"kind_from_the_future_v99","goal_id":"g1","ts":42}),
+        serde_json::json!({"event_id":"u2","kind":"kind_from_the_future_v99","goal_id":"g1","ts":43}),
+        serde_json::json!({"event_id":"e9","kind":"goal_started","goal_id":"g1","ts":1}),
+    ] {
+        writeln!(f, "{line}").unwrap();
+    }
+    drop(f);
+
+    // Unknown-kind lines are skipped; known lines are kept.
+    let events = store.events("g1").unwrap();
+    let kinds: Vec<String> = events.iter().map(kind_of).collect();
+    assert_eq!(kinds, vec!["goal_started", "todo_added", "goal_started"]);
+    assert!(events.iter().all(|e| !e.effective_id().is_empty()));
+
+    // Replay (the status/diagnose read model) still rebuilds from the kept
+    // events and surfaces the skip diagnostics.
+    let goal = store.replay("g1").unwrap().expect("replay succeeds");
+    assert_eq!(goal.todos.len(), 1);
+    let diag = store
+        .ledger_read_diagnostics("g1")
+        .expect("sidecar written");
+    assert_eq!(diag["skipped_unknown_kinds"], 2);
+    assert_eq!(diag["skipped_lines"], serde_json::json!([3, 4]));
+    assert_eq!(
+        diag["unknown_kinds"],
+        serde_json::json!(["kind_from_the_future_v99"])
+    );
+    let note = diag["note"].as_str().unwrap();
+    assert!(note.contains("2 unknown-kind event(s) skipped"), "{note}");
+    assert!(note.contains("please upgrade"), "{note}");
+
+    // store verify surfaces the same tolerance surface.
+    let report = store.verify("g1").unwrap();
+    assert_eq!(report.skipped_unknown_kinds, 2);
+    assert_eq!(report.unknown_kinds, vec!["kind_from_the_future_v99"]);
+    assert!(report.ok);
+}
+
+#[test]
+fn read_ledger_clears_diagnostics_when_ledger_clean_again() {
+    let (_d, root) = fresh_store("s-o1-clear");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap();
+    writeln!(
+        f,
+        "{}",
+        serde_json::json!({"event_id":"u1","kind":"kind_from_the_future_v99","goal_id":"g1","ts":42})
+    )
+    .unwrap();
+    drop(f);
+    assert!(store.ledger_read_diagnostics("g1").is_none());
+    let _ = store.events("g1").unwrap();
+    assert!(store.ledger_read_diagnostics("g1").is_some());
+    // Rewrite the ledger without unknown lines → next read clears the sidecar.
+    std::fs::write(
+        &events_path,
+        format!(
+            "{}\n",
+            serde_json::json!({"kind":"goal_started","goal_id":"g1","ts":1})
+        ),
+    )
+    .unwrap();
+    let events = store.events("g1").unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(store.ledger_read_diagnostics("g1").is_none());
+}
+
+#[test]
+fn read_ledger_still_hard_fails_on_structural_errors() {
+    // Known kind with a missing required field → hard fail (not a skip).
+    let (_d, root) = fresh_store("s-o1-hardfail");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    let events_path = store.goal_dir("g1").join("events.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path)
+        .unwrap();
+    writeln!(
+        f,
+        "{}",
+        serde_json::json!({"event_id":"e1","kind":"todo_added"})
+    )
+    .unwrap();
+    drop(f);
+    let err = store.events("g1").unwrap_err().to_string();
+    assert!(err.contains("parse event line"), "{err}");
+    assert!(!err.contains("skipped"), "{err}");
+
+    // A line with no `kind` at all → hard fail too.
+    let (_d2, root2) = fresh_store("s-o1-nokind");
+    let mut store2 = Store::open(&root2).unwrap();
+    registered_goal(&mut store2, "g2");
+    let events_path2 = store2.goal_dir("g2").join("events.jsonl");
+    let mut f2 = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&events_path2)
+        .unwrap();
+    writeln!(
+        f2,
+        "{}",
+        serde_json::json!({"event_id":"e2","goal_id":"g2","ts":1})
+    )
+    .unwrap();
+    drop(f2);
+    assert!(store2.events("g2").is_err());
+}


### PR DESCRIPTION
Wave 3 自愈 2/5。新二进制写过新事件类型后，旧装机 Future OS CLI — agent gateway for the Future Agent gRPC server (default 127.0.0.1:50051).

Usage:
  future <group> <command> [options] [args...]

Groups:
  init      Install built-in skills and initialize local commands
  auth      Authentication & API key management
  account   Platform account info
  run       Send a prompt to the agent (one-shot, non-interactive)
  skills    Install & manage agent skills
  tools     List, describe, and call platform & browser tools
  models    List available AI models from the agent
  session   List, inspect, rename, and delete agent sessions
  doctor    Environment diagnostic

Apps (run the FutureOS components — same as their standalone binaries):
  agent     Start the agent gRPC server (future-agent)
  tui       Launch the terminal UI (future-tui)
  channel   Start the IM channel bridge (future-channel)
  loop      Loop control plane: goals/todos/gates (future-loop)

Quick start:
  future init                                Initialize Future OS
  future auth login                          Sign in to the Future platform
  future agent                               Start the agent server
  future tui                                 Launch the terminal UI
  future run "Explain this project"          One-shot agent prompt
  future run @README.md "Summarize this"     Include files in prompt
  future skills install-builtin              Install all built-in skills
  future doctor                              Check everything is working

Run 'future <group> --help' for per-group details.
  future init --help         Initialization behavior
  future run --help          All run options (model, fork, thinking, tools, etc.)
  future auth --help         Auth subcommands
  future account --help      Account subcommands
  future skills --help       Skills subcommands
  future tools --help        Tool subcommands
  future models --help       Model listing options
  future session --help      Session management options
  future agent --help        Agent server options (gRPC addr, logging, profiling)
  future tui --help          TUI options (print mode, list models, etc.)
  future loop --help         Loop control plane commands
  future --version           Print version and exit 读该 goal 会  硬失败（本 session 撞 2 次）。

- 逐行解析：kind 非空但未知（前向兼容场景）→ 跳过该行 + 计数，写入 read_diagnostics.json
- 结构错误（缺字段/类型错）仍硬失败
- 单测：未知 kind + 已知 kind 混合，未知跳过/已知保留/计数正确

本地：fmt ✅ clippy ✅ future-loop 75 targets 全绿 ✅。源：claude/loop-wave2 830d967c