### PR TITLE
test(loop,cli): drain wave2 content_ops/change_quality/cdp per-line residual to DA:0 (cov100 ws)

### DIFF
--- a/cli/src/browser/chromium/cdp_connection.rs
+++ b/cli/src/browser/chromium/cdp_connection.rs
@@ -14,8 +14,8 @@ use super::target_registry::{AttachedTarget, SharedTargetRegistry, TargetSession
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use tokio::sync::oneshot;
+use std::sync::{Arc, Mutex, Weak};
+use tokio::sync::{broadcast, oneshot};
 
 // ── Errors ───────────────────────────────────────────────────────────
 
@@ -98,6 +98,35 @@ pub struct CdpConnection {
     connected: AtomicBool,
 }
 
+/// The dispatch loop body, extracted from `connect` so the broadcast
+/// `Lagged`/`Closed` arms can be exercised directly with a small-capacity
+/// channel in tests (a lagged receiver is otherwise only reachable after a
+/// 1024-event burst on a live transport).
+async fn run_dispatch_loop(
+    mut rx: broadcast::Receiver<TransportEvent>,
+    dispatch: Weak<CdpConnection>,
+) {
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                // Upgrade failed → the connection is gone and its
+                // transport's sender dropped with it; the next recv
+                // observes Closed and breaks.
+                if let Some(conn) = dispatch.upgrade() {
+                    match event {
+                        TransportEvent::Message(raw) => conn.handle_message(&raw),
+                        TransportEvent::Close(reason) => conn.handle_close(reason),
+                    }
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            // Every sender is gone (the last connection Arc was dropped):
+            // nothing more can arrive.
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
 impl CdpConnection {
     /// Connect to a CDP WebSocket endpoint and start the dispatch loop.
     pub async fn connect(
@@ -126,28 +155,8 @@ impl CdpConnection {
         // "no subscribers" as fatal (broadcast buffers up to 1024 events
         // until the loop starts polling).
         let dispatch = Arc::downgrade(&conn);
-        let mut rx = conn.transport.subscribe();
-        tokio::spawn(async move {
-            loop {
-                match rx.recv().await {
-                    Ok(event) => {
-                        // Upgrade failed → the connection is gone and its
-                        // transport's sender dropped with it; the next recv
-                        // observes Closed and breaks.
-                        if let Some(conn) = dispatch.upgrade() {
-                            match event {
-                                TransportEvent::Message(raw) => conn.handle_message(&raw),
-                                TransportEvent::Close(reason) => conn.handle_close(reason),
-                            }
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                    // Every sender is gone (the last connection Arc was
-                    // dropped): nothing more can arrive.
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        });
+        let rx = conn.transport.subscribe();
+        tokio::spawn(run_dispatch_loop(rx, dispatch));
 
         Ok(conn)
     }
@@ -938,5 +947,23 @@ mod tests {
         let s = seen.clone();
         assert!(crate::test_env::wait_for(move || s.load(Ordering::SeqCst) > 0).await);
         conn.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_loop_skips_lagged_broadcast_deterministically() {
+        // A small-capacity channel forces the receiver to lag after a burst,
+        // exercising the `Err(Lagged) => continue` arm without the 40k-event
+        // race of the live-transport flood test.
+        let (tx, rx) = broadcast::channel::<TransportEvent>(1);
+        tx.send(TransportEvent::Message("a".into())).unwrap();
+        tx.send(TransportEvent::Message("b".into())).unwrap();
+        tx.send(TransportEvent::Message("c".into())).unwrap();
+        drop(tx);
+        // Dead weak ref: the loop must skip the gap and exit on Closed.
+        let handle = tokio::spawn(run_dispatch_loop(rx, Weak::new()));
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("dispatch loop hung")
+            .expect("dispatch loop panicked");
     }
 }

--- a/orchestration/loop/src/capabilities/change_quality.rs
+++ b/orchestration/loop/src/capabilities/change_quality.rs
@@ -215,10 +215,7 @@ impl ChangeQualityPolicy {
 /// `C:\Users` / `C:/Users`-style drive paths (mirrors explore.rs).
 fn contains_windows_abs_path(text: &str) -> bool {
     let bytes = text.as_bytes();
-    for (index, _) in text.char_indices() {
-        let Some(drive) = text[index..].chars().next() else {
-            continue;
-        };
+    for (index, drive) in text.char_indices() {
         if !drive.is_ascii_alphabetic() {
             continue;
         }
@@ -3105,5 +3102,627 @@ mod tests {
         let proposals = cap.propose("--- a/lib.rs\n+++ b/lib.rs\n");
         assert_eq!(proposals.len(), 1);
         assert_eq!(proposals[0].kind, ProposalKind::Gate);
+    }
+
+    // ── deep per-line coverage: every error arm + defensive branch ────────
+
+    #[test]
+    fn policy_to_value_roundtrips_flags() {
+        let value = ChangeQualityPolicy {
+            enabled: true,
+            safe_fix: true,
+            strict_receipt: true,
+        }
+        .to_value();
+        assert_eq!(
+            value.get("schema_version").and_then(Value::as_str),
+            Some(CHANGE_QUALITY_POLICY_SCHEMA_VERSION)
+        );
+        assert_eq!(value.get("enabled"), Some(&Value::Bool(true)));
+        assert_eq!(value.get("safe_fix"), Some(&Value::Bool(true)));
+        assert_eq!(value.get("strict_receipt"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn capability_metadata_is_nonempty() {
+        assert_eq!(ChangeQualityCapability.name(), "change_quality");
+        assert!(!ChangeQualityCapability.describe().is_empty());
+    }
+
+    #[test]
+    fn bounded_text_accepts_non_string_scalars() {
+        assert_eq!(bounded_text(&serde_json::json!(42), "x", 10).unwrap(), "42");
+        assert_eq!(
+            bounded_text(&serde_json::json!(true), "x", 10).unwrap(),
+            "true"
+        );
+    }
+
+    #[test]
+    fn reject_private_material_rejects_file_and_windows_paths() {
+        assert!(
+            bounded_text(&Value::String("file:///etc/passwd".into()), "x", 100)
+                .unwrap_err()
+                .contains("private")
+        );
+        assert!(
+            bounded_text(&Value::String("C:\\Users\\alice\\s.txt".into()), "x", 100)
+                .unwrap_err()
+                .contains("private")
+        );
+        assert!(
+            bounded_text(&Value::String("C:/Users/alice".into()), "x", 100)
+                .unwrap_err()
+                .contains("private")
+        );
+        // A bare drive letter or a lone "C:" is not an absolute path.
+        assert_eq!(
+            bounded_text(&Value::String("C: drive".into()), "x", 100).unwrap(),
+            "C: drive"
+        );
+        assert_eq!(
+            bounded_text(&Value::String("C".into()), "x", 100).unwrap(),
+            "C"
+        );
+        assert_eq!(
+            bounded_text(&Value::String("C:".into()), "x", 100).unwrap(),
+            "C:"
+        );
+    }
+
+    #[test]
+    fn relative_path_normalizes_and_rejects() {
+        assert_eq!(relative_path(&Value::String("".into()), "x").unwrap(), None);
+        assert!(relative_path(&Value::String("/abs".into()), "x")
+            .unwrap_err()
+            .contains("repo-relative"));
+        assert!(relative_path(&Value::String("a/../b".into()), "x")
+            .unwrap_err()
+            .contains("repo-relative"));
+        assert_eq!(
+            relative_path(&Value::String("src/lib.rs".into()), "x").unwrap(),
+            Some("src/lib.rs".to_string())
+        );
+        assert_eq!(
+            relative_path(&Value::String("src\\lib.rs".into()), "x").unwrap(),
+            Some("src/lib.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_evidence_ref_covers_every_branch() {
+        assert!(
+            normalize_evidence_ref(&Value::String("no-colon".into()), "x")
+                .unwrap_err()
+                .contains("one of")
+        );
+        assert!(
+            normalize_evidence_ref(&Value::String("bogus:target".into()), "x")
+                .unwrap_err()
+                .contains("one of")
+        );
+        assert!(normalize_evidence_ref(&Value::String("path:".into()), "x")
+            .unwrap_err()
+            .contains("non-empty"));
+        assert!(
+            normalize_evidence_ref(&Value::String("validator:".into()), "x")
+                .unwrap_err()
+                .contains("non-empty")
+        );
+        assert_eq!(
+            normalize_evidence_ref(&Value::String("path:src/lib.rs".into()), "x").unwrap(),
+            "path:src/lib.rs"
+        );
+        assert_eq!(
+            normalize_evidence_ref(&Value::String("instruction:CONTRIBUTING.md".into()), "x")
+                .unwrap(),
+            "instruction:CONTRIBUTING.md"
+        );
+        assert_eq!(
+            normalize_evidence_ref(&Value::String("validator:cargo test".into()), "x").unwrap(),
+            "validator:cargo test"
+        );
+    }
+
+    #[test]
+    fn normalize_evidence_refs_rejects_bad_collections() {
+        assert!(
+            normalize_evidence_refs(Some(&Value::String("x".into())), "x")
+                .unwrap_err()
+                .contains("array")
+        );
+        let many: Vec<Value> = (0..21)
+            .map(|i| Value::String(format!("path:p{i}")))
+            .collect();
+        assert!(normalize_evidence_refs(Some(&Value::Array(many)), "x")
+            .unwrap_err()
+            .contains("20"));
+        let dup = vec![
+            Value::String("path:a".into()),
+            Value::String("path:a".into()),
+        ];
+        assert!(normalize_evidence_refs(Some(&Value::Array(dup)), "x")
+            .unwrap_err()
+            .contains("duplicates"));
+    }
+
+    #[test]
+    fn normalize_conclusion_rejects_bad_objects() {
+        assert!(normalize_conclusion(None, "reuse", &REUSE_OUTCOMES)
+            .unwrap_err()
+            .contains("object"));
+        let bad_outcome =
+            serde_json::json!({"outcome": "nope", "summary": "s", "evidence_refs": ["path:a"]});
+        assert!(
+            normalize_conclusion(Some(&bad_outcome), "reuse", &REUSE_OUTCOMES)
+                .unwrap_err()
+                .contains("outcome")
+        );
+        let empty_summary =
+            serde_json::json!({"outcome": "reused", "summary": "", "evidence_refs": ["path:a"]});
+        assert!(
+            normalize_conclusion(Some(&empty_summary), "reuse", &REUSE_OUTCOMES)
+                .unwrap_err()
+                .contains("summary")
+        );
+        let empty_evidence =
+            serde_json::json!({"outcome": "reused", "summary": "s", "evidence_refs": []});
+        assert!(
+            normalize_conclusion(Some(&empty_evidence), "reuse", &REUSE_OUTCOMES)
+                .unwrap_err()
+                .contains("grounded")
+        );
+    }
+
+    #[test]
+    fn normalize_risk_covers_every_error_branch() {
+        assert!(normalize_risk(&Value::String("x".into()), 0)
+            .unwrap_err()
+            .contains("object"));
+        let bad_category = serde_json::json!({"category": "nope", "severity": "warning", "code": "c", "message": "m", "evidence_refs": ["path:a"]});
+        assert!(normalize_risk(&bad_category, 0)
+            .unwrap_err()
+            .contains("category"));
+        let bad_severity = serde_json::json!({"category": "efficiency", "severity": "nope", "code": "c", "message": "m", "evidence_refs": ["path:a"]});
+        assert!(normalize_risk(&bad_severity, 0)
+            .unwrap_err()
+            .contains("severity"));
+        let empty_code = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "", "message": "m", "evidence_refs": ["path:a"]});
+        assert!(normalize_risk(&empty_code, 0)
+            .unwrap_err()
+            .contains("code and message"));
+        let oversize_code = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "x".repeat(81), "message": "m", "evidence_refs": ["path:a"]});
+        assert!(normalize_risk(&oversize_code, 0)
+            .unwrap_err()
+            .contains("exceeds"));
+        let oversize_message = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "x".repeat(321), "evidence_refs": ["path:a"]});
+        assert!(normalize_risk(&oversize_message, 0)
+            .unwrap_err()
+            .contains("exceeds"));
+        let bad_evidence = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": "not-array"});
+        assert!(normalize_risk(&bad_evidence, 0)
+            .unwrap_err()
+            .contains("array"));
+        let empty_evidence = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": []});
+        assert!(normalize_risk(&empty_evidence, 0)
+            .unwrap_err()
+            .contains("grounded"));
+        let zero_line = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": ["path:a"], "line": 0});
+        assert!(normalize_risk(&zero_line, 0)
+            .unwrap_err()
+            .contains("positive"));
+        let string_line = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": ["path:a"], "line": "x"});
+        assert!(normalize_risk(&string_line, 0)
+            .unwrap_err()
+            .contains("positive"));
+        let ok = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": ["path:a"], "path": "a.rs", "line": 3});
+        let risk = normalize_risk(&ok, 0).unwrap();
+        assert_eq!(risk.path.as_deref(), Some("a.rs"));
+        assert_eq!(risk.line, Some(3));
+        assert!(!risk.resolved);
+    }
+
+    #[test]
+    fn normalize_risks_rejects_bad_collections() {
+        assert!(normalize_risks(Some(&Value::String("x".into())))
+            .unwrap_err()
+            .contains("array"));
+        let many: Vec<Value> = (0..21)
+            .map(|i| {
+                serde_json::json!({"category": "efficiency", "severity": "warning", "code": format!("c{i}"), "message": "m", "evidence_refs": ["path:a"]})
+            })
+            .collect();
+        assert!(normalize_risks(Some(&Value::Array(many)))
+            .unwrap_err()
+            .contains("20"));
+    }
+
+    #[test]
+    fn normalize_validation_entry_covers_every_error_branch() {
+        assert!(normalize_validation_entry(&Value::String("x".into()), 0)
+            .unwrap_err()
+            .contains("object"));
+        let bad_status = serde_json::json!({"validator": "v", "status": "nope", "scope": "s"});
+        assert!(normalize_validation_entry(&bad_status, 0)
+            .unwrap_err()
+            .contains("status"));
+        let empty_validator =
+            serde_json::json!({"validator": "", "status": "passed", "scope": "s"});
+        assert!(normalize_validation_entry(&empty_validator, 0)
+            .unwrap_err()
+            .contains("validator and scope"));
+        let failed_no_reason =
+            serde_json::json!({"validator": "v", "status": "failed", "scope": "s"});
+        assert!(normalize_validation_entry(&failed_no_reason, 0)
+            .unwrap_err()
+            .contains("reason"));
+        let skipped_no_reason =
+            serde_json::json!({"validator": "v", "status": "skipped", "scope": "s"});
+        assert!(normalize_validation_entry(&skipped_no_reason, 0)
+            .unwrap_err()
+            .contains("reason"));
+        let ok = serde_json::json!({"validator": "v", "status": "passed", "scope": "s", "required": false, "command": "make test", "reason": "why"});
+        let entry = normalize_validation_entry(&ok, 0).unwrap();
+        assert!(!entry.required);
+        assert_eq!(entry.command.as_deref(), Some("make test"));
+        assert_eq!(entry.reason.as_deref(), Some("why"));
+    }
+
+    #[test]
+    fn normalize_validations_rejects_bad_collections() {
+        assert!(normalize_validations(Some(&Value::String("x".into())))
+            .unwrap_err()
+            .contains("at least one"));
+        assert!(normalize_validations(Some(&Value::Array(vec![])))
+            .unwrap_err()
+            .contains("at least one"));
+        let many: Vec<Value> = (0..21)
+            .map(|i| serde_json::json!({"validator": format!("v{i}"), "status": "passed", "scope": "s"}))
+            .collect();
+        assert!(normalize_validations(Some(&Value::Array(many)))
+            .unwrap_err()
+            .contains("20"));
+    }
+
+    #[test]
+    fn validate_evidence_targets_rejects_malformed_and_unknown() {
+        let changed: BTreeSet<&str> = ["src/lib.rs"].into_iter().collect();
+        let instructions: BTreeSet<&str> = ["CONTRIBUTING.md"].into_iter().collect();
+        let validators: BTreeSet<&str> = ["cargo test"].into_iter().collect();
+        let empty: BTreeSet<&str> = BTreeSet::new();
+        assert!(validate_evidence_targets(
+            &["no-colon".to_string()],
+            "x",
+            &changed,
+            &empty,
+            &empty
+        )
+        .unwrap_err()
+        .contains("malformed"));
+        assert!(validate_evidence_targets(
+            &["bogus:target".to_string()],
+            "x",
+            &changed,
+            &empty,
+            &empty
+        )
+        .unwrap_err()
+        .contains("unknown"));
+        validate_evidence_targets(
+            &["path:src/lib.rs".to_string()],
+            "x",
+            &changed,
+            &empty,
+            &empty,
+        )
+        .unwrap();
+        validate_evidence_targets(
+            &["instruction:CONTRIBUTING.md".to_string()],
+            "x",
+            &changed,
+            &instructions,
+            &empty,
+        )
+        .unwrap();
+        validate_evidence_targets(
+            &["validator:cargo test".to_string()],
+            "x",
+            &changed,
+            &empty,
+            &validators,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn result_normalization_rejects_wrong_schema() {
+        let mut forged = valid_result();
+        forged["schema_version"] = Value::String("wrong".into());
+        let err = normalize_change_quality_result(&forged, "fp_1", false, None, None).unwrap_err();
+        assert!(err.contains("schema_version"), "{err}");
+    }
+
+    #[test]
+    fn result_normalization_propagates_conclusion_errors() {
+        let mut bad = valid_result();
+        bad["reuse"] = serde_json::json!({"outcome": "nope", "summary": "s", "evidence_refs": ["path:src/lib.rs"]});
+        let err = normalize_change_quality_result(
+            &bad,
+            "fp_1",
+            false,
+            Some(&["src/lib.rs".to_string()]),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("reuse.outcome"), "{err}");
+        let mut bad2 = valid_result();
+        bad2["simplification"] = serde_json::json!({"outcome": "nope", "summary": "s", "evidence_refs": ["path:src/lib.rs"]});
+        let err = normalize_change_quality_result(
+            &bad2,
+            "fp_1",
+            false,
+            Some(&["src/lib.rs".to_string()]),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("simplification.outcome"), "{err}");
+    }
+
+    #[test]
+    fn safe_task_name_rejects_empty_and_bad_first_char() {
+        assert!(!safe_task_name(""));
+        assert!(!safe_task_name("-start"));
+        assert!(safe_task_name("ok-test"));
+        assert!(safe_task_name("@scope:test"));
+    }
+
+    #[test]
+    fn source_ref_joins_parts() {
+        assert_eq!(
+            source_ref("pyproject.toml", &["tool", "poe"]),
+            "pyproject.toml#tool.poe"
+        );
+        assert_eq!(source_ref("path", &[]), "path");
+    }
+
+    #[test]
+    fn python_hatch_env_scripts_are_discovered() {
+        let manifests = vec![serde_json::json!({
+            "path": "pyproject.toml",
+            "content": "[tool.hatch.envs.default.scripts]\ntest = \"pytest\"\nformat = \"ruff format\"\n"
+        })];
+        let plan = build_change_quality_validation_plan(&manifests, &[]);
+        let candidates = plan.get("candidates").and_then(Value::as_array).unwrap();
+        let hatch: Vec<&Value> = candidates
+            .iter()
+            .filter(|c| c.get("runner").and_then(Value::as_str) == Some("hatch_script"))
+            .collect();
+        assert_eq!(hatch.len(), 2);
+        let categories: BTreeSet<&str> = hatch
+            .iter()
+            .filter_map(|c| c.get("category").and_then(Value::as_str))
+            .collect();
+        assert_eq!(
+            categories,
+            ["format", "test"].into_iter().collect::<BTreeSet<&str>>()
+        );
+    }
+
+    #[test]
+    fn toml_to_json_maps_every_value_kind() {
+        let parsed: toml::Value = toml::from_str(
+            "int = 3\nfloat = 2.5\nbool = true\narr = [1, 2, 3]\ndate = 1979-05-27T07:32:00Z\nstr = \"x\"\n[table]\nkey = \"v\"\n",
+        )
+        .unwrap();
+        let json = toml_to_json(&parsed);
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("int"), Some(&serde_json::json!(3)));
+        assert_eq!(obj.get("bool"), Some(&serde_json::json!(true)));
+        assert_eq!(obj.get("str"), Some(&serde_json::json!("x")));
+        assert_eq!(obj.get("arr").unwrap().as_array().unwrap().len(), 3);
+        assert_eq!(
+            obj.get("table").unwrap().get("key"),
+            Some(&serde_json::json!("v"))
+        );
+        assert!(obj.get("float").unwrap().is_number());
+        assert!(obj.get("date").unwrap().is_string());
+    }
+
+    #[test]
+    fn read_manifest_reports_root_not_object() {
+        let (payload, warning) = read_manifest("package.json", "[1, 2, 3]");
+        assert!(payload.is_none());
+        assert_eq!(warning, Some("manifest_root_not_object"));
+    }
+
+    #[test]
+    fn validation_plan_handles_missing_and_unreadable_manifests() {
+        let manifests = vec![
+            serde_json::json!({"content": "[tool.poe.tasks]\ntest = \"x\""}),
+            serde_json::json!({"path": "pyproject.toml"}),
+            serde_json::json!({"path": "/abs/pyproject.toml", "content": "[tool.poe.tasks]\ntest = \"x\""}),
+            serde_json::json!({"path": "../pyproject.toml", "content": "[tool.poe.tasks]\ntest = \"x\""}),
+            serde_json::json!({"path": "Makefile", "content": "x"}),
+            serde_json::json!({"path": "pyproject.toml", "content": "not [valid"}),
+        ];
+        let plan = build_change_quality_validation_plan(&manifests, &[]);
+        let warnings = plan
+            .get("discovery_warnings")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(
+            plan.get("candidates")
+                .and_then(Value::as_array)
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn parse_status_maps_unknown_to_skipped() {
+        assert_eq!(parse_status("fail"), VALIDATION_STATUS_FAILED);
+        assert_eq!(parse_status("error"), VALIDATION_STATUS_FAILED);
+        assert_eq!(parse_status("skip"), VALIDATION_STATUS_SKIPPED);
+        assert_eq!(parse_status("pass"), VALIDATION_STATUS_PASSED);
+        assert_eq!(parse_status("ok"), VALIDATION_STATUS_PASSED);
+        assert_eq!(parse_status("unknown"), VALIDATION_STATUS_SKIPPED);
+    }
+
+    #[test]
+    fn classify_parses_exit_code_command_and_unknown_status() {
+        let c = classify_change_input("validator: v\nexit_code: 1\ncommand: make test\n");
+        assert_eq!(c.validators[0].status, "failed");
+        assert_eq!(c.validators[0].command.as_deref(), Some("make test"));
+        let c2 = classify_change_input("validator: v\nstatus: whatever\n");
+        assert_eq!(c2.validators[0].status, "skipped");
+        assert!(!c2.tests_pass && !c2.tests_fail);
+    }
+
+    #[test]
+    fn change_kind_as_str_is_stable() {
+        assert_eq!(ChangeKind::Addition.as_str(), "addition");
+        assert_eq!(ChangeKind::Deletion.as_str(), "deletion");
+        assert_eq!(ChangeKind::Rename.as_str(), "rename");
+        assert_eq!(ChangeKind::Move.as_str(), "move");
+        assert_eq!(ChangeKind::BehaviorChange.as_str(), "behavior_change");
+    }
+
+    #[test]
+    fn classify_fallback_shapes_without_markers() {
+        let deletion = "diff --git a/old.rs b/old.rs\n--- a/old.rs\n+++ b/old.rs\n@@ -1,2 +0,0 @@\n-old line\n-old line2\n";
+        assert_eq!(classify(deletion), vec![ChangeKind::Deletion]);
+        let context = "diff --git a/lib.rs b/lib.rs\n@@ -1,1 +1,1 @@\n context line\n";
+        assert_eq!(classify(context), vec![ChangeKind::BehaviorChange]);
+    }
+
+    #[test]
+    fn looks_like_diff_detects_header_pair() {
+        assert!(looks_like_diff("diff --git a b"));
+        assert!(looks_like_diff("--- a\n"));
+        assert!(looks_like_diff("prose\n@@ -1 +1 @@\n"));
+        assert!(looks_like_diff("header\n+++ b/lib.rs\n--- a/lib.rs\n"));
+        assert!(!looks_like_diff("just prose"));
+    }
+
+    #[test]
+    fn qualification_proposals_require_result_and_fingerprint() {
+        // Missing result → defensive gate (only reachable via direct call).
+        let p =
+            ChangeQualityCapability::qualification_proposals(&serde_json::json!({"goal_id": "g1"}));
+        assert_eq!(p[0].kind, ProposalKind::Gate);
+        assert!(p[0].gate_question.as_deref().unwrap().contains("result"));
+
+        // Result without fingerprint → gate.
+        let p = ChangeQualityCapability::qualification_proposals(
+            &serde_json::json!({"result": valid_result()}),
+        );
+        assert_eq!(p[0].kind, ProposalKind::Gate);
+        assert!(p[0]
+            .gate_question
+            .as_deref()
+            .unwrap()
+            .contains("fingerprint"));
+
+        // Fingerprint via the scope fallback → accepted.
+        let p = ChangeQualityCapability::qualification_proposals(&serde_json::json!({
+            "result": valid_result(),
+            "scope": {"scope_fingerprint": "fp_1", "changed_files": ["src/lib.rs"]}
+        }));
+        assert_eq!(p[0].kind, ProposalKind::SuccessorTodo);
+        assert!(p[0].reason.contains("all guardrails pass"));
+    }
+
+    #[test]
+    fn double_separator_after_drive_is_not_absolute() {
+        assert_eq!(
+            bounded_text(&Value::String("C://foo".into()), "x", 100).unwrap(),
+            "C://foo"
+        );
+    }
+
+    #[test]
+    fn validator_evidence_ref_enforces_its_own_length_limit() {
+        // The first bounded_text (limit 400) passes; only the validator
+        // branch's tighter 160-char limit fails.
+        let long_target = "x".repeat(170);
+        let ref_str = format!("validator:{long_target}");
+        let err = normalize_evidence_ref(&Value::String(ref_str), "x").unwrap_err();
+        assert!(err.contains("exceeds"), "{err}");
+    }
+
+    #[test]
+    fn evidence_ref_and_conclusion_error_arms() {
+        // validator ref with private material → the validator bounded_text ? arm.
+        assert!(
+            normalize_evidence_ref(&Value::String("validator:/Users/secret".into()), "x")
+                .unwrap_err()
+                .contains("private")
+        );
+        // conclusion summary with private material → summary bounded_text ? arm.
+        let private_summary = serde_json::json!({"outcome": "reused", "summary": "/Users/secret", "evidence_refs": ["path:a"]});
+        assert!(
+            normalize_conclusion(Some(&private_summary), "reuse", &REUSE_OUTCOMES)
+                .unwrap_err()
+                .contains("private")
+        );
+        // conclusion evidence_refs not an array → normalize_evidence_refs ? arm.
+        let bad_evidence =
+            serde_json::json!({"outcome": "reused", "summary": "s", "evidence_refs": "not-array"});
+        assert!(
+            normalize_conclusion(Some(&bad_evidence), "reuse", &REUSE_OUTCOMES)
+                .unwrap_err()
+                .contains("array")
+        );
+    }
+
+    #[test]
+    fn risk_and_validation_error_arms() {
+        // risk path must be repo-relative → relative_path ? arm.
+        let bad_path = serde_json::json!({"category": "efficiency", "severity": "warning", "code": "c", "message": "m", "evidence_refs": ["path:a"], "path": "/abs"});
+        assert!(normalize_risk(&bad_path, 0)
+            .unwrap_err()
+            .contains("repo-relative"));
+        // validator with private material → validator bounded_text ? arm.
+        let private_validator =
+            serde_json::json!({"validator": "/Users/x", "status": "passed", "scope": "s"});
+        assert!(normalize_validation_entry(&private_validator, 0)
+            .unwrap_err()
+            .contains("private"));
+        // scope oversize → scope bounded_text ? arm.
+        let oversize_scope =
+            serde_json::json!({"validator": "v", "status": "passed", "scope": "x".repeat(241)});
+        assert!(normalize_validation_entry(&oversize_scope, 0)
+            .unwrap_err()
+            .contains("exceeds"));
+    }
+
+    #[test]
+    fn result_normalization_rejects_unknown_simplification_and_risk_evidence() {
+        let changed: &[String] = &["src/lib.rs".to_string()];
+        // reuse evidence valid, simplification evidence unknown → simplification ? arm.
+        let mut bad_simpl = valid_result();
+        bad_simpl["simplification"] = serde_json::json!({
+            "outcome": "retained",
+            "summary": "kept",
+            "evidence_refs": ["path:unknown_file.rs"],
+            "safe_fix_applied": false
+        });
+        let err = normalize_change_quality_result(&bad_simpl, "fp_1", false, Some(changed), None)
+            .unwrap_err();
+        assert!(err.contains("simplification"), "{err}");
+        // reuse + simplification valid, risk evidence unknown → risk ? arm.
+        let mut bad_risk = valid_result();
+        bad_risk["risks"] = serde_json::json!([{
+            "category": "efficiency",
+            "severity": "warning",
+            "code": "c",
+            "message": "m",
+            "evidence_refs": ["path:unknown_file.rs"]
+        }]);
+        let err = normalize_change_quality_result(&bad_risk, "fp_1", false, Some(changed), None)
+            .unwrap_err();
+        assert!(err.contains("risks[0]"), "{err}");
     }
 }

--- a/orchestration/loop/src/capabilities/content_ops.rs
+++ b/orchestration/loop/src/capabilities/content_ops.rs
@@ -759,16 +759,14 @@ pub struct SurfaceValidation {
 fn raw_material_key_names(groups: &[&[&Value]]) -> Vec<String> {
     let mut names: BTreeSet<String> = BTreeSet::new();
     for group in groups {
-        for record in group.iter() {
-            if let Some(object) = record.as_object() {
-                for key in object.keys() {
-                    let lowered = key.to_lowercase();
-                    if RAW_MATERIAL_KEY_HINTS
-                        .iter()
-                        .any(|hint| lowered.contains(hint))
-                    {
-                        names.insert(key.clone());
-                    }
+        for object in group.iter().filter_map(|record| record.as_object()) {
+            for key in object.keys() {
+                let lowered = key.to_lowercase();
+                if RAW_MATERIAL_KEY_HINTS
+                    .iter()
+                    .any(|hint| lowered.contains(hint))
+                {
+                    names.insert(key.clone());
                 }
             }
         }
@@ -1609,9 +1607,6 @@ impl Capability for ContentOpsCapability {
         let class = classify_content(text);
         let signals = quality_signals(text, class.kind);
         let ops = suggest_operations(&class, &signals);
-        if ops.is_empty() {
-            return vec![TypedProposal::no_followup("no content operation applies")];
-        }
         ops.into_iter()
             .map(|op| match op.role {
                 "user" => TypedProposal::gate(&op.title, op.action_kind),

--- a/orchestration/loop/tests/content_ops_deep_contract.rs
+++ b/orchestration/loop/tests/content_ops_deep_contract.rs
@@ -1,0 +1,889 @@
+//! Deep per-line coverage for the content_ops capability (Wave 2 G2):
+//! every classification lane, quality-signal band, URL-normalization error,
+//! surface-validation rule, projection branch, connector runtime policy,
+//! and the synthetic fixture. Deterministic, host-supplied inputs only.
+
+use future_loop::capabilities::content_ops::{
+    build_content_ops_connector_runtime_policy, build_content_ops_surface_fixture,
+    classify_content, normalize_public_https_url, project_content_ops_surface, quality_signals,
+    suggest_operations, validate_content_ops_surface, ContentKind,
+};
+use future_loop::capabilities::ProposalKind;
+
+// ── classification vocabulary ─────────────────────────────────────────────
+
+#[test]
+fn content_kind_as_str_is_stable() {
+    let kinds = [
+        (ContentKind::Outline, "outline"),
+        (ContentKind::Draft, "draft"),
+        (ContentKind::Feedback, "feedback"),
+        (ContentKind::Url, "url"),
+        (ContentKind::SourceNote, "source_note"),
+        (ContentKind::ConnectorReport, "connector_report"),
+        (ContentKind::Unrecognized, "unrecognized"),
+    ];
+    for (kind, expected) in kinds {
+        assert_eq!(kind.as_str(), expected);
+    }
+}
+
+#[test]
+fn classify_detects_every_shape_marker() {
+    // URL + api path + source attribution + publish intent + list.
+    let class = classify_content(
+        "# Title\nhttps://example.com/api/post\nsource: a post\n- a\n- b\npublish now",
+    );
+    assert_eq!(class.kind, ContentKind::Url);
+    assert!(class.has_url);
+    assert!(class.has_api_path);
+    assert!(class.has_headline);
+    assert!(class.has_list);
+    assert!(class.has_source_attribution);
+    assert!(class.has_publish_marker);
+    assert!(!class.has_feedback_marker);
+    assert!(!class.has_private_signal);
+    assert!(class.word_count > 0);
+}
+
+#[test]
+fn classify_numbered_list_is_a_list() {
+    let class = classify_content("# T\n1. first\n2. second\n3. third");
+    assert!(class.has_list);
+    assert!(class.has_headline);
+    assert_eq!(class.kind, ContentKind::Outline);
+}
+
+#[test]
+fn classify_connector_report_without_api_path() {
+    let class = classify_content("connector report channel_count=3 record_count=9");
+    assert_eq!(class.kind, ContentKind::ConnectorReport);
+}
+
+#[test]
+fn classify_source_note_from_attribution() {
+    let class = classify_content("source: an operator-owned note");
+    assert_eq!(class.kind, ContentKind::SourceNote);
+}
+
+#[test]
+fn classify_unrecognized_for_short_neutral_text() {
+    let class = classify_content("hello world");
+    assert_eq!(class.kind, ContentKind::Unrecognized);
+}
+
+#[test]
+fn classify_private_signal_and_public_https_only() {
+    let class = classify_content("a password and a secret token here");
+    assert!(class.has_private_signal);
+    assert!(!class.has_url);
+}
+
+// ── quality & length signals ─────────────────────────────────────────────
+
+#[test]
+fn quality_length_and_quality_bands() {
+    let short = quality_signals("one two", ContentKind::Draft);
+    assert_eq!(short.length_band(), "short");
+    assert_eq!(short.quality_band(), "weak");
+    let medium_strong = quality_signals(
+        "# Headline\nnext: ship\nsource: https://example.com/a\n- a\n- b\n- c\n\
+         this is a medium length piece of prose that is just long enough to land \
+         in the medium band and it keeps going with more words so that the word \
+         count crosses the sixty word threshold and the score benefits from the \
+         headline list source and call to action",
+        ContentKind::Draft,
+    );
+    assert_eq!(medium_strong.length_band(), "medium");
+    assert_eq!(medium_strong.quality_band(), "strong");
+    let long = quality_signals(&"word ".repeat(1300), ContentKind::Draft);
+    assert_eq!(long.length_band(), "long");
+}
+
+#[test]
+fn quality_score_fit_bands_and_flags() {
+    // 120..=1200 → +15; headline +10; list>=3 +5; source +5; url 1..=2 +2;
+    // call-to-action present → no -5.
+    let text = "# Title\nnext: ship\nsource: ref\n- a\n- b\n- c\nhttps://example.com\n\
+                one two three four five six seven eight nine ten eleven twelve thirteen \
+                fourteen fifteen sixteen seventeen eighteen nineteen twenty";
+    let signals = quality_signals(text, ContentKind::Outline);
+    assert_eq!(signals.headline_chars, Some(5));
+    assert_eq!(signals.list_item_count, 3);
+    assert_eq!(signals.url_count, 1);
+    assert_eq!(signals.source_ref_count, 1);
+    assert!(signals.call_to_action);
+    // 33 words is short (< 60): -10, headline +10, list>=3 +5, source +5,
+    // single url +2, call-to-action present (no penalty).
+    assert_eq!(signals.score, 50 - 10 + 10 + 5 + 5 + 2);
+
+    // Very short + no headline + no call-to-action → penalty and flags.
+    let weak = quality_signals("just a few words here", ContentKind::Draft);
+    assert!(weak.score < 50);
+    assert!(weak.flags.iter().any(|f| f == "too short"));
+    assert!(weak.flags.iter().any(|f| f == "no headline"));
+    assert!(weak.flags.iter().any(|f| f == "no call to action"));
+}
+
+#[test]
+fn quality_private_raw_and_link_heavy_flags() {
+    let text = "# T\nnext: go\npassword secret token\nraw body transcript\n\
+                https://a.com https://b.com https://c.com\nword "
+        .to_string()
+        + &"long ".repeat(80);
+    let signals = quality_signals(&text, ContentKind::Draft);
+    assert!(!signals.private_hits.is_empty());
+    assert!(!signals.raw_key_hits.is_empty());
+    assert!(signals.flags.iter().any(|f| f == "private signal present"));
+    assert!(signals
+        .flags
+        .iter()
+        .any(|f| f == "raw material key present"));
+    assert!(signals.flags.iter().any(|f| f == "link heavy"));
+    assert!(signals.score < 40, "score {}", signals.score);
+    assert_eq!(signals.paragraphs, 1);
+    assert!(signals.lines >= 1);
+    assert!(signals.chars > 0);
+}
+
+#[test]
+fn quality_too_long_flag_and_score_bands() {
+    let mut text = String::new();
+    for _ in 0..2500 {
+        text.push_str("word ");
+    }
+    let signals = quality_signals(&text, ContentKind::Draft);
+    assert!(signals.flags.iter().any(|f| f == "too long"));
+    assert!(signals.words > 2400);
+}
+
+// ── operation suggestions ────────────────────────────────────────────────
+
+fn class_of(
+    input: &str,
+) -> (
+    future_loop::capabilities::content_ops::ContentClass,
+    future_loop::capabilities::content_ops::QualitySignals,
+) {
+    let class = classify_content(input);
+    let signals = quality_signals(input, class.kind);
+    (class, signals)
+}
+
+#[test]
+fn suggest_operations_for_each_kind() {
+    let (url_class, url_sig) = class_of("https://example.com/post");
+    let url_ops = suggest_operations(&url_class, &url_sig);
+    assert!(url_ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_observe_public_handle"));
+
+    let (note_class, note_sig) = class_of("source: an operator-owned note");
+    let note_ops = suggest_operations(&note_class, &note_sig);
+    assert!(note_ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_register_source"));
+
+    let (report_class, report_sig) = class_of("connector report channel_count=3");
+    let report_ops = suggest_operations(&report_class, &report_sig);
+    assert!(report_ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_connector_owner_gate"));
+
+    let (unrec_class, unrec_sig) = class_of("hello world");
+    let unrec_ops = suggest_operations(&unrec_class, &unrec_sig);
+    assert!(unrec_ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_register_source"));
+
+    let (fb_class, fb_sig) = class_of("prefer a shorter angle");
+    let fb_ops = suggest_operations(&fb_class, &fb_sig);
+    assert!(fb_ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_record_feedback"));
+}
+
+#[test]
+fn suggest_draft_submit_vs_revise() {
+    // Strong draft (>= 120 words, headline + source + cta, no list/url so
+    // it stays a Draft): score 80 (>= 70) → submit review.
+    let strong = format!("# T\nnext: go\nsource: r\n{}", vec!["word"; 120].join(" "));
+    let (class, signals) = class_of(&strong);
+    let ops = suggest_operations(&class, &signals);
+    assert!(ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_submit_review"));
+
+    // Weak draft with no flags → "tighten the angle": headline + cta keep
+    // the flag list empty, but no list/source/url keeps the score 65 (< 70).
+    let weak = format!("# T\nnext: go\n{}", vec!["word"; 60].join(" "));
+    let (class, signals) = class_of(&weak);
+    let ops = suggest_operations(&class, &signals);
+    let revise = ops
+        .iter()
+        .find(|op| op.action_kind == "content_ops_revise_draft")
+        .unwrap();
+    assert!(revise.title.contains("tighten the angle"));
+
+    // Weak draft with flags → flag list in title.
+    let flagged = "a draft with a password inside";
+    let (class, signals) = class_of(flagged);
+    let ops = suggest_operations(&class, &signals);
+    assert!(ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_source_boundary"));
+}
+
+#[test]
+fn suggest_private_material_and_publish_gate_combos() {
+    // Private → source boundary first; publish marker without private → publish gate.
+    let (class, signals) = class_of("publish this draft with a password");
+    let ops = suggest_operations(&class, &signals);
+    assert!(ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_source_boundary"));
+    // has_private_signal true → publish gate suppressed.
+    assert!(!ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_publish_gate"));
+
+    let (class, signals) = class_of("publish this great new post for everyone");
+    let ops = suggest_operations(&class, &signals);
+    assert!(ops
+        .iter()
+        .any(|op| op.action_kind == "content_ops_publish_gate"));
+}
+
+// ── public https URL normalization ───────────────────────────────────────
+
+#[test]
+fn normalize_url_accepts_public_https() {
+    assert_eq!(
+        normalize_public_https_url("https://example.com/path").unwrap(),
+        "https://example.com/path"
+    );
+    // Default port and trailing dot are normalized out.
+    assert_eq!(
+        normalize_public_https_url("https://example.com:443/").unwrap(),
+        "https://example.com:443/"
+    );
+    assert_eq!(
+        normalize_public_https_url("https://example.com./x").unwrap(),
+        "https://example.com./x"
+    );
+    // Public IPs (not localish) pass through.
+    assert_eq!(
+        normalize_public_https_url("https://8.8.8.8/").unwrap(),
+        "https://8.8.8.8/"
+    );
+    // Bracketed public IPv6 with the explicit default port reaches the
+    // address-family localish check and passes through.
+    assert_eq!(
+        normalize_public_https_url("https://[2001:db8::1]:443/").unwrap(),
+        "https://[2001:db8::1]:443/"
+    );
+}
+
+#[test]
+fn normalize_url_rejects_non_https() {
+    let err = normalize_public_https_url("http://example.com").unwrap_err();
+    assert!(err.contains("https"), "{err}");
+}
+
+#[test]
+fn normalize_url_rejects_missing_host() {
+    assert!(normalize_public_https_url("https://")
+        .unwrap_err()
+        .contains("host"));
+    assert!(normalize_public_https_url("https://[]/")
+        .unwrap_err()
+        .contains("host"));
+}
+
+#[test]
+fn normalize_url_rejects_credentials_and_query_fragment() {
+    assert!(normalize_public_https_url("https://u:p@example.com/")
+        .unwrap_err()
+        .contains("credentials"));
+    assert!(normalize_public_https_url("https://example.com?x=1")
+        .unwrap_err()
+        .contains("query or fragment"));
+    assert!(normalize_public_https_url("https://example.com#f")
+        .unwrap_err()
+        .contains("query or fragment"));
+    assert!(normalize_public_https_url("https://example.com/p?x=1")
+        .unwrap_err()
+        .contains("query or fragment"));
+    assert!(normalize_public_https_url("https://example.com/p#f")
+        .unwrap_err()
+        .contains("query or fragment"));
+}
+
+#[test]
+fn normalize_url_rejects_non_default_port() {
+    assert!(normalize_public_https_url("https://example.com:8080/")
+        .unwrap_err()
+        .contains("default"));
+}
+
+#[test]
+fn normalize_url_rejects_localhost_and_local_domains() {
+    assert!(normalize_public_https_url("https://localhost/")
+        .unwrap_err()
+        .contains("local"));
+    assert!(normalize_public_https_url("https://x.localhost/")
+        .unwrap_err()
+        .contains("local"));
+    assert!(normalize_public_https_url("https://x.local/")
+        .unwrap_err()
+        .contains("local"));
+}
+
+#[test]
+fn normalize_url_rejects_private_ipv4_and_ipv6() {
+    for host in [
+        "192.168.1.1",     // private
+        "127.0.0.1",       // loopback
+        "169.254.0.1",     // link-local
+        "255.255.255.255", // broadcast
+        "224.0.0.1",       // multicast
+        "0.0.0.0",         // unspecified
+    ] {
+        assert!(
+            normalize_public_https_url(&format!("https://{host}/")).is_err(),
+            "{host} should be rejected"
+        );
+    }
+    for host in [
+        "::1",     // loopback
+        "fe80::1", // link-local
+        "ff02::1", // multicast
+        "::",      // unspecified
+        "fc00::1", // unique-local
+    ] {
+        assert!(
+            normalize_public_https_url(&format!("https://[{host}]/")).is_err(),
+            "{host} should be rejected"
+        );
+    }
+}
+
+// ── state surface validation ─────────────────────────────────────────────
+
+fn fixture() -> serde_json::Value {
+    build_content_ops_surface_fixture("2026-01-01T00:00:00Z")
+}
+
+#[test]
+fn validate_accepts_the_fixture() {
+    let validation = validate_content_ops_surface(&fixture());
+    assert!(validation.ok, "{:?}", validation.errors);
+    assert!(validation.errors.is_empty());
+    assert_eq!(validation.record_counts["source_items"], 2);
+    assert_eq!(validation.record_counts["connector_trials"], 2);
+}
+
+#[test]
+fn validate_requires_schema_version() {
+    let mut s = fixture();
+    s["schema_version"] = serde_json::json!("wrong");
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("schema_version")));
+}
+
+#[test]
+fn validate_requires_each_record_group() {
+    for key in [
+        "source_items",
+        "angle_candidates",
+        "draft_items",
+        "feedback_signals",
+        "publish_gates",
+        "material_memory",
+        "connector_trials",
+    ] {
+        let mut s = fixture();
+        s[key] = serde_json::json!([]);
+        let v = validate_content_ops_surface(&s);
+        assert!(
+            v.errors.iter().any(|e| e.contains("required")),
+            "{key}: {:?}",
+            v.errors
+        );
+    }
+}
+
+#[test]
+fn validate_source_item_contract() {
+    let mut s = fixture();
+    s["source_items"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "source_item_id": "s1",
+        "source_status": "nope",
+        "freshness": "nope",
+        "allowed_use": "nope"
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("source_status")));
+    assert!(v.errors.iter().any(|e| e.contains("freshness")));
+    assert!(v.errors.iter().any(|e| e.contains("allowed_use")));
+}
+
+#[test]
+fn validate_angle_contract() {
+    let mut s = fixture();
+    s["angle_candidates"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "angle_id": "a1",
+        "decision": "nope",
+        "source_item_ids": ["unknown_source"]
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("decision")));
+    assert!(v.errors.iter().any(|e| e.contains("unknown source")));
+}
+
+#[test]
+fn validate_draft_contract() {
+    let mut s = fixture();
+    s["draft_items"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "draft_id": "d1",
+        "state": "nope",
+        "angle_id": "unknown_angle",
+        "publish_gate_id": "unknown_gate"
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("state")));
+    assert!(v.errors.iter().any(|e| e.contains("unknown angle")));
+    assert!(v.errors.iter().any(|e| e.contains("unknown publish gate")));
+
+    // Missing source_map.
+    let mut s2 = fixture();
+    s2["draft_items"] = serde_json::json!([{
+        "schema_version": "draft_item_v0",
+        "draft_id": "d1",
+        "state": "outline",
+        "angle_id": "angle_source_aware_loop",
+        "publish_gate_id": "publish_gate_source_aware_loop"
+    }]);
+    let v2 = validate_content_ops_surface(&s2);
+    assert!(v2.errors.iter().any(|e| e.contains("source_map")));
+
+    // source_map references unknown source.
+    let mut s3 = fixture();
+    s3["draft_items"][0]["source_map"] = serde_json::json!([{"source_item_id": "nope"}]);
+    let v3 = validate_content_ops_surface(&s3);
+    assert!(v3.errors.iter().any(|e| e.contains("unknown source")));
+
+    // source_map is not an array.
+    let mut s4 = fixture();
+    s4["draft_items"][0]["source_map"] = serde_json::json!("not-array");
+    let v4 = validate_content_ops_surface(&s4);
+    assert!(v4.errors.iter().any(|e| e.contains("source_map")));
+}
+
+#[test]
+fn validate_feedback_contract() {
+    let mut s = fixture();
+    s["feedback_signals"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "feedback_id": "f1",
+        "effect": "nope",
+        "target_id": "unknown"
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("effect")));
+    assert!(v.errors.iter().any(|e| e.contains("unknown target")));
+}
+
+#[test]
+fn validate_publish_gate_contract() {
+    let mut s = fixture();
+    s["publish_gates"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "gate_id": "g1",
+        "status": "nope",
+        "autopublish_allowed": true,
+        "approval_required": false
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("status")));
+    assert!(v.errors.iter().any(|e| e.contains("autopublish_allowed")));
+    assert!(v.errors.iter().any(|e| e.contains("approval")));
+}
+
+#[test]
+fn validate_material_memory_contract() {
+    let mut s = fixture();
+    s["material_memory"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "memory_id": "m1",
+        "source_item_id": "unknown"
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("unknown source")));
+}
+
+#[test]
+fn validate_connector_trial_contract() {
+    let mut s = fixture();
+    s["connector_trials"] = serde_json::json!([{
+        "schema_version": "wrong",
+        "trial_id": "t1",
+        "source_status": "nope",
+        "freshness": "nope",
+        "allowed_use": "nope",
+        "trial_state": "nope",
+        "access_mode": "nope",
+        "external_write_allowed": true
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("wrong schema")));
+    assert!(v.errors.iter().any(|e| e.contains("source_status")));
+    assert!(v.errors.iter().any(|e| e.contains("freshness")));
+    assert!(v.errors.iter().any(|e| e.contains("allowed_use")));
+    assert!(v.errors.iter().any(|e| e.contains("trial_state")));
+    assert!(v.errors.iter().any(|e| e.contains("access_mode")));
+    assert!(v
+        .errors
+        .iter()
+        .any(|e| e.contains("external_write_allowed")));
+
+    // private_metadata_only requires requires_user_gate=true.
+    let mut s2 = fixture();
+    s2["connector_trials"] = serde_json::json!([{
+        "schema_version": "connector_trial_v0",
+        "trial_id": "t1",
+        "access_mode": "private_metadata_only",
+        "source_status": "public",
+        "freshness": "fresh",
+        "allowed_use": "metadata_only",
+        "trial_state": "candidate",
+        "external_write_allowed": false,
+        "requires_user_gate": false
+    }]);
+    let v2 = validate_content_ops_surface(&s2);
+    assert!(v2
+        .errors
+        .iter()
+        .any(|e| e.contains("gate private metadata")));
+}
+
+#[test]
+fn validate_boundary_flags_are_required() {
+    let mut s = fixture();
+    s["boundary"] = serde_json::json!("nope");
+    let v = validate_content_ops_surface(&s);
+    assert!(v
+        .errors
+        .iter()
+        .any(|e| e.contains("boundary flags are required")));
+
+    let mut s2 = fixture();
+    s2.as_object_mut().unwrap().remove("boundary");
+    let v2 = validate_content_ops_surface(&s2);
+    assert!(v2
+        .errors
+        .iter()
+        .any(|e| e.contains("boundary flags are required")));
+
+    let mut s3 = fixture();
+    s3["boundary"] = serde_json::json!({
+        "public_safe": false,
+        "raw_private_material_recorded": true,
+        "raw_platform_data_recorded": true,
+        "credentials_recorded": true,
+        "autopublish_allowed": true,
+        "publish_requires_user_gate": false,
+        "connector_bodies_are_source_of_truth": true
+    });
+    let v3 = validate_content_ops_surface(&s3);
+    assert!(v3.errors.iter().any(|e| e.contains("public_safe")));
+    assert!(v3
+        .errors
+        .iter()
+        .any(|e| e.contains("raw_private_material_recorded")));
+    assert!(v3
+        .errors
+        .iter()
+        .any(|e| e.contains("raw_platform_data_recorded")));
+    assert!(v3.errors.iter().any(|e| e.contains("credentials_recorded")));
+    assert!(v3.errors.iter().any(|e| e.contains("autopublish_allowed")));
+    assert!(v3
+        .errors
+        .iter()
+        .any(|e| e.contains("publish_requires_user_gate")));
+    assert!(v3
+        .errors
+        .iter()
+        .any(|e| e.contains("connector_bodies_are_source_of_truth")));
+}
+
+#[test]
+fn validate_rejects_raw_material_key_names() {
+    let mut s = fixture();
+    s["source_items"][0]["raw_transcript"] = serde_json::json!("private");
+    let v = validate_content_ops_surface(&s);
+    assert!(v
+        .errors
+        .iter()
+        .any(|e| e.contains("raw/private-looking key names")));
+    assert!(v
+        .raw_material_key_names
+        .contains(&"raw_transcript".to_string()));
+}
+
+// ── state surface projection ─────────────────────────────────────────────
+
+#[test]
+fn project_fixture_produces_first_screen() {
+    let projection = project_content_ops_surface(&fixture());
+    assert_eq!(
+        projection.surface_id.as_deref(),
+        Some("creator_ops_public_safe_demo")
+    );
+    assert!(projection.first_screen.user_action_required);
+    assert!(projection.first_screen.safe_side_work_available);
+    assert!(projection.first_screen.agent_can_continue);
+    assert_eq!(projection.first_screen.waiting_on, "user");
+    assert_eq!(projection.first_screen.source_review_required_count, 1);
+    assert_eq!(projection.first_screen.ready_to_draft_count, 1);
+    assert_eq!(projection.first_screen.waiting_for_feedback_count, 1);
+    assert_eq!(projection.first_screen.publish_decision_count, 1);
+    // Counters present.
+    assert_eq!(projection.source_statuses["synthetic_public_safe"], 1);
+    assert_eq!(projection.source_statuses["private_needs_review"], 1);
+    assert_eq!(projection.draft_states["outline"], 1);
+    assert_eq!(projection.feedback_effects["preference_hint"], 1);
+    assert_eq!(
+        projection.publish_gate_statuses["blocked_until_user_approval"],
+        1
+    );
+    assert_eq!(
+        projection.connector_trial_state_counts["metadata_packet_collected"],
+        1
+    );
+    // Gated connector trial → owner gate candidate.
+    assert!(projection
+        .todo_candidates
+        .iter()
+        .any(|c| c.action_kind == "content_ops_connector_owner_gate"));
+}
+
+#[test]
+fn project_ready_angle_routes_to_agent_draft() {
+    let mut s = fixture();
+    s["publish_gates"] = serde_json::json!([]);
+    let projection = project_content_ops_surface(&s);
+    assert!(!projection.first_screen.user_action_required);
+    assert_eq!(projection.first_screen.waiting_on, "agent");
+    assert!(projection
+        .todo_candidates
+        .iter()
+        .any(|c| c.action_kind == "content_ops_draft_from_angle"));
+}
+
+#[test]
+fn project_source_review_routes_to_operator() {
+    let mut s = fixture();
+    s["publish_gates"] = serde_json::json!([]);
+    // No draft-ready angle.
+    s["angle_candidates"][0]["decision"] = serde_json::json!("hold");
+    s["angle_candidates"][1]["decision"] = serde_json::json!("reject");
+    let projection = project_content_ops_surface(&s);
+    assert_eq!(projection.first_screen.waiting_on, "operator");
+    assert!(projection
+        .todo_candidates
+        .iter()
+        .any(|c| c.action_kind == "content_ops_source_review"));
+}
+
+#[test]
+fn project_fallback_routes_to_collect_more() {
+    let mut s = fixture();
+    s["publish_gates"] = serde_json::json!([]);
+    s["angle_candidates"][0]["decision"] = serde_json::json!("hold");
+    s["angle_candidates"][1]["decision"] = serde_json::json!("reject");
+    // Remove private sources so no source review is required either.
+    s["source_items"] = serde_json::json!([{
+        "schema_version": "source_item_v0",
+        "source_item_id": "s1",
+        "source_status": "public",
+        "freshness": "fresh",
+        "allowed_use": "summarize_and_transform"
+    }]);
+    let projection = project_content_ops_surface(&s);
+    assert_eq!(projection.first_screen.waiting_on, "agent");
+    assert_eq!(
+        projection.first_screen.next_safe_action,
+        "collect more compact source signals"
+    );
+}
+
+#[test]
+fn project_runnable_connector_trial() {
+    let mut s = fixture();
+    s["connector_trials"] = serde_json::json!([{
+        "schema_version": "connector_trial_v0",
+        "trial_id": "t1",
+        "access_mode": "public_metadata_only",
+        "source_status": "public",
+        "freshness": "fresh",
+        "allowed_use": "metadata_only",
+        "trial_state": "ready_for_metadata_trial",
+        "external_write_allowed": false
+    }]);
+    let projection = project_content_ops_surface(&s);
+    assert!(projection
+        .todo_candidates
+        .iter()
+        .any(|c| c.action_kind == "content_ops_connector_metadata_trial"));
+}
+
+// ── synthetic fixture + connector runtime policy ──────────────────────────
+
+#[test]
+fn fixture_shape_is_complete() {
+    let value = build_content_ops_surface_fixture("2026-01-01T00:00:00Z");
+    assert_eq!(
+        value
+            .get("schema_version")
+            .and_then(serde_json::Value::as_str),
+        Some("content_ops_surface_v0")
+    );
+    assert_eq!(
+        value.get("surface_id").and_then(serde_json::Value::as_str),
+        Some("creator_ops_public_safe_demo")
+    );
+    assert!(value.get("boundary").is_some());
+}
+
+#[test]
+fn connector_runtime_policy_rejects_unknown_mode() {
+    let err = build_content_ops_connector_runtime_policy("nope", "id", "name", None).unwrap_err();
+    assert!(err.contains("access_mode"), "{err}");
+}
+
+#[test]
+fn connector_runtime_policy_for_each_mode() {
+    let public =
+        build_content_ops_connector_runtime_policy("public_metadata_only", "id", "name", None)
+            .unwrap();
+    assert_eq!(
+        public
+            .get("safe_default")
+            .and_then(serde_json::Value::as_str),
+        Some("head_only_metadata_probe")
+    );
+    assert_eq!(
+        public
+            .get("allowed_probe_methods")
+            .and_then(serde_json::Value::as_array)
+            .unwrap(),
+        &[serde_json::json!("HEAD")]
+    );
+
+    let private = build_content_ops_connector_runtime_policy(
+        "private_metadata_only",
+        "id",
+        "name",
+        Some("https://x.example/"),
+    )
+    .unwrap();
+    assert_eq!(
+        private
+            .get("safe_default")
+            .and_then(serde_json::Value::as_str),
+        Some("gate_projection_only")
+    );
+    assert_eq!(
+        private
+            .get("connector_url")
+            .and_then(serde_json::Value::as_str),
+        Some("https://x.example/")
+    );
+
+    let fixture_only =
+        build_content_ops_connector_runtime_policy("synthetic_fixture_only", "id", "name", None)
+            .unwrap();
+    assert_eq!(
+        fixture_only
+            .get("safe_default")
+            .and_then(serde_json::Value::as_str),
+        Some("fixture_only")
+    );
+}
+
+// ── capability entry point ───────────────────────────────────────────────
+
+#[test]
+fn propose_valid_json_surface_is_clean() {
+    let cap = future_loop::capabilities::CapabilityRegistry::with_builtin();
+    let proposals = cap
+        .get("content_ops")
+        .unwrap()
+        .propose(&build_content_ops_surface_fixture("2026-01-01").to_string());
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0].kind, ProposalKind::NoFollowUp);
+    assert!(proposals[0]
+        .reason
+        .contains("content-ops surface validated clean"));
+}
+
+#[test]
+fn propose_unrecognized_free_text_registers_source() {
+    let cap = future_loop::capabilities::CapabilityRegistry::with_builtin();
+    let proposals = cap.get("content_ops").unwrap().propose("just a thought");
+    assert!(proposals.iter().any(
+        |p| p.kind == ProposalKind::SuccessorTodo && p.reason == "content_ops_register_source"
+    ));
+}
+
+#[test]
+fn quality_band_needs_work_middle_band() {
+    let text = format!("# T\nnext: go\n{}", vec!["word"; 60].join(" "));
+    let signals = quality_signals(&text, ContentKind::Draft);
+    assert_eq!(signals.score, 65);
+    assert_eq!(signals.quality_band(), "needs_work");
+}
+
+#[test]
+fn quality_numbered_list_is_counted() {
+    let text = "# T\n1. first\n2. second\n3. third";
+    let signals = quality_signals(text, ContentKind::Outline);
+    assert_eq!(signals.list_item_count, 3);
+}
+
+#[test]
+fn validate_compacts_empty_and_oversize_ids() {
+    // Empty/whitespace id compacts to None (id: None in the error).
+    let mut s = fixture();
+    s["source_items"] = serde_json::json!([{
+        "schema_version": "source_item_v0",
+        "source_item_id": "   ",
+        "source_status": "nope",
+        "freshness": "fresh",
+        "allowed_use": "summarize_and_transform"
+    }]);
+    let v = validate_content_ops_surface(&s);
+    assert!(v.errors.iter().any(|e| e.contains("None")));
+
+    // Oversize id is truncated with an ellipsis.
+    let mut s2 = fixture();
+    s2["source_items"] = serde_json::json!([{
+        "schema_version": "source_item_v0",
+        "source_item_id": "x".repeat(130),
+        "source_status": "nope",
+        "freshness": "fresh",
+        "allowed_use": "summarize_and_transform"
+    }]);
+    let v2 = validate_content_ops_surface(&s2);
+    assert!(v2.errors.iter().any(|e| e.contains("...")));
+}


### PR DESCRIPTION
## Summary

Final per-line coverage drain for the workspace six crates (口径 A: lcov DA:0 = 0).

- **loop**: `content_ops.rs` (662→0) and `change_quality.rs` (134→0) — Wave 2 deep-implementation residual lines, covered by a new 889-line integration test (`content_ops_deep_contract.rs`) plus inline error-arm tests in `change_quality.rs`.
- **cli**: `cdp_connection.rs` (1→0) — the broadcast `Lagged` dispatch-loop arm, made deterministically testable by extracting `run_dispatch_loop` and exercising a small-capacity channel.

### Refactors (semantics-preserving, per goal allowance)
- `content_ops.rs`: `raw_material_key_names` if-let → `filter_map` (eliminates an if-let ghost `}`); removed the provably-unreachable `if ops.is_empty()` arm (every `ContentKind` arm pushes an op).
- `change_quality.rs`: `contains_windows_abs_path` loop uses the `char_indices()` char directly instead of a `let Some(drive) else { continue }` that is never `None`.
- `cdp_connection.rs`: extracted the dispatch loop body into `run_dispatch_loop` so the `Lagged`/`Closed` arms can be hit directly.

## Verification
- `CARGO_TARGET_DIR=target/final-cov cargo llvm-cov --workspace --no-report` + `report --lcov` → **TOTAL DA:0 = 0** across 243 source files (six workspace crates).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt` applied.
- Canary smoke (`canary_contract`/`canary_drive`) green.