### PR TITLE
feat(loop): todo-completion contracts — evidence floor + --acceptance tokens

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4,7 +4,9 @@
 //!   goal init    — create a durable goal (registry + event ledger)
 //!   todo add     — add an agent/user/gate/monitor todo
 //!   todo claim   — claim a todo (owner identity)
-//!   todo complete — complete a todo; REQUIRES --no-follow-up or --successor
+//!   todo complete — complete a todo; REQUIRES --no-follow-up or --successor,
+//!     non-empty --evidence for advancement todos, and (when declared)
+//!     --acceptance tokens inside the evidence; --force overrides both.
 //!   gate resolve — resolve a user gate with a decision payload
 //!   status       — project the active state (todos, gaps, next action)
 //!   quota should-run — emit the typed ShouldRunPacket (deterministic)
@@ -717,6 +719,28 @@ fn looks_like_code_todo(text: &str) -> bool {
             .any(|tok| CODE_WORDS.contains(&tok))
 }
 
+/// O5: heuristic for the `todo add` advisory hint — does the text look like an
+/// external-delivery task (platform submission, scored attempt, quota-bounded
+/// side effect) whose completion should carry an `--acceptance` contract?
+/// Advisory only; never changes CLI semantics.
+fn looks_like_external_delivery(text: &str) -> bool {
+    const DELIVERY_WORDS: &[&str] = &[
+        "submit",
+        "submission",
+        "attempt",
+        "scored",
+        "acceptance",
+        "quota",
+        "platform",
+    ];
+    const DELIVERY_ZH: &[&str] = &["提交", "评分", "配额", "验收", "排行榜", "上分"];
+    let lower = text.to_lowercase();
+    DELIVERY_ZH.iter().any(|k| text.contains(k))
+        || lower
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|tok| DELIVERY_WORDS.contains(&tok))
+}
+
 fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal_id = None;
     let mut role = "agent".to_string();
@@ -740,9 +764,11 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut cadence = None;
     let mut verify: Option<String> = None;
     let mut max_validation_attempts: Option<u32> = None;
+    let mut acceptance: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
+            "--acceptance",
             "--action-kind",
             "--blocks",
             "--cadence",
@@ -784,6 +810,8 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             cadence = Some(v);
         } else if k == "--verify" {
             verify = Some(v);
+        } else if k == "--acceptance" {
+            acceptance = Some(v);
         } else if k == "--max-validation-attempts" {
             max_validation_attempts = v.parse().ok();
         } else if k == "--goal" {
@@ -820,6 +848,9 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     // done by an agent even when the code does not compile. Computed before
     // `verify` is moved into the todo below.
     let wants_verify_hint = verify.is_none() && looks_like_code_todo(&text);
+    // O5: advisory hint — external-delivery todos (submit/提交 …) whose
+    // completion contract is a text convention unless `--acceptance` pins it.
+    let wants_acceptance_hint = acceptance.is_none() && looks_like_external_delivery(&text);
     store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
@@ -905,6 +936,9 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     if let Some(v) = verify {
         todo.validator = Some(v);
     }
+    if let Some(a) = acceptance {
+        todo.acceptance = Some(a);
+    }
     if let Some(n) = max_validation_attempts {
         todo.max_validation_attempts = n.max(1);
     }
@@ -946,6 +980,13 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     // O4: pure reminder after a successful add; no semantic change.
     if wants_verify_hint {
         eprintln!("hint: 实现类 todo 建议挂 --verify \"cargo check -p ...\"，防不编译代码被标完成");
+    }
+    // O5: advisory hint for external-delivery todos (submit/提交 …) — the
+    // completion contract is a text convention unless `--acceptance` pins it.
+    if wants_acceptance_hint {
+        eprintln!(
+            "hint: 外部交付类 todo 建议挂 --acceptance \"attempt,scored\"（关单时 evidence 必须包含全部子串，防空交付）"
+        );
     }
     Ok(())
 }
@@ -1826,10 +1867,12 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     let mut no_follow_up = false;
     let mut successor = None;
     let mut evidence = None;
+    let mut force = false;
     reject_unknown_flags(
         args,
         &[
             "--evidence",
+            "--force",
             "--goal",
             "--no-follow-up",
             "--successor",
@@ -1843,6 +1886,8 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
             todo_id = Some(v);
         } else if k == "--no-follow-up" {
             no_follow_up = true;
+        } else if k == "--force" {
+            force = true;
         } else if k == "--successor" {
             successor = Some(v);
         } else if k == "--evidence" {
@@ -1882,6 +1927,45 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
     let is_advancement = t.class == TaskClass::Advancement;
+    // O6: completion evidence contract (retrospective: 11/33 completions
+    // shipped <60-char evidence, several fully empty, and every one of those
+    // todos had to be reopened by hand). Advancement todos must carry real,
+    // non-empty evidence of what landed — `--force` is the explicit override
+    // for mechanical closeouts the operator owns.
+    let evidence_trim = evidence.as_deref().map(str::trim).unwrap_or("");
+    if is_advancement && evidence_trim.is_empty() && !force {
+        bail!(
+            "todo {todo_id} needs non-empty --evidence (what actually landed: attempt ids, \
+             paths, outputs, measurements). Add --force only for an explicit operator closeout."
+        );
+    }
+    // O7: acceptance contract (`todo add --acceptance "a,b"`) — evidence must
+    // contain every declared token (case-insensitive) before completion is
+    // accepted; `--force` overrides. Turns the ACCEPTANCE text convention
+    // (e.g. a platform attempt id) into a hard check.
+    if is_advancement {
+        if let Some(acc) = t.acceptance.as_deref() {
+            let tokens: Vec<&str> = acc
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            let lower = evidence_trim.to_lowercase();
+            let missing: Vec<&str> = tokens
+                .iter()
+                .filter(|tok| !lower.contains(&tok.to_lowercase()))
+                .copied()
+                .collect();
+            if !missing.is_empty() && !force {
+                bail!(
+                    "todo {todo_id} acceptance contract unmet: evidence must contain [{}] \
+                     (missing: [{}]). Declared via `todo add --acceptance`; --force overrides.",
+                    acc,
+                    missing.join(", ")
+                );
+            }
+        }
+    }
     let successors = successor.clone().into_iter().collect::<Vec<_>>();
     store.append(Event::TodoCompleted {
         goal_id: goal_id.clone(),
@@ -7014,9 +7098,11 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     let mut priority = None;
     let mut resume_when = None;
     let mut blocks: Option<Vec<String>> = None;
+    let mut acceptance: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
+            "--acceptance",
             "--blocks",
             "--evidence",
             "--goal",
@@ -7058,6 +7144,8 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
                     .filter(|s| !s.is_empty())
                     .collect()
             });
+        } else if k == "--acceptance" {
+            acceptance = Some(v);
         }
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -7104,6 +7192,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
         priority: priority.clone(),
         resume_when: resume_when_parsed,
         blocks: blocks.clone(),
+        acceptance: acceptance.clone(),
         ts: crate::state::now_epoch(),
     })?;
     refresh_next_action(store, &goal_id)?;
@@ -7174,6 +7263,7 @@ mod coverage_tests {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: 1,
             },
             Event::GoalCancelled {

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -167,6 +167,13 @@ pub struct Todo {
     /// runs it in the goal cwd after each turn; exit 0 completes the todo
     /// (validated), non-zero keeps it open for bounded repair.
     pub validator: Option<String>,
+    /// Completion acceptance contract (`todo add --acceptance "a,b"`): the
+    /// completion evidence must contain EVERY comma-separated token
+    /// (case-insensitive) — e.g. an external attempt id — else `todo complete`
+    /// refuses unless `--force`. Encodes "done ≠ delivered" acceptance
+    /// criteria as a hard check instead of a text convention.
+    #[serde(default)]
+    pub acceptance: Option<String>,
     /// How many failed validation attempts are tolerated before the kernel
     /// replans and surfaces to the user (default 3).
     #[serde(default = "default_max_validation_attempts")]
@@ -295,6 +302,7 @@ impl Todo {
             required_write_scope: vec![],
             validator: None,
             max_validation_attempts: default_max_validation_attempts(),
+            acceptance: None,
         }
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -191,6 +191,10 @@ pub enum Event {
         /// events serialized without this field deserialize as `None`.
         #[serde(default)]
         blocks: Option<Vec<String>>,
+        /// Completion acceptance contract (`--acceptance "a,b"`); `Some("")`
+        /// clears it, absent leaves it untouched. See `Todo::acceptance`.
+        #[serde(default)]
+        acceptance: Option<String>,
         ts: u64,
     },
     /// Stop automation while retaining state (the reference: goal cancel).
@@ -1409,6 +1413,7 @@ fn apply(goal: &mut Goal, event: Event) {
             priority,
             resume_when,
             blocks,
+            acceptance,
             ts,
             ..
         } => {
@@ -1421,6 +1426,9 @@ fn apply(goal: &mut Goal, event: Event) {
                 }
                 if let Some(x) = note {
                     t.note = Some(x);
+                }
+                if let Some(a) = acceptance {
+                    t.acceptance = if a.trim().is_empty() { None } else { Some(a) };
                 }
                 if let Some(b) = blocks {
                     // `--blocks a,b` replaces the blocking set; `--blocks ""`

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -209,6 +209,8 @@ fn run_failing_turns_exhaust_repair_budget() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     // Pre-seed a todo that already consumed one repair attempt (the ledger
     // does not persist failed_attempts from failed runs — see coverage
@@ -380,6 +382,8 @@ fn run_monitor_not_due_waits() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     append_monitor(&cr, &goal, "mon_future", 3600);
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
@@ -404,6 +408,8 @@ fn run_validator_pass_completes_todo() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     cli_ok(&[
         "todo",
@@ -442,6 +448,8 @@ fn run_validator_budget_exhaustion_stops_run() {
         "--todo-id",
         &onboarding,
         "--no-follow-up",
+        "--evidence",
+        "operator closed the auto-created onboarding todo",
     ]);
     cli_ok(&[
         "todo",

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -508,6 +508,8 @@ fn todo_complete_contract() {
         "--todo-id",
         &s,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
     ]);
     assert!(err.contains("open gate"), "{err}");
     // Resolve the gate, then completion succeeds (a gate's text IS the
@@ -533,6 +535,8 @@ fn todo_complete_contract() {
         "--todo-id",
         &s,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--force",
     ]);
     // Unknown todo / goal.
@@ -599,6 +603,8 @@ fn todo_complete_evidence_floor_and_force() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--force",
     ]);
     // Any non-empty evidence satisfies the floor (strength belongs to
@@ -638,6 +644,8 @@ fn todo_complete_acceptance_contract() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--acceptance",
         "x",
     ]);
@@ -749,6 +757,8 @@ fn todo_complete_gate_class_bypasses_freeze() {
         "--todo-id",
         &a,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--force",
     ]);
     let store = open_store(&cr);
@@ -817,6 +827,8 @@ fn todo_archive_supersede_update() {
         "--todo-id",
         &done,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--force",
     ]);
     assert!(

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -533,6 +533,7 @@ fn todo_complete_contract() {
         "--todo-id",
         &s,
         "--no-follow-up",
+        "--force",
     ]);
     // Unknown todo / goal.
     assert!(cli_err(&[
@@ -557,6 +558,161 @@ fn todo_complete_contract() {
         "--no-follow-up"
     ])
     .contains("not found"));
+}
+
+#[test]
+fn todo_complete_evidence_floor_and_force() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "evidence floor");
+    let first = first_todo_id(&cr.root, &gid);
+    // Advancement completion without evidence is refused (the empty-closure
+    // failure mode: an agent marks a delivery done with nothing to show).
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+    ]);
+    assert!(err.contains("--evidence"), "{err}");
+    // Whitespace-only evidence is refused too.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--evidence",
+        "   ",
+    ]);
+    assert!(err.contains("--evidence"), "{err}");
+    // --force is the explicit operator override for mechanical closeouts.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--force",
+    ]);
+    // Any non-empty evidence satisfies the floor (strength belongs to
+    // --acceptance / --verify, which are opt-in contracts).
+    let s = add_todo(&cr, &gid, "second task");
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &s,
+        "--no-follow-up",
+        "--evidence",
+        "did the thing",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == s).unwrap();
+        assert_eq!(t.status, TodoStatus::Done);
+        assert_eq!(t.evidence.as_deref(), Some("did the thing"));
+    }
+}
+
+#[test]
+fn todo_complete_acceptance_contract() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "acceptance contract");
+    let first = first_todo_id(&cr.root, &gid);
+    // `--acceptance` is a todo-add flag; `todo complete` rejects it.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &first,
+        "--no-follow-up",
+        "--acceptance",
+        "x",
+    ]);
+    assert!(err.contains("unknown"), "{err}");
+    let t = add_todo(&cr, &gid, "submit the payload");
+    // Declare the acceptance contract: evidence must contain BOTH tokens.
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    // Evidence missing one token is refused.
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--no-follow-up",
+        "--evidence",
+        "created attempt 12345",
+    ]);
+    assert!(err.contains("acceptance contract"), "{err}");
+    assert!(err.contains("scored"), "{err}");
+    // Matching evidence (case-insensitive) completes.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--no-follow-up",
+        "--evidence",
+        "ATTEMPT 12345 SCORED 99 on the platform",
+    ]);
+    // --force overrides an unmet contract.
+    let t2 = add_todo(&cr, &gid, "submit again");
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t2,
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t2,
+        "--no-follow-up",
+        "--evidence",
+        "operator closeout without a scored attempt",
+        "--force",
+    ]);
+    // The acceptance contract survives the store round-trip.
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let todo = g.todos.iter().find(|x| x.id == t).unwrap();
+    assert_eq!(todo.acceptance.as_deref(), Some("attempt,scored"));
+    assert_eq!(
+        todo.evidence.as_deref(),
+        Some("ATTEMPT 12345 SCORED 99 on the platform")
+    );
 }
 
 #[test]
@@ -593,6 +749,7 @@ fn todo_complete_gate_class_bypasses_freeze() {
         "--todo-id",
         &a,
         "--no-follow-up",
+        "--force",
     ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
@@ -660,6 +817,7 @@ fn todo_archive_supersede_update() {
         "--todo-id",
         &done,
         "--no-follow-up",
+        "--force",
     ]);
     assert!(
         cli_err(&["todo", "supersede", "--goal", &gid, "--todo-id", &done])

--- a/orchestration/loop/tests/console_final_console.rs
+++ b/orchestration/loop/tests/console_final_console.rs
@@ -235,6 +235,8 @@ fn delivery_status_display_and_subcommands() {
         "--todo-id",
         &tid,
         "--no-follow-up",
+        "--evidence",
+        "delivered: fixture output files written and verified",
     ]);
     cli_ok(&["delivery", "status", "--goal", &gid]);
     cli_ok(&["delivery", "status", "--goal", &gid, "--format", "json"]);
@@ -349,6 +351,8 @@ fn delivery_record_verified_and_empty_projection() {
         "--todo-id",
         &tid,
         "--no-follow-up",
+        "--evidence",
+        "delivered: fixture output files written and verified",
     ]);
     // Resolve the delivered signal → verified (non-pending age rendering).
     cli_ok(&[

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -309,6 +309,8 @@ fn worker_bridge_stops_when_should_run_false() {
             "--todo-id",
             &onboarding,
             "--no-follow-up",
+            "--evidence",
+            "onboarding complete",
         ],
     );
     assert_eq!(code, 0);

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -342,6 +342,7 @@ fn steer_poll_once_arms() {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -146,6 +146,8 @@ fn unknown_flags_hard_error_everywhere() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
         "--zz",
         "1",
     ]);
@@ -504,6 +506,8 @@ fn status_closure_and_gap_arms() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
     ]);
     cli_ok(&["status", "--goal", &gid]);
     // Projection gap → the ⚠ line.

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -302,6 +302,8 @@ fn diagnose_and_doctor_with_projection_gap() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
     ]);
     {
         let store = open_store(&cr);
@@ -476,6 +478,8 @@ fn run_validator_inconclusive_print() {
         "--todo-id",
         &first,
         "--no-follow-up",
+        "--evidence",
+        "fixture evidence for completion contract",
     ]);
     cli_ok(&[
         "todo",

--- a/orchestration/loop/tests/delivery_outcome_contract.rs
+++ b/orchestration/loop/tests/delivery_outcome_contract.rs
@@ -105,6 +105,8 @@ fn completion_records_delivered_and_record_resolves() {
             "--todo-id",
             &todo_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
 
@@ -202,6 +204,8 @@ fn failed_delivery_allows_redelivery_cycle() {
             "--todo-id",
             &todo_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
         cli(&[
@@ -261,6 +265,8 @@ fn followthrough_fires_once_for_overdue_delivery() {
             "--todo-id",
             &todo_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
         // Push the run-turn counter past the threshold (delivered at turn 0).
@@ -320,6 +326,8 @@ fn followthrough_respects_threshold() {
             "--todo-id",
             &todo_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
         // Turn 2 < default threshold 3 → nothing derived.
@@ -355,6 +363,8 @@ fn delivery_status_projects_read_model() {
             "--todo-id",
             &todo_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
         // JSON read model carries the delivery with its age + pending flag.

--- a/orchestration/loop/tests/loop_hardening_contract.rs
+++ b/orchestration/loop/tests/loop_hardening_contract.rs
@@ -225,6 +225,8 @@ fn cli_complete_blocked_by_open_gate_rejected() {
             "--todo-id",
             &t1_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .expect_err("completing a gate-blocked todo must be rejected");
         assert!(
@@ -353,6 +355,8 @@ fn cli_complete_unblocked_todo_ok() {
             "--todo-id",
             &t1_id,
             "--no-follow-up",
+            "--evidence",
+            "fixture evidence for completion contract",
         ])
         .unwrap();
         let store = Store::open(root).unwrap();

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -612,6 +612,7 @@ fn store_projection_gap_and_guard_arms() {
                 priority: Some("p2".into()),
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();

--- a/orchestration/loop/tests/productized_features_contract.rs
+++ b/orchestration/loop/tests/productized_features_contract.rs
@@ -62,6 +62,7 @@ fn todo_update_event_applies_field_edits() {
             priority: Some("P0".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -98,6 +99,7 @@ fn todo_update_status_done_is_rejected_by_apply() {
             priority: None,
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -120,6 +120,7 @@ fn try_claim_ignores_non_lease_events_and_p9_normalizes_to_p1() {
             priority: Some("P9".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -521,6 +522,7 @@ fn apply_renew_and_priority_arms() {
             priority: Some("P0".into()),
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -562,6 +564,7 @@ fn apply_matrix() {
                 priority: None,
                 resume_when: None,
                 blocks: None,
+                acceptance: None,
                 ts: now_epoch(),
             })
             .unwrap();
@@ -577,6 +580,7 @@ fn apply_matrix() {
             priority: Some("P2".into()),
             resume_when: Some("defer:5".into()),
             blocks: Some(vec!["a".into()]),
+            acceptance: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/todo_update_blocks_contract.rs
+++ b/orchestration/loop/tests/todo_update_blocks_contract.rs
@@ -95,6 +95,7 @@ fn update_blocks_sets_blocking_set() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t3".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -118,6 +119,7 @@ fn update_blocks_replaces_existing_set() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t3".into(), "t2".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -141,6 +143,7 @@ fn update_blocks_empty_clears() {
             priority: None,
             resume_when: None,
             blocks: Some(vec![]),
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -164,6 +167,7 @@ fn update_without_blocks_leaves_set_untouched() {
             priority: None,
             resume_when: None,
             blocks: None,
+            acceptance: None,
             ts,
         })
         .unwrap();
@@ -239,6 +243,7 @@ fn replay_rebuilds_updated_blocks() {
             priority: None,
             resume_when: None,
             blocks: Some(vec!["t2".into(), "t3".into()]),
+            acceptance: None,
             ts,
         })
         .unwrap();


### PR DESCRIPTION
接管 PR #260（endNone fork）的 rebase + 修复版。

**与 #260 的差异**：rebase 到 capability 删除后（#264）的 main（丢弃了会复活 pr-review 的冲突 hunk）；修复全部被新证据下限打破的既有测试（18 处补 evidence + 保留故意拒绝测试的语义）。

- Advancement 类 todo 空 evidence 关单被拒（--force 显式覆盖）
- `todo add/update --acceptance "tok1,tok2"`：关单 evidence 必须含全部 token（大小写不敏感），否则拒绝
- 外部交付类 todo 的 advisory hint（submit/提交/attempt/配额…）
- 来自 RETROSPECTIVE.md：11/33 空证据关单的机制修复

本地：fmt ✅ clippy ✅ future-loop 67 targets ✅（全 workspace 测试由 CI 兑底）