### PR TITLE
feat(loop): G12 multi_agent subdomain — contract/recipe/succession/wake-roster/collective-turn-ledger

### DIFF
--- a/orchestration/loop/src/agents/mod.rs
+++ b/orchestration/loop/src/agents/mod.rs
@@ -1,12 +1,15 @@
-//! agents subdomain (G-16/G-24) — single-process multi-agent reservation:
+//! agents subdomain (G-16/G-24/G12) — single-process multi-agent reservation:
 //! identity-scoped frontiers (scope), lane recommendations (lane), the
 //! supervisor proposal/receipt event surface (supervisor), the capability
 //! gate binding agent capabilities to todo runnability (capability_gate),
-//! and the workspace guard against shared-workspace write conflicts
-//! (workspace_guard). Cross-process A2A stays a contract-schema concern.
+//! the workspace guard against shared-workspace write conflicts
+//! (workspace_guard), and the multi-agent contract/recipe/succession/
+//! wake-roster/collective-turn-ledger surface (multi_agent). Cross-process
+//! A2A stays a contract-schema concern.
 
 pub mod capability_gate;
 pub mod lane;
+pub mod multi_agent;
 pub mod scope;
 pub mod supervisor;
 pub mod workspace_guard;

--- a/orchestration/loop/src/agents/multi_agent.rs
+++ b/orchestration/loop/src/agents/multi_agent.rs
@@ -1,0 +1,656 @@
+//! G12 multi_agent subdomain — the reference
+//! `control_plane/agents/multi_agent/` package (contract.py, recipe.py,
+//! role_successor.py, collective_round_ledger.py, visible_wake_scheduler.py),
+//! natively (core subset).
+//!
+//! The contract is the single declarative surface for a goal's multi-agent
+//! topology: peers (with backup/succession edges), handoff rules, and named
+//! collectives. Everything else is a PROJECTION over the event ledger —
+//! the goal state itself is untouched (same rule as the G-16 supervisor):
+//!
+//! - [`MultiAgentContract`] + validation → `MultiAgentContractSet` event;
+//! - [`AgentRecipe`] (named capabilities/workspaces/priority) →
+//!   `AgentRecipeAdded` event, applied by `agent onboard --recipe`;
+//! - role succession: a primary whose live lease expired or whose scheduler
+//!   heartbeat went silent past the threshold is succeeded by its declared
+//!   backup → `SuccessionOccurred` event + attention hint;
+//! - [`wake_roster`]: the round-robin wake order inside a collective;
+//! - [`collective_turn_ledger`]: per-collective turn counts derived from
+//!   claim events (a claim = one bounded turn opportunity, the same unit the
+//!   reference collective-round ledger counts).
+
+use std::collections::{BTreeMap, HashSet};
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::state::{now_epoch, Goal, Priority, TodoStatus};
+use crate::store::{Event, Store};
+use crate::work_items::attention::AttentionItem;
+
+pub const MULTI_AGENT_CONTRACT_SCHEMA_VERSION: &str = "multi_agent_contract_v0";
+pub const MULTI_AGENT_RECIPE_SCHEMA_VERSION: &str = "multi_agent_recipe_v0";
+pub const ROLE_SUCCESSOR_PROJECTION_SCHEMA_VERSION: &str = "multi_agent_role_succession_v0";
+pub const WAKE_ROSTER_SCHEMA_VERSION: &str = "multi_agent_wake_roster_v0";
+pub const COLLECTIVE_TURN_LEDGER_SCHEMA_VERSION: &str = "multi_agent_collective_turn_ledger_v0";
+
+/// Succession reasons (reference role_successor trigger vocabulary).
+pub const SUCCESSION_REASON_LEASE_EXPIRED: &str = "lease_expired";
+pub const SUCCESSION_REASON_OFFLINE: &str = "offline";
+
+/// Default offline threshold before a backup may succeed a primary
+/// (30 minutes; the automation-liveness threshold is deliberately larger).
+pub const DEFAULT_SUCCESSOR_OFFLINE_THRESHOLD_SECS: u64 = 30 * 60;
+
+/// Effective successor offline threshold. The `FUTURE_LOOP_SUCCESSOR_OFFLINE_SECS`
+/// env var shrinks it in tests (mirrors the FUTURE_LOOP_NO_PROGRESS_SECS
+/// hook); invalid or non-positive values fall back to the 30-minute default.
+pub fn successor_offline_threshold_secs() -> u64 {
+    std::env::var("FUTURE_LOOP_SUCCESSOR_OFFLINE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_SUCCESSOR_OFFLINE_THRESHOLD_SECS)
+}
+
+// ── Multi-agent contract ───────────────────────────────────────────────────
+
+/// One peer's role inside the contract. `backup_for` names the primary agent
+/// this peer succeeds when the primary dies (None = this peer is a primary
+/// itself, or standalone). In this native single-process subset a role maps
+/// 1:1 to an agent id, so `handoff_rules.to_role` resolves to a peer agent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerRole {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_for: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub workspaces: Vec<String>,
+}
+
+/// One event→role handoff rule (reference handoff_hints, compact): when
+/// `from_event` occurs (e.g. `lease_expired`, `todo_completed`), the wake
+/// order favors `to_role` (a contract peer agent).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandoffRule {
+    pub from_event: String,
+    pub to_role: String,
+}
+
+/// The declarative multi-agent topology for one goal. `collectives` are
+/// named peer groups — the scope of the wake roster and the collective turn
+/// ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiAgentContract {
+    pub schema_version: String,
+    #[serde(default)]
+    pub peers: BTreeMap<String, PeerRole>,
+    #[serde(default)]
+    pub handoff_rules: Vec<HandoffRule>,
+    #[serde(default)]
+    pub collectives: BTreeMap<String, Vec<String>>,
+}
+
+impl Default for MultiAgentContract {
+    fn default() -> Self {
+        Self {
+            schema_version: MULTI_AGENT_CONTRACT_SCHEMA_VERSION.to_string(),
+            peers: BTreeMap::new(),
+            handoff_rules: vec![],
+            collectives: BTreeMap::new(),
+        }
+    }
+}
+
+impl MultiAgentContract {
+    /// The backup agent declared for `primary` (None when undeclared).
+    pub fn backup_of(&self, primary: &str) -> Option<&str> {
+        self.peers
+            .iter()
+            .find(|(_, role)| role.backup_for.as_deref() == Some(primary))
+            .map(|(agent, _)| agent.as_str())
+    }
+
+    /// Members of a collective (contract order; unknown → None).
+    pub fn collective_members(&self, collective: &str) -> Option<&Vec<String>> {
+        self.collectives.get(collective)
+    }
+
+    /// The collective an agent belongs to (None = no collective).
+    pub fn collective_of(&self, agent_id: &str) -> Option<&str> {
+        self.collectives
+            .iter()
+            .find(|(_, members)| members.iter().any(|m| m == agent_id))
+            .map(|(name, _)| name.as_str())
+    }
+
+    /// The first handoff rule matching `from_event` → its target peer.
+    pub fn handoff_target(&self, from_event: &str) -> Option<&str> {
+        self.handoff_rules
+            .iter()
+            .find(|r| r.from_event == from_event)
+            .map(|r| r.to_role.as_str())
+    }
+}
+
+/// Validate a contract (reference: contracts fail closed — a topology that
+/// cannot be trusted must not be recorded). Returns every issue found
+/// (empty = valid).
+pub fn contract_issues(contract: &MultiAgentContract) -> Vec<String> {
+    let mut issues = vec![];
+    if contract.schema_version != MULTI_AGENT_CONTRACT_SCHEMA_VERSION {
+        issues.push(format!(
+            "schema_version must be `{MULTI_AGENT_CONTRACT_SCHEMA_VERSION}` (got `{}`)",
+            contract.schema_version
+        ));
+    }
+    for (id, role) in &contract.peers {
+        if id.trim().is_empty() {
+            issues.push("peer agent id must be non-empty".to_string());
+        }
+        if let Some(target) = &role.backup_for {
+            if target.trim().is_empty() {
+                issues.push(format!("peer `{id}`: backup_for must be non-empty"));
+            } else if target == id {
+                issues.push(format!("peer `{id}` cannot back up itself"));
+            } else if !contract.peers.contains_key(target) {
+                issues.push(format!(
+                    "peer `{id}`: backup_for `{target}` is not a contract peer"
+                ));
+            }
+        }
+    }
+    // Backup chains must be acyclic (a cycle would make succession
+    // oscillate forever).
+    for id in contract.peers.keys() {
+        let mut seen: HashSet<&str> = HashSet::from([id.as_str()]);
+        let mut cur = id.as_str();
+        while let Some(next) = contract
+            .peers
+            .get(cur)
+            .and_then(|role| role.backup_for.as_deref())
+        {
+            if !seen.insert(next) {
+                issues.push(format!("backup chain cycle involving `{next}`"));
+                break;
+            }
+            if !contract.peers.contains_key(next) {
+                break; // unknown target already reported above
+            }
+            cur = next;
+        }
+    }
+    let mut seen_rules: HashSet<(String, String)> = HashSet::new();
+    for rule in &contract.handoff_rules {
+        if rule.from_event.trim().is_empty() {
+            issues.push("handoff rule: from_event must be non-empty".to_string());
+        }
+        if rule.to_role.trim().is_empty() {
+            issues.push("handoff rule: to_role must be non-empty".to_string());
+        } else if !contract.peers.contains_key(&rule.to_role) {
+            issues.push(format!(
+                "handoff rule: to_role `{}` is not a contract peer",
+                rule.to_role
+            ));
+        }
+        if !seen_rules.insert((rule.from_event.clone(), rule.to_role.clone())) {
+            issues.push(format!(
+                "duplicate handoff rule `{}` → `{}`",
+                rule.from_event, rule.to_role
+            ));
+        }
+    }
+    let mut membership: HashSet<&str> = HashSet::new();
+    for (name, members) in &contract.collectives {
+        if name.trim().is_empty() {
+            issues.push("collective name must be non-empty".to_string());
+        }
+        if members.is_empty() {
+            issues.push(format!("collective `{name}` must have at least one member"));
+        }
+        let mut local: HashSet<&str> = HashSet::new();
+        for m in members {
+            if !contract.peers.contains_key(m) {
+                issues.push(format!(
+                    "collective `{name}`: member `{m}` is not a contract peer"
+                ));
+            } else if !local.insert(m.as_str()) {
+                issues.push(format!("collective `{name}`: duplicate member `{m}`"));
+            } else if !membership.insert(m.as_str()) {
+                issues.push(format!("agent `{m}` appears in more than one collective"));
+            }
+        }
+    }
+    issues
+}
+
+/// Record a contract set (full replace — the latest event wins). Validation
+/// fails closed: an invalid contract is never appended.
+pub fn record_contract(
+    store: &mut Store,
+    goal_id: &str,
+    contract: &MultiAgentContract,
+) -> Result<String> {
+    let issues = contract_issues(contract);
+    if !issues.is_empty() {
+        bail!("invalid multi-agent contract: {}", issues.join("; "));
+    }
+    store.append(Event::MultiAgentContractSet {
+        goal_id: goal_id.to_string(),
+        contract: contract.clone(),
+        ts: now_epoch(),
+    })
+}
+
+/// The latest recorded contract (None when none was ever set).
+pub fn latest_contract(store: &Store, goal_id: &str) -> Result<Option<MultiAgentContract>> {
+    let events = store.events(goal_id)?;
+    let mut contract: Option<MultiAgentContract> = None;
+    for stored in &events {
+        if let Event::MultiAgentContractSet {
+            goal_id: g,
+            contract: c,
+            ..
+        } = &stored.event
+        {
+            if g == goal_id {
+                contract = Some(c.clone());
+            }
+        }
+    }
+    Ok(contract)
+}
+
+// ── Agent recipes ──────────────────────────────────────────────────────────
+
+/// A named onboarding recipe: capabilities + workspaces + the default
+/// priority for work this agent claims (LoopX minimal-recipe idea, native:
+/// the reusable part is the declarative profile, not process mechanics).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentRecipe {
+    pub schema_version: String,
+    pub name: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub workspaces: Vec<String>,
+    #[serde(default)]
+    pub priority: Priority,
+}
+
+/// Validate a recipe (fail closed — a recipe is a reusable onboarding
+/// profile, so it must be well-formed before it can be applied).
+pub fn recipe_issues(recipe: &AgentRecipe) -> Vec<String> {
+    let mut issues = vec![];
+    if recipe.schema_version != MULTI_AGENT_RECIPE_SCHEMA_VERSION {
+        issues.push(format!(
+            "schema_version must be `{MULTI_AGENT_RECIPE_SCHEMA_VERSION}` (got `{}`)",
+            recipe.schema_version
+        ));
+    }
+    if recipe.name.trim().is_empty() {
+        issues.push("recipe name must be non-empty".to_string());
+    }
+    issues
+}
+
+/// Record a recipe (`AgentRecipeAdded`). Re-adding a name is allowed —
+/// lookups resolve the latest event (latest wins).
+pub fn record_recipe(store: &mut Store, goal_id: &str, recipe: &AgentRecipe) -> Result<String> {
+    let issues = recipe_issues(recipe);
+    if !issues.is_empty() {
+        bail!("invalid agent recipe: {}", issues.join("; "));
+    }
+    store.append(Event::AgentRecipeAdded {
+        goal_id: goal_id.to_string(),
+        recipe: recipe.clone(),
+        ts: now_epoch(),
+    })
+}
+
+/// All recorded recipes in ledger order.
+pub fn recipes(store: &Store, goal_id: &str) -> Result<Vec<AgentRecipe>> {
+    let events = store.events(goal_id)?;
+    let mut out = vec![];
+    for stored in &events {
+        if let Event::AgentRecipeAdded {
+            goal_id: g, recipe, ..
+        } = &stored.event
+        {
+            if g == goal_id {
+                out.push(recipe.clone());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The latest recipe under `name` (None when unknown).
+pub fn recipe_named(store: &Store, goal_id: &str, name: &str) -> Result<Option<AgentRecipe>> {
+    Ok(recipes(store, goal_id)?
+        .into_iter()
+        .rfind(|r| r.name == name))
+}
+
+/// Onboard `agent_id` with a recipe (capabilities + workspaces land on the
+/// same `AgentOnboarded` event the explicit onboard path uses — the
+/// capability gate and workspace guard consume them identically).
+pub fn apply_recipe_onboard(
+    store: &mut Store,
+    goal_id: &str,
+    agent_id: &str,
+    recipe: &AgentRecipe,
+) -> Result<String> {
+    store.append(Event::AgentOnboarded {
+        goal_id: goal_id.to_string(),
+        agent_id: agent_id.to_string(),
+        capabilities: recipe.capabilities.clone(),
+        workspaces: recipe.workspaces.clone(),
+        ts: now_epoch(),
+    })
+}
+
+// ── Role succession ────────────────────────────────────────────────────────
+
+/// One succession trigger detected from current state (not yet recorded).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SuccessionCandidate {
+    /// The role slot being succeeded (= the primary agent id).
+    pub role: String,
+    pub primary: String,
+    pub backup: String,
+    /// `lease_expired` | `offline`.
+    pub reason: String,
+    /// When the trigger state was observed: the expired lease timestamp for
+    /// `lease_expired`, the last heartbeat for `offline`.
+    pub since: u64,
+}
+
+/// One recorded succession (read back from the ledger).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SuccessionRecord {
+    pub primary: String,
+    pub backup: String,
+    pub reason: String,
+    pub ts: u64,
+    pub event_id: String,
+}
+
+/// Detect succession triggers against current goal state. A primary is
+/// succeeded when (a) it holds a live-lease todo whose lease has expired
+/// (stalled mid-slice), or (b) its scheduler heartbeat went silent past the
+/// offline threshold. Heartbeat-less primaries are NOT presumed offline
+/// (no "first seen" anchor) — they fall back to lease-expiry detection.
+pub fn succession_candidates_with(
+    goal: &Goal,
+    contract: &MultiAgentContract,
+    now: u64,
+    offline_threshold_secs: u64,
+) -> Vec<SuccessionCandidate> {
+    let mut out = vec![];
+    for (backup, role) in &contract.peers {
+        let Some(primary) = role.backup_for.as_deref() else {
+            continue;
+        };
+        if primary == backup || primary.trim().is_empty() {
+            continue; // validation rejects these; defensive here
+        }
+        // The primary must actually be part of this goal's automation.
+        if !goal.registered_agents.iter().any(|a| a == primary) {
+            continue;
+        }
+        let expired_lease = goal
+            .todos
+            .iter()
+            .filter(|t| t.claimed_by.as_deref() == Some(primary) && t.status == TodoStatus::Open)
+            .filter_map(|t| t.lease_expires_at)
+            .filter(|e| *e <= now)
+            .max();
+        if let Some(expired) = expired_lease {
+            out.push(SuccessionCandidate {
+                role: primary.to_string(),
+                primary: primary.to_string(),
+                backup: backup.clone(),
+                reason: SUCCESSION_REASON_LEASE_EXPIRED.to_string(),
+                since: expired,
+            });
+            continue;
+        }
+        if let Some(last_hb) = goal.scheduler_heartbeats.get(primary) {
+            if now.saturating_sub(*last_hb) >= offline_threshold_secs {
+                out.push(SuccessionCandidate {
+                    role: primary.to_string(),
+                    primary: primary.to_string(),
+                    backup: backup.clone(),
+                    reason: SUCCESSION_REASON_OFFLINE.to_string(),
+                    since: *last_hb,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// [`succession_candidates_with`] using the effective threshold
+/// (env-overridable, see [`successor_offline_threshold_secs`]).
+pub fn succession_candidates(
+    goal: &Goal,
+    contract: &MultiAgentContract,
+    now: u64,
+) -> Vec<SuccessionCandidate> {
+    succession_candidates_with(goal, contract, now, successor_offline_threshold_secs())
+}
+
+/// Record a succession (`SuccessionOccurred`). Idempotent per trigger
+/// episode: re-recording the same (primary, backup, reason) returns the
+/// existing event id instead of appending a duplicate.
+pub fn record_succession(
+    store: &mut Store,
+    goal_id: &str,
+    candidate: &SuccessionCandidate,
+) -> Result<String> {
+    if let Some(existing) = successions(store, goal_id)?.into_iter().find(|r| {
+        r.primary == candidate.primary
+            && r.backup == candidate.backup
+            && r.reason == candidate.reason
+    }) {
+        return Ok(existing.event_id);
+    }
+    store.append(Event::SuccessionOccurred {
+        goal_id: goal_id.to_string(),
+        primary: candidate.primary.clone(),
+        backup: candidate.backup.clone(),
+        reason: candidate.reason.clone(),
+        ts: now_epoch(),
+    })
+}
+
+/// Recorded successions in ledger order.
+pub fn successions(store: &Store, goal_id: &str) -> Result<Vec<SuccessionRecord>> {
+    let events = store.events(goal_id)?;
+    let mut out = vec![];
+    for stored in &events {
+        if let Event::SuccessionOccurred {
+            goal_id: g,
+            primary,
+            backup,
+            reason,
+            ts,
+        } = &stored.event
+        {
+            if g == goal_id {
+                out.push(SuccessionRecord {
+                    primary: primary.clone(),
+                    backup: backup.clone(),
+                    reason: reason.clone(),
+                    ts: *ts,
+                    event_id: stored.effective_id(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Attention hints for recorded successions — one item per role slot
+/// (latest succession per primary wins). A succession is considered
+/// recovered once the primary's scheduler heartbeat lands at or after the
+/// succession event (the primary proved it is alive again), which
+/// suppresses the item.
+pub fn succession_attention_items(store: &Store, goal: &Goal) -> Result<Vec<AttentionItem>> {
+    let mut items = vec![];
+    let mut latest_per_primary: BTreeMap<String, SuccessionRecord> = BTreeMap::new();
+    for r in successions(store, &goal.goal_id)? {
+        latest_per_primary.insert(r.primary.clone(), r);
+    }
+    for (primary, record) in latest_per_primary {
+        let recovered = goal
+            .scheduler_heartbeats
+            .get(&primary)
+            .is_some_and(|hb| *hb >= record.ts);
+        if recovered {
+            continue;
+        }
+        items.push(AttentionItem {
+            goal_id: goal.goal_id.clone(),
+            status: "role_succession".to_string(),
+            waiting_on: "user_or_controller".to_string(),
+            severity: "high".to_string(),
+            recommended_action: format!(
+                "primary `{primary}` → backup `{}` promoted ({}) — verify/restore the primary or make the promotion permanent",
+                record.backup, record.reason
+            ),
+            source: "role_succession".to_string(),
+        });
+    }
+    Ok(items)
+}
+
+// ── Wake roster ────────────────────────────────────────────────────────────
+
+/// The round-robin wake order inside a collective (reference
+/// visible_wake_scheduler, native projection): agents wake in contract
+/// order, rotated by the collective's completed turn count. `order[0]`
+/// (`current`) wakes next.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WakeRoster {
+    pub schema_version: String,
+    pub collective: String,
+    /// Completed collective turns this roster is projected for.
+    pub turn: u32,
+    /// Wake order for the NEXT turn (rotated).
+    pub order: Vec<String>,
+    /// Who wakes first (= `order[0]`).
+    pub current: String,
+}
+
+/// Project the wake roster for a collective. `turn` completed turns rotate
+/// the order by `turn % member_count` (deterministic — contract order is
+/// BTreeMap order). None for an unknown/empty collective.
+pub fn wake_roster(
+    contract: &MultiAgentContract,
+    collective: &str,
+    turn: u32,
+) -> Option<WakeRoster> {
+    let members = contract.collective_members(collective)?;
+    if members.is_empty() {
+        return None;
+    }
+    let mut order = members.clone();
+    let len = order.len();
+    order.rotate_left((turn as usize) % len);
+    Some(WakeRoster {
+        schema_version: WAKE_ROSTER_SCHEMA_VERSION.to_string(),
+        collective: collective.to_string(),
+        turn,
+        current: order[0].clone(),
+        order,
+    })
+}
+
+// ── Collective turn ledger ─────────────────────────────────────────────────
+
+/// One agent's turn count inside a collective (a claim = one bounded turn
+/// opportunity — the same unit the reference collective-round ledger
+/// counts as an asynchronous turn).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CollectiveTurnEntry {
+    pub agent_id: String,
+    pub turns: u32,
+    pub last_turn_ts: Option<u64>,
+}
+
+/// Per-collective turn counts, derived from `TodoClaimed` events (a claim
+/// precedes every bounded turn). `full_participation_rounds` is the min
+/// count across members — the asynchronous full-participation basis of the
+/// reference ledger (0 until every member has claimed at least once).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CollectiveTurnLedger {
+    pub schema_version: String,
+    pub collective: String,
+    pub agents: Vec<String>,
+    pub per_agent: BTreeMap<String, CollectiveTurnEntry>,
+    pub full_participation_rounds: u32,
+    pub total_claims: u32,
+}
+
+/// Project the turn ledger for one collective. None for an unknown or
+/// empty collective.
+pub fn collective_turn_ledger(
+    store: &Store,
+    goal_id: &str,
+    contract: &MultiAgentContract,
+    collective: &str,
+) -> Result<Option<CollectiveTurnLedger>> {
+    let Some(members) = contract.collective_members(collective) else {
+        return Ok(None);
+    };
+    if members.is_empty() {
+        return Ok(None);
+    }
+    let mut per_agent: BTreeMap<String, CollectiveTurnEntry> = members
+        .iter()
+        .map(|a| {
+            (
+                a.clone(),
+                CollectiveTurnEntry {
+                    agent_id: a.clone(),
+                    turns: 0,
+                    last_turn_ts: None,
+                },
+            )
+        })
+        .collect();
+    let mut total = 0u32;
+    for stored in store.events(goal_id)? {
+        if let Event::TodoClaimed {
+            goal_id: g,
+            agent_id,
+            ts,
+            ..
+        } = &stored.event
+        {
+            if g == goal_id {
+                if let Some(entry) = per_agent.get_mut(agent_id) {
+                    entry.turns += 1;
+                    entry.last_turn_ts = Some(entry.last_turn_ts.map_or(*ts, |t| t.max(*ts)));
+                    total += 1;
+                }
+            }
+        }
+    }
+    let full = members
+        .iter()
+        .map(|a| per_agent.get(a).map(|e| e.turns).unwrap_or(0))
+        .min()
+        .unwrap_or(0);
+    Ok(Some(CollectiveTurnLedger {
+        schema_version: COLLECTIVE_TURN_LEDGER_SCHEMA_VERSION.to_string(),
+        collective: collective.to_string(),
+        agents: members.clone(),
+        per_agent,
+        full_participation_rounds: full,
+        total_claims: total,
+    }))
+}

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -22,7 +22,7 @@ use crate::decision::{complete_todo, decide_for, MAX_REPAIR_ATTEMPTS};
 use crate::executor::{execute_turn, writeback};
 use crate::state::{now_epoch, Goal, RunRecord, TaskClass, Todo, TodoStatus};
 use crate::store::{Event, Store};
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
 /// Materialize the project-local active-state projection for one goal:
 /// `<cwd>/.future/loop/goals/<id>/ACTIVE_GOAL_STATE.md`.
@@ -311,8 +311,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         agent,
         "agent",
-        "register/onboard agents (declare capabilities + workspaces)",
-        "agent onboard --goal G --agent-id A [--capabilities c1,c2] [--workspace p1,p2]",
+        "register/onboard agents + multi-agent contract/recipe/succession/collective surface (G12)",
+        "agent onboard --goal G --agent-id A [--capabilities c1,c2] [--recipe N] | list|contract|recipe|succession|collective --goal G",
     );
     r.command(
         agent,
@@ -1250,11 +1250,14 @@ fn parse_workspaces(raw: &str) -> Vec<String> {
 /// register a peer (LoopX: coordination.registered_agents; precondition for
 /// quota --agent-id). `--workspace` declares the P0-1 guard write set.
 fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
-    if args.first().map(|s| s.as_str()) == Some("onboard") {
-        return cmd_agent_onboard(store, &args[1..]);
-    }
-    if args.first().map(|s| s.as_str()) == Some("list") {
-        return cmd_agent_list(store, &args[1..]);
+    match args.first().map(|s| s.as_str()) {
+        Some("onboard") => return cmd_agent_onboard(store, &args[1..]),
+        Some("list") => return cmd_agent_list(store, &args[1..]),
+        Some("contract") => return cmd_agent_contract(store, &args[1..]),
+        Some("recipe") => return cmd_agent_recipe(store, &args[1..]),
+        Some("succession") => return cmd_agent_succession(store, &args[1..]),
+        Some("collective") => return cmd_agent_collective(store, &args[1..]),
+        _ => {}
     }
     let mut goal_id = None;
     let mut agent_id = None;
@@ -1289,14 +1292,18 @@ fn cmd_agent(store: &mut Store, args: &[String]) -> Result<()> {
 }
 
 /// `loopx agent onboard --goal G --agent-id A [--capability shell,github]
-/// [--workspace p1,p2]` — register a peer AND declare its capabilities
-/// (LoopX: agent_profiles; input to the capability gate) plus the P0-1
-/// workspace-guard write set.
+/// [--workspace p1,p2] [--recipe NAME]` — register a peer AND declare its
+/// capabilities (LoopX: agent_profiles; input to the capability gate) plus
+/// the P0-1 workspace-guard write set. `--recipe NAME` applies a recorded
+/// G12 agent recipe (capabilities + workspaces + default priority) — when
+/// given, explicit `--capability`/`--workspace` flags are rejected (the
+/// recipe is the single source).
 fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut agent_id = None;
     let mut capabilities = vec![];
     let mut workspaces = vec![];
+    let mut recipe_name = None;
     reject_unknown_flags(
         args,
         &[
@@ -1304,6 +1311,7 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
             "--capabilities",
             "--capability",
             "--goal",
+            "--recipe",
             "--workspace",
         ],
     )?;
@@ -1316,6 +1324,8 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
             capabilities = v.split(',').map(|s| s.trim().to_string()).collect();
         } else if k == "--workspace" {
             workspaces = parse_workspaces(&v);
+        } else if k == "--recipe" {
+            recipe_name = Some(v);
         }
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -1323,6 +1333,25 @@ fn cmd_agent_onboard(store: &mut Store, args: &[String]) -> Result<()> {
     store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    if let Some(name) = recipe_name {
+        if !capabilities.is_empty() || !workspaces.is_empty() {
+            bail!(
+                "--recipe {name} conflicts with explicit --capability/--workspace flags \
+                 (the recipe owns the onboarding profile)"
+            );
+        }
+        let recipe = crate::agents::multi_agent::recipe_named(store, &goal_id, &name)?
+            .ok_or_else(|| {
+                anyhow::anyhow!("no agent recipe named `{name}` for {goal_id} (add one first: agent recipe add)")
+            })?;
+        crate::agents::multi_agent::apply_recipe_onboard(store, &goal_id, &agent_id, &recipe)?;
+        println!(
+            "agent `{agent_id}` onboarded via recipe `{name}` \
+             (capabilities={:?} workspaces={:?} priority={}) ✔",
+            recipe.capabilities, recipe.workspaces, recipe.priority
+        );
+        return Ok(());
+    }
     store.append(Event::AgentOnboarded {
         goal_id: goal_id.clone(),
         agent_id: agent_id.clone(),
@@ -1513,6 +1542,456 @@ fn agent_list_rows(goal: &Goal, last_active: &HashMap<String, u64>, now: u64) ->
             }
         })
         .collect()
+}
+
+/// `agent contract set --goal G --contract '<json>' | --contract-file PATH`
+/// and `agent contract show --goal G [--format json]` — the G12 multi-agent
+/// topology surface. Set validates fail-closed before appending
+/// (`MultiAgentContractSet`, latest event wins); show projects the current
+/// contract plus its validation issues (a drifted on-disk contract that was
+/// never re-validated would surface here).
+fn cmd_agent_contract(store: &mut Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    match sub {
+        "set" => {
+            let mut goal_id = None;
+            let mut inline = None;
+            let mut file = None;
+            reject_unknown_flags(&args[1..], &["--contract", "--contract-file", "--goal"])?;
+            parse_pairs(&args[1..], |k, v| match k {
+                "--goal" => goal_id = Some(v),
+                "--contract" => inline = Some(v),
+                "--contract-file" => file = Some(v),
+                _ => {}
+            });
+            let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+            let raw = match (inline, file) {
+                (Some(v), _) => v,
+                (None, Some(path)) => std::fs::read_to_string(&path)
+                    .with_context(|| format!("read contract file {path}"))?,
+                (None, None) => {
+                    bail!("contract required: --contract '<json>' or --contract-file PATH")
+                }
+            };
+            let contract: crate::agents::multi_agent::MultiAgentContract =
+                serde_json::from_str(&raw).context("parse contract JSON")?;
+            store
+                .replay(&goal_id)?
+                .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+            let event_id = crate::agents::multi_agent::record_contract(store, &goal_id, &contract)?;
+            println!(
+                "multi-agent contract set for {goal_id}: {} peer(s), {} handoff rule(s), {} collective(s) (event {event_id}) ✔",
+                contract.peers.len(),
+                contract.handoff_rules.len(),
+                contract.collectives.len()
+            );
+        }
+        "show" => {
+            let mut goal_id = None;
+            reject_unknown_flags(&args[1..], &["--format", "--goal", "--json"])?;
+            parse_pairs(&args[1..], |k, v| {
+                if k == "--goal" {
+                    goal_id = Some(v);
+                }
+            });
+            let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+            store
+                .replay(&goal_id)?
+                .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+            match crate::agents::multi_agent::latest_contract(store, &goal_id)? {
+                None => println!("no multi-agent contract set for {goal_id}"),
+                Some(contract) => {
+                    let issues = crate::agents::multi_agent::contract_issues(&contract);
+                    if wants_json(&args[1..]) {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "ok": true,
+                                "goal_id": goal_id,
+                                "contract": contract,
+                                "validation_issues": issues,
+                            }))?
+                        );
+                    } else {
+                        println!(
+                            "multi-agent contract for {goal_id}: {} peer(s), {} handoff rule(s), {} collective(s){}",
+                            contract.peers.len(),
+                            contract.handoff_rules.len(),
+                            contract.collectives.len(),
+                            if issues.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" — ⚠ validation issues: {}", issues.join("; "))
+                            }
+                        );
+                        for (id, role) in &contract.peers {
+                            let backup = role
+                                .backup_for
+                                .as_deref()
+                                .map(|b| format!(" backups {b}"))
+                                .unwrap_or_default();
+                            let caps = if role.capabilities.is_empty() {
+                                "-".to_string()
+                            } else {
+                                role.capabilities.join(",")
+                            };
+                            let ws = if role.workspaces.is_empty() {
+                                "-".to_string()
+                            } else {
+                                role.workspaces.join(",")
+                            };
+                            println!("  peer {id}{backup} capabilities={caps} workspaces={ws}");
+                        }
+                        for rule in &contract.handoff_rules {
+                            println!("  handoff: {} → {}", rule.from_event, rule.to_role);
+                        }
+                        for (name, members) in &contract.collectives {
+                            println!("  collective {name}: {}", members.join(","));
+                        }
+                    }
+                }
+            }
+        }
+        other => bail!("unknown agent contract subcommand `{other}` (set|show)"),
+    }
+    Ok(())
+}
+
+/// `agent recipe add --goal G --name N [--capabilities c1,c2] [--workspace p]
+/// [--priority P0]` and `agent recipe show --goal G [--name N] [--format json]`
+/// — the G12 named-recipe surface consumed by `agent onboard --recipe N`.
+fn cmd_agent_recipe(store: &mut Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    match sub {
+        "add" => {
+            let mut goal_id = None;
+            let mut name = None;
+            let mut capabilities = vec![];
+            let mut workspaces = vec![];
+            let mut priority = crate::state::Priority::P1;
+            reject_unknown_flags(
+                &args[1..],
+                &[
+                    "--capabilities",
+                    "--capability",
+                    "--goal",
+                    "--name",
+                    "--priority",
+                    "--workspace",
+                ],
+            )?;
+            parse_pairs(&args[1..], |k, v| match k {
+                "--goal" => goal_id = Some(v),
+                "--name" => name = Some(v),
+                "--capability" | "--capabilities" => {
+                    capabilities = v.split(',').map(|s| s.trim().to_string()).collect()
+                }
+                "--workspace" => workspaces = parse_workspaces(&v),
+                "--priority" => {
+                    priority = match v.to_uppercase().as_str() {
+                        "P0" => crate::state::Priority::P0,
+                        "P2" => crate::state::Priority::P2,
+                        _ => crate::state::Priority::P1,
+                    }
+                }
+                _ => {}
+            });
+            let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+            let name = name.ok_or_else(|| anyhow::anyhow!("--name required"))?;
+            store
+                .replay(&goal_id)?
+                .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+            let recipe = crate::agents::multi_agent::AgentRecipe {
+                schema_version: crate::agents::multi_agent::MULTI_AGENT_RECIPE_SCHEMA_VERSION
+                    .to_string(),
+                name: name.clone(),
+                capabilities: capabilities.clone(),
+                workspaces: workspaces.clone(),
+                priority,
+            };
+            let event_id = crate::agents::multi_agent::record_recipe(store, &goal_id, &recipe)?;
+            println!(
+                "agent recipe `{name}` added for {goal_id} \
+                 (capabilities={capabilities:?} workspaces={workspaces:?} priority={priority}) \
+                 (event {event_id}) ✔"
+            );
+        }
+        "show" => {
+            let mut goal_id = None;
+            let mut name = None;
+            reject_unknown_flags(&args[1..], &["--format", "--goal", "--json", "--name"])?;
+            parse_pairs(&args[1..], |k, v| match k {
+                "--goal" => goal_id = Some(v),
+                "--name" => name = Some(v),
+                _ => {}
+            });
+            let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+            let recipes = crate::agents::multi_agent::recipes(store, &goal_id)?;
+            let shown: Vec<_> = recipes
+                .iter()
+                .filter(|r| name.as_deref().is_none_or(|n| r.name == n))
+                .collect();
+            if wants_json(&args[1..]) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": true,
+                        "goal_id": goal_id,
+                        "recipe_count": shown.len(),
+                        "recipes": shown,
+                    }))?
+                );
+            } else {
+                if shown.is_empty() {
+                    let label = name.map(|n| format!(" named `{n}`")).unwrap_or_default();
+                    println!("no agent recipes{label} for {goal_id}");
+                } else {
+                    println!("agent recipes for {goal_id} ({}):", shown.len());
+                    for r in &shown {
+                        println!(
+                            "  {:<20} priority={:<3} capabilities={} workspaces={}",
+                            r.name,
+                            r.priority,
+                            if r.capabilities.is_empty() {
+                                "-".to_string()
+                            } else {
+                                r.capabilities.join(",")
+                            },
+                            if r.workspaces.is_empty() {
+                                "-".to_string()
+                            } else {
+                                r.workspaces.join(",")
+                            }
+                        );
+                    }
+                }
+            }
+        }
+        other => bail!("unknown agent recipe subcommand `{other}` (add|show)"),
+    }
+    Ok(())
+}
+
+/// `agent succession show|apply --goal G ...` — the G12 role-succession
+/// surface. `show` projects recorded successions plus the currently-met
+/// (unrecorded) triggers; `apply` records them (`SuccessionOccurred`, one
+/// per trigger episode — idempotent).
+fn cmd_agent_succession(store: &mut Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    let mut goal_id = None;
+    let mut primary = None;
+    let mut reason = None;
+    reject_unknown_flags(
+        &args[1..],
+        &["--format", "--goal", "--json", "--primary", "--reason"],
+    )?;
+    parse_pairs(&args[1..], |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--primary" => primary = Some(v),
+        "--reason" => reason = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let contract =
+        crate::agents::multi_agent::latest_contract(store, &goal_id)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "no multi-agent contract set for {goal_id} (set one first: agent contract set)"
+            )
+        })?;
+    let now = crate::state::now_epoch();
+    let mut candidates = crate::agents::multi_agent::succession_candidates(&goal, &contract, now);
+    if let Some(p) = &primary {
+        candidates.retain(|c| &c.primary == p);
+    }
+    if let Some(r) = &reason {
+        candidates.retain(|c| &c.reason == r);
+    }
+    let recorded = crate::agents::multi_agent::successions(store, &goal_id)?;
+    match sub {
+        "show" => {
+            if wants_json(&args[1..]) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": true,
+                        "schema_version": crate::agents::multi_agent::ROLE_SUCCESSOR_PROJECTION_SCHEMA_VERSION,
+                        "goal_id": goal_id,
+                        "offline_threshold_secs": crate::agents::multi_agent::successor_offline_threshold_secs(),
+                        "candidates": candidates,
+                        "recorded": recorded,
+                    }))?
+                );
+            } else {
+                println!("role succession for {goal_id}:");
+                if recorded.is_empty() && candidates.is_empty() {
+                    println!("  no succession triggers met, no successions recorded");
+                }
+                for r in &recorded {
+                    println!(
+                        "  recorded: primary `{}` → backup `{}` ({}) [event {}]",
+                        r.primary, r.backup, r.reason, r.event_id
+                    );
+                }
+                for c in &candidates {
+                    println!(
+                        "  pending: primary `{}` → backup `{}` ({}) — run `agent succession apply` to record",
+                        c.primary, c.backup, c.reason
+                    );
+                }
+            }
+        }
+        "apply" => {
+            if candidates.is_empty() {
+                println!(
+                    "no succession triggers met for {goal_id}{}",
+                    primary
+                        .map(|p| format!(" (primary {p})"))
+                        .unwrap_or_default()
+                );
+                return Ok(());
+            }
+            for candidate in &candidates {
+                let already = recorded.iter().any(|r| {
+                    r.primary == candidate.primary
+                        && r.backup == candidate.backup
+                        && r.reason == candidate.reason
+                });
+                let event_id =
+                    crate::agents::multi_agent::record_succession(store, &goal_id, candidate)?;
+                println!(
+                    "succession {}: primary `{}` → backup `{}` ({}) (event {event_id}) ✔",
+                    if already {
+                        "already recorded"
+                    } else {
+                        "recorded"
+                    },
+                    candidate.primary,
+                    candidate.backup,
+                    candidate.reason
+                );
+            }
+        }
+        other => bail!("unknown agent succession subcommand `{other}` (show|apply)"),
+    }
+    Ok(())
+}
+
+/// `agent collective show --goal G [--collective NAME] [--format json]` —
+/// the G12 collective projection: per-agent turn counts (claims) plus the
+/// round-robin wake roster for the next collective turn.
+fn cmd_agent_collective(store: &Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    if sub != "show" {
+        bail!("unknown agent collective subcommand `{sub}` (show)");
+    }
+    let mut goal_id = None;
+    let mut collective = None;
+    reject_unknown_flags(
+        &args[1..],
+        &["--collective", "--format", "--goal", "--json"],
+    )?;
+    parse_pairs(&args[1..], |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--collective" => collective = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let contract =
+        crate::agents::multi_agent::latest_contract(store, &goal_id)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "no multi-agent contract set for {goal_id} (set one first: agent contract set)"
+            )
+        })?;
+    let names: Vec<String> = match &collective {
+        Some(name) => {
+            if !contract.collectives.contains_key(name) {
+                bail!("collective `{name}` is not part of the contract for {goal_id}");
+            }
+            vec![name.clone()]
+        }
+        None => contract.collectives.keys().cloned().collect(),
+    };
+    let mut ledgers = vec![];
+    for name in &names {
+        if let Some(ledger) =
+            crate::agents::multi_agent::collective_turn_ledger(store, &goal_id, &contract, name)?
+        {
+            let roster = crate::agents::multi_agent::wake_roster(
+                &contract,
+                name,
+                ledger.full_participation_rounds,
+            );
+            ledgers.push(serde_json::json!({
+                "collective": name,
+                "agents": ledger.agents,
+                "per_agent": ledger.per_agent,
+                "full_participation_rounds": ledger.full_participation_rounds,
+                "total_claims": ledger.total_claims,
+                "wake_roster": roster,
+            }));
+        }
+    }
+    if wants_json(&args[1..]) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "schema_version": crate::agents::multi_agent::COLLECTIVE_TURN_LEDGER_SCHEMA_VERSION,
+                "goal_id": goal_id,
+                "collective_count": ledgers.len(),
+                "collectives": ledgers,
+            }))?
+        );
+    } else {
+        if ledgers.is_empty() {
+            println!("no collectives in the contract for {goal_id}");
+            return Ok(());
+        }
+        for entry in &ledgers {
+            let name = entry["collective"].as_str().unwrap_or("");
+            let agents = entry["agents"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+                .unwrap_or_default();
+            let rounds = entry["full_participation_rounds"].as_u64().unwrap_or(0);
+            let total = entry["total_claims"].as_u64().unwrap_or(0);
+            println!(
+                "collective `{name}`: agents={agents} full_participation_rounds={rounds} total_claims={total}"
+            );
+            if let Some(per) = entry["per_agent"].as_object() {
+                for (agent, row) in per {
+                    let turns = row["turns"].as_u64().unwrap_or(0);
+                    let last = row["last_turn_ts"]
+                        .as_u64()
+                        .map(|ts| format!(" (last {ts})"))
+                        .unwrap_or_default();
+                    println!("    {agent}: {turns} turn(s){last}");
+                }
+            }
+            if let Some(roster) = entry["wake_roster"].as_object() {
+                let current = roster["current"].as_str().unwrap_or("-");
+                let order = roster["order"]
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" → ")
+                    })
+                    .unwrap_or_default();
+                println!("    next wake: {current} (roster: {order})");
+            }
+        }
+    }
+    Ok(())
 }
 
 /// P0-3③: JSON projection of one todo's lease state
@@ -5657,6 +6136,11 @@ fn cmd_attention(store: &Store, args: &[String]) -> Result<()> {
             if let Some(item) = crate::work_items::attention::goal_attention_item(&goal) {
                 items.push(item);
             }
+            // G12: role-succession hints join the queue (one per succeeded
+            // role slot; a fresh primary heartbeat recovers/suppresses).
+            items.extend(crate::agents::multi_agent::succession_attention_items(
+                store, &goal,
+            )?);
         }
     } else if all {
         for entry in store.registry() {
@@ -7708,6 +8192,32 @@ fn describe_event(event: &crate::store::Event) -> String {
             return format!(
                 "decision_outcome {} {} → {}",
                 receipt.receipt_id, receipt.decision_id, receipt.verification_status
+            );
+        }
+        Event::MultiAgentContractSet { contract, .. } => {
+            return format!(
+                "multi_agent_contract_set peers={} handoff_rules={} collectives={}",
+                contract.peers.len(),
+                contract.handoff_rules.len(),
+                contract.collectives.len()
+            );
+        }
+        Event::AgentRecipeAdded { recipe, .. } => {
+            return format!(
+                "agent_recipe_added name={} capabilities={} priority={}",
+                recipe.name,
+                recipe.capabilities.join(","),
+                recipe.priority
+            );
+        }
+        Event::SuccessionOccurred {
+            primary,
+            backup,
+            reason,
+            ..
+        } => {
+            return format!(
+                "succession_occurred primary={primary} backup={backup} reason={reason}"
             );
         }
     };

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -554,6 +554,35 @@ pub enum Event {
         receipt: crate::capabilities::decision_context::packets::DecisionOutcomeReceipt,
         ts: u64,
     },
+    /// G12: multi-agent contract set — the declarative peer/handoff/
+    /// collective topology for a goal (full replace; the latest event wins).
+    /// Projection-only: goal state is unchanged; the multi_agent read model
+    /// (`agent contract show`) reads the ledger. Validation fails closed at
+    /// the command layer before append.
+    MultiAgentContractSet {
+        goal_id: String,
+        contract: crate::agents::multi_agent::MultiAgentContract,
+        ts: u64,
+    },
+    /// G12: named agent recipe added (capabilities / workspaces / default
+    /// priority). Re-adding a name is allowed — lookups resolve the latest
+    /// event. Projection-only.
+    AgentRecipeAdded {
+        goal_id: String,
+        recipe: crate::agents::multi_agent::AgentRecipe,
+        ts: u64,
+    },
+    /// G12: role succession occurred — a primary's lease expired or its
+    /// heartbeat went silent past the threshold, so the declared backup was
+    /// promoted. Projection-only: the succession read model and the
+    /// attention hint read the ledger.
+    SuccessionOccurred {
+        goal_id: String,
+        primary: String,
+        backup: String,
+        reason: String,
+        ts: u64,
+    },
 }
 
 impl Event {
@@ -595,7 +624,10 @@ impl Event {
             | Event::SupervisorProposed { goal_id, .. }
             | Event::SupervisorReceiptRecorded { goal_id, .. }
             | Event::ProjectionRepaired { goal_id, .. }
-            | Event::DecisionOutcomeRecorded { goal_id, .. } => goal_id,
+            | Event::DecisionOutcomeRecorded { goal_id, .. }
+            | Event::MultiAgentContractSet { goal_id, .. }
+            | Event::AgentRecipeAdded { goal_id, .. }
+            | Event::SuccessionOccurred { goal_id, .. } => goal_id,
         }
     }
 }
@@ -1714,8 +1746,9 @@ fn apply(goal: &mut Goal, event: Event) {
                 tool_calls_total,
                 ts,
             }),
-        // P1-5 + P1-1 + P1-4 + G-16 projection-only events: read from the
-        // event log by their read models; goal state is unchanged on replay.
+        // P1-5 + P1-1 + P1-4 + G-16 + G12 projection-only events: read from
+        // the event log by their read models; goal state is unchanged on
+        // replay.
         Event::RewardSignalRecorded { .. }
         | Event::DecisionSummaryRecorded { .. }
         | Event::HeartbeatReceiptRecorded { .. }
@@ -1723,7 +1756,10 @@ fn apply(goal: &mut Goal, event: Event) {
         | Event::SupervisorProposed { .. }
         | Event::SupervisorReceiptRecorded { .. }
         | Event::ProjectionRepaired { .. }
-        | Event::DecisionOutcomeRecorded { .. } => {}
+        | Event::DecisionOutcomeRecorded { .. }
+        | Event::MultiAgentContractSet { .. }
+        | Event::AgentRecipeAdded { .. }
+        | Event::SuccessionOccurred { .. } => {}
     }
 }
 

--- a/orchestration/loop/tests/multi_agent_contract.rs
+++ b/orchestration/loop/tests/multi_agent_contract.rs
@@ -1,0 +1,599 @@
+//! G12 multi-agent contract tests — the five assertion groups for the
+//! multi_agent subdomain:
+//! ① contract validation (fail-closed topology checks),
+//! ② recipe application (record → resolve → onboard),
+//! ③ succession triggering (lease expiry / offline → promotion + attention),
+//! ④ wake roster (deterministic round-robin rotation),
+//! ⑤ collective turn ledger (per-agent claim counts, full-participation min).
+
+use std::collections::BTreeMap;
+
+use future_loop::agents::multi_agent::{
+    apply_recipe_onboard, collective_turn_ledger, contract_issues, latest_contract, recipe_named,
+    recipes, record_contract, record_recipe, record_succession, succession_attention_items,
+    succession_candidates_with, successions, wake_roster, AgentRecipe, HandoffRule,
+    MultiAgentContract, PeerRole, SuccessionCandidate, MULTI_AGENT_CONTRACT_SCHEMA_VERSION,
+    MULTI_AGENT_RECIPE_SCHEMA_VERSION, SUCCESSION_REASON_LEASE_EXPIRED, SUCCESSION_REASON_OFFLINE,
+};
+use future_loop::state::{now_epoch, Goal, Priority, Todo};
+use future_loop::store::{Event, Store};
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-g12-multi-agent-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn open_goal(store: &mut Store, goal_id: &str) {
+    let goal = Goal::new(goal_id, "objective", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: goal_id.into(),
+            ts: goal.created_at,
+        })
+        .unwrap();
+}
+
+fn peer(backup_for: Option<&str>, capabilities: &[&str], workspaces: &[&str]) -> PeerRole {
+    PeerRole {
+        backup_for: backup_for.map(|s| s.to_string()),
+        capabilities: capabilities.iter().map(|s| s.to_string()).collect(),
+        workspaces: workspaces.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// A three-agent contract: `primary` (backed up by `backup`), `backup`, and
+/// `worker`, with one collective `crew` covering all three.
+fn sample_contract() -> MultiAgentContract {
+    let mut contract = MultiAgentContract::default();
+    contract
+        .peers
+        .insert("primary".into(), peer(None, &["shell"], &["/ws/p"]));
+    contract.peers.insert(
+        "backup".into(),
+        peer(Some("primary"), &["shell"], &["/ws/b"]),
+    );
+    contract
+        .peers
+        .insert("worker".into(), peer(None, &["github"], &["/ws/w"]));
+    contract.handoff_rules.push(HandoffRule {
+        from_event: "lease_expired".into(),
+        to_role: "backup".into(),
+    });
+    contract.collectives.insert(
+        "crew".into(),
+        vec!["primary".into(), "backup".into(), "worker".into()],
+    );
+    contract
+}
+
+// ── ① contract validation ─────────────────────────────────────────────────
+
+#[test]
+fn contract_validation_accepts_well_formed_topology() {
+    let contract = sample_contract();
+    assert!(
+        contract_issues(&contract).is_empty(),
+        "sample must be valid"
+    );
+    assert_eq!(contract.backup_of("primary"), Some("backup"));
+    assert_eq!(contract.backup_of("backup"), None);
+    assert_eq!(contract.handoff_target("lease_expired"), Some("backup"));
+    assert_eq!(contract.collective_of("worker"), Some("crew"));
+}
+
+#[test]
+fn contract_validation_rejects_unknown_and_self_backup() {
+    let mut contract = MultiAgentContract::default();
+    contract.peers.insert("a".into(), peer(None, &[], &[]));
+    contract
+        .peers
+        .insert("b".into(), peer(Some("ghost"), &[], &[]));
+    let issues = contract_issues(&contract);
+    assert!(
+        issues.iter().any(|i| i.contains("backup_for `ghost`")),
+        "got: {issues:?}"
+    );
+
+    let mut self_contract = MultiAgentContract::default();
+    self_contract
+        .peers
+        .insert("a".into(), peer(Some("a"), &[], &[]));
+    let issues = contract_issues(&self_contract);
+    assert!(
+        issues.iter().any(|i| i.contains("cannot back up itself")),
+        "got: {issues:?}"
+    );
+}
+
+#[test]
+fn contract_validation_rejects_backup_cycles() {
+    let mut contract = MultiAgentContract::default();
+    contract.peers.insert("a".into(), peer(Some("b"), &[], &[]));
+    contract.peers.insert("b".into(), peer(Some("a"), &[], &[]));
+    let issues = contract_issues(&contract);
+    assert!(
+        issues.iter().any(|i| i.contains("cycle")),
+        "got: {issues:?}"
+    );
+
+    // A longer chain must also be caught.
+    let mut chain = MultiAgentContract::default();
+    chain.peers.insert("a".into(), peer(Some("b"), &[], &[]));
+    chain.peers.insert("b".into(), peer(Some("c"), &[], &[]));
+    chain.peers.insert("c".into(), peer(Some("a"), &[], &[]));
+    assert!(contract_issues(&chain).iter().any(|i| i.contains("cycle")));
+}
+
+#[test]
+fn contract_validation_rejects_bad_handoff_rules_and_collectives() {
+    let mut contract = MultiAgentContract::default();
+    contract.peers.insert("a".into(), peer(None, &[], &[]));
+    contract.peers.insert("b".into(), peer(None, &[], &[]));
+    // to_role must resolve to a contract peer.
+    contract.handoff_rules.push(HandoffRule {
+        from_event: "ev".into(),
+        to_role: "ghost".into(),
+    });
+    let issues = contract_issues(&contract);
+    assert!(
+        issues.iter().any(|i| i.contains("to_role `ghost`")),
+        "got: {issues:?}"
+    );
+
+    // Duplicate handoff rule.
+    let mut dup = MultiAgentContract::default();
+    dup.peers.insert("a".into(), peer(None, &[], &[]));
+    dup.handoff_rules.push(HandoffRule {
+        from_event: "ev".into(),
+        to_role: "a".into(),
+    });
+    dup.handoff_rules.push(HandoffRule {
+        from_event: "ev".into(),
+        to_role: "a".into(),
+    });
+    assert!(contract_issues(&dup)
+        .iter()
+        .any(|i| i.contains("duplicate handoff rule")));
+
+    // Unknown collective member + cross-collective membership.
+    let mut coll = MultiAgentContract::default();
+    coll.peers.insert("a".into(), peer(None, &[], &[]));
+    coll.peers.insert("b".into(), peer(None, &[], &[]));
+    coll.collectives
+        .insert("c1".into(), vec!["a".into(), "ghost".into()]);
+    let issues = contract_issues(&coll);
+    assert!(issues.iter().any(|i| i.contains("member `ghost`")));
+    coll.collectives.insert("c1".into(), vec!["a".into()]);
+    coll.collectives
+        .insert("c2".into(), vec!["a".into(), "b".into()]);
+    let issues = contract_issues(&coll);
+    assert!(
+        issues
+            .iter()
+            .any(|i| i.contains("more than one collective")),
+        "got: {issues:?}"
+    );
+}
+
+#[test]
+fn record_contract_fails_closed_on_invalid_and_persists_valid() {
+    let root = tmp_root("contract");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+
+    let bad = MultiAgentContract {
+        schema_version: "something_else_v9".into(),
+        ..MultiAgentContract::default()
+    };
+    assert!(record_contract(&mut store, "g1", &bad).is_err());
+
+    let contract = sample_contract();
+    let event_id = record_contract(&mut store, "g1", &contract).unwrap();
+    assert!(event_id.starts_with("evt-"));
+
+    // Latest wins: a second, smaller contract replaces the first.
+    let mut smaller = MultiAgentContract::default();
+    smaller.peers.insert("solo".into(), peer(None, &[], &[]));
+    record_contract(&mut store, "g1", &smaller).unwrap();
+    let latest = latest_contract(&store, "g1").unwrap().unwrap();
+    assert_eq!(latest.peers.len(), 1);
+    assert!(latest.peers.contains_key("solo"));
+
+    // Replay is untouched by the projection-only events.
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert!(goal.todos.is_empty());
+    assert!(goal.registered_agents.is_empty());
+}
+
+// ── ② recipe application ──────────────────────────────────────────────────
+
+#[test]
+fn recipe_record_resolve_and_apply() {
+    let root = tmp_root("recipe");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+
+    let recipe = AgentRecipe {
+        schema_version: MULTI_AGENT_RECIPE_SCHEMA_VERSION.to_string(),
+        name: "researcher".into(),
+        capabilities: vec!["shell".into(), "github".into()],
+        workspaces: vec!["/ws/r".into()],
+        priority: Priority::P0,
+    };
+    record_recipe(&mut store, "g1", &recipe).unwrap();
+
+    assert_eq!(recipes(&store, "g1").unwrap().len(), 1);
+    let resolved = recipe_named(&store, "g1", "researcher").unwrap().unwrap();
+    assert_eq!(resolved.capabilities, recipe.capabilities);
+    assert_eq!(resolved.workspaces, recipe.workspaces);
+    assert_eq!(resolved.priority, Priority::P0);
+    assert!(recipe_named(&store, "g1", "missing").unwrap().is_none());
+
+    // Applying the recipe onboards the agent with the recipe profile — the
+    // capability gate / workspace guard consume the same AgentOnboarded
+    // event as the explicit onboard path.
+    apply_recipe_onboard(&mut store, "g1", "agent-r", &resolved).unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert!(goal.registered_agents.contains(&"agent-r".to_string()));
+    let profile = goal
+        .agent_profiles
+        .iter()
+        .find(|p| p.id == "agent-r")
+        .unwrap();
+    assert_eq!(profile.capabilities, vec!["shell", "github"]);
+    assert_eq!(profile.workspaces, vec!["/ws/r"]);
+}
+
+#[test]
+fn recipe_re_add_resolves_latest_and_invalid_recipe_fails() {
+    let root = tmp_root("recipe2");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+
+    let v1 = AgentRecipe {
+        schema_version: MULTI_AGENT_RECIPE_SCHEMA_VERSION.to_string(),
+        name: "worker".into(),
+        capabilities: vec!["shell".into()],
+        workspaces: vec![],
+        priority: Priority::P1,
+    };
+    record_recipe(&mut store, "g1", &v1).unwrap();
+    let v2 = AgentRecipe {
+        schema_version: MULTI_AGENT_RECIPE_SCHEMA_VERSION.to_string(),
+        name: "worker".into(),
+        capabilities: vec!["shell".into(), "network".into()],
+        workspaces: vec!["/ws/2".into()],
+        priority: Priority::P2,
+    };
+    record_recipe(&mut store, "g1", &v2).unwrap();
+
+    assert_eq!(recipes(&store, "g1").unwrap().len(), 2);
+    let latest = recipe_named(&store, "g1", "worker").unwrap().unwrap();
+    assert_eq!(latest.capabilities, v2.capabilities);
+    assert_eq!(latest.priority, Priority::P2);
+
+    // Empty name fails closed.
+    let bad = AgentRecipe {
+        schema_version: MULTI_AGENT_RECIPE_SCHEMA_VERSION.to_string(),
+        name: "   ".into(),
+        capabilities: vec![],
+        workspaces: vec![],
+        priority: Priority::P1,
+    };
+    assert!(record_recipe(&mut store, "g1", &bad).is_err());
+}
+
+// ── ③ succession triggering ───────────────────────────────────────────────
+
+fn contract_with_backup() -> MultiAgentContract {
+    let mut contract = MultiAgentContract::default();
+    contract
+        .peers
+        .insert("primary".into(), peer(None, &[], &[]));
+    contract
+        .peers
+        .insert("backup".into(), peer(Some("primary"), &[], &[]));
+    contract
+}
+
+fn goal_with_primary(store: &mut Store, goal_id: &str) {
+    open_goal(store, goal_id);
+    store
+        .append(Event::AgentRegistered {
+            goal_id: goal_id.into(),
+            agent_id: "primary".into(),
+            workspaces: vec![],
+            ts: now_epoch(),
+        })
+        .unwrap();
+    store
+        .append(Event::AgentRegistered {
+            goal_id: goal_id.into(),
+            agent_id: "backup".into(),
+            workspaces: vec![],
+            ts: now_epoch(),
+        })
+        .unwrap();
+}
+
+#[test]
+fn succession_triggers_on_expired_lease() {
+    let root = tmp_root("succession-lease");
+    let mut store = Store::open(&root).unwrap();
+    goal_with_primary(&mut store, "g1");
+    let contract = contract_with_backup();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let now = now_epoch();
+    let mut todo = Todo::advancement("t1", "stalled work");
+    todo.claimed_by = Some("primary".into());
+    todo.lease_expires_at = Some(now - 10); // expired 10s ago
+    let mut goal = store.replay("g1").unwrap().unwrap();
+    goal.add(todo);
+
+    let candidates = succession_candidates_with(&goal, &contract, now, 600);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].primary, "primary");
+    assert_eq!(candidates[0].backup, "backup");
+    assert_eq!(candidates[0].reason, SUCCESSION_REASON_LEASE_EXPIRED);
+
+    // Recording lands one SuccessionOccurred event and is idempotent.
+    let candidate = candidates[0].clone();
+    let event_id = record_succession(&mut store, "g1", &candidate).unwrap();
+    let recorded = successions(&store, "g1").unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].event_id, event_id);
+    let again = record_succession(&mut store, "g1", &candidate).unwrap();
+    assert_eq!(again, event_id);
+    assert_eq!(successions(&store, "g1").unwrap().len(), 1);
+}
+
+#[test]
+fn succession_triggers_on_offline_heartbeat() {
+    let root = tmp_root("succession-offline");
+    let mut store = Store::open(&root).unwrap();
+    goal_with_primary(&mut store, "g1");
+    let contract = contract_with_backup();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let now = now_epoch();
+    // Primary heartbeated an hour ago → past the 600s threshold.
+    store
+        .append(Event::SchedulerTicked {
+            goal_id: "g1".into(),
+            agent_id: "primary".into(),
+            action: "tick".into(),
+            rrule: None,
+            ts: now - 3600,
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    let candidates = succession_candidates_with(&goal, &contract, now, 600);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].reason, SUCCESSION_REASON_OFFLINE);
+    assert_eq!(candidates[0].since, now - 3600);
+
+    // A heartbeat-less primary is NOT presumed offline (no anchor).
+    let root2 = tmp_root("succession-no-hb");
+    let mut store2 = Store::open(&root2).unwrap();
+    goal_with_primary(&mut store2, "g2");
+    record_contract(&mut store2, "g2", &contract).unwrap();
+    let goal2 = store2.replay("g2").unwrap().unwrap();
+    assert!(succession_candidates_with(&goal2, &contract, now, 600).is_empty());
+
+    // A fresh heartbeat suppresses the trigger.
+    store
+        .append(Event::SchedulerTicked {
+            goal_id: "g1".into(),
+            agent_id: "primary".into(),
+            action: "tick".into(),
+            rrule: None,
+            ts: now,
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert!(succession_candidates_with(&goal, &contract, now, 600).is_empty());
+}
+
+#[test]
+fn succession_attention_item_until_primary_recovers() {
+    let root = tmp_root("succession-attention");
+    let mut store = Store::open(&root).unwrap();
+    goal_with_primary(&mut store, "g1");
+    let contract = contract_with_backup();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let candidate = SuccessionCandidate {
+        role: "primary".into(),
+        primary: "primary".into(),
+        backup: "backup".into(),
+        reason: SUCCESSION_REASON_LEASE_EXPIRED.into(),
+        since: now_epoch(),
+    };
+    record_succession(&mut store, "g1", &candidate).unwrap();
+
+    let goal = store.replay("g1").unwrap().unwrap();
+    let items = succession_attention_items(&store, &goal).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].status, "role_succession");
+    assert_eq!(items[0].source, "role_succession");
+    assert_eq!(items[0].waiting_on, "user_or_controller");
+    assert!(items[0].recommended_action.contains("primary"));
+    assert!(items[0].recommended_action.contains("backup"));
+
+    // Primary heartbeats after the succession → recovered, hint suppressed.
+    let succession_ts = successions(&store, "g1").unwrap()[0].ts;
+    store
+        .append(Event::SchedulerTicked {
+            goal_id: "g1".into(),
+            agent_id: "primary".into(),
+            action: "tick".into(),
+            rrule: None,
+            ts: succession_ts + 1,
+        })
+        .unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert!(succession_attention_items(&store, &goal)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn succession_ignores_unregistered_primary() {
+    let root = tmp_root("succession-unregistered");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1"); // no agents registered
+    let contract = contract_with_backup();
+    record_contract(&mut store, "g1", &contract).unwrap();
+    let goal = store.replay("g1").unwrap().unwrap();
+    // Even a stale heartbeat cannot trigger: the primary is not part of
+    // this goal's automation.
+    let mut g = goal.clone();
+    g.scheduler_heartbeats
+        .insert("primary".into(), now_epoch() - 7200);
+    assert!(succession_candidates_with(&g, &contract, now_epoch(), 600).is_empty());
+}
+
+// ── ④ wake roster ─────────────────────────────────────────────────────────
+
+#[test]
+fn wake_roster_rotates_round_robin() {
+    let contract = sample_contract();
+    let r0 = wake_roster(&contract, "crew", 0).unwrap();
+    assert_eq!(r0.order, vec!["primary", "backup", "worker"]);
+    assert_eq!(r0.current, "primary");
+
+    let r1 = wake_roster(&contract, "crew", 1).unwrap();
+    assert_eq!(r1.order, vec!["backup", "worker", "primary"]);
+    assert_eq!(r1.current, "backup");
+
+    let r2 = wake_roster(&contract, "crew", 2).unwrap();
+    assert_eq!(r2.order, vec!["worker", "primary", "backup"]);
+    assert_eq!(r2.current, "worker");
+
+    // Full cycle wraps deterministically.
+    let r3 = wake_roster(&contract, "crew", 3).unwrap();
+    assert_eq!(r3.order, r0.order);
+
+    // Unknown collectives project to None.
+    assert!(wake_roster(&contract, "nope", 0).is_none());
+}
+
+// ── ⑤ collective turn ledger ──────────────────────────────────────────────
+
+#[test]
+fn collective_turn_ledger_counts_claims_and_full_rounds() {
+    let root = tmp_root("ledger");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+    let contract = sample_contract();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let base = now_epoch();
+    // Claims: primary ×3, backup ×2, worker ×2 (each claim = one bounded
+    // turn opportunity).
+    for (agent, n) in [("primary", 3), ("backup", 2), ("worker", 2)] {
+        for i in 0..n {
+            store
+                .append(Event::TodoClaimed {
+                    goal_id: "g1".into(),
+                    todo_id: format!("t-{agent}-{i}"),
+                    agent_id: agent.into(),
+                    lease_expires_at: base + 1000,
+                    ts: base + i,
+                })
+                .unwrap();
+        }
+    }
+    // A claim by an agent OUTSIDE the collective must not be counted.
+    store
+        .append(Event::TodoClaimed {
+            goal_id: "g1".into(),
+            todo_id: "t-outsider".into(),
+            agent_id: "outsider".into(),
+            lease_expires_at: base + 1000,
+            ts: base + 99,
+        })
+        .unwrap();
+
+    let ledger = collective_turn_ledger(&store, "g1", &contract, "crew")
+        .unwrap()
+        .unwrap();
+    assert_eq!(ledger.agents, vec!["primary", "backup", "worker"]);
+    assert_eq!(ledger.per_agent["primary"].turns, 3);
+    assert_eq!(ledger.per_agent["backup"].turns, 2);
+    assert_eq!(ledger.per_agent["worker"].turns, 2);
+    assert_eq!(ledger.per_agent["primary"].last_turn_ts, Some(base + 2));
+    assert_eq!(ledger.total_claims, 7);
+    // Asynchronous full participation = min across members.
+    assert_eq!(ledger.full_participation_rounds, 2);
+
+    // The wake roster for the NEXT collective turn uses the completed
+    // rounds as the rotation input (turn 2 → worker wakes first).
+    let roster = wake_roster(&contract, "crew", ledger.full_participation_rounds).unwrap();
+    assert_eq!(roster.current, "worker");
+
+    // Unknown collective → None.
+    assert!(collective_turn_ledger(&store, "g1", &contract, "nope")
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn collective_full_participation_is_zero_until_every_member_claims() {
+    let root = tmp_root("ledger-partial");
+    let mut store = Store::open(&root).unwrap();
+    open_goal(&mut store, "g1");
+    let contract = sample_contract();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let base = now_epoch();
+    for agent in ["primary", "backup"] {
+        store
+            .append(Event::TodoClaimed {
+                goal_id: "g1".into(),
+                todo_id: format!("t-{agent}"),
+                agent_id: agent.into(),
+                lease_expires_at: base + 1000,
+                ts: base,
+            })
+            .unwrap();
+    }
+    let ledger = collective_turn_ledger(&store, "g1", &contract, "crew")
+        .unwrap()
+        .unwrap();
+    assert_eq!(ledger.total_claims, 2);
+    assert_eq!(ledger.per_agent["worker"].turns, 0);
+    // `worker` never claimed → no complete collective round yet.
+    assert_eq!(ledger.full_participation_rounds, 0);
+    // Rotation at turn 0 still starts at the contract order head.
+    let roster = wake_roster(&contract, "crew", ledger.full_participation_rounds).unwrap();
+    assert_eq!(roster.current, "primary");
+}
+
+#[test]
+fn contract_schema_version_constant_is_stable() {
+    assert_eq!(
+        MULTI_AGENT_CONTRACT_SCHEMA_VERSION,
+        "multi_agent_contract_v0"
+    );
+    // The event payload round-trips through serde (BTreeMap ordering is
+    // preserved, so ledger JSON stays deterministic).
+    let contract = sample_contract();
+    let json = serde_json::to_string(&contract).unwrap();
+    let parsed: MultiAgentContract = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, contract);
+    let peers: BTreeMap<String, PeerRole> = parsed.peers;
+    assert_eq!(
+        peers.keys().cloned().collect::<Vec<_>>(),
+        vec!["backup", "primary", "worker"]
+    );
+}


### PR DESCRIPTION
Wave 4 1/2（loopx-stub-and-gaps.md G12，P1 级缺口，参照 ~/loopx agents/multi_agent/ 8 文件取核心子集）。

- MultiAgentContract：peers/PeerRole(backup_for)/handoff_rules + 校验 + 事件
- AgentRecipe：命名配方，`agent onboard --recipe NAME`
- RoleSuccession：主 agent 离线超阈值 → backup 晋升（事件 + attention）
- WakeRoster 唤醒顺序投影；CollectiveTurnLedger 集体轮次账本
- CLI：`future loop agent contract set|show`、`agent recipe add|show`、`agent succession show`、`agent collective show [--format json]`
- 契约测试 multi_agent_contract.rs（5 组断言）

本地：fmt ✅ clippy ✅ future-loop 79 targets 全绿 ✅。源：claude/loop-wave2 be36f25d