### PR TITLE
fix(mobile): align recovery actions with desktop

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -474,11 +474,12 @@ async fn handle_command(
             };
             match crate::agent_bridge::get_session_entries(cmd.session_id.clone()).await {
                 Ok(data) => {
+                    let entries = entries_with_run_status(&cmd.session_id, entries_vec(data));
                     reply(
                         client,
                         &msg,
                         true,
-                        paginate_items(entries_vec(data), offset, limit, "entries"),
+                        paginate_items(entries, offset, limit, "entries"),
                         None,
                     )
                     .await;
@@ -1241,6 +1242,34 @@ fn entries_vec(data: Value) -> Vec<Value> {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+/// Add the GUI store's authoritative run outcome to Agent-owned history rows.
+/// The Agent journal deliberately contains conversation content only; mobile
+/// needs this outcome to use the same recovery predicate as the desktop UI.
+fn entries_with_run_status(session_id: &str, mut entries: Vec<Value>) -> Vec<Value> {
+    let statuses: HashMap<String, String> = crate::store::find_thread_by_agent_session(session_id)
+        .ok()
+        .flatten()
+        .and_then(|thread| crate::store::list_runs(&thread.id).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|run| (run.id, run.status))
+        .collect();
+    if statuses.is_empty() {
+        return entries;
+    }
+    for entry in &mut entries {
+        let status = entry
+            .pointer("/meta/run_id")
+            .and_then(Value::as_str)
+            .and_then(|run_id| statuses.get(run_id))
+            .cloned();
+        if let (Some(status), Some(object)) = (status, entry.as_object_mut()) {
+            object.insert("run_status".to_string(), Value::String(status));
+        }
+    }
+    entries
 }
 
 fn paginate_messages(messages: Vec<Value>, offset: usize, limit: usize) -> Value {
@@ -2234,6 +2263,30 @@ mod bridge_tests {
         let agent = ensure_mock_agent();
         agent.clear_scripts();
         let session = unique("sess");
+        let thread = crate::store::create_thread(crate::store::CreateThreadInput {
+            mode: "chat".to_string(),
+            title: Some("History".to_string()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: Some(session.clone()),
+        })
+        .unwrap();
+        let history_run = crate::store::create_run(crate::store::CreateRunInput {
+            id: Some(unique("run-history")),
+            thread_id: thread.id,
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        crate::store::update_run_status_if_active(crate::store::UpdateRunStatusInput {
+            run_id: history_run.id.clone(),
+            status: "failed".to_string(),
+            error_message: None,
+            error_type: None,
+        })
+        .unwrap();
 
         let reply = bridge
             .call(json!({ "id": unique("cmd"), "type": "get_messages", "sessionId": session }))
@@ -2270,7 +2323,11 @@ mod bridge_tests {
         // Entries page through too.
         agent.set_session_entries(
             &session,
-            json!({ "entries": [{ "entryType": "user", "content": "hi" }] }),
+            json!({ "entries": [{
+                "entryType": "assistant",
+                "content": "partial",
+                "meta": { "run_id": history_run.id }
+            }] }),
         );
         let reply = bridge
             .call(
@@ -2279,6 +2336,7 @@ mod bridge_tests {
             .await;
         assert_eq!(reply["success"], json!(true));
         assert_eq!(reply["data"]["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(reply["data"]["entries"][0]["run_status"], json!("failed"));
 
         // Entries honor an explicit positive limit too.
         let reply = bridge

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -24,11 +24,13 @@ import type {
   TimelineSegment,
   TimelineToolRow,
 } from "../remote/types";
+import { canRecoverMessage } from "../remote/recovery";
 import { colors, radius, spacing } from "../theme/tokens";
 import { Button } from "./Button";
 
 interface TimelineCardProps {
   item: TimelineItem;
+  isLatestAssistant?: boolean;
   onOpenAttachment?(attachment: HistoryAttachment): void;
   onOpenFile?(path: string): void;
   onRetry?(item: TimelineItem): void;
@@ -405,6 +407,7 @@ function SegmentBlock({
 
 export function TimelineCard({
   item,
+  isLatestAssistant,
   onOpenAttachment,
   onOpenFile,
   onRetry,
@@ -482,7 +485,7 @@ export function TimelineCard({
               {footerStats.length > 0 && <Text style={styles.messageDuration}>{footerStats}</Text>}
             </View>
           )}
-          {(item.failed || item.truncated) && (
+          {canRecoverMessage(item, isLatestAssistant ? item.id : null) && (
             <View style={styles.recoveryRow}>
               <Button
                 compact

--- a/mobile/src/remote/__tests__/eventReducer.test.ts
+++ b/mobile/src/remote/__tests__/eventReducer.test.ts
@@ -108,6 +108,25 @@ describe("entry reducer", () => {
     ]);
   });
 
+  test("projects authoritative run outcomes from remote history", () => {
+    const timeline = timelineFromEntries([
+      { id: "u1", role: "user", content: "try", meta: { run_id: "run-failed" } },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "partial",
+        meta: { run_id: "run-failed" },
+        run_status: "failed",
+      },
+    ]);
+    expect(timeline.items[1]).toMatchObject({
+      kind: "message",
+      role: "assistant",
+      runId: "run-failed",
+      failed: true,
+    });
+  });
+
   test("keeps attachment-only user entries and drops malformed attachments", () => {
     const timeline = timelineFromEntries([
       {
@@ -681,7 +700,7 @@ describe("stream event reducer", () => {
 });
 
 describe("shared-projection semantic flags", () => {
-  test("a shell exit-code footer marks the tool row failed (G1)", () => {
+  test("a shell exit-code marks only the tool row failed (G1)", () => {
     let state = applyStreamEvent(emptyTimeline(), {
       type: "tool_start",
       data: JSON.stringify({
@@ -704,7 +723,7 @@ describe("shared-projection semantic flags", () => {
     });
     const reply = state.items.find(item => item.kind === "message");
     if (!reply || reply.kind !== "message") throw new Error("reply bubble missing");
-    expect(reply.failed).toBe(true);
+    expect(reply.failed).toBeUndefined();
     const toolSegment = reply.segments?.find(segment => segment.kind === "tool");
     expect(toolSegment && toolSegment.kind === "tool" && toolSegment.tool.status).toBe("failed");
   });
@@ -766,6 +785,26 @@ describe("shared-projection semantic flags", () => {
     const reply = state.items.find(item => item.kind === "message" && item.role === "assistant");
     if (!reply || reply.kind !== "message") throw new Error("reply bubble missing");
     expect(reply.truncated).toBe(true);
+    expect(reply.failed).toBe(true);
+    expect(reply.stopped).toBeUndefined();
+  });
+
+  test("an agent error marks the run failed", () => {
+    let state = applyStreamEvent(emptyTimeline(), {
+      type: "text_chunk",
+      data: JSON.stringify({ text: "partial" }),
+      runId: "run-1",
+      idx: 0,
+    });
+    state = applyStreamEvent(state, {
+      type: "agent_end",
+      data: JSON.stringify({ state: "error", error: "provider failed" }),
+      runId: "run-1",
+      idx: 1,
+    });
+    const reply = state.items.find(item => item.kind === "message" && item.role === "assistant");
+    if (!reply || reply.kind !== "message") throw new Error("reply bubble missing");
+    expect(reply.failed).toBe(true);
     expect(reply.stopped).toBeUndefined();
   });
 

--- a/mobile/src/remote/__tests__/recovery.test.ts
+++ b/mobile/src/remote/__tests__/recovery.test.ts
@@ -1,0 +1,32 @@
+import { canRecoverMessage } from "../recovery";
+import type { TimelineItem } from "../types";
+
+function assistant(
+  overrides: Partial<Extract<TimelineItem, { kind: "message" }>> = {},
+): TimelineItem {
+  return {
+    id: "assistant-1",
+    kind: "message",
+    role: "assistant",
+    text: "partial",
+    runId: "run-1",
+    failed: true,
+    ...overrides,
+  };
+}
+
+describe("desktop-parity recovery predicate", () => {
+  test("allows only the latest failed run", () => {
+    expect(canRecoverMessage(assistant(), "assistant-1")).toBe(true);
+    expect(canRecoverMessage(assistant(), "assistant-2")).toBe(false);
+  });
+
+  test("suppresses user-stopped and unidentified runs", () => {
+    expect(canRecoverMessage(assistant({ stopped: true }), "assistant-1")).toBe(false);
+    expect(canRecoverMessage(assistant({ runId: undefined }), "assistant-1")).toBe(false);
+  });
+
+  test("does not recover a handled tool failure without a failed run", () => {
+    expect(canRecoverMessage(assistant({ failed: undefined }), "assistant-1")).toBe(false);
+  });
+});

--- a/mobile/src/remote/files.ts
+++ b/mobile/src/remote/files.ts
@@ -52,7 +52,7 @@ function imageSize(uri: string): Promise<{ width: number; height: number }> {
   });
 }
 
-function mimeFor(name: string, fallback = "application/octet-stream"): string {
+export function mimeFor(name: string, fallback = "application/octet-stream"): string {
   // Only extensions that can actually reach this helper are mapped. Image
   // inputs that are re-encoded to JPEG (jpg/jpeg/bmp/heic/heif) always set
   // their mime to "image/jpeg" directly, so mimeFor is never consulted for

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -39,6 +39,7 @@ interface LiveRunState {
   startedAt: number;
   streaming: boolean;
   durationMs?: number;
+  failed: boolean;
 }
 
 export function emptyTimeline(): TimelineState {
@@ -106,7 +107,7 @@ export function messageToItems(message: AgentMessage): TimelineItem[] {
     ...(message.stopped ? { stopped: true } : {}),
     ...(message.truncated ? { truncated: true } : {}),
   };
-  if (message.activityItems?.some(activity => activity.status === "failed")) item.failed = true;
+  if (message.status === "failed") item.failed = true;
   return [item];
 }
 
@@ -154,7 +155,28 @@ function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
  * shared package (`entriesToMessages`), then mapped to the render contract. */
 export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
   const messages = entriesToMessages(toSessionEntries(entries));
-  return { ...emptyTimeline(), items: messages.flatMap(messageToItems) };
+  const runStatuses = new Map(
+    entries
+      .filter(
+        entry => typeof entry.meta?.run_id === "string" && typeof entry.run_status === "string",
+      )
+      .map(entry => [entry.meta!.run_id!, entry.run_status!] as const),
+  );
+  const items = messages.flatMap(message => {
+    const projected = messageToItems(message);
+    const status = message.runId ? runStatuses.get(message.runId) : undefined;
+    if (!status) return projected;
+    return projected.map(item =>
+      item.kind === "message" && item.role === "assistant"
+        ? {
+            ...item,
+            ...(status === "failed" ? { failed: true } : {}),
+            ...(status === "cancelled" ? { stopped: true } : {}),
+          }
+        : item,
+    );
+  });
+  return { ...emptyTimeline(), items };
 }
 
 /** Message-shaped history fallback (old desktops without get_session_entries). */
@@ -445,6 +467,7 @@ function applyLiveEvent(
       assistantId: `assistant:${runKey}`,
       startedAt: 0,
       streaming: false,
+      failed: false,
     };
     liveRuns.set(runKey, acc);
   }
@@ -462,6 +485,13 @@ function applyLiveEvent(
   let durationMs = acc.durationMs;
   if (event.type === "agent_end") {
     acc.streaming = false;
+    const terminalState = textValue(data.state);
+    acc.failed =
+      terminalState === "error" ||
+      terminalState === "failed" ||
+      terminalState === "incomplete" ||
+      data.reason === "incomplete" ||
+      typeof data.error === "string";
     durationMs = runDurationMs(data) ?? (acc.startedAt ? Date.now() - acc.startedAt : undefined);
     acc.durationMs = durationMs;
   }
@@ -536,7 +566,7 @@ function buildLiveAssistantItem(
     ...(projection.stopped ? { stopped: true } : {}),
     ...(projection.truncated ? { truncated: true } : {}),
   };
-  if (projection.activityItems.some(activity => activity.status === "failed")) item.failed = true;
+  if (acc.failed) item.failed = true;
   return item;
 }
 

--- a/mobile/src/remote/recovery.ts
+++ b/mobile/src/remote/recovery.ts
@@ -1,0 +1,14 @@
+import type { TimelineItem } from "./types";
+
+/** Desktop-parity recovery predicate: failed latest run, never a user stop. */
+export function canRecoverMessage(item: TimelineItem, latestAssistantId: string | null): boolean {
+  return (
+    item.kind === "message" &&
+    item.role === "assistant" &&
+    item.failed === true &&
+    item.id === latestAssistantId &&
+    item.stopped !== true &&
+    typeof item.runId === "string" &&
+    item.runId.length > 0
+  );
+}

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -169,6 +169,8 @@ export interface HistoryEntry {
   output_tokens?: number;
   /** Reply wall-clock duration in ms — paired with `output_tokens`. */
   duration_ms?: number;
+  /** Desktop-store run outcome, added by the remote bridge for recovery parity. */
+  run_status?: "completed" | "failed" | "cancelled" | string;
   /** RFC3339 entry time; preserved across re-saves so history keeps real times. */
   timestamp?: string;
 }
@@ -252,8 +254,7 @@ export type TimelineItem =
        * back to `text` when absent (optimistic, legacy, plain history).
        */
       segments?: TimelineSegment[];
-      /** A tool row in this reply failed (shell non-zero exit / error) — the
-       *  bubble gets a danger affordance. */
+      /** The owning run failed. A handled tool error alone is not recoverable. */
       failed?: boolean;
       /** The user cancelled this run (agent_end state "cancelled"). */
       stopped?: boolean;

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -50,6 +50,7 @@ import { loadSessionDraft, saveSessionDraft } from "../remote/draftStorage";
 import {
   deleteTemporaryAttachment,
   MAX_FILE_BYTES,
+  mimeFor,
   pickAttachments,
   pickFromAlbum,
   takePhoto,
@@ -184,6 +185,13 @@ export function ChatScreen() {
     () => timelineItems.filter(item => item.kind !== "approval"),
     [timelineItems],
   );
+  const latestAssistantId = useMemo(() => {
+    for (let index = transcriptItems.length - 1; index >= 0; index -= 1) {
+      const item = transcriptItems[index];
+      if (item?.kind === "message") return item.role === "assistant" ? item.id : null;
+    }
+    return null;
+  }, [transcriptItems]);
   const pendingApprovals = useMemo(
     () =>
       timelineItems.filter(
@@ -382,7 +390,38 @@ export function ChatScreen() {
       for (let i = index - 1; i >= 0; i -= 1) {
         const prev = items[i];
         if (prev?.kind === "message" && prev.role === "user") {
-          void remote.sendMessage(prev.text).catch(() => showToast(t("chat.sendFailed")));
+          void (async () => {
+            const retryAttachments: MobileAttachment[] = [];
+            for (const attachment of prev.attachments ?? []) {
+              if (/^[a-z][a-z0-9+.-]*:\/\//i.test(attachment.path)) {
+                const file = new File(attachment.path);
+                retryAttachments.push({
+                  localUri: file.uri,
+                  name: attachment.name,
+                  mimeType: mimeFor(attachment.name),
+                  kind: attachment.kind === "image" ? "image" : "file",
+                  originalSize: file.size,
+                  transferSize: file.size,
+                  mobilePreviewUnsupported: attachment.mobilePreviewUnsupported,
+                });
+                continue;
+              }
+              const info = await remote.prepareAttachment(attachment);
+              const cached = remote.cachedAttachment(attachment);
+              const file = cached?.file ?? (await remote.downloadAttachment(info));
+              retryAttachments.push({
+                localUri: file.uri,
+                name: attachment.name,
+                transferName: info.name,
+                mimeType: info.mimeType,
+                kind: attachment.kind === "image" ? "image" : "file",
+                originalSize: info.size,
+                transferSize: info.size,
+                mobilePreviewUnsupported: attachment.mobilePreviewUnsupported,
+              });
+            }
+            await remote.sendMessage(prev.text, retryAttachments);
+          })().catch(() => showToast(t("chat.sendFailed")));
           return;
         }
       }
@@ -737,6 +776,7 @@ export function ChatScreen() {
             renderItem={({ item }) => (
               <TimelineCard
                 item={item}
+                isLatestAssistant={item.id === latestAssistantId}
                 onOpenAttachment={attachment => void openAttachment(attachment)}
                 onOpenFile={path => void openFileLink(path)}
                 onRetry={retryMessage}


### PR DESCRIPTION
## Summary
- Align mobile Retry/Continue visibility with the desktop recovery policy.
- Surface persisted run outcomes to mobile history and distinguish run failure from tool failure.
- Preserve attachments when retrying the latest failed message.

## Validation
- `npm test -- --watchman=false` (300 passed)
- `cargo test` in `desktop/src-tauri` (990 passed)
- Mobile typecheck, ESLint, Prettier, and Tauri `cargo check`
