### PR TITLE
feat(loop): todo-completion contracts — evidence floor + --acceptance tokens

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4,7 +4,9 @@
 //!   goal init    — create a durable goal (registry + event ledger)
 //!   todo add     — add an agent/user/gate/monitor todo
 //!   todo claim   — claim a todo (owner identity)
-//!   todo complete — complete a todo; REQUIRES --no-follow-up or --successor
+//!   todo complete — complete a todo; REQUIRES --no-follow-up or --successor,
+//!     non-empty --evidence for advancement todos, and (when declared)
+//!     --acceptance tokens inside the evidence; --force overrides both.
 //!   gate resolve — resolve a user gate with a decision payload
 //!   status       — project the active state (todos, gaps, next action)
 //!   quota should-run — emit the typed ShouldRunPacket (deterministic)
@@ -899,6 +901,28 @@ fn looks_like_code_todo(text: &str) -> bool {
             .any(|tok| CODE_WORDS.contains(&tok))
 }
 
+/// O5: heuristic for the `todo add` advisory hint — does the text look like an
+/// external-delivery task (platform submission, scored attempt, quota-bounded
+/// side effect) whose completion should carry an `--acceptance` contract?
+/// Advisory only; never changes CLI semantics.
+fn looks_like_external_delivery(text: &str) -> bool {
+    const DELIVERY_WORDS: &[&str] = &[
+        "submit",
+        "submission",
+        "attempt",
+        "scored",
+        "acceptance",
+        "quota",
+        "platform",
+    ];
+    const DELIVERY_ZH: &[&str] = &["提交", "评分", "配额", "验收", "排行榜", "上分"];
+    let lower = text.to_lowercase();
+    DELIVERY_ZH.iter().any(|k| text.contains(k))
+        || lower
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|tok| DELIVERY_WORDS.contains(&tok))
+}
+
 fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut role = "agent".to_string();
@@ -924,9 +948,11 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut cadence = None;
     let mut verify: Option<String> = None;
     let mut max_validation_attempts: Option<u32> = None;
+    let mut acceptance: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
+            "--acceptance",
             "--action-kind",
             "--blocks",
             "--cadence",
@@ -970,6 +996,8 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             cadence = Some(v);
         } else if k == "--verify" {
             verify = Some(v);
+        } else if k == "--acceptance" {
+            acceptance = Some(v);
         } else if k == "--max-validation-attempts" {
             max_validation_attempts = v.parse().ok();
         } else if k == "--goal" {
@@ -1010,6 +1038,9 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     // done by an agent even when the code does not compile. Computed before
     // `verify` is moved into the todo below.
     let wants_verify_hint = verify.is_none() && looks_like_code_todo(&text);
+    // O5: advisory hint — external-delivery todos (submit/提交 …) whose
+    // completion contract is a text convention unless `--acceptance` pins it.
+    let wants_acceptance_hint = acceptance.is_none() && looks_like_external_delivery(&text);
     store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
@@ -1098,6 +1129,9 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     if let Some(v) = verify {
         todo.validator = Some(v);
     }
+    if let Some(a) = acceptance {
+        todo.acceptance = Some(a);
+    }
     if let Some(n) = max_validation_attempts {
         todo.max_validation_attempts = n.max(1);
     }
@@ -1142,6 +1176,13 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     // O4: pure reminder after a successful add; no semantic change.
     if wants_verify_hint {
         eprintln!("hint: 实现类 todo 建议挂 --verify \"cargo check -p ...\"，防不编译代码被标完成");
+    }
+    // O5: advisory hint for external-delivery todos (submit/提交 …) — the
+    // completion contract is a text convention unless `--acceptance` pins it.
+    if wants_acceptance_hint {
+        eprintln!(
+            "hint: 外部交付类 todo 建议挂 --acceptance \"attempt,scored\"（关单时 evidence 必须包含全部子串，防空交付）"
+        );
     }
     Ok(())
 }
@@ -2038,10 +2079,12 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     let mut no_follow_up = false;
     let mut successor = None;
     let mut evidence = None;
+    let mut force = false;
     reject_unknown_flags(
         args,
         &[
             "--evidence",
+            "--force",
             "--goal",
             "--no-follow-up",
             "--successor",
@@ -2055,6 +2098,8 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
             todo_id = Some(v);
         } else if k == "--no-follow-up" {
             no_follow_up = true;
+        } else if k == "--force" {
+            force = true;
         } else if k == "--successor" {
             successor = Some(v);
         } else if k == "--evidence" {
@@ -2094,6 +2139,45 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
     let is_advancement = t.class == TaskClass::Advancement;
+    // O6: completion evidence contract (retrospective: 11/33 completions
+    // shipped <60-char evidence, several fully empty, and every one of those
+    // todos had to be reopened by hand). Advancement todos must carry real,
+    // non-empty evidence of what landed — `--force` is the explicit override
+    // for mechanical closeouts the operator owns.
+    let evidence_trim = evidence.as_deref().map(str::trim).unwrap_or("");
+    if is_advancement && evidence_trim.is_empty() && !force {
+        bail!(
+            "todo {todo_id} needs non-empty --evidence (what actually landed: attempt ids, \
+             paths, outputs, measurements). Add --force only for an explicit operator closeout."
+        );
+    }
+    // O7: acceptance contract (`todo add --acceptance "a,b"`) — evidence must
+    // contain every declared token (case-insensitive) before completion is
+    // accepted; `--force` overrides. Turns the ACCEPTANCE text convention
+    // (e.g. a platform attempt id) into a hard check.
+    if is_advancement {
+        if let Some(acc) = t.acceptance.as_deref() {
+            let tokens: Vec<&str> = acc
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            let lower = evidence_trim.to_lowercase();
+            let missing: Vec<&str> = tokens
+                .iter()
+                .filter(|tok| !lower.contains(&tok.to_lowercase()))
+                .copied()
+                .collect();
+            if !missing.is_empty() && !force {
+                bail!(
+                    "todo {todo_id} acceptance contract unmet: evidence must contain [{}] \
+                     (missing: [{}]). Declared via `todo add --acceptance`; --force overrides.",
+                    acc,
+                    missing.join(", ")
+                );
+            }
+        }
+    }
     let successors = successor.clone().into_iter().collect::<Vec<_>>();
     store.append(Event::TodoCompleted {
         goal_id: goal_id.clone(),
@@ -4996,6 +5080,7 @@ fn pr_review_verdict(store: &mut Store, args: &[String]) -> Result<()> {
         priority: None,
         resume_when: None,
         blocks: None,
+        acceptance: None,
         ts: now,
     })?;
     store.append(Event::TodoCompleted {
@@ -8646,9 +8731,11 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     let mut priority = None;
     let mut resume_when = None;
     let mut blocks: Option<Vec<String>> = None;
+    let mut acceptance: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
+            "--acceptance",
             "--blocks",
             "--evidence",
             "--goal",
@@ -8690,6 +8777,8 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
                     .filter(|s| !s.is_empty())
                     .collect()
             });
+        } else if k == "--acceptance" {
+            acceptance = Some(v);
         }
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -8736,6 +8825,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
         priority: priority.clone(),
         resume_when: resume_when_parsed,
         blocks: blocks.clone(),
+        acceptance: acceptance.clone(),
         ts: crate::state::now_epoch(),
     })?;
     refresh_next_action(store, &goal_id)?;
@@ -8806,6 +8896,7 @@ mod coverage_tests {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: 1,
             },
             Event::GoalCancelled {

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -172,6 +172,13 @@ pub struct Todo {
     /// runs it in the goal cwd after each turn; exit 0 completes the todo
     /// (validated), non-zero keeps it open for bounded repair.
     pub validator: Option<String>,
+    /// Completion acceptance contract (`todo add --acceptance "a,b"`): the
+    /// completion evidence must contain EVERY comma-separated token
+    /// (case-insensitive) — e.g. an external attempt id — else `todo complete`
+    /// refuses unless `--force`. Encodes "done ≠ delivered" acceptance
+    /// criteria as a hard check instead of a text convention.
+    #[serde(default)]
+    pub acceptance: Option<String>,
     /// How many failed validation attempts are tolerated before the kernel
     /// replans and surfaces to the user (default 3).
     #[serde(default = "default_max_validation_attempts")]
@@ -302,6 +309,7 @@ impl Todo {
             capability_binding_ref: None,
             validator: None,
             max_validation_attempts: default_max_validation_attempts(),
+            acceptance: None,
         }
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -191,6 +191,10 @@ pub enum Event {
         /// events serialized without this field deserialize as `None`.
         #[serde(default)]
         blocks: Option<Vec<String>>,
+        /// Completion acceptance contract (`--acceptance "a,b"`); `Some("")`
+        /// clears it, absent leaves it untouched. See `Todo::acceptance`.
+        #[serde(default)]
+        acceptance: Option<String>,
         ts: u64,
     },
     /// Stop automation while retaining state (the reference: goal cancel).
@@ -1479,6 +1483,7 @@ fn apply(goal: &mut Goal, event: Event) {
             priority,
             resume_when,
             blocks,
+            acceptance,
             ts,
             ..
         } => {
@@ -1491,6 +1496,9 @@ fn apply(goal: &mut Goal, event: Event) {
                 }
                 if let Some(x) = note {
                     t.note = Some(x);
+                }
+                if let Some(a) = acceptance {
+                    t.acceptance = if a.trim().is_empty() { None } else { Some(a) };
                 }
                 if let Some(b) = blocks {
                     // `--blocks a,b` replaces the blocking set; `--blocks ""`

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -209,6 +209,8 @@ fn run_failing_turns_exhaust_repair_budget() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     // Pre-seed a todo that already consumed one repair attempt (the ledger
     // does not persist failed_attempts from failed runs — see coverage
@@ -380,6 +382,8 @@ fn run_monitor_not_due_waits() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     append_monitor(&cr, &goal, "mon_future", 3600);
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
@@ -404,6 +408,8 @@ fn run_validator_pass_completes_todo() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     cli_ok(&[
         "todo",
@@ -442,6 +448,8 @@ fn run_validator_budget_exhaustion_stops_run() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     cli_ok(&[
         "todo",

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -539,6 +539,7 @@ fn todo_complete_contract() {
         "--todo-id",
         &s,
         "--no-follow-up",
+        "--force",
     ]);
     // Unknown todo / goal.
     assert!(cli_err(&[
@@ -563,6 +564,161 @@ fn todo_complete_contract() {
         "--no-follow-up"
     ])
     .contains("not found"));
+}
+
+#[test]
+fn todo_complete_evidence_floor_and_force() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "evidence floor");
+    let first = first_todo_id(&cr.root, &gid);
+    // Advancement completion without evidence is refused (the empty-closure
+    // failure mode: an agent marks a delivery done with nothing to show).
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+    ]);
+    assert!(err.contains("--evidence"), "{err}");
+    // Whitespace-only evidence is refused too.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--evidence",
+        "   ",
+    ]);
+    assert!(err.contains("--evidence"), "{err}");
+    // --force is the explicit operator override for mechanical closeouts.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--force",
+    ]);
+    // Any non-empty evidence satisfies the floor (strength belongs to
+    // --acceptance / --verify, which are opt-in contracts).
+    let s = add_todo(&cr, &gid, "second task");
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &s,
+        "--no-follow-up",
+        "--evidence",
+        "did the thing",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == s).unwrap();
+        assert_eq!(t.status, TodoStatus::Done);
+        assert_eq!(t.evidence.as_deref(), Some("did the thing"));
+    }
+}
+
+#[test]
+fn todo_complete_acceptance_contract() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "acceptance contract");
+    let first = first_todo_id(&cr.root, &gid);
+    // `--acceptance` is a todo-add flag; `todo complete` rejects it.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--acceptance",
+        "x",
+    ]);
+    assert!(err.contains("unknown"), "{err}");
+    let t = add_todo(&cr, &gid, "submit the payload");
+    // Declare the acceptance contract: evidence must contain BOTH tokens.
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    // Evidence missing one token is refused.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--no-follow-up",
+        "--evidence",
+        "created attempt 12345",
+    ]);
+    assert!(err.contains("acceptance contract"), "{err}");
+    assert!(err.contains("scored"), "{err}");
+    // Matching evidence (case-insensitive) completes.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--no-follow-up",
+        "--evidence",
+        "ATTEMPT 12345 SCORED 99 on the platform",
+    ]);
+    // --force overrides an unmet contract.
+    let t2 = add_todo(&cr, &gid, "submit again");
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t2,
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t2,
+        "--no-follow-up",
+        "--evidence",
+        "operator closeout without a scored attempt",
+        "--force",
+    ]);
+    // The acceptance contract survives the store round-trip.
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let todo = g.todos.iter().find(|x| x.id == t).unwrap();
+    assert_eq!(todo.acceptance.as_deref(), Some("attempt,scored"));
+    assert_eq!(
+        todo.evidence.as_deref(),
+        Some("ATTEMPT 12345 SCORED 99 on the platform")
+    );
 }
 
 #[test]
@@ -599,6 +755,7 @@ fn todo_complete_gate_class_bypasses_freeze() {
         "--todo-id",
         &a,
         "--no-follow-up",
+        "--force",
     ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
@@ -666,6 +823,7 @@ fn todo_archive_supersede_update() {
         "--todo-id",
         &done,
         "--no-follow-up",
+        "--force",
     ]);
     assert!(
         cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", &done])

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -349,6 +349,7 @@ fn steer_poll_once_arms() {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -711,6 +711,7 @@ fn store_projection_gap_and_guard_arms() {
                 priority: Some("p2".into()),
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();

--- a/orchestration/loop/tests/productized_features_contract.rs
+++ b/orchestration/loop/tests/productized_features_contract.rs
@@ -62,6 +62,7 @@ fn todo_update_event_applies_field_edits() {
             priority: Some("P0".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -98,6 +99,7 @@ fn todo_update_status_done_is_rejected_by_apply() {
             priority: None,
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -120,6 +120,7 @@ fn try_claim_ignores_non_lease_events_and_p9_normalizes_to_p1() {
             priority: Some("P9".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -521,6 +522,7 @@ fn apply_renew_and_priority_arms() {
             priority: Some("P0".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -562,6 +564,7 @@ fn apply_matrix() {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();
@@ -577,6 +580,7 @@ fn apply_matrix() {
             priority: Some("P2".into()),
             resume_when: Some("defer:5".into()),
             blocks: Some(vec!["a".into()]),
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/todo_update_blocks_contract.rs
+++ b/orchestration/loop/tests/todo_update_blocks_contract.rs
@@ -95,6 +95,7 @@ fn update_blocks_sets_blocking_set() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t3".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -118,6 +119,7 @@ fn update_blocks_replaces_existing_set() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t3".into(), "t2".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -141,6 +143,7 @@ fn update_blocks_empty_clears() {
             priority: None,
             resume_when: None,
             blocks: Some(vec![]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -164,6 +167,7 @@ fn update_without_blocks_leaves_set_untouched() {
             priority: None,
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -239,6 +243,7 @@ fn replay_rebuilds_updated_blocks() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t2".into(), "t3".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();


### PR DESCRIPTION
# feat(loop): todo-completion contracts — evidence floor + `--acceptance` tokens

Closes a class of completion-contract violations observed driving a 24h multi-agent
competition (37 turns / 30 agents / 38 todos): **11 of 33 todo completions closed with
empty or one-line evidence**, and several external-delivery todos were marked done with
no platform attempt ever landing. Every violated discipline was communicated via todo
text; text conventions were repeatedly ignored by run agents. This PR turns two of them
into hard CLI checks (the boundary the run agent drives through), plus an advisory hint.

## Changes

### 1. Evidence floor on `todo complete`

Advancement todos now require **non-empty `--evidence`** (what actually landed: attempt
ids, paths, outputs, measurements). `--force` is the explicit operator override for
mechanical closeouts.

```bash
# before: silently accepted (the empty-closure failure mode)
# after:  refused
$ future loop todo complete --goal G --todo-id T --no-follow-up
todo T needs non-empty --evidence (what actually landed: attempt ids, paths, outputs,
measurements). Add --force only for an explicit operator closeout.
```

### 2. Acceptance contract (`todo add|update --acceptance "a,b"`)

Completion evidence must contain **every** comma-separated token (case-insensitive)
before the todo can close; `--force` overrides. Persisted on the todo, survives store
round-trips, and can be retrofitted onto existing todos mid-flight via `todo update`.

```bash
$ future loop todo add --goal G --text "submit the payload" \
    --acceptance "attempt,scored"
$ future loop todo complete --goal G --todo-id T --no-follow-up \
    --evidence "created attempt 12345"
# refused: acceptance contract unmet — evidence must contain [attempt,scored] (missing: [scored])
$ future loop todo complete --goal G --todo-id T --no-follow-up \
    --evidence "ATTEMPT 12345 SCORED 99 on the platform"   # accepted (case-insensitive)
```

This encodes the "ACCEPTANCE = a scored attempt id on the platform" convention as a
hard check instead of a text convention inside the todo text.

### 3. Advisory hint at `todo add`

External-delivery-looking todos (submit / 提交 / attempt / scored / quota / …) without
`--acceptance` or `--verify` now print a hint to pin the contract — the same pattern as
the existing code-todo `--verify` hint (O4).

## Ledger compatibility

`Todo.acceptance` and `TodoUpdated.acceptance` both carry `#[serde(default)]`; old
ledgers replay unchanged (the forward-compat rule: unknown fields are tolerated).

## Tests

- `todo_complete_evidence_floor_and_force` — no/whitespace evidence refused, `--force`
  override, non-empty evidence accepted, store round-trip.
- `todo_complete_acceptance_contract` — unknown-flag rejection on `todo complete`,
  token matching + case-insensitivity, `--force` override, contract + evidence
  persisted through replay, retrofit via `todo update --acceptance`.
- Existing tests updated where they completed advancement todos mechanically
  (`--force` / explicit evidence added).

Full suite: `cargo test -p future-loop` passes (the two
`compat_projection_contract` timezone-shape failures are pre-existing on this
machine and reproducible on clean `main`). `cargo fmt` + `cargo clippy --all-targets`
clean. Coverage ratchet: this PR only adds tests + covered branches; please let CI
confirm the floor.

## Out of scope (documented follow-ups from the same retrospective)

- External-action budget ledger (per-challenge submission quotas consumed only by
  capability-declared agents) — new `quota/` module alongside `tool_quota.rs`.
- Lease holder pid liveness (`kill -0` auto-recycle of dead holders, aligned with the
  ACTIVE_GOAL_STATE.md.lock precedent).
- `TurnNoProgress` action policy (steer / kill+relaunch instead of detect-only).
- `run --follow-until-terminal` foreman mode (auto-relaunch, kills orchestrator dead
  time).
- `--prepend-file` shared-memory injection into the turn envelope.
- `todo split` recipe (s1..sN + per-section validators + assembler todo).

Each maps to a concrete failure mode measured during the drive; filed here as
follow-ups to keep this PR reviewable.
