### PR TITLE
feat(loop): O3 idle-turn no-progress detection — TurnNoProgress event + progress tracker

### DIFF
--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -43,6 +43,66 @@ pub struct SessionTotals {
     pub cost: f64,
 }
 
+/// O3: write-class tools — a `tool_start` of any of these resets the idle
+/// clock. Everything else (read, grep, todo, …) is observation-only.
+pub fn is_write_class_tool(name: &str) -> bool {
+    matches!(name, "write" | "edit" | "shell")
+}
+
+/// O3: per-turn progress signals observed on the event stream. Shared between
+/// `run_turn` (writer) and the run loop (reader) so the budget-truncation
+/// path can still evaluate progress after dropping the turn future. Atomics:
+/// written from the stream task, read from the loop task.
+#[derive(Debug)]
+pub struct TurnProgressTracker {
+    /// Wall-clock epoch secs at turn start (the idle baseline when no
+    /// write-class tool ever starts).
+    turn_start_at: std::sync::atomic::AtomicU64,
+    /// Wall-clock epoch secs of the last write-class tool start; 0 = none.
+    last_write_tool_at: std::sync::atomic::AtomicU64,
+    /// Total tool_start events observed (all classes).
+    tool_calls_total: std::sync::atomic::AtomicU32,
+}
+
+/// Immutable snapshot of [`TurnProgressTracker`] for turn-end evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnProgressSnapshot {
+    pub turn_start_at: u64,
+    /// `None` when no write-class tool started this turn.
+    pub last_write_tool_at: Option<u64>,
+    pub tool_calls_total: u32,
+}
+
+impl TurnProgressTracker {
+    pub fn new(turn_start_at: u64) -> Self {
+        Self {
+            turn_start_at: std::sync::atomic::AtomicU64::new(turn_start_at),
+            last_write_tool_at: std::sync::atomic::AtomicU64::new(0),
+            tool_calls_total: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+
+    /// Record one `tool_start` event (the live-log wall_ts doubles as the
+    /// observation clock, same as the streamed events).
+    pub fn observe_tool_start(&self, tool: &str, at: u64) {
+        use std::sync::atomic::Ordering;
+        self.tool_calls_total.fetch_add(1, Ordering::Relaxed);
+        if is_write_class_tool(tool) {
+            self.last_write_tool_at.store(at, Ordering::Relaxed);
+        }
+    }
+
+    pub fn snapshot(&self) -> TurnProgressSnapshot {
+        use std::sync::atomic::Ordering;
+        let last = self.last_write_tool_at.load(Ordering::Relaxed);
+        TurnProgressSnapshot {
+            turn_start_at: self.turn_start_at.load(Ordering::Relaxed),
+            last_write_tool_at: (last != 0).then_some(last),
+            tool_calls_total: self.tool_calls_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
 pub struct AgentClient {
     inner: FutureAgentClient<tonic::transport::Channel>,
 }
@@ -253,6 +313,7 @@ impl AgentClient {
         session_id: &str,
         run_id: &str,
         live_log: Option<&std::path::Path>,
+        progress: Option<&TurnProgressTracker>,
     ) -> Result<RunSummary> {
         let request = tonic::Request::new(StreamRequest {
             session_id: session_id.to_string(),
@@ -290,10 +351,11 @@ impl AgentClient {
                 continue;
             };
             if let Some(path) = live_log {
+                let wall_ts = crate::state::now_epoch();
                 let mut line = serde_json::json!({
                     "type": ev.r#type.as_str(),
                     "idx": ev.idx,
-                    "wall_ts": crate::state::now_epoch(),
+                    "wall_ts": wall_ts,
                 });
                 if ev.r#type == "tool_start" {
                     if let Some(n) = data.get("tool_name").and_then(|v| v.as_str()) {
@@ -308,6 +370,15 @@ impl AgentClient {
                         use std::io::Write;
                         let _ = writeln!(f, "{}", line);
                     });
+            }
+            // O3: fold tool_start into the progress tracker (write-class
+            // starts reset the idle clock; all starts count).
+            if ev.r#type == "tool_start" {
+                if let (Some(progress), Some(name)) =
+                    (progress, data.get("tool_name").and_then(|v| v.as_str()))
+                {
+                    progress.observe_tool_start(name, crate::state::now_epoch());
+                }
             }
             match ev.r#type.as_str() {
                 "tool_start" => {

--- a/orchestration/loop/src/benchmark/adapter.rs
+++ b/orchestration/loop/src/benchmark/adapter.rs
@@ -242,7 +242,11 @@ impl BenchmarkAdapter for GrpcLoopxAdapter {
 
     fn observe(&mut self, handle: &RunHandle) -> Result<Observation> {
         let before = Self::block_on(self.client.session_totals(&self.session_id))?;
-        let summary = Self::block_on(self.client.run_turn(&self.session_id, &handle.run_id, None))?;
+        let summary =
+            Self::block_on(
+                self.client
+                    .run_turn(&self.session_id, &handle.run_id, None, None),
+            )?;
         let after = Self::block_on(self.client.session_totals(&self.session_id))?;
         Ok(Observation {
             terminal_state: summary.terminal_state,

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::time::SystemTime;
 
+use crate::agent_client::TurnProgressTracker;
 use crate::cli::registry::{CommandRegistry, Journey};
 use crate::decision::{complete_todo, decide_for, MAX_REPAIR_ATTEMPTS};
 use crate::executor::{execute_turn, writeback};
@@ -1947,6 +1948,13 @@ fn print_status_json(store: &Store, goal_filter: Option<String>) -> Result<()> {
             "objective": goal.objective,
             "status": goal.status,
             "ledger_read_diagnostics": store.ledger_read_diagnostics(&gid),
+            "turn_no_progress": goal.turn_no_progress.iter().map(|np| serde_json::json!({
+                "todo_id": np.todo_id,
+                "agent_id": np.agent_id,
+                "idle_secs": np.idle_secs,
+                "tool_calls_total": np.tool_calls_total,
+                "ts": np.ts,
+            })).collect::<Vec<_>>(),
             "todos": goal.todos.iter().map(|t| serde_json::json!({
                 "id": t.id,
                 "text": t.text,
@@ -2018,6 +2026,18 @@ fn print_goal_status(goal: &Goal) {
     );
     let spent: u64 = goal.history.len() as u64;
     println!("spent     : {spent} turns");
+    // O3: idle-turn no-progress breaches (recent last) — the orchestrator's
+    // signal to nudge via `todo update` steering.
+    for np in goal.turn_no_progress.iter().rev().take(3) {
+        println!(
+            "no-progress: turn todo={} agent={} idle={}s tools={} ts={}",
+            np.todo_id,
+            np.agent_id.as_deref().unwrap_or("anonymous"),
+            np.idle_secs,
+            np.tool_calls_total,
+            np.ts
+        );
+    }
 }
 
 fn status_label(t: &Todo) -> &'static str {
@@ -3268,6 +3288,9 @@ async fn run_turns(
             todo_id.clone(),
             session_id.to_string(),
         ));
+        // O3: progress signals for this turn (tool starts observed on the
+        // stream; read at turn end, including the budget-truncation path).
+        let progress = std::sync::Arc::new(TurnProgressTracker::new(now_epoch()));
         let turn_future = execute_turn(
             client,
             session_id,
@@ -3280,6 +3303,7 @@ async fn run_turns(
             // the turn envelope.
             Some(&packet),
             Some(runs_dir),
+            Some(&progress),
         );
         let record = if max_turn_secs > 0 {
             // Wall-clock budget per turn: a long turn that never sees new
@@ -3291,6 +3315,10 @@ async fn run_turns(
                 Ok(r) => r?,
                 Err(_) => {
                     steer_handle.abort();
+                    // O3: budget truncation is a turn end — evaluate the
+                    // no-progress window against the observed tool starts
+                    // before stopping the run.
+                    record_no_progress_if_idle(store, goal_id, &todo_id, agent_id, &progress)?;
                     println!(
                         "   ⏱ turn exceeded --max-turn-secs ({max_turn_secs}s) — stopping run gracefully; relaunch to continue"
                     );
@@ -3365,6 +3393,9 @@ async fn run_turns(
             record: record.clone(),
             ts: now_epoch(),
         })?;
+        // O3: normal turn end — evaluate the no-progress window and ledger
+        // the breach (detection + bookkeeping; no auto-injection).
+        record_no_progress_if_idle(store, goal_id, &todo_id, agent_id, &progress)?;
         // P1-5 reward_memory ingestion: the turn's independent validation
         // receipt (if any) lands in the reward ledger (source `validator`).
         if ingest_validator_reward(store, goal_id, &todo_id, agent_id, &record)? {
@@ -3457,6 +3488,43 @@ async fn run_turns(
         store.set_next_action(goal_id, &next_text)?;
         println!("   ✔ writeback ok — next action synced");
     }
+    Ok(())
+}
+
+/// O3: evaluate the no-progress window at turn end (normal or budget-truncated)
+/// and append a `TurnNoProgress` ledger event when breached. Detection +
+/// bookkeeping only — nudge injection is the orchestrator's job via the
+/// existing todo update steering channel.
+fn record_no_progress_if_idle(
+    store: &mut Store,
+    goal_id: &str,
+    todo_id: &str,
+    agent_id: Option<&str>,
+    progress: &TurnProgressTracker,
+) -> Result<()> {
+    let now = now_epoch();
+    let snap = progress.snapshot();
+    let threshold = crate::state::no_progress_idle_secs();
+    let Some(idle_secs) = crate::executor::no_progress_idle_secs(
+        snap.turn_start_at,
+        snap.last_write_tool_at,
+        now,
+        threshold,
+    ) else {
+        return Ok(());
+    };
+    store.append(Event::TurnNoProgress {
+        goal_id: goal_id.to_string(),
+        todo_id: todo_id.to_string(),
+        agent_id: agent_id.map(String::from),
+        idle_secs,
+        tool_calls_total: snap.tool_calls_total,
+        ts: now,
+    })?;
+    println!(
+        "   ⏳ TurnNoProgress: no write-class tool started for {idle_secs}s (threshold {threshold}s, {} tool calls)",
+        snap.tool_calls_total
+    );
     Ok(())
 }
 
@@ -7374,6 +7442,7 @@ fn event_touches_todo(event: &crate::store::Event, todo_id: &str) -> bool {
             ..
         } => source_todo_id == todo_id || followup_todo_id == todo_id,
         Event::RunRecorded { record, .. } => record.todo_id == todo_id,
+        Event::TurnNoProgress { todo_id: id, .. } => id == todo_id,
         Event::HeartbeatReceiptRecorded { todo_id: id, .. } => id.as_deref() == Some(todo_id),
         _ => false,
     }
@@ -7484,6 +7553,18 @@ fn describe_event(event: &crate::store::Event) -> String {
         } => {
             return format!(
                 "monitor_polled todo={todo_id} result={result} no_change_count={no_change_count}"
+            );
+        }
+        Event::TurnNoProgress {
+            todo_id,
+            agent_id,
+            idle_secs,
+            tool_calls_total,
+            ..
+        } => {
+            return format!(
+                "turn_no_progress todo={todo_id} agent={} idle={idle_secs}s tool_calls={tool_calls_total}",
+                agent_id.as_deref().unwrap_or("anonymous")
             );
         }
         Event::QuotaSpent {

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 
-use crate::agent_client::{AgentClient, RunSummary};
+use crate::agent_client::{AgentClient, RunSummary, TurnProgressTracker};
 use crate::decision::{compose_goal_boundary, compose_turn_envelope, compose_turn_message};
 use crate::state::{
     now_epoch, task_validation_receipt, Goal, RecoveryKind, RunRecord, TaskValidation, Todo,
@@ -17,6 +17,21 @@ use crate::state::{
 /// independent validator passed (no validator ⇒ not required ⇒ ok).
 pub fn turn_succeeded(record: &RunRecord) -> bool {
     record.terminal_state == "completed" && record.validation.as_ref().map(|v| v.ok).unwrap_or(true)
+}
+
+/// O3: evaluate turn-end progress. Returns `Some(idle_secs)` when the last
+/// write-class tool (write/edit/shell) start — or the turn start when no
+/// write-class tool started at all — is at least `threshold_secs` before
+/// `now`; `None` otherwise. Pure so tests exercise it without wall-clock
+/// waits.
+pub fn no_progress_idle_secs(
+    turn_start_at: u64,
+    last_write_tool_at: Option<u64>,
+    now: u64,
+    threshold_secs: u64,
+) -> Option<u64> {
+    let idle_secs = now.saturating_sub(last_write_tool_at.unwrap_or(turn_start_at));
+    (idle_secs >= threshold_secs).then_some(idle_secs)
 }
 
 /// Run the todo's independent validator (if any) after a completed turn.
@@ -78,6 +93,7 @@ pub async fn execute_turn(
     boundary_injected: bool,
     decision_summary: Option<&crate::contract::ShouldRunPacket>,
     runs_dir: Option<std::path::PathBuf>,
+    progress: Option<&TurnProgressTracker>,
 ) -> Result<RunRecord> {
     if !boundary_injected {
         client
@@ -101,7 +117,7 @@ pub async fn execute_turn(
         .await?;
     let live_path = runs_dir.map(|d| d.join(format!("{run_id}.live.jsonl")));
     let summary: RunSummary = client
-        .run_turn(session_id, &run_id, live_path.as_deref())
+        .run_turn(session_id, &run_id, live_path.as_deref(), progress)
         .await?;
     let after = client.session_totals(session_id).await?;
     let terminal_state = summary.terminal_state.clone();

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -767,6 +767,10 @@ pub struct Goal {
     /// comparing against `scheduler_heartbeats`).
     #[serde(default)]
     pub liveness_alerts: Vec<LivenessAlert>,
+    /// O3: idle-turn no-progress records, folded from `TurnNoProgress`
+    /// (append-only; detection + bookkeeping, no auto-injection).
+    #[serde(default)]
+    pub turn_no_progress: Vec<TurnNoProgressRecord>,
 }
 
 /// P1-3①: one automation-liveness breach alert (LoopX automation_liveness):
@@ -779,6 +783,38 @@ pub struct LivenessAlert {
     /// 1-based alert ordinal for this (goal, agent) scope.
     pub consecutive: u32,
     pub ts: u64,
+}
+
+/// O3: one idle-turn (no-progress) breach — the turn ended with no write-class
+/// tool (write/edit/shell) started inside the no-progress window. Folded from
+/// `TurnNoProgress` events; the orchestrator nudges via the todo update
+/// steering channel (the loop itself never auto-injects).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TurnNoProgressRecord {
+    pub goal_id: String,
+    pub todo_id: String,
+    pub agent_id: Option<String>,
+    /// Seconds since the last write-class tool start (turn start when none).
+    pub idle_secs: u64,
+    /// Total tool calls observed this turn (all classes).
+    pub tool_calls_total: u32,
+    pub ts: u64,
+}
+
+/// O3: default idle-turn no-progress window (15 minutes). A turn that ends
+/// without any write-class tool (write/edit/shell) starting inside this
+/// window is ledgered as `TurnNoProgress`.
+pub const TURN_NO_PROGRESS_IDLE_SECS_DEFAULT: u64 = 15 * 60;
+
+/// O3: effective no-progress window (secs). The `FUTURE_LOOP_NO_PROGRESS_SECS`
+/// env var shrinks it in tests (mirrors the FUTURE_LOOP_AGENT_ADDR hook);
+/// invalid or non-positive values fall back to the 15-minute default.
+pub fn no_progress_idle_secs() -> u64 {
+    std::env::var("FUTURE_LOOP_NO_PROGRESS_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(TURN_NO_PROGRESS_IDLE_SECS_DEFAULT)
 }
 
 /// P1-2②: freshness stamp of the event ledger a decision was compiled
@@ -836,6 +872,7 @@ impl Goal {
             decision_freshness: None,
             scheduler_heartbeats: std::collections::BTreeMap::new(),
             liveness_alerts: vec![],
+            turn_no_progress: vec![],
         }
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -295,6 +295,21 @@ pub enum Event {
         no_change_count: u32,
         ts: u64,
     },
+    /// O3: idle-turn detection — a turn ended with no write-class tool
+    /// (write/edit/shell) started inside the no-progress window. Detection +
+    /// bookkeeping only (no auto-injection): orchestrators nudge via the todo
+    /// update steering channel. `agent_id` is `None` for anonymous runs.
+    TurnNoProgress {
+        goal_id: String,
+        todo_id: String,
+        #[serde(default)]
+        agent_id: Option<String>,
+        /// Seconds since the last write-class tool start (turn start when none).
+        idle_secs: u64,
+        /// Total tool calls observed this turn (all classes).
+        tool_calls_total: u32,
+        ts: u64,
+    },
     /// G-3: a quota slot was spent (reference QUOTA_SPENT). Recorded alongside
     /// the run ledger; `source` mirrors the slot-accounting spend source
     /// (`run` / `agent` / `heartbeat`) and `slots` the count spent (1 per
@@ -562,6 +577,7 @@ impl Event {
             | Event::AuthoritySet { goal_id, .. }
             | Event::TodoArchived { goal_id, .. }
             | Event::MonitorPolled { goal_id, .. }
+            | Event::TurnNoProgress { goal_id, .. }
             | Event::QuotaSpent { goal_id, .. }
             | Event::CapabilityInvoked { goal_id, .. }
             | Event::EvidenceAttached { goal_id, .. }
@@ -1678,6 +1694,26 @@ fn apply(goal: &mut Goal, event: Event) {
             consecutive,
             ts,
         }),
+        // O3: idle-turn no-progress records fold into goal state
+        // (append-only) — visible in `status` so orchestrators can see the
+        // breach without replaying the raw ledger.
+        Event::TurnNoProgress {
+            goal_id,
+            todo_id,
+            agent_id,
+            idle_secs,
+            tool_calls_total,
+            ts,
+        } => goal
+            .turn_no_progress
+            .push(crate::state::TurnNoProgressRecord {
+                goal_id,
+                todo_id,
+                agent_id,
+                idle_secs,
+                tool_calls_total,
+                ts,
+            }),
         // P1-5 + P1-1 + P1-4 + G-16 projection-only events: read from the
         // event log by their read models; goal state is unchanged on replay.
         Event::RewardSignalRecorded { .. }

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -189,7 +189,7 @@ fn run_turn_completed_with_live_log() {
         let dir = tempfile::tempdir().unwrap();
         let live = dir.path().join("live.jsonl");
         let summary = client
-            .run_turn("sess", "mock-run-1", Some(&live))
+            .run_turn("sess", "mock-run-1", Some(&live), None)
             .await
             .unwrap();
         assert_eq!(summary.terminal_state, "completed");
@@ -232,7 +232,7 @@ fn run_turn_skips_foreign_and_malformed_events() {
         })
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert_eq!(summary.terminal_state, "completed");
         assert_eq!(summary.error.as_deref(), Some("soft fail"));
         assert!(summary.tools.is_empty());
@@ -258,7 +258,7 @@ fn run_turn_long_text_truncates_at_char_boundary() {
         })
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert!(summary.text.len() <= 8003, "{}", summary.text.len());
         assert!(summary.text.starts_with("aaaa"));
     });
@@ -279,7 +279,7 @@ fn run_turn_error_event_and_stream_failure() {
         })
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert_eq!(summary.terminal_state, "error");
         assert_eq!(summary.error.as_deref(), Some("boom"));
 
@@ -291,7 +291,7 @@ fn run_turn_error_event_and_stream_failure() {
         })
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert_eq!(summary.error.as_deref(), Some("unknown error"));
 
         // Mid-stream transport failure.
@@ -302,7 +302,10 @@ fn run_turn_error_event_and_stream_failure() {
         st.stream_fail_after = Some(1);
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let err = client.run_turn("sess", "mine", None).await.unwrap_err();
+        let err = client
+            .run_turn("sess", "mine", None, None)
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("stream error"));
 
         // Attach failure.
@@ -312,7 +315,10 @@ fn run_turn_error_event_and_stream_failure() {
         };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let err = client.run_turn("sess", "mine", None).await.unwrap_err();
+        let err = client
+            .run_turn("sess", "mine", None, None)
+            .await
+            .unwrap_err();
         assert!(format!("{err:#}").contains("Failed to attach"));
 
         // Stream closes without agent_end → incomplete.
@@ -323,7 +329,7 @@ fn run_turn_error_event_and_stream_failure() {
         })
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let summary = client.run_turn("sess", "mine", None).await.unwrap();
+        let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert_eq!(summary.terminal_state, "incomplete");
     });
 }
@@ -344,7 +350,10 @@ fn run_turn_live_log_without_tool_name() {
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let dir = tempfile::tempdir().unwrap();
         let live = dir.path().join("live.jsonl");
-        let summary = client.run_turn("sess", "mine", Some(&live)).await.unwrap();
+        let summary = client
+            .run_turn("sess", "mine", Some(&live), None)
+            .await
+            .unwrap();
         assert!(summary.tools.is_empty());
         let log = std::fs::read_to_string(&live).unwrap();
         assert!(log.contains("tool_start"), "{log}");
@@ -381,6 +390,7 @@ fn execute_turn_completed_no_validator() {
             false,
             None,
             Some(runs_dir.clone()),
+            None,
         )
         .await
         .unwrap();
@@ -420,6 +430,7 @@ fn execute_turn_with_decision_summary_and_prev() {
             true,
             Some(&packet),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -444,9 +455,20 @@ fn execute_turn_error_turn_skips_validator() {
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let (goal, mut todo) = sample_goal_with_todo();
         todo.validator = Some("exit 0".to_string());
-        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
-            .await
-            .unwrap();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(record.terminal_state, "error");
         assert!(record.validation.is_none(), "failed turn never validates");
     });
@@ -464,9 +486,20 @@ fn execute_turn_validator_pass_and_fail() {
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let (goal, mut todo) = sample_goal_with_todo();
         todo.validator = Some("exit 0".to_string());
-        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
-            .await
-            .unwrap();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let v = record.validation.unwrap();
         assert!(v.ok, "validator exit 0 passes: {}", v.summary);
 
@@ -479,9 +512,20 @@ fn execute_turn_validator_pass_and_fail() {
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let (goal, mut todo) = sample_goal_with_todo();
         todo.validator = Some("exit 3".to_string());
-        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
-            .await
-            .unwrap();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let v = record.validation.unwrap();
         assert!(!v.ok, "validator exit 3 fails");
         assert_eq!(v.exit_code, Some(3));

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use future_rpc::proto::future_agent_server::{FutureAgent, FutureAgentServer};
 use future_rpc::proto::{RpcCommand, RpcResponse, StreamEvent, StreamRequest};
+use tokio_stream::StreamExt;
 
 #[derive(Default)]
 pub struct MockState {
@@ -28,6 +29,9 @@ pub struct MockState {
     pub grpc_error: bool,
     /// stream_events returns a stream that never yields (timeout tests).
     pub hang_stream: bool,
+    /// Replays the scripted `events` first, then never yields — the
+    /// budget-truncation path WITH observed tool starts (O3 idle detection).
+    pub events_then_hang: bool,
     /// stream_events fails immediately with a tonic status.
     pub stream_error: bool,
     /// After N scripted events the stream yields one tonic error (mid-stream
@@ -151,6 +155,11 @@ impl FutureAgent for MockAgent {
             if items.len() >= n {
                 items.insert(n, Err(tonic::Status::data_loss("mock mid-stream failure")));
             }
+        }
+        if st.events_then_hang {
+            let scripted = tokio_stream::iter(items);
+            let pending = tokio_stream::pending::<Result<StreamEvent, tonic::Status>>();
+            return Ok(tonic::Response::new(Box::pin(scripted.chain(pending))));
         }
         Ok(tonic::Response::new(Box::pin(tokio_stream::iter(items))))
     }

--- a/orchestration/loop/tests/executor_env_drive.rs
+++ b/orchestration/loop/tests/executor_env_drive.rs
@@ -29,9 +29,20 @@ fn validator_spawn_failure_is_inconclusive() {
 
         let saved = std::env::var_os("PATH");
         std::env::set_var("PATH", "/nonexistent-dir-xyz");
-        let record = execute_turn(&mut client, "sess", &goal, &todo, 1, None, true, None, None)
-            .await
-            .unwrap();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         if let Some(p) = saved {
             std::env::set_var("PATH", p);
         }

--- a/orchestration/loop/tests/no_progress_drive.rs
+++ b/orchestration/loop/tests/no_progress_drive.rs
@@ -1,0 +1,237 @@
+//! O3 drive: idle-turn (no-progress) detection — pure evaluation, stream
+//! tracking, and the budget-truncation ledger path. Detection + bookkeeping
+//! only: no auto-injection (orchestrators nudge via todo update steering).
+
+mod common;
+
+use common::mock_agent::{ev, spawn_mock, MockState};
+use common::{cli_ok, cli_root, init_goal, open_store};
+use future_loop::agent_client::{is_write_class_tool, TurnProgressTracker};
+use future_loop::executor::no_progress_idle_secs;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::SharedState) {
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(state));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    (rt, shared)
+}
+
+// ── pure evaluation ────────────────────────────────────────────────────────
+
+#[test]
+fn no_progress_pure_read_sequence_breaches() {
+    // Turn started 100s ago, only read-class tools → idle == turn age.
+    let now = 1_700_000_100;
+    let idle = no_progress_idle_secs(now - 100, None, now, 60).unwrap();
+    assert_eq!(idle, 100);
+}
+
+#[test]
+fn no_progress_pure_recent_write_does_not_breach() {
+    let now = 1_700_000_100;
+    // Last write 5s ago — inside the 60s window.
+    assert_eq!(
+        no_progress_idle_secs(now - 100, Some(now - 5), now, 60),
+        None
+    );
+}
+
+#[test]
+fn no_progress_pure_old_write_breaches() {
+    let now = 1_700_000_100;
+    // Last write 61s ago — outside the 60s window → idle measured from it.
+    let idle = no_progress_idle_secs(now - 200, Some(now - 61), now, 60).unwrap();
+    assert_eq!(idle, 61);
+}
+
+#[test]
+fn no_progress_pure_boundary_and_skew() {
+    let now = 1_700_000_100;
+    // idle == threshold → breach (>=).
+    assert!(no_progress_idle_secs(now - 60, None, now, 60).is_some());
+    // idle just under threshold → no breach.
+    assert!(no_progress_idle_secs(now - 59, None, now, 60).is_none());
+    // Clock skew (tool timestamp ahead of now) → idle 0 → no breach.
+    assert!(no_progress_idle_secs(now, Some(now + 5), now, 60).is_none());
+}
+
+// ── write-class classification + tracker ───────────────────────────────────
+
+#[test]
+fn write_class_tool_matrix() {
+    for t in ["write", "edit", "shell"] {
+        assert!(is_write_class_tool(t), "{t} is write-class");
+    }
+    for t in ["read", "grep", "todo_update", "list", ""] {
+        assert!(!is_write_class_tool(t), "{t} is not write-class");
+    }
+}
+
+#[test]
+fn tracker_records_write_class_only() {
+    let t = TurnProgressTracker::new(1_000);
+    t.observe_tool_start("read", 1_010);
+    t.observe_tool_start("write", 1_020);
+    t.observe_tool_start("grep", 1_030);
+    t.observe_tool_start("edit", 1_040);
+    let snap = t.snapshot();
+    assert_eq!(snap.tool_calls_total, 4);
+    assert_eq!(snap.last_write_tool_at, Some(1_040));
+    assert_eq!(snap.turn_start_at, 1_000);
+
+    // Read-only stream → no write marker, all calls still counted.
+    let t = TurnProgressTracker::new(2_000);
+    t.observe_tool_start("read", 2_010);
+    t.observe_tool_start("grep", 2_020);
+    let snap = t.snapshot();
+    assert_eq!(snap.tool_calls_total, 2);
+    assert_eq!(snap.last_write_tool_at, None);
+}
+
+// ── stream tracking through run_turn ───────────────────────────────────────
+
+#[test]
+fn run_turn_folds_tool_starts_into_tracker() {
+    rt().block_on(async {
+        let events = vec![
+            ev("mine", 0, "tool_start", "{\"tool_name\":\"read\"}"),
+            ev("mine", 1, "tool_start", "{\"tool_name\":\"shell\"}"),
+            ev("mine", 2, "text_chunk", "{\"text\":\"x\"}"),
+            ev("mine", 3, "agent_end", "{\"state\":\"completed\"}"),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = future_loop::agent_client::AgentClient::connect(&addr)
+            .await
+            .unwrap();
+        let progress = TurnProgressTracker::new(1);
+        let summary = client
+            .run_turn("sess", "mine", None, Some(&progress))
+            .await
+            .unwrap();
+        assert_eq!(summary.terminal_state, "completed");
+        let snap = progress.snapshot();
+        assert_eq!(snap.tool_calls_total, 2);
+        assert!(snap.last_write_tool_at.is_some(), "shell is write-class");
+    });
+}
+
+// ── budget truncation → ledger event ───────────────────────────────────────
+
+#[test]
+fn budget_truncation_read_only_turn_records_turn_no_progress() {
+    let cr = cli_root();
+    let events = vec![ev(
+        "mock-run-1",
+        0,
+        "tool_start",
+        "{\"tool_name\":\"read\"}",
+    )];
+    let st = MockState {
+        events,
+        events_then_hang: true,
+        ..Default::default()
+    };
+    let (_rt, _shared) = mock_env(st);
+    // Shrink the idle window to 1s so the 2s budget truncation breaches it
+    // (the env hook mirrors FUTURE_LOOP_AGENT_ADDR; default is 15 min).
+    std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "1");
+    let goal = init_goal(&cr, "read-only hang");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "2",
+        "--max-turns",
+        "3",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    assert_eq!(g.turn_no_progress.len(), 1, "{:?}", g.turn_no_progress);
+    let np = &g.turn_no_progress[0];
+    assert!(np.idle_secs >= 1, "idle {np:?}");
+    assert_eq!(np.tool_calls_total, 1, "the read tool_start was observed");
+    assert!(np.agent_id.is_none(), "anonymous run");
+    // The ledger carries the real event (replay folds it, so this must hold).
+    let text = std::fs::read_to_string(store.goal_dir(&goal).join("events.jsonl")).unwrap();
+    assert!(text.contains("\"kind\":\"turn_no_progress\""), "{text}");
+    // Status surfaces the breach (recent-last).
+    cli_ok(&["status", "--goal", &goal]);
+}
+
+#[test]
+fn budget_truncation_after_write_tool_no_event() {
+    let cr = cli_root();
+    let events = vec![ev(
+        "mock-run-1",
+        0,
+        "tool_start",
+        "{\"tool_name\":\"write\"}",
+    )];
+    let st = MockState {
+        events,
+        events_then_hang: true,
+        ..Default::default()
+    };
+    let (_rt, _shared) = mock_env(st);
+    // Window 5s: the 2s budget truncation ends well inside it → no breach.
+    std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "5");
+    let goal = init_goal(&cr, "write then hang");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "2",
+        "--max-turns",
+        "3",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    assert!(g.turn_no_progress.is_empty(), "{:?}", g.turn_no_progress);
+    // Status projections (human + json) render the empty state cleanly.
+    cli_ok(&["status", "--goal", &goal]);
+    cli_ok(&["status", "--format", "json", "--goal", &goal]);
+}
+
+#[test]
+fn normal_completion_inside_window_no_event() {
+    let cr = cli_root();
+    // completed_events starts a `shell` (write-class) right before end →
+    // idle ≈ 0 even with a 1s window.
+    let (_rt, _shared) = mock_env(MockState {
+        events: common::mock_agent::completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "1");
+    let goal = init_goal(&cr, "normal completion");
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "600",
+        "--max-turns",
+        "3",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
+    let store = open_store(&cr);
+    let g = store.replay(&goal).unwrap().unwrap();
+    assert!(g.turn_no_progress.is_empty(), "{:?}", g.turn_no_progress);
+}


### PR DESCRIPTION
Wave 3 自愈 4/5。xhigh 模型在开放设计题上烧满整段预算不写代码，kernel 对零产出 turn 无感。

- run 执行循环跟踪最近 write/edit/shell 工具启动时间
- turn 结束（含预算截断）时无写类工具超过 15 分钟（可调常量）→ 追加 TurnNoProgress 事件（goal/todo/agent/idle_secs/tool_calls_total）
- 只做检测+记账，nudge 由 orchestrator 用现有 todo update steering 通道做（技能 v2.2.0 已写明流程）
- 新契约测试 no_progress_drive.rs：纯 read 超时出事件 / 有 write 不出

本地：fmt ✅ clippy ✅ future-loop 78 targets 全绿 ✅。源：claude/loop-wave2 7f566d55