### PR TITLE
fix(loop): O5 session event-stream gap recovery — 2s backoff + cursor resume retry

### DIFF
--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -308,6 +308,14 @@ impl AgentClient {
     /// `live_log`: when set, every streamed event is teed to this JSONL file
     /// so operators can watch a long turn live (`loop status` shows one line
     /// otherwise).
+    ///
+    /// O5: when the stream terminates with a gap-class error (the agent's
+    /// `DataLoss` "event stream gap" — its replay ring lagged), reconnect
+    /// once after a 2s backoff on the same session and resume from the last
+    /// observed idx (atomic attach replays everything after the cursor, so
+    /// nothing double-counts). A second consecutive gap-class failure —
+    /// including a failed reconnect — terminates the turn carrying the
+    /// original error.
     pub async fn run_turn(
         &mut self,
         session_id: &str,
@@ -315,20 +323,6 @@ impl AgentClient {
         live_log: Option<&std::path::Path>,
         progress: Option<&TurnProgressTracker>,
     ) -> Result<RunSummary> {
-        let request = tonic::Request::new(StreamRequest {
-            session_id: session_id.to_string(),
-            run_id: run_id.to_string(),
-            event_types: vec![],
-            after_idx: -1,
-            atomic_attach: true,
-        });
-        let mut stream = self
-            .inner
-            .stream_events(request)
-            .await
-            .map_err(|e| anyhow!("Failed to attach to run {run_id}: {e}"))?
-            .into_inner();
-
         let mut summary = RunSummary {
             run_id: run_id.to_string(),
             terminal_state: "incomplete".to_string(),
@@ -338,89 +332,181 @@ impl AgentClient {
             usage: None,
             duration_ms: None,
         };
-
-        use tokio_stream::StreamExt;
-        while let Some(ev) = stream.next().await {
-            let ev = ev.map_err(|e| anyhow!("stream error on run {run_id}: {e}"))?;
-            if ev.run_id != run_id {
-                // Stale tail from a previous run on the same session (or a
-                // supersede) — ignore foreign events.
-                continue;
-            }
-            let Some(data) = parse_data(&ev) else {
-                continue;
-            };
-            if let Some(path) = live_log {
-                let wall_ts = crate::state::now_epoch();
-                let mut line = serde_json::json!({
-                    "type": ev.r#type.as_str(),
-                    "idx": ev.idx,
-                    "wall_ts": wall_ts,
-                });
-                if ev.r#type == "tool_start" {
-                    if let Some(n) = data.get("tool_name").and_then(|v| v.as_str()) {
-                        line["tool"] = serde_json::Value::String(n.to_string());
-                    }
-                }
-                let _ = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(path)
-                    .map(|mut f| {
-                        use std::io::Write;
-                        let _ = writeln!(f, "{}", line);
-                    });
-            }
-            // O3: fold tool_start into the progress tracker (write-class
-            // starts reset the idle clock; all starts count).
-            if ev.r#type == "tool_start" {
-                if let (Some(progress), Some(name)) =
-                    (progress, data.get("tool_name").and_then(|v| v.as_str()))
-                {
-                    progress.observe_tool_start(name, crate::state::now_epoch());
-                }
-            }
-            match ev.r#type.as_str() {
-                "tool_start" => {
-                    if let Some(name) = data.get("tool_name").and_then(|v| v.as_str()) {
-                        summary.tools.push(name.to_string());
-                    }
-                }
-                "text_chunk" => {
-                    if let Some(text) = data.get("text").and_then(|v| v.as_str()) {
-                        summary.text.push_str(text);
-                        if summary.text.len() > 8_000 {
-                            // truncate at a UTF-8 char boundary — str::truncate panics mid-char
-                            let boundary = summary.text.floor_char_boundary(8_000);
-                            summary.text.truncate(boundary);
+        // O5: resume cursor (last event idx actually observed) and the
+        // original gap error (carried if the retry also fails).
+        let mut after_idx: i64 = -1;
+        let mut first_gap_error: Option<String> = None;
+        loop {
+            let request = tonic::Request::new(StreamRequest {
+                session_id: session_id.to_string(),
+                run_id: run_id.to_string(),
+                event_types: vec![],
+                after_idx,
+                atomic_attach: true,
+            });
+            let mut stream = match self.inner.stream_events(request).await {
+                Ok(resp) => resp.into_inner(),
+                Err(e) => {
+                    let attach_err = format!("Failed to attach to run {run_id}: {e}");
+                    return match first_gap_error {
+                        // The reconnect itself failed: a second consecutive
+                        // failure — terminate the turn with the ORIGINAL
+                        // gap error attached (O5).
+                        Some(original) => {
+                            Err(anyhow!("{original} (reconnect also failed: {attach_err})"))
                         }
+                        None => Err(anyhow!("{attach_err}")),
+                    };
+                }
+            };
+            match consume_run_stream(&mut stream, run_id, &mut summary, live_log, progress).await {
+                StreamOutcome::Done | StreamOutcome::Closed => return Ok(summary),
+                StreamOutcome::Failed { status, last_idx } => {
+                    after_idx = last_idx;
+                    let gap_err = format!("stream error on run {run_id}: {status}");
+                    if !is_stream_gap(&status) {
+                        return Err(anyhow!("{gap_err}"));
                     }
+                    if let Some(original) = first_gap_error.take() {
+                        // Second consecutive gap — terminate the turn with
+                        // the original error (O5: 把原错误带上).
+                        return Err(anyhow!("{original} (retry also failed: {gap_err})"));
+                    }
+                    first_gap_error = Some(gap_err);
+                    tokio::time::sleep(STREAM_GAP_RETRY_BACKOFF).await;
                 }
-                "agent_end" => {
-                    summary.error = data.get("error").and_then(|v| v.as_str()).map(String::from);
-                    summary.terminal_state = data
-                        .get("state")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("completed")
-                        .to_string();
-                    summary.usage = data.get("usage").cloned();
-                    summary.duration_ms = data.get("duration_ms").and_then(|v| v.as_i64());
-                    break;
-                }
-                "error" => {
-                    let msg = data
-                        .get("error")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown error");
-                    summary.error = Some(msg.to_string());
-                    summary.terminal_state = "error".to_string();
-                    break;
-                }
-                _ => {}
             }
         }
-        Ok(summary)
     }
+}
+
+/// O5: backoff between a stream-gap disconnect and the reconnect attempt.
+const STREAM_GAP_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// O5: gap-class stream errors. The agent terminates the event stream with
+/// `DataLoss` when its per-run replay ring lagged (message: "event stream
+/// gap … reconnect with atomic attach"). Those are recoverable by reconnect
+/// + cursor resume; anything else fails the turn immediately.
+fn is_stream_gap(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::DataLoss
+        || status
+            .message()
+            .to_ascii_lowercase()
+            .contains("event stream gap")
+}
+
+/// How one stream subscription ended (O5).
+enum StreamOutcome {
+    /// A terminal event (`agent_end` / run `error` event) was consumed.
+    Done,
+    /// The subscription closed cleanly without a terminal event.
+    Closed,
+    /// Transport failure — the `status` plus the last event idx actually
+    /// observed (the resume cursor for a gap retry).
+    Failed {
+        status: tonic::Status,
+        last_idx: i64,
+    },
+}
+
+/// Consume one subscription until it terminates; `summary` accumulates
+/// across reconnect attempts (each attempt replays only idx > last cursor,
+/// so nothing double-counts).
+async fn consume_run_stream(
+    stream: &mut tonic::Streaming<StreamEvent>,
+    run_id: &str,
+    summary: &mut RunSummary,
+    live_log: Option<&std::path::Path>,
+    progress: Option<&TurnProgressTracker>,
+) -> StreamOutcome {
+    use tokio_stream::StreamExt;
+    let mut last_idx: i64 = -1;
+    while let Some(ev) = stream.next().await {
+        let ev = match ev {
+            Ok(ev) => ev,
+            Err(status) => return StreamOutcome::Failed { status, last_idx },
+        };
+        if ev.run_id != run_id {
+            // Stale tail from a previous run on the same session (or a
+            // supersede) — ignore foreign events.
+            continue;
+        }
+        // Resume cursor: the last event of THIS run, even when its payload
+        // is malformed (attach replays strictly idx > cursor).
+        last_idx = ev.idx;
+        let Some(data) = parse_data(&ev) else {
+            continue;
+        };
+        if let Some(path) = live_log {
+            let wall_ts = crate::state::now_epoch();
+            let mut line = serde_json::json!({
+                "type": ev.r#type.as_str(),
+                "idx": ev.idx,
+                "wall_ts": wall_ts,
+            });
+            if ev.r#type == "tool_start" {
+                if let Some(n) = data.get("tool_name").and_then(|v| v.as_str()) {
+                    line["tool"] = serde_json::Value::String(n.to_string());
+                }
+            }
+            let _ = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .map(|mut f| {
+                    use std::io::Write;
+                    let _ = writeln!(f, "{}", line);
+                });
+        }
+        // O3: fold tool_start into the progress tracker (write-class
+        // starts reset the idle clock; all starts count).
+        if ev.r#type == "tool_start" {
+            if let (Some(progress), Some(name)) =
+                (progress, data.get("tool_name").and_then(|v| v.as_str()))
+            {
+                progress.observe_tool_start(name, crate::state::now_epoch());
+            }
+        }
+        match ev.r#type.as_str() {
+            "tool_start" => {
+                if let Some(name) = data.get("tool_name").and_then(|v| v.as_str()) {
+                    summary.tools.push(name.to_string());
+                }
+            }
+            "text_chunk" => {
+                if let Some(text) = data.get("text").and_then(|v| v.as_str()) {
+                    summary.text.push_str(text);
+                    if summary.text.len() > 8_000 {
+                        // truncate at a UTF-8 char boundary — str::truncate panics mid-char
+                        let boundary = summary.text.floor_char_boundary(8_000);
+                        summary.text.truncate(boundary);
+                    }
+                }
+            }
+            "agent_end" => {
+                summary.error = data.get("error").and_then(|v| v.as_str()).map(String::from);
+                summary.terminal_state = data
+                    .get("state")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("completed")
+                    .to_string();
+                summary.usage = data.get("usage").cloned();
+                summary.duration_ms = data.get("duration_ms").and_then(|v| v.as_i64());
+                return StreamOutcome::Done;
+            }
+            "error" => {
+                let msg = data
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                summary.error = Some(msg.to_string());
+                summary.terminal_state = "error".to_string();
+                return StreamOutcome::Done;
+            }
+            _ => {}
+        }
+    }
+    StreamOutcome::Closed
 }
 
 fn parse_data(ev: &StreamEvent) -> Option<Value> {

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
+use common::mock_agent::{completed_events, ev, spawn_mock, AttachPlan, MockState};
 use future_loop::agent_client::AgentClient;
 use future_loop::executor::{execute_turn, turn_succeeded, writeback};
 use future_loop::state::{Goal, RunRecord, Todo, TodoStatus};
@@ -358,6 +358,89 @@ fn run_turn_live_log_without_tool_name() {
         let log = std::fs::read_to_string(&live).unwrap();
         assert!(log.contains("tool_start"), "{log}");
         assert!(!log.contains("\"tool\":"), "{log}");
+    });
+}
+
+// ── O5: session event-stream gap recovery (backoff + cursor resume) ───────
+
+#[test]
+fn run_turn_recovers_from_single_stream_gap() {
+    rt().block_on(async {
+        // Attach 1 serves the first two events then drops the stream with the
+        // agent's DataLoss "event stream gap" status; attach 2 (resumed from
+        // the observed cursor) serves the rest to agent_end.
+        let (addr, shared) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            stream_attach_plan: vec![AttachPlan::GapAfter(2), AttachPlan::Complete],
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let summary = client
+            .run_turn("sess", "mock-run-1", None, None)
+            .await
+            .unwrap();
+        assert_eq!(summary.terminal_state, "completed");
+        assert_eq!(summary.tools, vec!["shell".to_string()]);
+        assert_eq!(summary.text, "artifact written", "no duplicated text");
+        assert!(summary.usage.is_some());
+        assert_eq!(summary.duration_ms, Some(7));
+        let shared = shared.lock().unwrap();
+        assert_eq!(
+            shared.attach_after_idx,
+            vec![-1, 1],
+            "reconnect resumes from the last observed idx"
+        );
+    });
+}
+
+#[test]
+fn run_turn_second_consecutive_gap_fails_with_original_error() {
+    rt().block_on(async {
+        // Both attaches drop mid-stream: the retry also fails, so the turn
+        // must terminate carrying the ORIGINAL error.
+        let (addr, shared) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            stream_attach_plan: vec![AttachPlan::GapAfter(1), AttachPlan::GapAfter(1)],
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client
+            .run_turn("sess", "mock-run-1", None, None)
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("mock gap #1"), "original error carried: {msg}");
+        assert!(msg.contains("retry also failed"), "{msg}");
+        let shared = shared.lock().unwrap();
+        assert_eq!(shared.attach_after_idx, vec![-1, 0]);
+    });
+}
+
+#[test]
+fn run_turn_non_gap_stream_error_fails_immediately() {
+    rt().block_on(async {
+        // A non-DataLoss transport error is NOT the agent's reconnect
+        // contract — no retry, exactly one attach.
+        let (addr, shared) = spawn_mock(MockState {
+            events: completed_events("mock-run-1"),
+            stream_attach_plan: vec![AttachPlan::HardErrorAfter(2)],
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let err = client
+            .run_turn("sess", "mock-run-1", None, None)
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("stream error"));
+        let shared = shared.lock().unwrap();
+        assert_eq!(
+            shared.attach_after_idx,
+            vec![-1],
+            "non-gap errors never retry"
+        );
     });
 }
 

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -12,6 +12,20 @@ use future_rpc::proto::future_agent_server::{FutureAgent, FutureAgentServer};
 use future_rpc::proto::{RpcCommand, RpcResponse, StreamEvent, StreamRequest};
 use tokio_stream::StreamExt;
 
+/// O5: scripted behavior for ONE `stream_events` attach (consumed in order;
+/// the first entry scripts the first attach, and so on).
+#[derive(Clone, Copy, Debug)]
+pub enum AttachPlan {
+    /// Serve the matching events (idx > after_idx), then terminate with a
+    /// `DataLoss` "event stream gap" error after `n` served events.
+    GapAfter(usize),
+    /// Like `GapAfter`, but with a non-recoverable `internal` status (no
+    /// retry path).
+    HardErrorAfter(usize),
+    /// Serve all matching events and close cleanly.
+    Complete,
+}
+
 #[derive(Default)]
 pub struct MockState {
     pub sessions_created: u64,
@@ -37,6 +51,11 @@ pub struct MockState {
     /// After N scripted events the stream yields one tonic error (mid-stream
     /// failure path in run_turn).
     pub stream_fail_after: Option<usize>,
+    /// O5: per-attach stream script for gap-recovery tests. Empty = the
+    /// legacy single-shot knobs above.
+    pub stream_attach_plan: Vec<AttachPlan>,
+    /// O5: `after_idx` values seen by stream_events, in attach order.
+    pub attach_after_idx: Vec<i64>,
     /// Per-command raw `data` payload override (valid JSON or not).
     pub raw: HashMap<String, String>,
     pub models_payload: Option<String>,
@@ -141,8 +160,41 @@ impl FutureAgent for MockAgent {
         &self,
         request: tonic::Request<StreamRequest>,
     ) -> Result<tonic::Response<Self::StreamEventsStream>, tonic::Status> {
-        let _ = request.into_inner();
-        let st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let req = request.into_inner();
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        st.attach_after_idx.push(req.after_idx);
+        if !st.stream_attach_plan.is_empty() {
+            let attach_no = st.attach_after_idx.len();
+            let plan = st.stream_attach_plan.remove(0);
+            // Like the real agent's atomic attach: replay only events after
+            // the client's cursor.
+            let matching: Vec<StreamEvent> = st
+                .events
+                .iter()
+                .filter(|e| e.idx > req.after_idx)
+                .cloned()
+                .collect();
+            let mut items: Vec<Result<StreamEvent, tonic::Status>> = Vec::new();
+            match plan {
+                AttachPlan::Complete => {
+                    items.extend(matching.into_iter().map(Ok));
+                }
+                AttachPlan::GapAfter(n) => {
+                    items.extend(matching.into_iter().take(n).map(Ok));
+                    items.push(Err(tonic::Status::data_loss(format!(
+                        "event stream gap for session sess, run mock; reconnect with \
+                         atomic attach (mock gap #{attach_no})"
+                    ))));
+                }
+                AttachPlan::HardErrorAfter(n) => {
+                    items.extend(matching.into_iter().take(n).map(Ok));
+                    items.push(Err(tonic::Status::internal(format!(
+                        "mock hard failure #{attach_no}"
+                    ))));
+                }
+            }
+            return Ok(tonic::Response::new(Box::pin(tokio_stream::iter(items))));
+        }
         if st.stream_error {
             return Err(tonic::Status::internal("mock stream attach failure"));
         }


### PR DESCRIPTION
Wave 3 自愈 5/5。agent session 事件流 DataLoss（'event stream gap'）会直接杀死 turn（本 session 中断 3 次，疑似与并行 worker 共挤 agent server 有关）。

- 流错误时：记原错误 → 退避 2s → 同 session 按最后已知 idx 续读重连
- 连续第二次失败才终止 turn 并带原错误
- mock server 测试：中途 drop 一次 → 重试成功继续；连续 drop 两次 → 按原样失败

本地：fmt ✅ clippy ✅ future-loop 78 targets 全绿 ✅。源：claude/loop-wave2 a8165281