### PR TITLE
test: clarify Remote status failure handling

### DIFF
--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -304,6 +304,27 @@ describe("RemoteClient terminal iterator recovery", () => {
     expect(recovery).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("remote_service_misconfigured") }),
     );
+    expect(recovery).toHaveBeenCalledTimes(1);
+  });
+
+  test("a protocol status fails its generation once without exhaustion fallback", async () => {
+    const { client } = recoveryClient();
+    const failGeneration = jest.fn();
+    const testClient = client as unknown as {
+      watchStatus(connection: unknown, generation: number): void;
+      failGeneration(error: unknown, generation: number): void;
+    };
+    testClient.failGeneration = failGeneration;
+    async function* statuses() {
+      yield { type: "error", data: ErrorCode.ProtocolError };
+    }
+    testClient.watchStatus({ status: statuses }, 0);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(failGeneration).toHaveBeenCalledTimes(1);
+    expect(failGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("nats_protocol_error") }),
+      0,
+    );
   });
 
   test("a throwing NATS status iterator enters the outer recovery path", async () => {

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -609,11 +609,9 @@ export class RemoteClient {
               code === ErrorCode.AuthorizationViolation
             ) {
               this.handleFailure(new Error(`remote_service_misconfigured: ${code}`));
-              exitedNaturally = false;
               return;
             } else if (code === ErrorCode.ProtocolError) {
               this.failGeneration(new Error(`nats_protocol_error: ${code}`), generation);
-              exitedNaturally = false;
               return;
             }
           }


### PR DESCRIPTION
## Summary

- remove two dead assignments before terminal returns in the mobile NATS status watcher
- retain the intentional return behavior that prevents terminal permission and protocol failures from falling through to the connection-exhausted fallback
- add regression assertions that permission and protocol status errors are handled exactly once

## Validation

- npx jest --runInBand --no-watchman src/remote/__tests__/connectionState.test.ts