### PR TITLE
feat(loop): G13 goal_frontier deep implementation — outcome segments / replan rules / semantic history / terminal judgement

### DIFF
--- a/orchestration/loop/src/capabilities/decision_context/assembler.rs
+++ b/orchestration/loop/src/capabilities/decision_context/assembler.rs
@@ -55,6 +55,7 @@ impl DecisionContextAssembler {
             run_history: RunHistorySection::default(),
             outcome_streak: OutcomeStreakSection::default(),
             quota: QuotaStatusSection::default(),
+            semantic_history: None,
         };
         for provider in &self.providers {
             packet.providers.push(provider.id().to_string());
@@ -62,6 +63,9 @@ impl DecisionContextAssembler {
                 ProviderSection::RunHistory(section) => packet.run_history = section,
                 ProviderSection::OutcomeStreak(section) => packet.outcome_streak = section,
                 ProviderSection::QuotaStatus(section) => packet.quota = section,
+                ProviderSection::SemanticHistory(section) => {
+                    packet.semantic_history = Some(section)
+                }
             }
         }
         packet
@@ -98,12 +102,20 @@ mod tests {
             vec![
                 "run_history".to_string(),
                 "outcome_streak".to_string(),
-                "quota_status".to_string()
+                "quota_status".to_string(),
+                "semantic_history".to_string()
             ]
         );
         assert_eq!(packet.open_acceptance_gaps, vec!["A1".to_string()]);
         assert!(packet.outcome_streak.floor_breached);
         assert_eq!(packet.run_history.run_count, 0);
+        // G13 ③: the semantic-history section is attached by its provider.
+        let section = packet.semantic_history.expect("semantic history section");
+        assert_eq!(
+            section.schema_version,
+            crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_SCHEMA_VERSION
+        );
+        assert!(section.events.is_empty());
         assert_eq!(
             packet.quota.allowed_slots,
             crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS
@@ -158,7 +170,8 @@ mod tests {
             vec![
                 "run_history".to_string(),
                 "outcome_streak".to_string(),
-                "quota_status".to_string()
+                "quota_status".to_string(),
+                "semantic_history".to_string()
             ]
         );
         // The duplicate-provider test double exposes its description.
@@ -173,5 +186,21 @@ mod tests {
         assert_eq!(packet.run_history, RunHistorySection::default());
         assert_eq!(packet.outcome_streak, OutcomeStreakSection::default());
         assert_eq!(packet.quota, QuotaStatusSection::default());
+        assert_eq!(packet.semantic_history, None);
+    }
+
+    #[test]
+    fn semantic_history_section_reflects_folded_events() {
+        let mut g = Goal::new("g1", "objective", "/tmp");
+        g.record_semantic_event("run_landed", Some("T1"), "completed", 42);
+        let packet = assemble_decision_context(&g);
+        let section = packet.semantic_history.expect("semantic history section");
+        assert_eq!(section.events.len(), 1);
+        assert_eq!(section.events[0].kind, "run_landed");
+        assert_eq!(section.events[0].ts, 42);
+        assert_eq!(
+            section.schema_version,
+            crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_SCHEMA_VERSION
+        );
     }
 }

--- a/orchestration/loop/src/capabilities/decision_context/packets.rs
+++ b/orchestration/loop/src/capabilities/decision_context/packets.rs
@@ -106,6 +106,18 @@ pub struct QuotaStatusSection {
     pub projected_spent_slots: u32,
 }
 
+/// Semantic-history section (provider `semantic_history`, G13 ③): the
+/// goal-level bounded semantic event summaries (kind / todo_id / summary /
+/// ts — summaries are truncated at write time, public-safe).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticHistorySection {
+    pub schema_version: String,
+    pub cap: usize,
+    /// Newest-last, bounded to `cap`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<crate::decision::goal_frontier::semantic_history::SemanticEvent>,
+}
+
 /// The assembled decision context (LoopX evidence packet, compact set).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecisionContextPacket {
@@ -124,6 +136,9 @@ pub struct DecisionContextPacket {
     pub run_history: RunHistorySection,
     pub outcome_streak: OutcomeStreakSection,
     pub quota: QuotaStatusSection,
+    /// G13 ③: semantic event history (bounded) — provider `semantic_history`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_history: Option<SemanticHistorySection>,
 }
 
 impl DecisionContextPacket {
@@ -222,6 +237,7 @@ mod tests {
             run_history: RunHistorySection::default(),
             outcome_streak: OutcomeStreakSection::default(),
             quota: QuotaStatusSection::default(),
+            semantic_history: None,
         };
         assert_eq!(packet.digest(), packet.digest());
         assert_eq!(packet.digest().len(), 20);

--- a/orchestration/loop/src/capabilities/decision_context/providers.rs
+++ b/orchestration/loop/src/capabilities/decision_context/providers.rs
@@ -9,7 +9,9 @@
 
 use crate::state::Goal;
 
-use super::packets::{OutcomeStreakSection, QuotaStatusSection, RunHistorySection};
+use super::packets::{
+    OutcomeStreakSection, QuotaStatusSection, RunHistorySection, SemanticHistorySection,
+};
 
 /// One provider's contribution to the packet.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +19,7 @@ pub enum ProviderSection {
     RunHistory(RunHistorySection),
     OutcomeStreak(OutcomeStreakSection),
     QuotaStatus(QuotaStatusSection),
+    SemanticHistory(SemanticHistorySection),
 }
 
 impl ProviderSection {
@@ -25,6 +28,7 @@ impl ProviderSection {
             ProviderSection::RunHistory(_) => RunHistoryProvider.id(),
             ProviderSection::OutcomeStreak(_) => OutcomeStreakProvider.id(),
             ProviderSection::QuotaStatus(_) => QuotaStatusProvider.id(),
+            ProviderSection::SemanticHistory(_) => SemanticHistoryProvider.id(),
         }
     }
 }
@@ -111,13 +115,38 @@ impl DecisionContextProvider for QuotaStatusProvider {
     }
 }
 
+/// Provider `semantic_history` (G13 ③): the goal-level bounded semantic
+/// event summaries folded from the event ledger (kind / todo_id / summary /
+/// ts) — consumed as `semantic_history` in the decision-context packet.
+pub struct SemanticHistoryProvider;
+
+impl DecisionContextProvider for SemanticHistoryProvider {
+    fn id(&self) -> &'static str {
+        "semantic_history"
+    }
+    fn describe(&self) -> &'static str {
+        "bounded goal-level semantic event summaries folded from the event ledger"
+    }
+    fn collect(&self, goal: &Goal) -> ProviderSection {
+        ProviderSection::SemanticHistory(SemanticHistorySection {
+            schema_version:
+                crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_SCHEMA_VERSION
+                    .to_string(),
+            cap: crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_CAP,
+            events: goal.semantic_history.clone(),
+        })
+    }
+}
+
 /// The builtin provider set in deterministic assembly order (the report's
-/// P1-4 compact set: run history / outcome streak / quota status).
+/// P1-4 compact set: run history / outcome streak / quota status + the G13
+/// semantic history).
 pub fn builtin_providers() -> Vec<Box<dyn DecisionContextProvider>> {
     vec![
         Box::new(RunHistoryProvider),
         Box::new(OutcomeStreakProvider),
         Box::new(QuotaStatusProvider),
+        Box::new(SemanticHistoryProvider),
     ]
 }
 
@@ -260,7 +289,37 @@ mod tests {
     #[test]
     fn builtin_order_is_deterministic() {
         let ids: Vec<&str> = builtin_providers().iter().map(|p| p.id()).collect();
-        assert_eq!(ids, vec!["run_history", "outcome_streak", "quota_status"]);
+        assert_eq!(
+            ids,
+            vec![
+                "run_history",
+                "outcome_streak",
+                "quota_status",
+                "semantic_history"
+            ]
+        );
         assert!(!builtin_providers().iter().any(|p| p.describe().is_empty()));
+    }
+
+    #[test]
+    fn semantic_history_provider_collects_bounded_events() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.record_semantic_event("run_landed", Some("T1"), "completed", 10);
+        let section = SemanticHistoryProvider.collect(&g);
+        assert_eq!(section.provider_id(), "semantic_history");
+        let ProviderSection::SemanticHistory(s) = section else {
+            panic!("expected semantic history section")
+        };
+        assert_eq!(
+            s.schema_version,
+            crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_SCHEMA_VERSION
+        );
+        assert_eq!(s.events.len(), 1);
+        assert_eq!(s.events[0].kind, "run_landed");
+        assert_eq!(s.events[0].todo_id.as_deref(), Some("T1"));
+        assert_eq!(
+            s.cap,
+            crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_CAP
+        );
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -127,6 +127,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "backup" => cmd_backup(&store, &args[1..]),
         "authority" => cmd_authority(&mut store, &args[1..]),
         "replan" => cmd_replan(&mut store, &args[1..]),
+        "frontier" => cmd_frontier(&store, &args[1..]),
         "profile" => cmd_profile(&mut store, &args[1..]),
         "status" => cmd_status(&store, &args[1..]),
         "quota" => cmd_quota(&store, &args[1..]),
@@ -197,6 +198,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("todo", Journey::Daily),
     ("gate", Journey::Daily),
     ("replan", Journey::Daily),
+    ("frontier", Journey::Daily),
     ("lease", Journey::Daily),
     ("task-graph", Journey::Daily),
     ("quota", Journey::Daily),
@@ -291,8 +293,14 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         todo,
         "replan",
-        "ack a replan obligation / list obligations",
-        "replan ack --goal G --delta-kind ... | replan obligations --goal G",
+        "ack a replan obligation / list obligations / inspect or set the replan rule set",
+        "replan ack --goal G --delta-kind ... | replan obligations --goal G | replan rules show|set --goal G",
+    );
+    r.command(
+        todo,
+        "frontier",
+        "goal-frontier projection (G13): frontier + outcome segments + replan rule + terminal judgement + semantic history",
+        "frontier show --goal G [--format json]",
     );
     r.command(
         todo,
@@ -2252,7 +2260,12 @@ fn cmd_authority(store: &mut Store, args: &[String]) -> Result<()> {
 /// frontier-changing delta (LoopX: replan ACK contract).
 /// `loopx replan obligations --goal G` lists the unfulfilled replan
 /// obligations (G-13 bookkeeping).
+/// `loopx replan rules show|set --goal G [--rule-ids R1,R2,...]` inspects or
+/// updates the goal's replan rule set (G13 ②).
 fn cmd_replan(store: &mut Store, args: &[String]) -> Result<()> {
+    if args.first().map(|s| s.as_str()) == Some("rules") {
+        return cmd_replan_rules(store, &args[1..]);
+    }
     if args.first().map(|s| s.as_str()) == Some("obligations") {
         let mut goal_id = None;
         reject_unknown_flags(
@@ -2312,6 +2325,211 @@ fn cmd_replan(store: &mut Store, args: &[String]) -> Result<()> {
         ts: crate::state::now_epoch(),
     })?;
     println!("replan ack recorded (delta_kinds={delta_kinds:?}) ✔");
+    Ok(())
+}
+
+/// `loopx replan rules show --goal G [--format json]` — the goal's active
+/// replan rule set, the ordered policy table with per-rule match status,
+/// and the selected rule decision (disposition → replan decision +
+/// obligation).
+/// `loopx replan rules set --goal G [--rule-ids R1,R2,...]` — declare an
+/// explicit rule set (full replace; `--rule-ids ""` resets to the default
+/// set) via a `ReplanRuleSetUpdated` event.
+fn cmd_replan_rules(store: &mut Store, args: &[String]) -> Result<()> {
+    let sub = args.first().map(|s| s.as_str());
+    match sub {
+        Some("show") => {}
+        Some("set") => {}
+        _ => bail!("replan rules subcommand must be `show` or `set`"),
+    }
+    let mut goal_id = None;
+    let mut rule_ids: Option<String> = None;
+    reject_unknown_flags(&args[1..], &["--format", "--goal", "--json", "--rule-ids"])?;
+    parse_pairs(&args[1..], |k, v| match k {
+        "--goal" => goal_id = Some(v),
+        "--rule-ids" => rule_ids = Some(v),
+        _ => {}
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    if sub == Some("set") {
+        let ids: Vec<String> = match rule_ids {
+            Some(raw) => {
+                if raw.trim().is_empty() {
+                    vec![]
+                } else {
+                    raw.split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                }
+            }
+            None => vec![],
+        };
+        // Validate against the builtin vocabulary up front (unknown ids are
+        // allowed — selection skips them — but typos deserve a warning).
+        for id in &ids {
+            if !crate::decision::goal_frontier::replan_rules::is_known_rule(id) {
+                println!("warning: unknown rule id `{id}` — selection will skip it");
+            }
+        }
+        store
+            .replay(&goal_id)?
+            .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+        store.append(Event::ReplanRuleSetUpdated {
+            goal_id: goal_id.clone(),
+            rule_set_version:
+                crate::decision::goal_frontier::replan_rules::DEFAULT_REPLAN_RULE_SET_VERSION
+                    .to_string(),
+            rule_ids: ids.clone(),
+            ts: crate::state::now_epoch(),
+        })?;
+        if ids.is_empty() {
+            println!("replan rule set reset to the default set ✔");
+        } else {
+            println!("replan rule set updated (rule_ids={ids:?}) ✔");
+        }
+        return Ok(());
+    }
+    // show
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let active = crate::decision::goal_frontier::replan_rules::active_rule_set(&goal);
+    let facts = crate::decision::goal_frontier::replan_rules::facts_for_goal(&goal);
+    let decision = crate::decision::goal_frontier::replan_rules::select_replan_rule(&goal);
+    if wants_json(&args[1..]) {
+        let table: Vec<serde_json::Value> = active
+            .effective_rule_ids()
+            .iter()
+            .map(|id| {
+                serde_json::json!({
+                    "rule": id,
+                    "selected": id == &decision.rule,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema_version": crate::decision::goal_frontier::replan_rules::DEFAULT_REPLAN_RULE_SET_VERSION,
+                "goal_id": goal_id,
+                "rule_set": active,
+                "table": table,
+                "facts": {
+                    "existing_replan_required": facts.existing_replan_required,
+                    "blocking_user_open_count": facts.blocking_user_open_count,
+                    "succession_gap_count": facts.succession_gap_count,
+                    "acceptance_gap_count": facts.acceptance_gap_count,
+                    "selectable_frontier_advancement": facts.selectable_frontier_advancement,
+                    "monitor_count": facts.monitor_count,
+                    "monitor_no_change_streak_triggered": facts.monitor_no_change_streak_triggered,
+                    "monitor_only_lane": facts.monitor_only_lane,
+                },
+                "decision": decision,
+            }))?
+        );
+        return Ok(());
+    }
+    println!(
+        "replan rule set ({goal_id}) — version {}:",
+        active.schema_version
+    );
+    for id in active.effective_rule_ids() {
+        let mark = if id == decision.rule {
+            "◀ selected"
+        } else {
+            ""
+        };
+        println!("  {id} {mark}");
+    }
+    println!(
+        "decision: rule={} derives_obligation={} obligation={} reason=\"{}\"",
+        decision.rule,
+        decision.derives_obligation,
+        decision.obligation_kind.as_deref().unwrap_or("-"),
+        decision.reason
+    );
+    Ok(())
+}
+
+// ── frontier (G13) ────────────────────────────────────────────────────────
+
+/// `loopx frontier show --goal G [--format json]` — the composed goal
+/// frontier: the existing frontier projection plus the four G13 layers
+/// (outcome segments / replan rule decision / terminal judgement /
+/// semantic history).
+fn cmd_frontier(store: &Store, args: &[String]) -> Result<()> {
+    if args.first().map(|s| s.as_str()) != Some("show") {
+        bail!(
+            "frontier subcommand must be `show` (try `{} frontier show --help`)",
+            prog()
+        );
+    }
+    let mut goal_id = None;
+    reject_unknown_flags(&args[1..], &["--format", "--goal", "--json"])?;
+    parse_pairs(&args[1..], |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v)
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let goal = store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let show = crate::decision::goal_frontier::frontier_show(&goal);
+    if wants_json(&args[1..]) {
+        println!("{}", serde_json::to_string_pretty(&show)?);
+        return Ok(());
+    }
+    let fp = &show.frontier_projection;
+    println!("goal frontier ({goal_id}):");
+    println!(
+        "  lane={} replan_required={} unclaimed_advancement={} acceptance_gaps={} monitors_open={} monitors_due={}",
+        show.lane,
+        fp.replan_required,
+        fp.unclaimed_advancement,
+        fp.acceptance_gaps,
+        fp.monitors_open,
+        fp.monitors_due
+    );
+    if show.outcome_segments.is_empty() {
+        println!("  outcome_segments: (no runs yet)");
+    } else {
+        let segments = show
+            .outcome_segments
+            .iter()
+            .map(|s| format!("{} [{} ×{}]", s.segment_id, s.kind, s.length))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  outcome_segments: {segments}");
+    }
+    println!(
+        "  replan rule: {} (derives_obligation={}{})",
+        show.replan_rule.rule,
+        show.replan_rule.derives_obligation,
+        show.replan_rule
+            .obligation_kind
+            .as_deref()
+            .map(|k| format!(", obligation={k}"))
+            .unwrap_or_default()
+    );
+    if show.terminal_judgement.terminal {
+        println!("  terminal: yes (kind=no_followup, source=validated_goal_closure)");
+    } else {
+        println!(
+            "  terminal: no ({} gap(s)):",
+            show.terminal_judgement.gaps.len()
+        );
+        for gap in &show.terminal_judgement.gaps {
+            println!("    - [{}] {}", gap.kind, gap.description);
+        }
+    }
+    let recent: Vec<&crate::decision::goal_frontier::semantic_history::SemanticEvent> =
+        show.semantic_history.iter().rev().take(5).collect();
+    println!("  semantic_history (last {}):", recent.len());
+    for e in recent.iter().rev() {
+        println!("    {} {} — {}", e.ts, e.kind, e.summary);
+    }
     Ok(())
 }
 
@@ -8218,6 +8436,16 @@ fn describe_event(event: &crate::store::Event) -> String {
         } => {
             return format!(
                 "succession_occurred primary={primary} backup={backup} reason={reason}"
+            );
+        }
+        Event::ReplanRuleSetUpdated {
+            rule_set_version,
+            rule_ids,
+            ..
+        } => {
+            return format!(
+                "replan_rule_set_updated version={rule_set_version} rules={}",
+                rule_ids.join(",")
             );
         }
     };

--- a/orchestration/loop/src/decision/goal_frontier/mod.rs
+++ b/orchestration/loop/src/decision/goal_frontier/mod.rs
@@ -1,0 +1,84 @@
+//! goal_frontier subdomain (G13) — the reference
+//! `control_plane/goals/goal_frontier/` package (__init__.py 1960 lines +
+//! outcome_continuity / replan_rules / semantic_history / terminal),
+//! natively (core subset).
+//!
+//! Four deepening layers over the existing frontier projection:
+//!   - [`outcome_continuity`]: outcome-streak segmentation — consecutive
+//!     surface-only turns form one segment; a material turn or a
+//!     frontier-changing event between runs resets the segment;
+//!   - [`replan_rules`]: the structured replan trigger rule table
+//!     (disposition → replan decision + obligation), an ordered policy
+//!     table with a default rule set and a `ReplanRuleSetUpdated` event;
+//!   - [`semantic_history`]: the goal-level bounded semantic event history
+//!     (recent N=50 semantic summaries folded from the event ledger),
+//!     consumable by the decision-context assembler;
+//!   - [`terminal`]: terminal judgement — closure validation that
+//!     enumerates acceptance-gap semantics and every remaining blocker as
+//!     explicit gap entries, aligned with the existing
+//!     `TerminalClosureProof`.
+//!
+//! [`frontier_show`] composes the CLI surface (`future loop frontier show`)
+//! from all four layers plus the existing frontier projection.
+
+use serde::Serialize;
+
+use crate::contract::FrontierProjection;
+use crate::state::Goal;
+
+pub mod outcome_continuity;
+pub mod replan_rules;
+pub mod semantic_history;
+pub mod terminal;
+
+pub use outcome_continuity::{outcome_segments, OutcomeSegment, OUTCOME_SEGMENT_SCHEMA_VERSION};
+pub use replan_rules::{
+    active_rule_set, facts_for_goal, select_replan_rule, ReplanFacts, ReplanRuleDecision,
+    ReplanRuleSet, DEFAULT_REPLAN_RULE_SET_VERSION, REPLAN_RULE_DECISION_SCHEMA_VERSION,
+};
+pub use semantic_history::{SemanticEvent, SEMANTIC_HISTORY_CAP, SEMANTIC_HISTORY_SCHEMA_VERSION};
+pub use terminal::{
+    terminal_judgement, TerminalGap, TerminalJudgement, TERMINAL_JUDGEMENT_SCHEMA_VERSION,
+};
+
+/// The `frontier show` read model: frontier projection + the four G13
+/// deepening layers.
+pub const FRONTIER_SHOW_SCHEMA_VERSION: &str = "goal_frontier_show_v0";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FrontierShow {
+    pub schema_version: String,
+    pub goal_id: String,
+    /// The work lane (monitor vs advancement-task), same derivation as the
+    /// should-run packet's `work_lane_contract.lane`.
+    pub lane: String,
+    pub frontier_projection: FrontierProjection,
+    pub outcome_segments: Vec<OutcomeSegment>,
+    pub replan_rule: ReplanRuleDecision,
+    pub terminal_judgement: TerminalJudgement,
+    pub semantic_history: Vec<SemanticEvent>,
+}
+
+/// The replan-pressure flag the decision kernel uses (same formula as the
+/// should-run packet: open gates, unclosed completions, stalled monitors,
+/// unsatisfied acceptance gaps).
+fn replan_required(goal: &Goal) -> bool {
+    goal.open_gates().next().is_some()
+        || !goal.completed_without_closure_intent().is_empty()
+        || goal.open_monitors().any(super::stall::is_monitor_stalled)
+        || !goal.unsatisfied_gaps().is_empty()
+}
+
+/// Compose the `frontier show` projection for a goal.
+pub fn frontier_show(goal: &Goal) -> FrontierShow {
+    FrontierShow {
+        schema_version: FRONTIER_SHOW_SCHEMA_VERSION.to_string(),
+        goal_id: goal.goal_id.clone(),
+        lane: super::frontier::lane(goal).to_string(),
+        frontier_projection: super::frontier::frontier_projection(goal, replan_required(goal)),
+        outcome_segments: outcome_segments(goal),
+        replan_rule: select_replan_rule(goal),
+        terminal_judgement: terminal_judgement(goal),
+        semantic_history: goal.semantic_history.clone(),
+    }
+}

--- a/orchestration/loop/src/decision/goal_frontier/outcome_continuity.rs
+++ b/orchestration/loop/src/decision/goal_frontier/outcome_continuity.rs
@@ -1,0 +1,173 @@
+//! Outcome continuity (G13 ①) — outcome-streak segmentation, the reference
+//! `goal_frontier/outcome_continuity.py` (501 lines; core subset).
+//!
+//! The kernel's `outcome_streak` counter is a single number; the segment
+//! projection restores the *structure* of that streak: a segment is a
+//! maximal run of consecutive same-kind turns (surface-only vs material)
+//! over one frontier slice. A segment RESETS when:
+//!   - the turn kind flips (material ⇄ surface-only), or
+//!   - the frontier changed between the two runs — a frontier-changing
+//!     event (todo added/completed/superseded, gate resolved, frontier-delta
+//!     replan ack, todo archived) landed in `(prev.recorded_at, run.recorded_at]`.
+//!
+//! Segments are a PROJECTION over goal state (run history + the
+//! `Goal::frontier_change_ts` markers folded during replay) — never a
+//! second source of truth, same rule as `todo_summary`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::Goal;
+
+pub const OUTCOME_SEGMENT_SCHEMA_VERSION: &str = "goal_outcome_segment_v0";
+
+/// Segment kind vocabulary (reference VISION_OUTCOME_CHECKPOINT material vs
+/// continuation outcomes, collapsed to the two streak classes).
+pub const SEGMENT_KIND_SURFACE_ONLY: &str = "surface_only";
+pub const SEGMENT_KIND_MATERIAL: &str = "material";
+
+/// One outcome-continuity segment: `{segment_id, start_turn, length, kind}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutcomeSegment {
+    pub segment_id: String,
+    pub start_turn: u32,
+    pub length: u32,
+    pub kind: String,
+}
+
+/// Materiality rule shared with the executor writeback and the run-history
+/// decision-context provider: a turn is material when it produced a
+/// validated artifact (tools invoked + evidence).
+pub fn run_is_material(record: &crate::state::RunRecord) -> bool {
+    !record.tools.is_empty() && !record.evidence.trim().is_empty()
+}
+
+fn kind_of(record: &crate::state::RunRecord) -> &'static str {
+    if run_is_material(record) {
+        SEGMENT_KIND_MATERIAL
+    } else {
+        SEGMENT_KIND_SURFACE_ONLY
+    }
+}
+
+/// Did a frontier-changing event land between `prev_at` (exclusive) and
+/// `at` (inclusive)? Markers are the `Goal::frontier_change_ts` timestamps
+/// folded from frontier-changing events during replay.
+fn frontier_changed_between(goal: &Goal, prev_at: u64, at: u64) -> bool {
+    goal.frontier_change_ts
+        .iter()
+        .any(|ts| *ts > prev_at && *ts <= at)
+}
+
+/// Project the outcome-continuity segments over the run history.
+/// Deterministic: a pure function of goal state (run records in ledger
+/// order + frontier-change markers). Runs outside any segment are dropped
+/// from the projection (they are not part of a streak).
+pub fn outcome_segments(goal: &Goal) -> Vec<OutcomeSegment> {
+    let mut segments: Vec<OutcomeSegment> = vec![];
+    let mut current_kind: Option<&'static str> = None;
+    let mut prev_at: Option<u64> = None;
+
+    for record in &goal.history {
+        let kind = kind_of(record);
+        let frontier_reset = prev_at
+            .map(|prev| frontier_changed_between(goal, prev, record.recorded_at))
+            .unwrap_or(false);
+        if current_kind == Some(kind) && !frontier_reset {
+            if let Some(last) = segments.last_mut() {
+                last.length += 1;
+            }
+        } else {
+            segments.push(OutcomeSegment {
+                segment_id: format!("seg_{}", record.turn),
+                start_turn: record.turn,
+                length: 1,
+                kind: kind.to_string(),
+            });
+            current_kind = Some(kind);
+        }
+        prev_at = Some(record.recorded_at);
+    }
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::RunRecord;
+
+    fn run(turn: u32, at: u64, tools: &[&str], evidence: &str) -> RunRecord {
+        RunRecord {
+            turn,
+            todo_id: format!("T{turn}"),
+            run_id: format!("r{turn}"),
+            validation: None,
+            terminal_state: "completed".to_string(),
+            error: None,
+            tokens_in_delta: 0,
+            tokens_out_delta: 0,
+            cost_delta: 0.0,
+            tools: tools.iter().map(|s| s.to_string()).collect(),
+            evidence: evidence.to_string(),
+            recorded_at: at,
+            spend_source: None,
+        }
+    }
+
+    #[test]
+    fn surface_only_streak_forms_one_segment() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.history.push(run(1, 10, &[], ""));
+        g.history.push(run(2, 20, &[], ""));
+        g.history.push(run(3, 30, &[], ""));
+        let segments = outcome_segments(&g);
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].kind, SEGMENT_KIND_SURFACE_ONLY);
+        assert_eq!(segments[0].start_turn, 1);
+        assert_eq!(segments[0].length, 3);
+        assert_eq!(segments[0].segment_id, "seg_1");
+    }
+
+    #[test]
+    fn material_turn_flips_the_segment_kind() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.history.push(run(1, 10, &[], ""));
+        g.history.push(run(2, 20, &["shell"], "artifact"));
+        g.history.push(run(3, 30, &[], ""));
+        let segments = outcome_segments(&g);
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].kind, SEGMENT_KIND_SURFACE_ONLY);
+        assert_eq!(segments[1].kind, SEGMENT_KIND_MATERIAL);
+        assert_eq!(segments[1].length, 1);
+        assert_eq!(segments[2].kind, SEGMENT_KIND_SURFACE_ONLY);
+    }
+
+    #[test]
+    fn frontier_change_between_runs_resets_the_segment() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.history.push(run(1, 10, &[], ""));
+        g.history.push(run(2, 20, &[], ""));
+        // A todo completed at ts 25 (between run 2 and run 3) moved the
+        // frontier: the streak continuity resets even though run 3 is
+        // surface-only like its predecessors.
+        g.frontier_change_ts.push(25);
+        g.history.push(run(3, 30, &[], ""));
+        g.history.push(run(4, 40, &[], ""));
+        let segments = outcome_segments(&g);
+        assert_eq!(segments.len(), 2, "frontier change resets the segment");
+        assert_eq!(segments[0].length, 2);
+        assert_eq!(segments[1].length, 2);
+        assert_eq!(segments[1].start_turn, 3);
+        // A marker at/after the run start also resets (boundary inclusive).
+        let mut g2 = Goal::new("g2", "o", "/tmp");
+        g2.history.push(run(1, 10, &[], ""));
+        g2.frontier_change_ts.push(30);
+        g2.history.push(run(2, 30, &[], ""));
+        assert_eq!(outcome_segments(&g2).len(), 2);
+        // A marker BEFORE both runs does not reset mid-segment.
+        let mut g3 = Goal::new("g3", "o", "/tmp");
+        g3.frontier_change_ts.push(5);
+        g3.history.push(run(1, 10, &[], ""));
+        g3.history.push(run(2, 20, &[], ""));
+        assert_eq!(outcome_segments(&g3).len(), 1);
+    }
+}

--- a/orchestration/loop/src/decision/goal_frontier/replan_rules.rs
+++ b/orchestration/loop/src/decision/goal_frontier/replan_rules.rs
@@ -1,0 +1,382 @@
+//! Goal-frontier replan rule selection (G13 ②) — the reference
+//! `goal_frontier/replan_rules.py` (197 lines), natively.
+//!
+//! The disposition→decision interpreter: an ORDERED policy table of replan
+//! trigger rules. Given the goal's current facts, the first matching rule
+//! (in policy order) is the decision — carrying whether it DERIVES a replan
+//! obligation and, when it does, which obligation kind is owed.
+//!
+//! A goal may carry an explicit rule set (folded from the
+//! `ReplanRuleSetUpdated` event; latest wins). Without one the default rule
+//! set applies. Selection walks the ACTIVE set's ordered rule ids; unknown
+//! ids are skipped and the final rule (`monitor_frontier_exhausted`,
+//! unconditionally matching) guarantees a terminal decision.
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::Goal;
+use crate::work_items::replan_obligation::MONITOR_NO_CHANGE_OBLIGATION_THRESHOLD;
+
+pub const REPLAN_RULE_DECISION_SCHEMA_VERSION: &str = "goal_frontier_replan_rule_decision_v0";
+pub const DEFAULT_REPLAN_RULE_SET_VERSION: &str = "goal_frontier_replan_rules_v0";
+
+/// Rule ids (reference `GoalFrontierReplanRule` — the core subset our
+/// native kernel can decide; handoff-gate / long-chain / watch-lane rules
+/// are deliberately skipped, matching the existing decision pipeline).
+pub const RULE_EXISTING_OBLIGATION: &str = "existing_obligation";
+pub const RULE_OPEN_USER_TODO: &str = "open_user_todo";
+pub const RULE_TODO_SUCCESSION_GAP: &str = "todo_succession_gap";
+pub const RULE_VISION_ACCEPTANCE_GAP: &str = "vision_acceptance_gap";
+pub const RULE_MONITOR_NO_CHANGE_STREAK: &str = "monitor_no_change_streak";
+pub const RULE_NOT_MONITOR_ONLY: &str = "not_monitor_only";
+pub const RULE_NO_OPEN_MONITOR: &str = "no_open_monitor";
+pub const RULE_ADVANCEMENT_REMAINS: &str = "advancement_remains";
+pub const RULE_MONITOR_FRONTIER_EXHAUSTED: &str = "monitor_frontier_exhausted";
+
+/// The default rule set: the full builtin rule ids in policy order.
+pub fn default_rule_set() -> ReplanRuleSet {
+    ReplanRuleSet {
+        schema_version: DEFAULT_REPLAN_RULE_SET_VERSION.to_string(),
+        rule_ids: vec![
+            RULE_EXISTING_OBLIGATION.to_string(),
+            RULE_OPEN_USER_TODO.to_string(),
+            RULE_TODO_SUCCESSION_GAP.to_string(),
+            RULE_VISION_ACCEPTANCE_GAP.to_string(),
+            RULE_MONITOR_NO_CHANGE_STREAK.to_string(),
+            RULE_NOT_MONITOR_ONLY.to_string(),
+            RULE_NO_OPEN_MONITOR.to_string(),
+            RULE_ADVANCEMENT_REMAINS.to_string(),
+            RULE_MONITOR_FRONTIER_EXHAUSTED.to_string(),
+        ],
+    }
+}
+
+/// A goal's active replan rule set (folded from `ReplanRuleSetUpdated`;
+/// absent → the default set applies).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplanRuleSet {
+    pub schema_version: String,
+    /// Rule ids in policy order. Empty on the wire means "reset to the
+    /// default set"; the folded state never stores an empty list.
+    pub rule_ids: Vec<String>,
+}
+
+impl ReplanRuleSet {
+    /// The effective ordered rule ids: the declared set AS-IS when it names
+    /// at least one known rule (full replace — the caller's order wins);
+    /// otherwise the default order (a set of only unknown ids cannot
+    /// displace the builtin policy table).
+    pub fn effective_rule_ids(&self) -> Vec<String> {
+        if self.rule_ids.iter().any(|id| is_known_rule(id)) {
+            self.rule_ids.clone()
+        } else {
+            default_rule_set().rule_ids
+        }
+    }
+}
+
+/// The facts each rule matches on (reference `GoalFrontierReplanFacts`,
+/// core subset — handoff/watch-lane/chain facts dropped with their rules).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplanFacts {
+    /// An existing scoped obligation stays authoritative: the outcome floor
+    /// raised a `surface_only_progress_streak` obligation (the read model in
+    /// `work_items::replan_obligation`). The specific trigger rules below
+    /// own their own obligation kinds.
+    pub existing_replan_required: bool,
+    /// Open user gates + open user actions blocking the frontier.
+    pub blocking_user_open_count: usize,
+    /// Done advancement without successor/no-follow-up.
+    pub succession_gap_count: usize,
+    /// Unsatisfied acceptance gaps.
+    pub acceptance_gap_count: usize,
+    /// Runnable (selectable) advancement todos on the frontier.
+    pub selectable_frontier_advancement: usize,
+    /// Advancement todos still on the frontier (open/blocked/deferred —
+    /// selectable or not, e.g. held by another agent's lease).
+    pub advancement_open_count: usize,
+    /// Open monitors.
+    pub monitor_count: usize,
+    /// Any open monitor at/above the no-change obligation threshold.
+    pub monitor_no_change_streak_triggered: bool,
+    /// No runnable advancement remains — only monitor work can be lane work.
+    pub monitor_only_lane: bool,
+}
+
+/// Derive the replan facts from goal state (pure; deterministic).
+pub fn facts_for_goal(goal: &Goal) -> ReplanFacts {
+    let runnable = goal.runnable_advancement().count();
+    let advancement_open = goal
+        .todos
+        .iter()
+        .filter(|t| {
+            t.class == crate::state::TaskClass::Advancement
+                && !matches!(
+                    t.status,
+                    crate::state::TodoStatus::Done | crate::state::TodoStatus::Superseded
+                )
+        })
+        .count();
+    ReplanFacts {
+        // The one obligation kind not covered by a specific rule below: the
+        // outcome floor's surface-only streak (reference: an existing scoped
+        // obligation remains authoritative).
+        existing_replan_required: crate::work_items::replan_obligation::unfulfilled_obligations(
+            goal,
+        )
+        .iter()
+        .any(|o| o.kind == "surface_only_progress_streak"),
+        blocking_user_open_count: goal.open_gates().count()
+            + goal.open_of(crate::state::TaskClass::UserAction).count(),
+        succession_gap_count: goal.completed_without_closure_intent().len(),
+        acceptance_gap_count: goal.unsatisfied_gaps().len(),
+        selectable_frontier_advancement: runnable,
+        advancement_open_count: advancement_open,
+        monitor_count: goal.open_monitors().count(),
+        monitor_no_change_streak_triggered: goal
+            .open_monitors()
+            .any(|m| m.consecutive_no_change >= MONITOR_NO_CHANGE_OBLIGATION_THRESHOLD),
+        monitor_only_lane: runnable == 0,
+    }
+}
+
+/// One replan rule decision (reference `GoalFrontierReplanRuleDecision`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplanRuleDecision {
+    pub schema_version: String,
+    pub rule: String,
+    pub rule_index: u32,
+    pub derives_obligation: bool,
+    /// The obligation kind this rule owes when `derives_obligation`
+    /// (`replan_obligation_v0` vocabulary); `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub obligation_kind: Option<String>,
+    pub reason: String,
+}
+
+/// Whether a rule id is known to the builtin policy table.
+pub fn is_known_rule(id: &str) -> bool {
+    matches!(
+        id,
+        RULE_EXISTING_OBLIGATION
+            | RULE_OPEN_USER_TODO
+            | RULE_TODO_SUCCESSION_GAP
+            | RULE_VISION_ACCEPTANCE_GAP
+            | RULE_MONITOR_NO_CHANGE_STREAK
+            | RULE_NOT_MONITOR_ONLY
+            | RULE_NO_OPEN_MONITOR
+            | RULE_ADVANCEMENT_REMAINS
+            | RULE_MONITOR_FRONTIER_EXHAUSTED
+    )
+}
+
+/// Select the first matching rule in the ACTIVE rule set's policy order.
+/// `monitor_frontier_exhausted` always matches — the terminal rule.
+pub fn select_replan_rule_with_set(facts: &ReplanFacts, rule_ids: &[String]) -> ReplanRuleDecision {
+    let ordered: Vec<(u32, &str)> = rule_ids
+        .iter()
+        .enumerate()
+        .filter(|(_, id)| is_known_rule(id))
+        .map(|(i, id)| (i as u32, id.as_str()))
+        .collect();
+    let decision_for = |rule: &str, rule_index: u32, reason: &str| {
+        let (derives, obligation_kind) = match rule {
+            RULE_TODO_SUCCESSION_GAP => (true, Some("succession_gap".to_string())),
+            RULE_VISION_ACCEPTANCE_GAP => (true, Some("vision_acceptance_gap".to_string())),
+            RULE_MONITOR_NO_CHANGE_STREAK => (true, Some("monitor_no_change_streak".to_string())),
+            RULE_MONITOR_FRONTIER_EXHAUSTED => {
+                (true, Some("surface_only_progress_streak".to_string()))
+            }
+            _ => (false, None),
+        };
+        ReplanRuleDecision {
+            schema_version: REPLAN_RULE_DECISION_SCHEMA_VERSION.to_string(),
+            rule: rule.to_string(),
+            rule_index,
+            derives_obligation: derives,
+            obligation_kind,
+            reason: reason.to_string(),
+        }
+    };
+    let matching = |rule: &str| -> Option<&'static str> {
+        Some(match rule {
+            RULE_EXISTING_OBLIGATION if facts.existing_replan_required => {
+                "an existing scoped obligation remains authoritative"
+            }
+            RULE_OPEN_USER_TODO if facts.blocking_user_open_count > 0 => {
+                "open blocking user work owns the frontier"
+            }
+            RULE_TODO_SUCCESSION_GAP
+                if facts.succession_gap_count > 0
+                    && facts.selectable_frontier_advancement == 0
+                    && facts.advancement_open_count == 0 =>
+            {
+                "completed advancement work lacks a successor or no-followup rationale"
+            }
+            RULE_VISION_ACCEPTANCE_GAP
+                if facts.acceptance_gap_count > 0 && facts.selectable_frontier_advancement == 0 =>
+            {
+                "the scoped vision gap lacks a satisfying runnable frontier"
+            }
+            RULE_MONITOR_NO_CHANGE_STREAK
+                if facts.monitor_only_lane
+                    && facts.monitor_count > 0
+                    && facts.monitor_no_change_streak_triggered =>
+            {
+                "the current agent monitor crossed the no-change replan threshold"
+            }
+            RULE_NOT_MONITOR_ONLY if !facts.monitor_only_lane => {
+                "the selected lane is not monitor-only"
+            }
+            RULE_NO_OPEN_MONITOR if facts.monitor_count == 0 => "no open monitor remains",
+            RULE_ADVANCEMENT_REMAINS if facts.advancement_open_count > 0 => {
+                "advancement work remains on the frontier"
+            }
+            RULE_MONITOR_FRONTIER_EXHAUSTED => {
+                "only monitor work remains on an empty advancement frontier"
+            }
+            _ => return None,
+        })
+    };
+    for (index, rule) in &ordered {
+        if let Some(reason) = matching(rule) {
+            return decision_for(rule, *index, reason);
+        }
+    }
+    // Custom set contained only unknown ids: fall back to the default order.
+    let default_ids = default_rule_set().rule_ids;
+    for (index, rule) in default_ids.iter().enumerate() {
+        if let Some(reason) = matching(rule) {
+            return decision_for(rule, index as u32, reason);
+        }
+    }
+    unreachable!("monitor_frontier_exhausted is the unconditional terminal rule");
+}
+
+/// Select the replan rule for a goal under its ACTIVE rule set.
+pub fn select_replan_rule(goal: &Goal) -> ReplanRuleDecision {
+    let facts = facts_for_goal(goal);
+    let ids = match &goal.replan_rule_set {
+        Some(set) => set.effective_rule_ids(),
+        None => default_rule_set().rule_ids,
+    };
+    select_replan_rule_with_set(&facts, &ids)
+}
+
+/// The active rule set for a goal (explicit set or the default).
+pub fn active_rule_set(goal: &Goal) -> ReplanRuleSet {
+    goal.replan_rule_set
+        .clone()
+        .unwrap_or_else(default_rule_set)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Todo, TodoStatus};
+    use std::time::Duration;
+
+    #[test]
+    fn default_set_orders_rules_in_policy_order() {
+        let set = default_rule_set();
+        assert_eq!(set.schema_version, DEFAULT_REPLAN_RULE_SET_VERSION);
+        assert_eq!(
+            set.rule_ids.first().map(String::as_str),
+            Some(RULE_EXISTING_OBLIGATION)
+        );
+        assert_eq!(
+            set.rule_ids.last().map(String::as_str),
+            Some(RULE_MONITOR_FRONTIER_EXHAUSTED)
+        );
+    }
+
+    #[test]
+    fn succession_gap_selects_rule_and_derives_obligation() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut todo = Todo::advancement("T1", "work");
+        todo.complete(false, vec![]); // no successor, no no-follow-up
+        g.add(todo);
+        let d = select_replan_rule(&g);
+        assert_eq!(d.rule, RULE_TODO_SUCCESSION_GAP);
+        assert!(d.derives_obligation);
+        assert_eq!(d.obligation_kind.as_deref(), Some("succession_gap"));
+    }
+
+    #[test]
+    fn acceptance_gap_without_frontier_selects_vision_rule() {
+        let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match")]);
+        g.add(Todo::advancement("T1", "work"));
+        g.todo_mut("T1").unwrap().status = TodoStatus::Done;
+        g.todo_mut("T1").unwrap().no_follow_up = true;
+        let d = select_replan_rule(&g);
+        assert_eq!(d.rule, RULE_VISION_ACCEPTANCE_GAP);
+        assert!(d.derives_obligation);
+        assert_eq!(d.obligation_kind.as_deref(), Some("vision_acceptance_gap"));
+    }
+
+    #[test]
+    fn runnable_frontier_selects_not_monitor_only_without_obligation() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "work"));
+        let d = select_replan_rule(&g);
+        // reference policy order: NOT_MONITOR_ONLY precedes the
+        // advancement-remains fallthrough when the lane has selectable work.
+        assert_eq!(d.rule, RULE_NOT_MONITOR_ONLY);
+        assert!(!d.derives_obligation);
+        assert_eq!(d.obligation_kind, None);
+    }
+
+    #[test]
+    fn monitor_streak_on_monitor_only_lane_derives_obligation() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut m = Todo::monitor("M1", "watch", Duration::from_secs(60));
+        m.consecutive_no_change = MONITOR_NO_CHANGE_OBLIGATION_THRESHOLD;
+        g.add(m);
+        let d = select_replan_rule(&g);
+        assert_eq!(d.rule, RULE_MONITOR_NO_CHANGE_STREAK);
+        assert!(d.derives_obligation);
+        assert_eq!(
+            d.obligation_kind.as_deref(),
+            Some("monitor_no_change_streak")
+        );
+    }
+
+    #[test]
+    fn surface_only_streak_obligation_is_authoritative_first() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "work"));
+        // Outcome floor breached → the surface-only-streak obligation is on
+        // record → EXISTING_OBLIGATION fires even though work is runnable.
+        g.execution_profile.outcome_floor_streak_threshold = 2;
+        g.outcome_streak = 2;
+        let d = select_replan_rule(&g);
+        assert_eq!(d.rule, RULE_EXISTING_OBLIGATION);
+        assert!(!d.derives_obligation);
+        assert!(d.reason.contains("authoritative"));
+    }
+
+    #[test]
+    fn custom_rule_set_respects_declared_order() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "work"));
+        // Custom set puts the exhausted rule first: it fires before
+        // not_monitor_only (policy order is the caller's).
+        g.replan_rule_set = Some(ReplanRuleSet {
+            schema_version: DEFAULT_REPLAN_RULE_SET_VERSION.to_string(),
+            rule_ids: vec![
+                RULE_MONITOR_FRONTIER_EXHAUSTED.to_string(),
+                RULE_ADVANCEMENT_REMAINS.to_string(),
+            ],
+        });
+        let d = select_replan_rule(&g);
+        assert_eq!(d.rule, RULE_MONITOR_FRONTIER_EXHAUSTED);
+        // Unknown ids are skipped; default order still resolves.
+        let mut g2 = Goal::new("g2", "o", "/tmp");
+        g2.add(Todo::advancement("T1", "work"));
+        g2.replan_rule_set = Some(ReplanRuleSet {
+            schema_version: DEFAULT_REPLAN_RULE_SET_VERSION.to_string(),
+            rule_ids: vec!["custom_unknown_rule".to_string()],
+        });
+        assert_eq!(select_replan_rule(&g2).rule, RULE_NOT_MONITOR_ONLY);
+    }
+}

--- a/orchestration/loop/src/decision/goal_frontier/semantic_history.rs
+++ b/orchestration/loop/src/decision/goal_frontier/semantic_history.rs
@@ -1,0 +1,113 @@
+//! Goal-level bounded semantic history (G13 ③) — the reference
+//! `goal_frontier/semantic_history.py` (299 lines; core subset).
+//!
+//! The reference keeps per-agent semantic slots (latest vision / checkpoint
+//! / replan-ack runs) inside `run_history.goals[].semantic_history`. Our
+//! native subset is the goal-LEVEL history: a bounded ring of semantic
+//! event summaries folded from the event ledger during replay, capped at
+//! [`SEMANTIC_HISTORY_CAP`] (oldest dropped) so the projection is a pure,
+//! deterministic function of event order.
+//!
+//! The decision-context assembler consumes it through the
+//! `semantic_history` provider (ids/summaries only — summaries are
+//! truncated at write time so the packet stays public-safe).
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::Goal;
+
+pub const SEMANTIC_HISTORY_SCHEMA_VERSION: &str = "goal_semantic_history_v0";
+/// Bounded history cap (LoopX semantic slots keep the newest N events).
+pub const SEMANTIC_HISTORY_CAP: usize = 50;
+/// Summaries never exceed this length (public-safe truncation).
+pub const SEMANTIC_SUMMARY_MAX_CHARS: usize = 200;
+
+/// One semantic event summary `{kind, todo_id, summary, ts}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticEvent {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub todo_id: Option<String>,
+    pub summary: String,
+    pub ts: u64,
+}
+
+/// Semantic event kind vocabulary (folded event → kind).
+pub const KIND_RUN_LANDED: &str = "run_landed";
+pub const KIND_TODO_COMPLETED: &str = "todo_completed";
+pub const KIND_TODO_SUPERSEDED: &str = "todo_superseded";
+pub const KIND_ACCEPTANCE_GAP_SATISFIED: &str = "acceptance_gap_satisfied";
+pub const KIND_REPLAN_ACKED: &str = "replan_acked";
+pub const KIND_MONITOR_POLL: &str = "monitor_poll";
+pub const KIND_GATE_RESOLVED: &str = "gate_resolved";
+pub const KIND_DELIVERY_OUTCOME: &str = "delivery_outcome";
+pub const KIND_ROLE_SUCCESSION: &str = "role_succession";
+pub const KIND_TURN_NO_PROGRESS: &str = "turn_no_progress";
+
+/// Truncate a summary to the public-safe bound.
+pub fn truncate_summary(text: &str) -> String {
+    crate::decision::truncate(text, SEMANTIC_SUMMARY_MAX_CHARS)
+}
+
+impl Goal {
+    /// Record one semantic event summary, keeping the ring bounded
+    /// (oldest dropped past [`SEMANTIC_HISTORY_CAP`]). Replay folds events
+    /// through this same path, so the projection is deterministic.
+    pub fn record_semantic_event(
+        &mut self,
+        kind: &str,
+        todo_id: Option<&str>,
+        summary: &str,
+        ts: u64,
+    ) {
+        self.semantic_history.push(SemanticEvent {
+            kind: kind.to_string(),
+            todo_id: todo_id.map(|s| s.to_string()),
+            summary: truncate_summary(summary),
+            ts,
+        });
+        let overflow = self
+            .semantic_history
+            .len()
+            .saturating_sub(SEMANTIC_HISTORY_CAP);
+        if overflow > 0 {
+            self.semantic_history.drain(..overflow);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_is_bounded_to_cap_oldest_dropped() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        for i in 0..(SEMANTIC_HISTORY_CAP + 12) {
+            g.record_semantic_event(KIND_RUN_LANDED, Some("T1"), &format!("run {i}"), i as u64);
+        }
+        assert_eq!(g.semantic_history.len(), SEMANTIC_HISTORY_CAP);
+        // Newest 50 kept: first entry is event 12, last is event 61.
+        assert_eq!(g.semantic_history.first().unwrap().ts, 12);
+        assert_eq!(
+            g.semantic_history.last().unwrap().ts,
+            (SEMANTIC_HISTORY_CAP + 11) as u64
+        );
+    }
+
+    #[test]
+    fn summaries_are_truncated_to_the_public_safe_bound() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let long = "x".repeat(SEMANTIC_SUMMARY_MAX_CHARS + 100);
+        g.record_semantic_event(KIND_REPLAN_ACKED, None, &long, 1);
+        let event = &g.semantic_history[0];
+        assert!(
+            event.summary.chars().count() <= SEMANTIC_SUMMARY_MAX_CHARS + 1,
+            "summary over the public-safe bound: {} chars",
+            event.summary.chars().count()
+        );
+        assert!(event.summary.ends_with('…'));
+        assert_eq!(event.kind, KIND_REPLAN_ACKED);
+        assert_eq!(event.todo_id, None);
+    }
+}

--- a/orchestration/loop/src/decision/goal_frontier/terminal.rs
+++ b/orchestration/loop/src/decision/goal_frontier/terminal.rs
@@ -1,0 +1,275 @@
+//! Terminal judgement (G13 ④) — the reference
+//! `goal_frontier/terminal.py` (180 lines; core subset).
+//!
+//! The tightened terminal determination: closure is validated from complete
+//! sources (the structured todo state + acceptance gaps + closure-intent
+//! contract), and every remaining blocker is enumerated as an explicit
+//! [`TerminalGap`] entry — including acceptance-gap semantics (each
+//! unsatisfied gap appears with its id + description, `satisfied: false`).
+//!
+//! The judgement aligns with the existing `TerminalClosureProof`
+//! (`todo_summary` output): it carries the same proof verbatim and adds the
+//! gap detail on top. `terminal == gaps.is_empty()` matches
+//! `Goal::is_terminal()` exactly — the judgement is the single authoritative
+//! gate the decision kernel consults (step 6, validated closure).
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::{Goal, TerminalClosureProof, TodoStatus};
+
+pub const TERMINAL_JUDGEMENT_SCHEMA_VERSION: &str = "goal_terminal_judgement_v0";
+
+/// Terminal-closure kind (reference `goal_terminal_state_v0`).
+pub const TERMINAL_KIND_NO_FOLLOWUP: &str = "no_followup";
+/// Terminal-closure source (reference: validated closure, never hand-written).
+pub const TERMINAL_SOURCE_VALIDATED: &str = "validated_goal_closure";
+
+/// Gap-kind vocabulary — each entry is a blocker that keeps the goal open.
+pub const GAP_OPEN_TODO: &str = "open_todo";
+pub const GAP_OPEN_MONITOR: &str = "open_monitor";
+pub const GAP_PENDING_DEFERRED: &str = "pending_deferred";
+pub const GAP_UNSATISFIED_ACCEPTANCE: &str = "unsatisfied_acceptance";
+pub const GAP_SUCCESSION: &str = "succession_gap";
+
+/// One blocking item on the road to terminal closure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalGap {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub todo_id: Option<String>,
+    /// Acceptance-gap id (kind `unsatisfied_acceptance` only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gap_id: Option<String>,
+    pub description: String,
+    /// Acceptance gaps carry their satisfaction flag (always false here —
+    /// a satisfied gap never blocks terminal closure).
+    pub satisfied: bool,
+}
+
+/// The terminal judgement: closure proof + explicit gap detail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalJudgement {
+    pub schema_version: String,
+    pub terminal: bool,
+    /// `no_followup` when terminal; empty otherwise (reference
+    /// `goal_terminal_state_v0.kind` is only present for a terminal state).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Explicit blockers; empty ⇔ `terminal`.
+    pub gaps: Vec<TerminalGap>,
+    /// The existing `TerminalClosureProof` verbatim (todo_summary aligned).
+    pub closure_proof: TerminalClosureProof,
+}
+
+fn not_done(todo: &crate::state::Todo) -> bool {
+    !matches!(todo.status, TodoStatus::Done | TodoStatus::Superseded)
+}
+
+/// Derive the terminal judgement from goal state. Pure; deterministic.
+/// `terminal` ⇔ `Goal::is_terminal()` (the same sources, enumerated).
+pub fn terminal_judgement(goal: &Goal) -> TerminalJudgement {
+    let now = std::time::SystemTime::now();
+    let mut gaps: Vec<TerminalGap> = vec![];
+
+    for todo in &goal.todos {
+        if !not_done(todo) {
+            continue;
+        }
+        match todo.status {
+            TodoStatus::Deferred if !todo.is_due_deferred(now) => {
+                gaps.push(TerminalGap {
+                    kind: GAP_PENDING_DEFERRED.to_string(),
+                    todo_id: Some(todo.id.clone()),
+                    gap_id: None,
+                    description: format!("deferred todo {} not yet due", todo.id),
+                    satisfied: false,
+                });
+            }
+            _ => {
+                let kind = if todo.class == crate::state::TaskClass::Monitor {
+                    GAP_OPEN_MONITOR
+                } else {
+                    GAP_OPEN_TODO
+                };
+                gaps.push(TerminalGap {
+                    kind: kind.to_string(),
+                    todo_id: Some(todo.id.clone()),
+                    gap_id: None,
+                    description: format!(
+                        "todo {} still {} (class {})",
+                        todo.id,
+                        crate::compat::future_loop_status(todo.status),
+                        crate::compat::future_loop_task_class(todo.class)
+                    ),
+                    satisfied: false,
+                });
+            }
+        }
+    }
+
+    // Acceptance-gap semantics: every unsatisfied gap is an explicit
+    // terminal gap carrying its id + description + satisfied=false.
+    for gap in goal.unsatisfied_gaps() {
+        gaps.push(TerminalGap {
+            kind: GAP_UNSATISFIED_ACCEPTANCE.to_string(),
+            todo_id: None,
+            gap_id: Some(gap.id.clone()),
+            description: gap.description.clone(),
+            satisfied: false,
+        });
+    }
+
+    // Succession gaps: done advancement without closure intent.
+    for todo in goal.completed_without_closure_intent() {
+        gaps.push(TerminalGap {
+            kind: GAP_SUCCESSION.to_string(),
+            todo_id: Some(todo.id.clone()),
+            gap_id: None,
+            description: format!(
+                "todo {} completed without successor or no-follow-up",
+                todo.id
+            ),
+            satisfied: false,
+        });
+    }
+
+    let closure_proof = goal.todo_summary().terminal_closure_proof;
+    TerminalJudgement {
+        schema_version: TERMINAL_JUDGEMENT_SCHEMA_VERSION.to_string(),
+        terminal: gaps.is_empty(),
+        kind: gaps
+            .is_empty()
+            .then(|| TERMINAL_KIND_NO_FOLLOWUP.to_string()),
+        source: gaps
+            .is_empty()
+            .then(|| TERMINAL_SOURCE_VALIDATED.to_string()),
+        gaps,
+        closure_proof,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{TaskClass, Todo};
+    use std::time::Duration;
+
+    fn closed_goal() -> Goal {
+        let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match")]);
+        let mut todo = Todo::advancement("T1", "work");
+        todo.complete(true, vec![]);
+        g.add(todo);
+        g.satisfy_gap("A1");
+        g
+    }
+
+    #[test]
+    fn closed_goal_is_terminal_no_followup() {
+        let g = closed_goal();
+        assert!(g.is_terminal());
+        let j = terminal_judgement(&g);
+        assert!(j.terminal);
+        assert_eq!(j.kind.as_deref(), Some(TERMINAL_KIND_NO_FOLLOWUP));
+        assert_eq!(j.source.as_deref(), Some(TERMINAL_SOURCE_VALIDATED));
+        assert!(j.gaps.is_empty());
+        // Aligned with the existing closure proof.
+        assert!(j.closure_proof.all_todos_done);
+        assert_eq!(j.closure_proof.successor_gap_count, 0);
+        assert_eq!(j.closure_proof.monitor_open_count, 0);
+    }
+
+    #[test]
+    fn open_todo_and_acceptance_gap_enumerate_as_gaps() {
+        let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match")]);
+        g.add(Todo::advancement("T1", "work"));
+        let j = terminal_judgement(&g);
+        assert!(!j.terminal);
+        assert_eq!(j.kind, None);
+        assert_eq!(j.source, None);
+        assert_eq!(j.gaps.len(), 2);
+        let open: Vec<&TerminalGap> = j
+            .gaps
+            .iter()
+            .filter(|gap| gap.kind == GAP_OPEN_TODO)
+            .collect();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].todo_id.as_deref(), Some("T1"));
+        let acceptance: Vec<&TerminalGap> = j
+            .gaps
+            .iter()
+            .filter(|gap| gap.kind == GAP_UNSATISFIED_ACCEPTANCE)
+            .collect();
+        assert_eq!(acceptance.len(), 1);
+        assert_eq!(acceptance[0].gap_id.as_deref(), Some("A1"));
+        assert_eq!(acceptance[0].description, "match");
+        assert!(!acceptance[0].satisfied);
+        // The proof mirrors the gap detail.
+        assert!(!j.closure_proof.all_todos_done);
+        // Satisfying the gap + completing with no-follow-up closes it.
+        g.satisfy_gap("A1");
+        g.todo_mut("T1").unwrap().complete(true, vec![]);
+        assert!(terminal_judgement(&g).terminal);
+    }
+
+    #[test]
+    fn monitor_and_pending_deferred_have_distinct_gap_kinds() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut done = Todo::advancement("T1", "work");
+        done.complete(true, vec![]);
+        g.add(done);
+        g.add(Todo::monitor("M1", "watch", Duration::from_secs(600)));
+        g.add(Todo::deferred("D1", "later", Duration::from_secs(600)));
+        let j = terminal_judgement(&g);
+        assert!(!j.terminal);
+        let kinds: std::collections::HashSet<&str> =
+            j.gaps.iter().map(|gap| gap.kind.as_str()).collect();
+        assert!(kinds.contains(GAP_OPEN_MONITOR));
+        assert!(kinds.contains(GAP_PENDING_DEFERRED));
+        assert_eq!(j.closure_proof.monitor_open_count, 1);
+        // A DUE deferred returns to the frontier → open_todo, not pending.
+        let mut g2 = Goal::new("g2", "o", "/tmp");
+        g2.add(Todo::deferred("D1", "later", Duration::ZERO));
+        let j2 = terminal_judgement(&g2);
+        assert!(j2
+            .gaps
+            .iter()
+            .any(|gap| gap.kind == GAP_OPEN_TODO && gap.todo_id.as_deref() == Some("D1")));
+        assert!(!j2.gaps.iter().any(|gap| gap.kind == GAP_PENDING_DEFERRED));
+    }
+
+    #[test]
+    fn succession_gap_blocks_terminal_with_gap_detail() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut todo = Todo::advancement("T1", "work");
+        todo.complete(false, vec![]); // silent completion
+        g.add(todo);
+        assert!(!g.is_terminal());
+        let j = terminal_judgement(&g);
+        assert!(!j.terminal);
+        assert_eq!(j.gaps.len(), 1);
+        assert_eq!(j.gaps[0].kind, GAP_SUCCESSION);
+        assert_eq!(j.gaps[0].todo_id.as_deref(), Some("T1"));
+        assert_eq!(j.closure_proof.successor_gap_count, 1);
+    }
+
+    #[test]
+    fn judgement_matches_is_terminal_on_mixed_states() {
+        let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "x")]);
+        g.add(Todo::advancement("T1", "a"));
+        assert_eq!(terminal_judgement(&g).terminal, g.is_terminal());
+        g.todo_mut("T1").unwrap().complete(true, vec![]);
+        assert_eq!(terminal_judgement(&g).terminal, g.is_terminal());
+        g.satisfy_gap("A1");
+        assert_eq!(terminal_judgement(&g).terminal, g.is_terminal());
+        assert!(g.is_terminal());
+        // Superseded todos must not block terminal closure either.
+        let mut g2 = Goal::new("g2", "o", "/tmp");
+        g2.add(Todo::advancement("T1", "obsolete"));
+        g2.supersede("T1");
+        assert!(g2.is_terminal());
+        assert!(terminal_judgement(&g2).terminal);
+        assert!(!g2.todos.iter().any(|t| t.class == TaskClass::Monitor));
+    }
+}

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -28,6 +28,7 @@ pub mod arbitration;
 mod boundary;
 mod frontier;
 mod goal_boundary;
+pub mod goal_frontier;
 mod heartbeat_recommendation;
 mod identity;
 pub(crate) mod monitor;
@@ -383,7 +384,30 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         );
     }
 
-    // ── 6. Validated closure. ───────────────────────────────────────────
+    // ── 6. Validated closure — the terminal judgement (G13 ④): closure is
+    //       validated from complete sources (todos done/superseded, every
+    //       acceptance gap satisfied, closure intent declared, no pending
+    //       deferred work) and the judgement enumerates the gap detail.
+    //       `terminal` ⇔ `Goal::is_terminal()` — the judgement is the single
+    //       authoritative gate here; any remaining blocker surfaces as a
+    //       replan with the explicit gap list (defensive: the pipeline above
+    //       catches every blocker before this point). ───────────────────────
+    let judgement = crate::decision::goal_frontier::terminal::terminal_judgement(goal);
+    if !judgement.terminal {
+        let gaps: Vec<String> = judgement
+            .gaps
+            .iter()
+            .map(|g| {
+                let id = g.gap_id.as_deref().or(g.todo_id.as_deref()).unwrap_or("-");
+                format!("{}:{}", g.kind, id)
+            })
+            .collect();
+        return replan_packet(
+            goal,
+            DecisionReasonCode::AcceptanceGapOpen,
+            &format!("terminal judgement open gaps: {}", gaps.join(", ")),
+        );
+    }
     let mut p = packet(
         goal,
         DecisionReasonCode::ValidatedClosure,

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -771,6 +771,22 @@ pub struct Goal {
     /// (append-only; detection + bookkeeping, no auto-injection).
     #[serde(default)]
     pub turn_no_progress: Vec<TurnNoProgressRecord>,
+    /// G13 ①: timestamps of frontier-changing events (todo added/completed/
+    /// superseded, gate resolved, frontier-delta replan ack, todo archived),
+    /// folded during replay — the reset markers for outcome-continuity
+    /// segments ([`crate::decision::goal_frontier::outcome_continuity`]).
+    #[serde(default)]
+    pub frontier_change_ts: Vec<u64>,
+    /// G13 ③: goal-level bounded semantic event history (recent
+    /// [`crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_CAP`]
+    /// summaries, oldest dropped) — folded from the event ledger during
+    /// replay; consumable by the decision-context `semantic_history` provider.
+    #[serde(default)]
+    pub semantic_history: Vec<crate::decision::goal_frontier::semantic_history::SemanticEvent>,
+    /// G13 ②: explicit replan rule set (folded from `ReplanRuleSetUpdated`;
+    /// latest wins). `None` → the default rule set applies.
+    #[serde(default)]
+    pub replan_rule_set: Option<crate::decision::goal_frontier::replan_rules::ReplanRuleSet>,
 }
 
 /// P1-3①: one automation-liveness breach alert (LoopX automation_liveness):
@@ -873,6 +889,9 @@ impl Goal {
             scheduler_heartbeats: std::collections::BTreeMap::new(),
             liveness_alerts: vec![],
             turn_no_progress: vec![],
+            frontier_change_ts: vec![],
+            semantic_history: vec![],
+            replan_rule_set: None,
         }
     }
 
@@ -1223,7 +1242,7 @@ pub struct TodoSourceProof {
     pub schema_version: String,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TerminalClosureProof {
     pub all_todos_done: bool,
     pub derived: bool,

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -583,6 +583,16 @@ pub enum Event {
         reason: String,
         ts: u64,
     },
+    /// G13 ②: replan rule set updated — the goal's explicit rule set (full
+    /// replace; latest wins). `rule_ids` empty ⇒ reset to the default rule
+    /// set. Folded into `Goal::replan_rule_set` on replay.
+    ReplanRuleSetUpdated {
+        goal_id: String,
+        rule_set_version: String,
+        #[serde(default)]
+        rule_ids: Vec<String>,
+        ts: u64,
+    },
 }
 
 impl Event {
@@ -627,7 +637,8 @@ impl Event {
             | Event::DecisionOutcomeRecorded { goal_id, .. }
             | Event::MultiAgentContractSet { goal_id, .. }
             | Event::AgentRecipeAdded { goal_id, .. }
-            | Event::SuccessionOccurred { goal_id, .. } => goal_id,
+            | Event::SuccessionOccurred { goal_id, .. }
+            | Event::ReplanRuleSetUpdated { goal_id, .. } => goal_id,
         }
     }
 }
@@ -1401,7 +1412,7 @@ fn copy_dir_if_present(src: &Path, dest: &Path) -> Result<()> {
 fn apply(goal: &mut Goal, event: Event) {
     match event {
         Event::GoalStarted { .. } => {}
-        Event::TodoAdded { todo, .. } => {
+        Event::TodoAdded { todo, ts, .. } => {
             let mut t = todo;
             // Assign the goal-relative index on replay too (identity/order).
             if t.index == 0 {
@@ -1409,6 +1420,8 @@ fn apply(goal: &mut Goal, event: Event) {
                 t.index = goal.next_index;
             }
             goal.todos.push(t);
+            // G13 ①: a new todo changes the frontier (segment reset marker).
+            goal.frontier_change_ts.push(ts);
         }
         Event::TodoCompleted {
             todo_id,
@@ -1418,6 +1431,14 @@ fn apply(goal: &mut Goal, event: Event) {
             ts,
             ..
         } => {
+            // G13 ③: summary first — `complete` takes `successor_ids` by value.
+            let summary = if no_follow_up {
+                "no-follow-up".to_string()
+            } else if !successor_ids.is_empty() {
+                format!("successor {}", successor_ids.join(","))
+            } else {
+                "completed".to_string()
+            };
             if let Some(t) = goal.todo_mut(&todo_id) {
                 t.complete(no_follow_up, successor_ids);
                 // The event ts is authoritative for the completion stamp
@@ -1429,8 +1450,26 @@ fn apply(goal: &mut Goal, event: Event) {
                     t.evidence = Some(e);
                 }
             }
+            // G13 ①: completion moves the frontier (segment reset marker).
+            goal.frontier_change_ts.push(ts);
+            // G13 ③: semantic history fold.
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_TODO_COMPLETED,
+                Some(&todo_id),
+                &summary,
+                ts,
+            );
         }
-        Event::TodoSuperseded { todo_id, .. } => goal.supersede(&todo_id),
+        Event::TodoSuperseded { todo_id, ts, .. } => {
+            goal.supersede(&todo_id);
+            goal.frontier_change_ts.push(ts);
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_TODO_SUPERSEDED,
+                Some(&todo_id),
+                "superseded",
+                ts,
+            );
+        }
         Event::TodoUpdated {
             todo_id,
             text,
@@ -1517,9 +1556,43 @@ fn apply(goal: &mut Goal, event: Event) {
                     t.note = Some(n);
                 }
             }
+            // G13 ①: a resolved gate unblocks the frontier (segment reset).
+            goal.frontier_change_ts.push(ts);
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_GATE_RESOLVED,
+                Some(&todo_id),
+                "gate resolved",
+                ts,
+            );
         }
-        Event::GapSatisfied { gap_id, .. } => goal.satisfy_gap(&gap_id),
-        Event::RunRecorded { .. } => {} // run history is read from runs.jsonl
+        Event::GapSatisfied { gap_id, ts, .. } => {
+            goal.satisfy_gap(&gap_id);
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_ACCEPTANCE_GAP_SATISFIED,
+                None,
+                &format!("acceptance gap {gap_id} satisfied"),
+                ts,
+            );
+        }
+        Event::RunRecorded { record, ts, .. } => {
+            // run history itself is read from runs.jsonl; G13 ③ folds the
+            // semantic summary from the event ledger.
+            let summary = if record.evidence.trim().is_empty() {
+                record.terminal_state.clone()
+            } else {
+                format!(
+                    "{} — {}",
+                    record.terminal_state,
+                    crate::decision::truncate(&record.evidence, 120)
+                )
+            };
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_RUN_LANDED,
+                Some(&record.todo_id),
+                &summary,
+                ts,
+            );
+        }
         Event::TodoClaimed {
             todo_id,
             agent_id,
@@ -1571,9 +1644,20 @@ fn apply(goal: &mut Goal, event: Event) {
         } => {
             goal.replan_ack = Some(crate::state::ReplanAck {
                 recorded: true,
-                delta_kinds,
+                delta_kinds: delta_kinds.clone(),
                 at: ts,
             });
+            // G13 ①: only frontier-changing acks reset outcome segments.
+            let ack = goal.replan_ack.as_ref().expect("just recorded");
+            if ack.has_frontier_delta() {
+                goal.frontier_change_ts.push(ts);
+            }
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_REPLAN_ACKED,
+                None,
+                &format!("delta kinds: {}", delta_kinds.join(",")),
+                ts,
+            );
         }
         Event::ProfileSet {
             outcome_floor_streak_threshold,
@@ -1589,7 +1673,11 @@ fn apply(goal: &mut Goal, event: Event) {
             goal.authority.write_scope = write_scope;
             goal.authority.requires_approval = requires_approval;
         }
-        Event::TodoArchived { todo_id, .. } => goal.archive_todo(&todo_id),
+        Event::TodoArchived { todo_id, ts, .. } => {
+            goal.archive_todo(&todo_id);
+            // G13 ①: archiving removes the todo from the frontier.
+            goal.frontier_change_ts.push(ts);
+        }
         Event::MonitorPolled {
             todo_id,
             result,
@@ -1619,6 +1707,12 @@ fn apply(goal: &mut Goal, event: Event) {
                 }
                 m.updated_at = ts;
             }
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_MONITOR_POLL,
+                Some(&todo_id),
+                &result,
+                ts,
+            );
         }
         Event::QuotaSpent { slots, .. } => {
             goal.quota_spent_slots = goal.quota_spent_slots.saturating_add(slots);
@@ -1699,7 +1793,15 @@ fn apply(goal: &mut Goal, event: Event) {
             seq,
             ts,
             ..
-        } => goal.apply_delivery_outcome(&todo_id, &outcome, note, delivered_turn, seq, ts),
+        } => {
+            goal.apply_delivery_outcome(&todo_id, &outcome, note, delivered_turn, seq, ts);
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_DELIVERY_OUTCOME,
+                Some(&todo_id),
+                &outcome,
+                ts,
+            );
+        }
         Event::FollowthroughCreated {
             source_todo_id,
             followup_todo_id,
@@ -1736,16 +1838,50 @@ fn apply(goal: &mut Goal, event: Event) {
             idle_secs,
             tool_calls_total,
             ts,
-        } => goal
-            .turn_no_progress
-            .push(crate::state::TurnNoProgressRecord {
-                goal_id,
-                todo_id,
-                agent_id,
-                idle_secs,
-                tool_calls_total,
+        } => {
+            let summary = format!("{}s idle after {} tool calls", idle_secs, tool_calls_total);
+            goal.turn_no_progress
+                .push(crate::state::TurnNoProgressRecord {
+                    goal_id,
+                    todo_id,
+                    agent_id,
+                    idle_secs,
+                    tool_calls_total,
+                    ts,
+                });
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_TURN_NO_PROGRESS,
+                None,
+                &summary,
                 ts,
-            }),
+            );
+        }
+        // G13 ②: replan rule set update — latest wins; empty ids reset to
+        // the default rule set (the folded state never stores an empty list).
+        Event::ReplanRuleSetUpdated {
+            rule_set_version,
+            rule_ids,
+            ts,
+            ..
+        } => {
+            // Empty ids on the wire = reset to the default rule set.
+            goal.replan_rule_set = if rule_ids.is_empty() {
+                None
+            } else {
+                Some(
+                    crate::decision::goal_frontier::replan_rules::ReplanRuleSet {
+                        schema_version: rule_set_version,
+                        rule_ids,
+                    },
+                )
+            };
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_REPLAN_ACKED,
+                None,
+                "replan rule set updated",
+                ts,
+            );
+        }
         // P1-5 + P1-1 + P1-4 + G-16 + G12 projection-only events: read from
         // the event log by their read models; goal state is unchanged on
         // replay.
@@ -1758,8 +1894,21 @@ fn apply(goal: &mut Goal, event: Event) {
         | Event::ProjectionRepaired { .. }
         | Event::DecisionOutcomeRecorded { .. }
         | Event::MultiAgentContractSet { .. }
-        | Event::AgentRecipeAdded { .. }
-        | Event::SuccessionOccurred { .. } => {}
+        | Event::AgentRecipeAdded { .. } => {}
+        Event::SuccessionOccurred {
+            primary,
+            backup,
+            reason,
+            ts,
+            ..
+        } => {
+            goal.record_semantic_event(
+                crate::decision::goal_frontier::semantic_history::KIND_ROLE_SUCCESSION,
+                None,
+                &format!("{primary}→{backup} ({reason})"),
+                ts,
+            );
+        }
     }
 }
 

--- a/orchestration/loop/tests/decision_context_contract.rs
+++ b/orchestration/loop/tests/decision_context_contract.rs
@@ -126,7 +126,8 @@ fn assemble_reflects_goal_state_and_runs_via_cli() {
             vec![
                 "run_history".to_string(),
                 "outcome_streak".to_string(),
-                "quota_status".to_string()
+                "quota_status".to_string(),
+                "semantic_history".to_string()
             ]
         );
         assert_eq!(packet.run_history.run_count, 1);

--- a/orchestration/loop/tests/goal_frontier_contract.rs
+++ b/orchestration/loop/tests/goal_frontier_contract.rs
@@ -1,0 +1,465 @@
+//! G13 goal_frontier contract tests — the four assertion groups for the
+//! goal_frontier subdomain:
+//! ① OutcomeContinuity — segment reset on material turns and on
+//!    frontier-changing events between runs (replay-folded markers);
+//! ② ReplanRules — disposition → replan decision + obligation across the
+//!    ordered rule table; `ReplanRuleSetUpdated` custom set + reset;
+//! ③ SemanticHistory — bounded (N=50) goal-level semantic history folded
+//!    from the event ledger; decision-context consumability;
+//! ④ TerminalJudgement — terminal closure tightened with acceptance-gap
+//!    semantics and explicit gap detail, aligned with the closure proof.
+
+use future_loop::decision::goal_frontier::outcome_continuity::{
+    outcome_segments, run_is_material, SEGMENT_KIND_MATERIAL, SEGMENT_KIND_SURFACE_ONLY,
+};
+use future_loop::decision::goal_frontier::replan_rules::{
+    active_rule_set, select_replan_rule, ReplanRuleSet, RULE_ADVANCEMENT_REMAINS,
+    RULE_EXISTING_OBLIGATION, RULE_MONITOR_FRONTIER_EXHAUSTED, RULE_MONITOR_NO_CHANGE_STREAK,
+    RULE_TODO_SUCCESSION_GAP, RULE_VISION_ACCEPTANCE_GAP,
+};
+use future_loop::decision::goal_frontier::semantic_history::{
+    SemanticEvent, KIND_RUN_LANDED, SEMANTIC_HISTORY_CAP, SEMANTIC_HISTORY_SCHEMA_VERSION,
+};
+use future_loop::decision::goal_frontier::terminal::{
+    terminal_judgement, GAP_OPEN_MONITOR, GAP_OPEN_TODO, GAP_PENDING_DEFERRED, GAP_SUCCESSION,
+    GAP_UNSATISFIED_ACCEPTANCE, TERMINAL_KIND_NO_FOLLOWUP, TERMINAL_SOURCE_VALIDATED,
+};
+use future_loop::decision::goal_frontier::{frontier_show, FRONTIER_SHOW_SCHEMA_VERSION};
+use future_loop::state::{Goal, RunRecord, Todo};
+use future_loop::store::{Event, Store};
+
+fn tmp_root(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "future-loop-g13-goal-frontier-{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn open_goal(store: &mut Store, goal_id: &str) -> Goal {
+    let goal = Goal::new(goal_id, "objective", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: goal_id.into(),
+            ts: goal.created_at,
+        })
+        .unwrap();
+    goal
+}
+
+fn run(turn: u32, todo_id: &str, at: u64, tools: &[&str], evidence: &str) -> RunRecord {
+    RunRecord {
+        turn,
+        todo_id: todo_id.to_string(),
+        run_id: format!("r{turn}"),
+        validation: None,
+        terminal_state: "completed".to_string(),
+        error: None,
+        tokens_in_delta: 0,
+        tokens_out_delta: 0,
+        cost_delta: 0.0,
+        tools: tools.iter().map(|s| s.to_string()).collect(),
+        evidence: evidence.to_string(),
+        recorded_at: at,
+        spend_source: None,
+    }
+}
+
+// ── ① OutcomeContinuity: segment reset ─────────────────────────────────────
+
+#[test]
+fn outcome_segments_surface_streak_and_material_flip() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.history.push(run(1, "T1", 10, &[], ""));
+    g.history.push(run(2, "T1", 20, &[], ""));
+    g.history.push(run(3, "T1", 30, &["shell"], "artifact"));
+    g.history.push(run(4, "T1", 40, &[], ""));
+    let segments = outcome_segments(&g);
+    assert_eq!(segments.len(), 3);
+    assert_eq!(segments[0].kind, SEGMENT_KIND_SURFACE_ONLY);
+    assert_eq!(segments[0].start_turn, 1);
+    assert_eq!(segments[0].length, 2);
+    assert_eq!(segments[1].kind, SEGMENT_KIND_MATERIAL);
+    assert_eq!(segments[1].length, 1);
+    assert_eq!(segments[2].kind, SEGMENT_KIND_SURFACE_ONLY);
+    assert_eq!(segments[2].start_turn, 4);
+    // Materiality rule: tools + evidence.
+    assert!(run_is_material(&g.history[2]));
+    assert!(!run_is_material(&g.history[1]));
+}
+
+#[test]
+fn frontier_change_between_runs_resets_segment() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.history.push(run(1, "T1", 10, &[], ""));
+    g.history.push(run(2, "T1", 20, &[], ""));
+    // A frontier change (marker at ts 25 — e.g. a todo completed after the
+    // second run) splits the streak even though run 3 is surface-only.
+    g.frontier_change_ts.push(25);
+    g.history.push(run(3, "T2", 30, &[], ""));
+    g.history.push(run(4, "T2", 40, &[], ""));
+    let segments = outcome_segments(&g);
+    assert_eq!(segments.len(), 2, "frontier change resets the segment");
+    assert_eq!(segments[0].length, 2);
+    assert_eq!(segments[1].start_turn, 3);
+    assert_eq!(segments[1].length, 2);
+}
+
+#[test]
+fn replay_folds_frontier_markers_and_resets_segments() {
+    let mut store = Store::open(&tmp_root("segments")).unwrap();
+    open_goal(&mut store, "g");
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g".into(),
+            todo: Todo::advancement("T1", "first"),
+            ts: 1,
+        })
+        .unwrap();
+    // Two surface-only runs, then a completed todo (frontier change), then
+    // one more surface-only run — replay must fold the marker and split.
+    store.append_run("g", &run(1, "T1", 10, &[], "")).unwrap();
+    store.append_run("g", &run(2, "T1", 20, &[], "")).unwrap();
+    store
+        .append(Event::TodoCompleted {
+            goal_id: "g".into(),
+            todo_id: "T1".into(),
+            no_follow_up: true,
+            successor_ids: vec![],
+            evidence: None,
+            ts: 25,
+        })
+        .unwrap();
+    store.append_run("g", &run(3, "T2", 30, &[], "")).unwrap();
+    let goal = store.replay("g").unwrap().expect("goal exists");
+    assert!(goal.frontier_change_ts.contains(&25));
+    let segments = outcome_segments(&goal);
+    assert_eq!(segments.len(), 2, "completion marker resets the segment");
+    assert_eq!(segments[1].start_turn, 3);
+}
+
+// ── ② ReplanRules: rule trigger + rule set ─────────────────────────────────
+
+#[test]
+fn succession_gap_selects_rule_and_derives_obligation() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    let mut todo = Todo::advancement("T1", "work");
+    todo.complete(false, vec![]); // silent completion → succession gap
+    g.add(todo);
+    let d = select_replan_rule(&g);
+    assert_eq!(d.rule, RULE_TODO_SUCCESSION_GAP);
+    assert!(d.derives_obligation);
+    assert_eq!(d.obligation_kind.as_deref(), Some("succession_gap"));
+    assert!(d.reason.contains("successor"));
+}
+
+#[test]
+fn acceptance_gap_on_empty_frontier_selects_vision_rule() {
+    let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match")]);
+    let mut todo = Todo::advancement("T1", "work");
+    todo.complete(true, vec![]);
+    g.add(todo);
+    let d = select_replan_rule(&g);
+    assert_eq!(d.rule, RULE_VISION_ACCEPTANCE_GAP);
+    assert!(d.derives_obligation);
+    assert_eq!(d.obligation_kind.as_deref(), Some("vision_acceptance_gap"));
+}
+
+#[test]
+fn monitor_streak_on_monitor_only_lane_triggers_monitor_rule() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    let mut m = Todo::monitor("M1", "watch", std::time::Duration::from_secs(60));
+    m.consecutive_no_change = 3;
+    g.add(m);
+    let d = select_replan_rule(&g);
+    assert_eq!(d.rule, RULE_MONITOR_NO_CHANGE_STREAK);
+    assert!(d.derives_obligation);
+    assert_eq!(
+        d.obligation_kind.as_deref(),
+        Some("monitor_no_change_streak")
+    );
+    // A runnable todo reopens the lane: not_monitor_only, no obligation.
+    let mut g2 = Goal::new("g2", "o", "/tmp");
+    g2.add(Todo::advancement("T1", "work"));
+    let d2 = select_replan_rule(&g2);
+    assert_eq!(d2.rule, "not_monitor_only");
+    assert!(!d2.derives_obligation);
+}
+
+#[test]
+fn surface_only_streak_obligation_is_authoritative_and_first_in_policy_order() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.add(Todo::advancement("T1", "work"));
+    // The outcome floor breach puts a surface-only-streak obligation on
+    // record: EXISTING_OBLIGATION fires before any lane rule.
+    g.execution_profile.outcome_floor_streak_threshold = 2;
+    g.outcome_streak = 2;
+    let d = select_replan_rule(&g);
+    assert_eq!(d.rule, RULE_EXISTING_OBLIGATION);
+    assert!(!d.derives_obligation);
+    assert!(d.reason.contains("authoritative"));
+}
+
+#[test]
+fn replan_rule_set_updated_event_customizes_and_resets() {
+    let mut store = Store::open(&tmp_root("rules")).unwrap();
+    open_goal(&mut store, "g");
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g".into(),
+            todo: Todo::advancement("T1", "work"),
+            ts: 1,
+        })
+        .unwrap();
+    // Default: not_monitor_only (runnable advancement, no obligations).
+    let goal = store.replay("g").unwrap().unwrap();
+    assert_eq!(select_replan_rule(&goal).rule, "not_monitor_only");
+    // Custom set with the exhausted rule first: it fires instead.
+    store
+        .append(Event::ReplanRuleSetUpdated {
+            goal_id: "g".into(),
+            rule_set_version: "goal_frontier_replan_rules_v0".into(),
+            rule_ids: vec![RULE_MONITOR_FRONTIER_EXHAUSTED.to_string()],
+            ts: 2,
+        })
+        .unwrap();
+    let goal = store.replay("g").unwrap().unwrap();
+    assert_eq!(
+        select_replan_rule(&goal).rule,
+        RULE_MONITOR_FRONTIER_EXHAUSTED
+    );
+    let active = active_rule_set(&goal);
+    assert_eq!(
+        active.effective_rule_ids(),
+        vec![RULE_MONITOR_FRONTIER_EXHAUSTED.to_string()],
+        "a custom set with a known rule fully replaces the default order"
+    );
+    // Empty rule ids on the wire reset to the default set.
+    store
+        .append(Event::ReplanRuleSetUpdated {
+            goal_id: "g".into(),
+            rule_set_version: "goal_frontier_replan_rules_v0".into(),
+            rule_ids: vec![],
+            ts: 3,
+        })
+        .unwrap();
+    let goal = store.replay("g").unwrap().unwrap();
+    assert_eq!(select_replan_rule(&goal).rule, "not_monitor_only");
+    assert_eq!(
+        active_rule_set(&goal),
+        ReplanRuleSet {
+            schema_version: "goal_frontier_replan_rules_v0".to_string(),
+            rule_ids: vec![
+                RULE_EXISTING_OBLIGATION.to_string(),
+                "open_user_todo".to_string(),
+                RULE_TODO_SUCCESSION_GAP.to_string(),
+                RULE_VISION_ACCEPTANCE_GAP.to_string(),
+                RULE_MONITOR_NO_CHANGE_STREAK.to_string(),
+                "not_monitor_only".to_string(),
+                "no_open_monitor".to_string(),
+                RULE_ADVANCEMENT_REMAINS.to_string(),
+                RULE_MONITOR_FRONTIER_EXHAUSTED.to_string(),
+            ],
+        }
+    );
+}
+
+// ── ③ SemanticHistory: bounded fold + decision-context consumption ─────────
+
+#[test]
+fn semantic_history_is_bounded_to_cap() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    for i in 0..(SEMANTIC_HISTORY_CAP + 20) {
+        g.record_semantic_event(KIND_RUN_LANDED, Some("T1"), &format!("run {i}"), i as u64);
+    }
+    assert_eq!(g.semantic_history.len(), SEMANTIC_HISTORY_CAP);
+    assert_eq!(g.semantic_history.first().unwrap().ts, 20, "oldest dropped");
+    assert_eq!(
+        g.semantic_history.last().unwrap().ts,
+        (SEMANTIC_HISTORY_CAP + 19) as u64,
+        "newest kept"
+    );
+}
+
+#[test]
+fn replay_folds_semantic_events_from_the_ledger() {
+    let mut store = Store::open(&tmp_root("semantic")).unwrap();
+    open_goal(&mut store, "g");
+    store
+        .append(Event::TodoAdded {
+            goal_id: "g".into(),
+            todo: Todo::advancement("T1", "work"),
+            ts: 1,
+        })
+        .unwrap();
+    let r1 = run(1, "T1", 10, &["shell"], "artifact one");
+    store.append_run("g", &r1).unwrap();
+    store
+        .append(Event::RunRecorded {
+            goal_id: "g".into(),
+            record: r1,
+            ts: 10,
+        })
+        .unwrap();
+    store
+        .append(Event::TodoCompleted {
+            goal_id: "g".into(),
+            todo_id: "T1".into(),
+            no_follow_up: true,
+            successor_ids: vec![],
+            evidence: None,
+            ts: 11,
+        })
+        .unwrap();
+    store
+        .append(Event::ReplanAcked {
+            goal_id: "g".into(),
+            delta_kinds: vec!["vision_patch".to_string()],
+            ts: 12,
+        })
+        .unwrap();
+    store
+        .append(Event::SuccessionOccurred {
+            goal_id: "g".into(),
+            primary: "p".into(),
+            backup: "b".into(),
+            reason: "offline".into(),
+            ts: 13,
+        })
+        .unwrap();
+    let goal = store.replay("g").unwrap().unwrap();
+    let kinds: Vec<&str> = goal
+        .semantic_history
+        .iter()
+        .map(|e| e.kind.as_str())
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            "run_landed",
+            "todo_completed",
+            "replan_acked",
+            "role_succession"
+        ]
+    );
+    assert_eq!(
+        goal.semantic_history[0].summary, "completed — artifact one",
+        "run summary = terminal state + evidence excerpt"
+    );
+    assert_eq!(goal.semantic_history[1].todo_id.as_deref(), Some("T1"));
+    assert_eq!(goal.semantic_history[3].summary, "p→b (offline)");
+}
+
+#[test]
+fn decision_context_packet_consumes_semantic_history() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    g.record_semantic_event(KIND_RUN_LANDED, Some("T1"), "completed", 42);
+    let packet =
+        future_loop::capabilities::decision_context::assembler::assemble_decision_context(&g);
+    let section = packet.semantic_history.expect("section attached");
+    assert_eq!(section.schema_version, SEMANTIC_HISTORY_SCHEMA_VERSION);
+    assert_eq!(section.cap, SEMANTIC_HISTORY_CAP);
+    assert_eq!(section.events.len(), 1);
+    assert_eq!(section.events[0].kind, KIND_RUN_LANDED);
+    assert_eq!(section.events[0].ts, 42);
+    assert!(packet.providers.iter().any(|p| p == "semantic_history"));
+}
+
+// ── ④ TerminalJudgement: tightened terminal closure with gap detail ────────
+
+#[test]
+fn open_todo_and_acceptance_gap_enumerate_gap_details() {
+    let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match the spec")]);
+    g.add(Todo::advancement("T1", "work"));
+    let j = terminal_judgement(&g);
+    assert!(!j.terminal);
+    assert_eq!(j.kind, None);
+    assert_eq!(j.source, None);
+    assert_eq!(j.gaps.len(), 2);
+    let open = j.gaps.iter().find(|gap| gap.kind == GAP_OPEN_TODO).unwrap();
+    assert_eq!(open.todo_id.as_deref(), Some("T1"));
+    let acceptance = j
+        .gaps
+        .iter()
+        .find(|gap| gap.kind == GAP_UNSATISFIED_ACCEPTANCE)
+        .unwrap();
+    assert_eq!(acceptance.gap_id.as_deref(), Some("A1"));
+    assert_eq!(acceptance.description, "match the spec");
+    assert!(!acceptance.satisfied, "acceptance-gap semantics preserved");
+    // Closing both gaps → terminal no_followup from validated sources.
+    g.satisfy_gap("A1");
+    g.todo_mut("T1").unwrap().complete(true, vec![]);
+    let j = terminal_judgement(&g);
+    assert!(j.terminal);
+    assert_eq!(j.kind.as_deref(), Some(TERMINAL_KIND_NO_FOLLOWUP));
+    assert_eq!(j.source.as_deref(), Some(TERMINAL_SOURCE_VALIDATED));
+    assert!(j.gaps.is_empty());
+}
+
+#[test]
+fn monitor_and_deferred_gaps_have_distinct_kinds_and_align_with_proof() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    let mut done = Todo::advancement("T1", "work");
+    done.complete(true, vec![]);
+    g.add(done);
+    g.add(Todo::monitor(
+        "M1",
+        "watch",
+        std::time::Duration::from_secs(600),
+    ));
+    g.add(Todo::deferred(
+        "D1",
+        "later",
+        std::time::Duration::from_secs(600),
+    ));
+    let j = terminal_judgement(&g);
+    assert!(!j.terminal);
+    assert!(j.gaps.iter().any(|gap| gap.kind == GAP_OPEN_MONITOR));
+    assert!(j.gaps.iter().any(|gap| gap.kind == GAP_PENDING_DEFERRED));
+    // Closure proof alignment: monitor_open_count mirrors the gap detail.
+    assert_eq!(j.closure_proof.monitor_open_count, 1);
+    assert!(!j.closure_proof.all_todos_done);
+}
+
+#[test]
+fn succession_gap_blocks_terminal_and_matches_is_terminal() {
+    let mut g = Goal::new("g", "o", "/tmp");
+    let mut todo = Todo::advancement("T1", "work");
+    todo.complete(false, vec![]); // no successor, no no-follow-up
+    g.add(todo);
+    let j = terminal_judgement(&g);
+    assert!(!j.terminal);
+    assert_eq!(j.gaps.len(), 1);
+    assert_eq!(j.gaps[0].kind, GAP_SUCCESSION);
+    assert_eq!(j.gaps[0].todo_id.as_deref(), Some("T1"));
+    assert_eq!(j.closure_proof.successor_gap_count, 1);
+    // Judgement ⇔ kernel terminal predicate across mixed states.
+    assert_eq!(j.terminal, g.is_terminal());
+    g.todo_mut("T1").unwrap().no_follow_up = true;
+    g.todo_mut("T1").unwrap().successor_ids = vec![];
+    assert!(g.is_terminal());
+    assert!(terminal_judgement(&g).terminal);
+}
+
+#[test]
+fn frontier_show_composes_all_four_layers() {
+    let mut g = Goal::new("g", "o", "/tmp").with_acceptance(vec![("A1", "match")]);
+    g.add(Todo::advancement("T1", "work"));
+    g.record_semantic_event(KIND_RUN_LANDED, Some("T1"), "completed", 1);
+    let show = frontier_show(&g);
+    assert_eq!(show.schema_version, FRONTIER_SHOW_SCHEMA_VERSION);
+    assert_eq!(show.goal_id, "g");
+    assert_eq!(show.lane, "advancement_task");
+    assert_eq!(show.frontier_projection.acceptance_gaps, 1);
+    assert_eq!(show.frontier_projection.unclaimed_advancement, 1);
+    assert!(show.outcome_segments.is_empty(), "no runs yet");
+    assert_eq!(show.replan_rule.rule, "not_monitor_only");
+    assert!(!show.terminal_judgement.terminal);
+    assert_eq!(show.semantic_history.len(), 1);
+    let _: Vec<SemanticEvent> = show.semantic_history;
+}


### PR DESCRIPTION
Wave 4 2/2（loopx-stub-and-gaps.md G13，P1 级缺口，参照 ~/loopx goals/goal_frontier/ 4 文件取核心子集）。

- OutcomeContinuity：outcome streak 分段（frontier 变化重置段）
- ReplanRules：结构化 replan 触发规则表（disposition→决策+obligations）
- SemanticHistory：有界语义历史（N=50），并作为 decision_context 第 4 个内置 provider
- TerminalJudgement：终局判定收紧（closure 验证含 acceptance gaps 明细，单点权威门）
- CLI：`future loop frontier show --goal G [--format json]`、`replan rules show --goal G`
- 契约测试 goal_frontier_contract.rs（4 组断言）；decision/mod.rs 融合 main 新增的 5c leased-wait 段

本地：fmt ✅ clippy ✅ future-loop 80 targets 全绿 ✅。源：claude/loop-wave2 65797bc8