### PR TITLE
feat(loop): O4 todo add --verify advisory hint for code-like todos

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -870,6 +870,26 @@ fn cmd_todo(store: &mut Store, args: &[String]) -> Result<()> {
     }
 }
 
+/// O4: heuristic for the `todo add` advisory hint — does the text look like a
+/// code/implementation task that should carry a `--verify` validator? Matches
+/// coding keywords (worktree / commit / cargo / clippy / 测试 / 代码 …) or a
+/// `.rs` source path. Advisory only; never changes CLI semantics.
+fn looks_like_code_todo(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    if lower.contains(".rs") {
+        return true;
+    }
+    const CODE_WORDS: &[&str] = &[
+        "worktree", "commit", "cargo", "clippy", "rustfmt", "test", "tests", "compile", "build",
+        "lint", "refactor", "patch", "crate", "git", "merge", "code", "debug",
+    ];
+    const CODE_ZH: &[&str] = &["测试", "代码", "编译", "修复"];
+    CODE_ZH.iter().any(|k| text.contains(k))
+        || lower
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|tok| CODE_WORDS.contains(&tok))
+}
+
 fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut role = "agent".to_string();
@@ -977,6 +997,10 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let text = text.ok_or_else(|| anyhow::anyhow!("--text required"))?;
+    // O4: advisory hint — code-like todos without a validator can be marked
+    // done by an agent even when the code does not compile. Computed before
+    // `verify` is moved into the todo below.
+    let wants_verify_hint = verify.is_none() && looks_like_code_todo(&text);
     store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
@@ -1106,6 +1130,10 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     refresh_next_action(store, &goal_id)?;
     sync_compat(store, &goal_id)?;
     println!("todo {id} added to {goal_id} ✔");
+    // O4: pure reminder after a successful add; no semantic change.
+    if wants_verify_hint {
+        eprintln!("hint: 实现类 todo 建议挂 --verify \"cargo check -p ...\"，防不编译代码被标完成");
+    }
     Ok(())
 }
 
@@ -10310,5 +10338,48 @@ mod residual_branch_tests {
         };
         let err = render_premerge_gate(&report, false).unwrap_err();
         assert!(format!("{err:#}").contains("gate failed"), "{err:#}");
+    }
+}
+
+#[cfg(test)]
+mod todo_verify_hint_tests {
+    use super::looks_like_code_todo;
+
+    #[test]
+    fn code_keywords_detect_implementation_todos() {
+        // ASCII keywords (case-insensitive), Chinese keywords, and .rs paths.
+        for text in [
+            "cargo check -p future-loop",
+            "Commit worktree changes",
+            "clippy 全绿",
+            "写测试用例",
+            "修改代码",
+            "修复编译错误",
+            "refactor console.rs",
+            "fix orchestration/loop/src/console.rs",
+            "merge main 后补回归",
+        ] {
+            assert!(
+                looks_like_code_todo(text),
+                "{text:?} should look like a code todo"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_todos_do_not_trigger_the_hint() {
+        for text in [
+            "整理会议纪要",
+            "ship the widget",
+            "gate one",
+            "approve the plan",
+            "latest release notes", // "test" substring inside "latest" must not match
+            "version 1.2.3 bump",
+        ] {
+            assert!(
+                !looks_like_code_todo(text),
+                "{text:?} should not look like a code todo"
+            );
+        }
     }
 }

--- a/orchestration/loop/tests/todo_verify_hint_contract.rs
+++ b/orchestration/loop/tests/todo_verify_hint_contract.rs
@@ -1,0 +1,142 @@
+//! O4 contract — `todo add` prints an advisory `--verify` hint for
+//! code-like todos (coding keywords / `.rs` paths) and stays silent for
+//! ordinary todos or when `--verify` is already given. Runs the REAL built
+//! binary against a temp FUTURE_LOOP_ROOT so the actual printed streams are
+//! asserted.
+
+use std::process::Command;
+
+const HINT: &str = "hint: 实现类 todo 建议挂 --verify \"cargo check -p ...\"，防不编译代码被标完成";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_future-loop")
+}
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-o4-hint-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+/// Run the binary with an isolated FUTURE_LOOP_ROOT. Returns (stdout, stderr,
+/// exit code).
+fn run(root: &str, args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(bin())
+        .env("FUTURE_LOOP_ROOT", root)
+        .args(args)
+        .output()
+        .expect("future-loop binary runs");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+fn init(root: &str, goal: &str) {
+    let (_, err, code) = run(
+        root,
+        &[
+            "goal",
+            "init",
+            "--objective",
+            "o4 hint contract",
+            "--goal-id",
+            goal,
+            "--cwd",
+            "/tmp",
+        ],
+    );
+    assert_eq!(code, 0, "goal init failed: {err}");
+}
+
+#[test]
+fn code_like_todo_without_verify_prints_hint() {
+    let root = tmp_root("feature");
+    init(&root, "g1");
+    for text in [
+        "改写 console.rs 的 todo add",
+        "cargo clippy --workspace 全绿后 commit 到 worktree",
+        "写单元测试覆盖 store verify",
+    ] {
+        let (out, err, code) = run(
+            &root,
+            &[
+                "todo",
+                "add",
+                "--goal",
+                "g1",
+                "--role",
+                "agent",
+                "--class",
+                "advancement",
+                "--text",
+                text,
+            ],
+        );
+        assert_eq!(code, 0, "todo add failed: {err}");
+        assert!(out.contains("added to g1"), "stdout: {out}");
+        assert!(
+            err.contains(HINT),
+            "hint missing for {text:?}\nstderr: {err}"
+        );
+    }
+}
+
+#[test]
+fn ordinary_todo_does_not_print_hint() {
+    let root = tmp_root("plain");
+    init(&root, "g1");
+    let (out, err, code) = run(
+        &root,
+        &[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--role",
+            "agent",
+            "--class",
+            "advancement",
+            "--text",
+            "整理会议纪要",
+        ],
+    );
+    assert_eq!(code, 0, "todo add failed: {err}");
+    assert!(out.contains("added to g1"), "stdout: {out}");
+    assert!(!out.contains("hint:"), "unexpected hint on stdout: {out}");
+    assert!(!err.contains("hint:"), "unexpected hint on stderr: {err}");
+}
+
+#[test]
+fn code_like_todo_with_verify_does_not_print_hint() {
+    let root = tmp_root("verified");
+    init(&root, "g1");
+    let (out, err, code) = run(
+        &root,
+        &[
+            "todo",
+            "add",
+            "--goal",
+            "g1",
+            "--role",
+            "agent",
+            "--class",
+            "advancement",
+            "--text",
+            "修复 src/lib.rs 的编译错误",
+            "--verify",
+            "cargo check -p future-loop",
+        ],
+    );
+    assert_eq!(code, 0, "todo add failed: {err}");
+    assert!(out.contains("added to g1"), "stdout: {out}");
+    assert!(!out.contains("hint:"), "unexpected hint on stdout: {out}");
+    assert!(!err.contains("hint:"), "unexpected hint on stderr: {err}");
+}


### PR DESCRIPTION
Wave 3 自愈 3/5。实现类 todo 没挂 --verify 时，'写完' ≠ '能编译'（content_ops 教训）。

- todo add 的 --text 含代码任务特征（worktree/commit/cargo/clippy/测试/.rs 路径等）且未带 --verify → 成功后打印提醒
- 纯提示不改语义；looks_like_code_todo 判定器 + 契约测试（代码文本出提示/普通文本不提示/带 --verify 不提示）

本地：fmt ✅ clippy ✅ future-loop 76 targets 全绿 ✅。源：claude/loop-wave2 8a60e329