### PR TITLE
test(desktop): cover lib.rs shell loops + emit arms, generic menu/quit, sidecar spawn (cov100 shell)

### DIFF
--- a/desktop/src-tauri/src/agent_supervisor.rs
+++ b/desktop/src-tauri/src/agent_supervisor.rs
@@ -212,7 +212,7 @@ pub fn on_close_requested() -> QuitDecision {
 /// bundled sidecar or an externally-managed one), then kill the sidecar if we own
 /// it, then exit. On cancel: clear the in-progress flag so a later close prompts
 /// again.
-pub fn confirm_quit(app: AppHandle) {
+pub fn confirm_quit<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
     QUIT_DIALOG_OPEN.store(true, Ordering::SeqCst);
     // Read at prompt time so the count/list reflects the moment the user is
     // asked, not when the close was first requested.
@@ -244,36 +244,49 @@ pub fn confirm_quit(app: AppHandle) {
         }
         // Commit to quitting before any close can be re-requested.
         QUIT_CONFIRMED.store(true, Ordering::SeqCst);
-        // Abort each running session best-effort — an unreachable agent or a
-        // session that finished in the meantime is a harmless no-op.
-        tauri::async_runtime::block_on(async {
-            // Abort all sessions in parallel, then wait for all to go idle.
-            // Sequential waits would make force-quit take 3s per session;
-            // concurrent gRPC calls over the shared channel complete together.
-            let abort_futs: Vec<_> = sessions
-                .iter()
-                .map(|session| async move {
-                    if let Err(error) = crate::agent_bridge::abort_session(session).await {
-                        eprintln!("FutureOS: failed to abort session {session} on quit: {error}");
-                    }
-                })
-                .collect();
-            futures::future::join_all(abort_futs).await;
-            // Give the agent a moment for its abort to settle before the process
-            // exits or kills the sidecar. Without this the agent's LLM stream is
-            // torn down while it's still processing the abort interrupt, leaving a
-            // "LLM stream ended without a terminal signal" WARN in the agent log.
-            // Best-effort: an unreachable agent returns immediately.
-            let wait_futs: Vec<_> = sessions
-                .iter()
-                .map(|session| crate::agent_bridge::wait_for_agent_idle(session))
-                .collect();
-            futures::future::join_all(wait_futs).await;
-        });
-        // Kill the bundled sidecar if we own it (no-op for an external agent).
-        shutdown_agent();
-        callback_app.exit(0);
+        confirmed_quit_flow(&callback_app, &sessions, || callback_app.exit(0));
     });
+}
+
+/// Body of the force-quit confirmation: abort every running session, wait for
+/// idle, kill the bundled sidecar, then exit. Extracted so the flow is testable
+/// with a mock handle and an injectable exit (a real `exit(0)` ends the test
+/// process).
+fn confirmed_quit_flow<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    sessions: &[String],
+    exit: impl FnOnce(),
+) {
+    // Abort each running session best-effort — an unreachable agent or a
+    // session that finished in the meantime is a harmless no-op.
+    tauri::async_runtime::block_on(async {
+        // Abort all sessions in parallel, then wait for all to go idle.
+        // Sequential waits would make force-quit take 3s per session;
+        // concurrent gRPC calls over the shared channel complete together.
+        let abort_futs: Vec<_> = sessions
+            .iter()
+            .map(|session| async move {
+                if let Err(error) = crate::agent_bridge::abort_session(session).await {
+                    eprintln!("FutureOS: failed to abort session {session} on quit: {error}");
+                }
+            })
+            .collect();
+        futures::future::join_all(abort_futs).await;
+        // Give the agent a moment for its abort to settle before the process
+        // exits or kills the sidecar. Without this the agent's LLM stream is
+        // torn down while it's still processing the abort interrupt, leaving a
+        // "LLM stream ended without a terminal signal" WARN in the agent log.
+        // Best-effort: an unreachable agent returns immediately.
+        let wait_futs: Vec<_> = sessions
+            .iter()
+            .map(|session| crate::agent_bridge::wait_for_agent_idle(session))
+            .collect();
+        futures::future::join_all(wait_futs).await;
+    });
+    let _ = app;
+    // Kill the bundled sidecar if we own it (no-op for an external agent).
+    shutdown_agent();
+    exit();
 }
 
 /// Body of the force-quit confirmation, singular/plural by running-conversation
@@ -349,6 +362,89 @@ mod tests {
         // `AGENT_CHILD` is `None` by default in tests (no real sidecar spawn),
         // so this exercises the idempotent no-op path.
         shutdown_agent();
+    }
+
+    #[test]
+    fn confirmed_quit_flow_aborts_waits_and_exits() {
+        let _lock = crate::commands::agent_mock::mock_agent_lock();
+        crate::commands::agent_mock::ensure_mock_agent();
+        crate::commands::agent_mock::script_mock_agent(Default::default());
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let mut exited = false;
+        confirmed_quit_flow(app.handle(), &["sess-quit".to_string()], || exited = true);
+        assert!(exited);
+        crate::commands::agent_mock::script_mock_agent(Default::default());
+    }
+
+    #[test]
+    fn confirm_quit_builds_the_dialog_against_a_mock_handle() {
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .plugin(tauri_plugin_dialog::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        confirm_quit(app.handle().clone());
+    }
+
+    #[test]
+    fn spawn_bundled_agent_spawns_an_executable_sidecar() {
+        let _lock = crate::commands::agent_mock::mock_agent_lock();
+        // Install a real executable placeholder so the sidecar spawn succeeds —
+        // the default placeholder is an empty non-executable file (spawn Err).
+        let triple = std::env::var("CARGO_BUILD_TARGET")
+            .ok()
+            .or_else(|| {
+                Some(format!(
+                    "{}-{}",
+                    std::env::consts::ARCH,
+                    if cfg!(target_os = "macos") {
+                        "apple-darwin"
+                    } else {
+                        "unknown-linux-gnu"
+                    }
+                ))
+            })
+            .unwrap();
+        let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("binaries");
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join(format!("future-{triple}"));
+        let was_placeholder = !std::fs::metadata(&bin)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false);
+        std::fs::write(&bin, "#!/bin/sh\nsleep 30\n").unwrap();
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bin, perms).unwrap();
+
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        spawn_bundled_agent(app.handle(), "127.0.0.1:59999");
+        // Give the spawn a moment to start the child, then kill it via the
+        // ownership path (covers the shutdown kill-Ok arm too).
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        shutdown_agent();
+
+        // Restore the empty placeholder for other tests / CI builds.
+        if was_placeholder {
+            std::fs::write(&bin, b"").unwrap();
+        }
+    }
+
+    #[test]
+    fn spawn_bundled_agent_logs_spawn_failure_for_a_non_executable_sidecar() {
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_shell::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        // The default placeholder is empty/non-executable → spawn fails and the
+        // error arm logs without panicking.
+        spawn_bundled_agent(app.handle(), "127.0.0.1:59998");
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent_supervisor.rs
+++ b/desktop/src-tauri/src/agent_supervisor.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
-use tauri::{AppHandle, Manager};
+use tauri::Manager;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
@@ -366,6 +366,8 @@ mod tests {
 
     #[test]
     fn confirmed_quit_flow_aborts_waits_and_exits() {
+        let _home = crate::auth_store::test_support::HomeGuard::new("agent-supervisor-quit-flow");
+        crate::store::initialize_app_store().unwrap();
         let _lock = crate::commands::agent_mock::mock_agent_lock();
         crate::commands::agent_mock::ensure_mock_agent();
         crate::commands::agent_mock::script_mock_agent(Default::default());
@@ -381,6 +383,8 @@ mod tests {
 
     #[test]
     fn confirm_quit_builds_the_dialog_against_a_mock_handle() {
+        let _home = crate::auth_store::test_support::HomeGuard::new("agent-supervisor-quit-dialog");
+        crate::store::initialize_app_store().unwrap();
         let app = tauri::test::mock_builder()
             .plugin(tauri_plugin_shell::init())
             .plugin(tauri_plugin_dialog::init())

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -56,15 +56,29 @@ fn size_main_window_to_screen<R: tauri::Runtime>(app: &tauri::App<R>) {
     let Ok(Some(monitor)) = window.current_monitor() else {
         return;
     };
-    let scale = monitor.scale_factor();
-    let area = monitor.work_area();
-    let (width, height, x, y) = main_window_geometry(
-        scale,
-        area.size.width as f64,
-        area.size.height as f64,
-        area.position.x as f64,
-        area.position.y as f64,
+    apply_main_window_geometry(
+        &window,
+        monitor.scale_factor(),
+        monitor.work_area().size.width as f64,
+        monitor.work_area().size.height as f64,
+        monitor.work_area().position.x as f64,
+        monitor.work_area().position.y as f64,
     );
+}
+
+/// Size + position the window from a monitor's scale factor and work area.
+/// Extracted so the geometry application is testable with a mock window (the
+/// monitor lookup itself needs a real display server).
+fn apply_main_window_geometry<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    scale: f64,
+    area_width: f64,
+    area_height: f64,
+    area_x: f64,
+    area_y: f64,
+) {
+    let (width, height, x, y) =
+        main_window_geometry(scale, area_width, area_height, area_x, area_y);
     let _ = window.set_size(tauri::LogicalSize::new(width, height));
     // Center horizontally; sit a bit above vertical center (smaller top gap).
     let _ = window.set_position(tauri::LogicalPosition::new(x, y));
@@ -231,7 +245,17 @@ fn icon_ico_bytes() -> &'static [u8] {
 /// Notify the frontend that a Thread's "last-run changes" changeset has updated. The
 /// frontend bridges this to its typed event bus (§6.1, C1).
 pub(crate) fn emit_review_updated(thread_id: &str) {
-    if let Some(handle) = APP_HANDLE.get() {
+    emit_review_updated_via(APP_HANDLE.get(), thread_id);
+}
+
+/// Route an emit through an optional handle (see [`emit_review_updated_on`]).
+/// Extracted so the process-global `APP_HANDLE` Some/None arms are testable
+/// with a mock handle.
+fn emit_review_updated_via<R: tauri::Runtime>(
+    handle: Option<&tauri::AppHandle<R>>,
+    thread_id: &str,
+) {
+    if let Some(handle) = handle {
         emit_review_updated_on(handle, thread_id);
     }
 }
@@ -247,7 +271,15 @@ fn emit_review_updated_on<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, threa
 /// Notify the frontend that a remote (phone) client created/drove a thread, so
 /// the thread list + runs refresh and the conversation shows up live.
 pub(crate) fn emit_remote_activity(thread_id: &str) {
-    if let Some(handle) = APP_HANDLE.get() {
+    emit_remote_activity_via(APP_HANDLE.get(), thread_id);
+}
+
+/// Route an emit through an optional handle (see [`emit_remote_activity_on`]).
+fn emit_remote_activity_via<R: tauri::Runtime>(
+    handle: Option<&tauri::AppHandle<R>>,
+    thread_id: &str,
+) {
+    if let Some(handle) = handle {
         emit_remote_activity_on(handle, thread_id);
     }
 }
@@ -345,28 +377,7 @@ pub(crate) fn emit_thread_runtime_updated(
         let (tx, rx) = std::sync::mpsc::channel::<ThreadRuntimeUpdate>();
         std::thread::Builder::new()
             .name("thread-runtime-updates".to_string())
-            .spawn(move || {
-                use std::time::{Duration, Instant};
-
-                while let Ok(first) = rx.recv() {
-                    let deadline = Instant::now() + Duration::from_millis(40);
-                    let mut rest = Vec::new();
-                    loop {
-                        let remaining = deadline.saturating_duration_since(Instant::now());
-                        if remaining.is_zero() {
-                            break;
-                        }
-                        match rx.recv_timeout(remaining) {
-                            Ok(next) => rest.push(next),
-                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
-                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
-                        }
-                    }
-                    if let Some(handle) = APP_HANDLE.get() {
-                        emit_runtime_updates_on(handle, coalesce_runtime_updates(first, rest));
-                    }
-                }
-            })
+            .spawn(|| runtime_update_drain_loop(rx))
             .expect("spawn thread runtime update emitter");
         tx
     });
@@ -400,10 +411,18 @@ struct ThreadStreamingUpdate {
 /// the 40ms coalescing channel — the composer card and the sidebar badge
 /// react as soon as the write lands, and polling is only a backstop.
 pub(crate) fn emit_approvals_updated(thread_id: &str, approval_request_id: &str) {
-    let Some(handle) = APP_HANDLE.get() else {
-        return;
-    };
-    emit_approvals_updated_on(handle, thread_id, approval_request_id);
+    emit_approvals_updated_via(APP_HANDLE.get(), thread_id, approval_request_id);
+}
+
+/// Route an emit through an optional handle (see [`emit_approvals_updated_on`]).
+fn emit_approvals_updated_via<R: tauri::Runtime>(
+    handle: Option<&tauri::AppHandle<R>>,
+    thread_id: &str,
+    approval_request_id: &str,
+) {
+    if let Some(handle) = handle {
+        emit_approvals_updated_on(handle, thread_id, approval_request_id);
+    }
 }
 
 /// Emit the "approvals-updated" event on a caller-supplied handle (see
@@ -452,15 +471,45 @@ struct ApprovalsUpdate {
 /// the only source that can see runs started by older TUI/CLI clients which do
 /// not create a GUI StoredRun or route through the Tauri collector.
 fn start_thread_streaming_monitor() {
-    tauri::async_runtime::spawn(async move {
-        let mut previous: Option<Vec<String>> = None;
-        loop {
-            if let Some(handle) = APP_HANDLE.get() {
-                sample_thread_streaming(handle, &mut previous).await;
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tauri::async_runtime::spawn(thread_streaming_monitor_loop());
+}
+
+/// Poll the agent's streaming thread ids every second. Extracted so the loop
+/// body (sample + sleep) is testable; the `APP_HANDLE` Some arm needs the
+/// real Wry handle and stays untestable.
+async fn thread_streaming_monitor_loop() {
+    let mut previous: Option<Vec<String>> = None;
+    loop {
+        if let Some(handle) = APP_HANDLE.get() {
+            sample_thread_streaming(handle, &mut previous).await;
         }
-    });
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+/// Drain the runtime-update channel: coalesce bursts within a 40ms window,
+/// then emit the coalesced update. Extracted so the drain/coalesce/emit body
+/// is testable; the `APP_HANDLE` Some arm needs the real Wry handle.
+fn runtime_update_drain_loop(rx: std::sync::mpsc::Receiver<ThreadRuntimeUpdate>) {
+    use std::time::{Duration, Instant};
+    while let Ok(first) = rx.recv() {
+        let deadline = Instant::now() + Duration::from_millis(40);
+        let mut rest = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match rx.recv_timeout(remaining) {
+                Ok(next) => rest.push(next),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+            }
+        }
+        if let Some(handle) = APP_HANDLE.get() {
+            emit_runtime_updates_on(handle, coalesce_runtime_updates(first, rest));
+        }
+    }
 }
 
 /// Sample the agent's streaming thread ids once and, if the set changed, emit a
@@ -832,9 +881,11 @@ pub fn run() {
 #[cfg(test)]
 mod runtime_update_tests {
     use super::{
-        coalesce_runtime_updates, emit_approvals_updated_on, emit_remote_activity_on,
-        emit_review_updated_on, emit_runtime_updates_on, main_window_geometry,
-        sample_thread_streaming, sample_thread_streaming_with, size_main_window_to_screen,
+        apply_main_window_geometry, coalesce_runtime_updates, emit_approvals_updated_on,
+        emit_approvals_updated_via, emit_remote_activity_on, emit_remote_activity_via,
+        emit_review_updated_on, emit_review_updated_via, emit_runtime_updates_on,
+        main_window_geometry, runtime_update_drain_loop, sample_thread_streaming,
+        sample_thread_streaming_with, size_main_window_to_screen, thread_streaming_monitor_loop,
         ThreadRuntimeUpdate,
     };
 
@@ -992,5 +1043,53 @@ mod runtime_update_tests {
         sample_thread_streaming(handle, &mut previous).await;
         assert_eq!(previous, Some(Vec::new()));
         crate::commands::agent_mock::script_mock_agent(Default::default());
+    }
+
+    #[test]
+    fn apply_main_window_geometry_sizes_and_positions() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let window = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("build webview");
+        // Mock windows accept the set_* calls without a display server.
+        apply_main_window_geometry(&window, 2.0, 4000.0, 2000.0, 100.0, 50.0);
+    }
+
+    #[test]
+    fn emit_via_helpers_route_both_arms() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        emit_review_updated_via(Some(handle), "thread-1");
+        emit_remote_activity_via(Some(handle), "thread-1");
+        emit_approvals_updated_via(Some(handle), "thread-1", "approval-1");
+        // None arm: process-global APP_HANDLE unset in tests.
+        emit_review_updated_via::<tauri::test::MockRuntime>(None, "thread-1");
+        emit_remote_activity_via::<tauri::test::MockRuntime>(None, "thread-1");
+        emit_approvals_updated_via::<tauri::test::MockRuntime>(None, "thread-1", "approval-1");
+    }
+
+    #[test]
+    fn runtime_update_drain_loop_coalesces_and_exits() {
+        let (tx, rx) = std::sync::mpsc::channel::<ThreadRuntimeUpdate>();
+        let handle = std::thread::spawn(|| runtime_update_drain_loop(rx));
+        // One burst: both messages coalesce into a single emit attempt (the
+        // APP_HANDLE arm is skipped — no handle in tests — but the drain body
+        // runs end to end).
+        tx.send(update("run-1", 1, "running", false)).unwrap();
+        tx.send(update("run-2", 2, "running", false)).unwrap();
+        drop(tx);
+        handle.join().expect("drain loop exits on disconnect");
+    }
+
+    #[tokio::test]
+    async fn streaming_monitor_loop_enters_and_sleeps() {
+        // One iteration, then abort — the loop is infinite by design; this
+        // proves the iteration body (APP_HANDLE check + sleep) executes.
+        let task = tokio::spawn(thread_streaming_monitor_loop());
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        task.abort();
+        let _ = task.await;
     }
 }

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -12,7 +12,7 @@
 
 use tauri::{
     menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
-    AppHandle, Wry,
+    Runtime,
 };
 
 /// Menu item id for "About FutureOS" → opens Settings.
@@ -23,7 +23,7 @@ pub const MENU_RESTART_WEBVIEW: &str = "restart-webview";
 const APP_NAME: &str = "FutureOS";
 
 /// Build the full macOS menu bar with correct "FutureOS" naming.
-pub fn build_macos_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+pub fn build_macos_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<Menu<R>> {
     let about = MenuItemBuilder::with_id(MENU_ABOUT, format!("About {APP_NAME}")).build(app)?;
     let restart_webview =
         MenuItemBuilder::with_id(MENU_RESTART_WEBVIEW, "Restart Webview").build(app)?;
@@ -76,3 +76,7 @@ pub fn build_macos_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         .item(&window_menu)
         .build()
 }
+
+// NOTE: build_macos_menu cannot run in unit tests — muda requires menu
+// construction on the main thread (test threads are workers). Documented in
+// coverage/acceptance-waivers.md as W-menu.


### PR DESCRIPTION
Self-executed shell final: extracted apply_main_window_geometry / emit_*_via / runtime_update_drain_loop / thread_streaming_monitor_loop / confirmed_quit_flow (injectable exit), generic-ified build_macos_menu + confirm_quit, sidecar spawn Ok/Err arm tests. Goal goal_c86c1a0aa7b8.