### PR TITLE
fix(providers): centralize config updates in agent

### DIFF
--- a/agent/src/config/providers.rs
+++ b/agent/src/config/providers.rs
@@ -16,6 +16,9 @@ use std::sync::Mutex;
 
 use serde_json::{json, Map, Value};
 
+/// Consistent `(models.json, auth.json)` object snapshot used by provider RPCs.
+pub type ProviderDocuments = (Map<String, Value>, Map<String, Value>);
+
 /// One mutation of an `auth.json` provider entry (the domain carrier of the
 /// proto `AuthUpdate` sub-message; the gRPC layer maps proto onto this).
 #[derive(Debug, Clone, Default)]
@@ -60,12 +63,121 @@ pub struct ProviderUpsertSpec {
     pub base_url: Option<String>,
     /// Remove the `baseUrl` override; drop the entry if nothing remains.
     pub clear_base_url: bool,
-    /// Non-empty: replace the `models` list.
+    /// Replacement `models` list. Applied even when empty when
+    /// [`Self::replace_models`] is true.
     pub models: Vec<ProviderModelSpec>,
+    /// Presence bit for `models`; repeated proto fields cannot distinguish an
+    /// omitted list from an explicit request to clear it.
+    pub replace_models: bool,
     /// Fail when the provider already exists (create mode).
     pub create_only: bool,
     /// Non-empty: also store as this provider's `auth.json` key.
     pub api_key: Option<String>,
+    /// Remove the provider key in the same two-file transaction.
+    pub clear_api_key: bool,
+}
+
+impl ProviderUpsertSpec {
+    /// Whether this mutation changes the models.json side of provider state.
+    /// Non-empty model lists remain supported for older RPC clients that do
+    /// not yet send the explicit replacement presence bit.
+    fn changes_models_document(&self) -> bool {
+        self.name.is_some()
+            || self.api.is_some()
+            || self.base_url.is_some()
+            || self.clear_base_url
+            || self.replace_models
+            || !self.models.is_empty()
+    }
+}
+
+fn valid_provider_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-_".contains(&byte))
+}
+
+fn ascii_without_control(value: &str) -> bool {
+    value.is_ascii() && !value.bytes().any(|byte| byte.is_ascii_control())
+}
+
+pub fn validate_auth_mutation(mutation: &AuthMutation) -> Result<(), String> {
+    let provider = mutation.provider.trim();
+    if !valid_provider_id(provider) {
+        return Err("provider id must use lowercase letters, digits, '-' or '_'".to_string());
+    }
+    if let Some(key) = mutation.key.as_deref() {
+        if key.len() > 16_384 || !ascii_without_control(key) {
+            return Err("API key is invalid or too long".to_string());
+        }
+    }
+    if let Some(base_url) = mutation.base_url.as_deref() {
+        let url = reqwest::Url::parse(base_url)
+            .map_err(|_| "base URL must be a valid http/https address".to_string())?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err("base URL must be a valid http/https address".to_string());
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_provider_upsert(spec: &ProviderUpsertSpec) -> Result<(), String> {
+    let id = spec.id.trim();
+    if !valid_provider_id(id) {
+        return Err("provider id must use lowercase letters, digits, '-' or '_'".to_string());
+    }
+    if let Some(name) = spec.name.as_deref() {
+        if name.is_empty() || name.len() > 128 || !ascii_without_control(name) {
+            return Err("provider name is invalid or too long".to_string());
+        }
+    }
+    if let Some(api) = spec.api.as_deref() {
+        if !matches!(api, "openai-completions" | "openai-responses" | "anthropic") {
+            return Err("unsupported provider API type".to_string());
+        }
+    }
+    if let Some(base_url) = spec.base_url.as_deref() {
+        let url = reqwest::Url::parse(base_url)
+            .map_err(|_| "base URL must be a valid http/https address".to_string())?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err("base URL must be a valid http/https address".to_string());
+        }
+    }
+    if let Some(key) = spec.api_key.as_deref() {
+        if key.len() > 16_384 || !ascii_without_control(key) {
+            return Err("API key is invalid or too long".to_string());
+        }
+    }
+    if spec.api_key.is_some() && spec.clear_api_key {
+        return Err("cannot set and clear an API key in the same mutation".to_string());
+    }
+    if spec.models.len() > 100 {
+        return Err("provider has too many models".to_string());
+    }
+    let mut model_ids = std::collections::HashSet::new();
+    for model in &spec.models {
+        if model.id.is_empty()
+            || model.id.len() > 256
+            || !ascii_without_control(&model.id)
+            || !model_ids.insert(model.id.as_str())
+        {
+            return Err("provider model id is invalid or duplicated".to_string());
+        }
+        if model.name.len() > 128 || !ascii_without_control(&model.name) {
+            return Err("provider model name is invalid or too long".to_string());
+        }
+        if model.modalities.is_empty()
+            || model
+                .modalities
+                .iter()
+                .any(|modality| !matches!(modality.as_str(), "text" | "image"))
+        {
+            return Err("provider model modalities are invalid".to_string());
+        }
+    }
+    Ok(())
 }
 
 /// Serializes every config read-modify-write: commands are handled
@@ -281,6 +393,16 @@ pub fn apply_provider_upsert(
     root: &mut Map<String, Value>,
     spec: &ProviderUpsertSpec,
 ) -> Result<(), String> {
+    if !spec.changes_models_document() {
+        let exists = root
+            .get("providers")
+            .and_then(Value::as_object)
+            .is_some_and(|providers| providers.contains_key(&spec.id));
+        if spec.create_only && exists {
+            return Err(format!("Provider ID `{}` already exists.", spec.id));
+        }
+        return Ok(());
+    }
     let providers_value = root
         .entry("providers".to_string())
         .or_insert_with(|| Value::Object(Map::new()));
@@ -327,7 +449,7 @@ pub fn apply_provider_upsert(
     if spec.clear_base_url {
         provider.remove("baseUrl");
     }
-    if !spec.models.is_empty() {
+    if spec.replace_models || !spec.models.is_empty() {
         let models = spec
             .models
             .iter()
@@ -387,32 +509,62 @@ pub fn upsert_provider_files(
         // Only models.json can be rolled back in an upsert — auth.json is
         // written last and atomically, so a failed auth write leaves it
         // untouched and there is nothing to restore.
-        let models_snapshot = snapshot_file(models_path)?;
+        let models_change = spec.changes_models_document();
+        let models_snapshot = if models_change {
+            Some(snapshot_file(models_path)?)
+        } else {
+            None
+        };
 
         // Validate + apply in memory first; nothing is written if this fails.
-        let mut models_doc = read_json_object(models_path)?;
-        apply_provider_upsert(&mut models_doc, spec)?;
+        let models_doc = if models_change {
+            let mut models = read_json_object(models_path)?;
+            apply_provider_upsert(&mut models, spec)?;
+            Some(models)
+        } else {
+            None
+        };
 
         // Prepare the auth mutation in memory too, so all reads/validations
         // precede the first disk write.
         let mut auth_doc = None;
-        if let Some(key) = &spec.api_key {
+        if spec.api_key.is_some() || spec.clear_api_key {
             let mut auth = read_json_object(auth_path)?;
-            upsert_auth_entry(&mut auth, &spec.id)
-                .insert("key".to_string(), Value::String(key.clone()));
+            if let Some(key) = &spec.api_key {
+                upsert_auth_entry(&mut auth, &spec.id)
+                    .insert("key".to_string(), Value::String(key.clone()));
+            } else if let Some(entry) = auth.get_mut(&spec.id).and_then(Value::as_object_mut) {
+                entry.remove("key");
+            }
             auth_doc = Some(auth);
         }
 
         // Persist models.json, then auth.json. Restore only what this call
         // already wrote: a failed models write means nothing was persisted; a
         // failed auth write means only models.json changed.
-        if let Err(error) = write_json_atomic(models_path, &models_doc, false) {
-            restore_file(models_path, models_snapshot.as_deref(), false);
-            return Err(error);
+        if let Some(models) = models_doc {
+            if let Err(error) = write_json_atomic(models_path, &models, false) {
+                restore_file(
+                    models_path,
+                    models_snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.as_deref()),
+                    false,
+                );
+                return Err(error);
+            }
         }
         if let Some(auth) = auth_doc {
             if let Err(error) = write_json_atomic(auth_path, &auth, true) {
-                restore_file(models_path, models_snapshot.as_deref(), false);
+                if models_change {
+                    restore_file(
+                        models_path,
+                        models_snapshot
+                            .as_ref()
+                            .and_then(|snapshot| snapshot.as_deref()),
+                        false,
+                    );
+                }
                 return Err(error);
             }
         }
@@ -459,13 +611,30 @@ pub fn delete_provider_files(auth_path: &Path, models_path: &Path, id: &str) -> 
 
 /// Default-path wrappers used by the RPC handlers.
 pub fn mutate_auth(mutation: &AuthMutation) -> Result<(), String> {
+    validate_auth_mutation(mutation)?;
     mutate_auth_file(&auth_json_path(), mutation)
 }
 pub fn upsert_provider(spec: &ProviderUpsertSpec) -> Result<(), String> {
+    validate_provider_upsert(spec)?;
     upsert_provider_files(&auth_json_path(), &models_json_path(), spec)
 }
 pub fn delete_provider(id: &str) -> Result<(), String> {
+    if !valid_provider_id(id.trim()) {
+        return Err("provider id must use lowercase letters, digits, '-' or '_'".to_string());
+    }
     delete_provider_files(&auth_json_path(), &models_json_path(), id)
+}
+
+/// Read a consistent Agent-owned snapshot of the two provider configuration
+/// documents. The same lock as mutations prevents a view from combining the
+/// models half of one revision with the auth half of another.
+pub fn read_provider_documents() -> Result<ProviderDocuments, String> {
+    with_config_lock(|| {
+        Ok((
+            read_json_object(&models_json_path())?,
+            read_json_object(&auth_json_path())?,
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -603,6 +772,91 @@ mod tests {
         assert_eq!(provider["baseUrl"], json!("https://new.example.com"));
         assert_eq!(provider["compat"], json!("strict"), "unmanaged fields kept");
         assert_eq!(provider["models"][0]["modalities"][1], json!("image"));
+    }
+
+    #[test]
+    fn explicit_empty_models_replaces_the_existing_list() {
+        let mut root: Map<String, Value> = serde_json::from_str(
+            r#"{"providers":{"myprov":{"name":"My","models":[{"id":"old"}]}}}"#,
+        )
+        .unwrap();
+        apply_provider_upsert(
+            &mut root,
+            &ProviderUpsertSpec {
+                id: "myprov".to_string(),
+                replace_models: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(root["providers"]["myprov"]["models"], json!([]));
+    }
+
+    #[test]
+    fn auth_only_upsert_does_not_create_models_file() {
+        let (_dir, auth, models) = temp_paths("auth-only-upsert");
+        upsert_provider_files(
+            &auth,
+            &models,
+            &ProviderUpsertSpec {
+                id: "deepseek".to_string(),
+                api_key: Some("sk-new".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(!models.exists());
+        let stored: Value = serde_json::from_str(&std::fs::read_to_string(auth).unwrap()).unwrap();
+        assert_eq!(stored["deepseek"]["key"], json!("sk-new"));
+    }
+
+    #[test]
+    fn builtin_url_and_key_are_committed_by_one_upsert() {
+        let (_dir, auth, models) = temp_paths("builtin-atomic");
+        upsert_provider_files(
+            &auth,
+            &models,
+            &ProviderUpsertSpec {
+                id: "azure-openai-responses".to_string(),
+                base_url: Some("https://tenant.openai.azure.com/openai".to_string()),
+                api_key: Some("azure-key".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let stored_models: Value =
+            serde_json::from_str(&std::fs::read_to_string(&models).unwrap()).unwrap();
+        let stored_auth: Value =
+            serde_json::from_str(&std::fs::read_to_string(&auth).unwrap()).unwrap();
+        assert_eq!(
+            stored_models["providers"]["azure-openai-responses"]["baseUrl"],
+            json!("https://tenant.openai.azure.com/openai")
+        );
+        assert_eq!(
+            stored_auth["azure-openai-responses"]["key"],
+            json!("azure-key")
+        );
+
+        upsert_provider_files(
+            &auth,
+            &models,
+            &ProviderUpsertSpec {
+                id: "azure-openai-responses".to_string(),
+                base_url: Some("https://other.openai.azure.com/openai".to_string()),
+                clear_api_key: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let stored_models: Value =
+            serde_json::from_str(&std::fs::read_to_string(models).unwrap()).unwrap();
+        let stored_auth: Value =
+            serde_json::from_str(&std::fs::read_to_string(auth).unwrap()).unwrap();
+        assert_eq!(
+            stored_models["providers"]["azure-openai-responses"]["baseUrl"],
+            json!("https://other.openai.azure.com/openai")
+        );
+        assert!(stored_auth["azure-openai-responses"].get("key").is_none());
     }
 
     #[test]

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -280,8 +280,10 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                             modalities: model.modalities,
                         })
                         .collect(),
+                    replace_models: config.replace_models,
                     create_only: config.create_only,
                     api_key: nonempty(config.api_key),
+                    clear_api_key: config.clear_api_key,
                 }
             }),
         };
@@ -362,6 +364,44 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
         let atomic_attach = req.atomic_attach;
         let requested_run_id = req.run_id;
         let after_idx = req.after_idx;
+
+        if req.global_events {
+            if !session_id.is_empty() || atomic_attach || !requested_run_id.is_empty() {
+                return Err(tonic::Status::invalid_argument(
+                    "global_events cannot be combined with session/run attachment fields",
+                ));
+            }
+            let broadcaster = crate::rpc::global_config_broadcaster();
+            let rx = broadcaster.subscribe();
+            let revision = crate::rpc::current_config_revision();
+            let mut initial = vec![proto::StreamEvent {
+                r#type: "ping".to_string(),
+                data: serde_json::json!({
+                    "type": "ping",
+                    "configRevision": revision,
+                })
+                .to_string(),
+                session_idx: -1,
+                run_sequence: -1,
+                ..Default::default()
+            }];
+            if filter_enabled {
+                initial.retain(|event| event_types.contains(&event.r#type));
+            }
+            let filter_types = event_types.clone();
+            let snapshot = tokio_stream::iter(initial.into_iter().map(Ok));
+            let lag_broadcaster = broadcaster.clone();
+            let events = BroadcastStream::new(rx)
+                .filter(move |result| {
+                    !filter_enabled
+                        || result
+                            .as_ref()
+                            .map(|event| filter_types.contains(&event.event_type))
+                            .unwrap_or(true)
+                })
+                .map(move |result| map_broadcast_event(result, &lag_broadcaster, ""));
+            return Ok(tonic::Response::new(Box::pin(snapshot.chain(events))));
+        }
 
         // Sessions are equal peers — every subscription must name its
         // session.  An empty id previously subscribed to a global/default
@@ -679,8 +719,10 @@ mod tests {
                     name: "Model One".to_string(),
                     modalities: vec!["text".to_string()],
                 }],
+                replace_models: true,
                 create_only: false,
                 api_key: "k".to_string(),
+                clear_api_key: false,
             }),
             message: "hello".to_string(),
             ..Default::default()
@@ -762,6 +804,28 @@ mod tests {
             .map(|_| ())
             .expect_err("expected an error");
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn global_stream_reports_committed_provider_revision() {
+        let service = FutureAgentService {
+            state: grpc_app_state(false),
+        };
+        let response = service
+            .stream_events(tonic::Request::new(proto::StreamRequest {
+                event_types: vec!["provider_config_changed".to_string()],
+                global_events: true,
+                ..Default::default()
+            }))
+            .await
+            .expect("global subscription succeeds");
+        let mut stream = response.into_inner();
+        let revision = crate::rpc::publish_provider_config_changed("custom", "updated", true, true);
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event.r#type, "provider_config_changed");
+        let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
+        assert_eq!(data["revision"], revision);
+        assert_eq!(data["providerId"], "custom");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -747,6 +747,10 @@ impl crate::types::LLMProvider for Client {
         *self.api_key.write() = api_key.to_string();
     }
 
+    fn set_base_url(&self, base_url: &str) {
+        *self.base_url.write() = base_url.to_string();
+    }
+
     fn update_thinking(&self, level: &str, budget: i32) {
         *self.thinking_level.write() = level.to_string();
         *self.thinking_budget.write() = budget;

--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -179,6 +179,25 @@ fn platform_url_from_auth(auth: &serde_json::Value) -> Option<String> {
         .map(|url| url.trim_end_matches('/').to_string())
 }
 
+/// Future model API URL shown by provider-management clients. This consumes
+/// the already-locked auth snapshot instead of re-reading the file.
+pub(crate) fn display_base_url_from_auth(auth: &serde_json::Value) -> String {
+    let platform =
+        platform_url_from_auth(auth).unwrap_or_else(|| DEFAULT_FUTURE_PLATFORM_URL.to_string());
+    format!("{}/api/v1", platform.trim_end_matches('/'))
+}
+
+/// Count the last successfully cached Future model catalogue for the provider
+/// settings view, independent of whether the current key is present.
+pub(crate) fn cached_model_count() -> usize {
+    let path = crate::utils::default_config_dir().join(".future-models-cache.json");
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<FutureModelsCache>(&contents).ok())
+        .map(|cache| cache.models.len())
+        .unwrap_or(0)
+}
+
 fn resolve_future_platform_url() -> String {
     // Try to read base_url or platform_base_url from auth.json
     let auth_path = dirs::home_dir()

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod builtin;
 mod future;
+pub(crate) use future::{cached_model_count, display_base_url_from_auth};
 use future::{
     derive_thinking_compat, get_future_models_with_cache, resolve_future_base_url,
     sync_future_models_cache as sync_future_models_cache_inner,
@@ -739,7 +740,9 @@ impl Registry {
     pub fn all_models(&self) -> Vec<Model> {
         let mut models = self.builtin.as_ref().clone();
         for user_model in &self.user {
-            if let Some(idx) = models.iter().position(|m| m.id == user_model.id) {
+            if let Some(idx) = models.iter().position(|model| {
+                model.provider == user_model.provider && model.id == user_model.id
+            }) {
                 models[idx] = user_model.clone();
             } else {
                 models.push(user_model.clone());
@@ -1863,6 +1866,27 @@ mod tests {
         let models = reg.all_models();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].name, "User Override");
+    }
+
+    #[test]
+    fn all_models_keeps_same_id_from_different_providers() {
+        let builtin = make_model("shared-id", "provider-a");
+        let user = make_model("shared-id", "provider-b");
+        let reg = Registry {
+            builtin: std::sync::Arc::new(vec![builtin]),
+            user: vec![user],
+            provider_overrides: HashMap::new(),
+        };
+        let models = reg.all_models();
+        assert_eq!(models.len(), 2);
+        assert_eq!(
+            reg.resolve("provider-a/shared-id").unwrap().provider,
+            "provider-a"
+        );
+        assert_eq!(
+            reg.resolve("provider-b/shared-id").unwrap().provider,
+            "provider-b"
+        );
     }
 
     #[test]

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -30,6 +30,12 @@ const EVENTS_PAGE_BYTE_BUDGET: usize = 8 * 1024 * 1024;
 /// timestamp, idx…), approximating the journal line.
 const EVENT_WIRE_OVERHEAD: usize = 320;
 
+/// Serializes provider snapshots with config mutations through the registry
+/// refresh. The lower config lock protects file RMWs; this command-level lock
+/// additionally prevents readers from observing committed files before the
+/// matching in-memory registry revision has landed.
+static PROVIDER_COMMAND_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Cut `events` to one page for a paging caller (`max_events > 0`): at most
 /// `max_events` entries, and at most [`EVENTS_PAGE_BYTE_BUDGET`] of estimated
 /// serialized size, whichever comes first. The first event always goes out —
@@ -117,16 +123,27 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             cmd.include_builtin_providers,
         );
     }
+    if cmd_type == "list_providers" {
+        return list_providers_response(state, id);
+    }
 
     // Credential refresh operates on every session, not one — handle it before
     // resolving a target session (which would needlessly create/load one).
     if cmd_type == "reload_auth" {
+        let _provider_guard = PROVIDER_COMMAND_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         // Rebuild the shared model registry FIRST so runtime-added/
         // removed providers and models.json edits become visible to every
         // session — set_model now resolves against this cache instead of
         // constructing a fresh Registry per call.
         refresh_registry_and_credentials(state);
-        return RpcResponse::ok(id, "reload_auth", serde_json::json!({}));
+        let revision = crate::rpc::publish_provider_config_changed("*", "reload", true, true);
+        return RpcResponse::ok(
+            id,
+            "reload_auth",
+            serde_json::json!({ "revision": revision }),
+        );
     }
 
     // ── Config writes (audit item 2): the agent is the sole writer of
@@ -1005,14 +1022,14 @@ fn list_models_response(
     // Use the same default-model resolution as cmd_new_session so the list
     // and actual session creation agree on which model is the default.
     let effective_default = crate::models::get_default_model_with(registry)
-        .and_then(|full| full.rsplit_once('/').map(|(_, id)| id.to_string()))
-        .or_else(|| models.first().map(|m| m.id.clone()))
+        .or_else(|| models.first().map(|m| format!("{}/{}", m.provider, m.id)))
         .unwrap_or_default();
 
     let payload_models: Vec<serde_json::Value> = models
         .into_iter()
         .map(|model| {
             let id = model.id;
+            let qualified_id = format!("{}/{}", model.provider, id);
             let label = if model.name.is_empty() {
                 id.clone()
             } else {
@@ -1026,7 +1043,7 @@ fn list_models_response(
                 "supportsImages": model.input.iter().any(|input| input == "image"),
                 "thinkingLevel": thinking_level.to_string(),
                 "contextWindow": model.context_window,
-                "isDefault": id == effective_default,
+                "isDefault": qualified_id == effective_default,
                 "description": model.description,
                 "descriptionEn": model.description_en,
                 "recommended": model.recommended,
@@ -1048,6 +1065,126 @@ fn list_models_response(
     RpcResponse::ok(id, "list_models", payload)
 }
 
+fn list_providers_response(state: &AppState, id: &str) -> String {
+    let _provider_guard = PROVIDER_COMMAND_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    match provider_view(state) {
+        Ok(view) => RpcResponse::ok(id, "list_providers", view),
+        Err(error) => RpcResponse::build_fail(id, "list_providers", &error),
+    }
+}
+
+fn provider_view(state: &AppState) -> Result<serde_json::Value, String> {
+    let (models, auth) = crate::config::providers::read_provider_documents()?;
+    let models = serde_json::Value::Object(models);
+    let auth = serde_json::Value::Object(auth);
+    let provider_entries = models
+        .get("providers")
+        .and_then(serde_json::Value::as_object);
+    let has_key = |provider: &str| {
+        auth.get(provider)
+            .and_then(|entry| entry.get("key"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|key| !key.trim().is_empty())
+    };
+    let is_override_only = |config: &serde_json::Value| {
+        let has_text = |field: &str| {
+            config
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        };
+        let has_models = config
+            .get("models")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|items| !items.is_empty());
+        !has_text("name") && !has_text("api") && !has_models
+    };
+
+    let custom_ids: std::collections::HashSet<&str> = provider_entries
+        .into_iter()
+        .flat_map(|providers| providers.iter())
+        .filter(|(_, config)| !is_override_only(config))
+        .map(|(provider_id, _)| provider_id.as_str())
+        .collect();
+
+    let registry = state.model_registry.read();
+    let mut builtin = vec![serde_json::json!({
+        "id": "future",
+        "name": "Future",
+        "baseUrl": crate::models::display_base_url_from_auth(&auth),
+        "hasApiKey": has_key("future"),
+        "modelCount": crate::models::cached_model_count(),
+        "requiresBaseUrl": false,
+    })];
+    for (provider_id, summary) in registry.builtin_provider_summaries() {
+        if custom_ids.contains(provider_id.as_str()) {
+            continue;
+        }
+        let override_url = provider_entries
+            .and_then(|providers| providers.get(&provider_id))
+            .and_then(|config| config.get("baseUrl"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        builtin.push(serde_json::json!({
+            "id": provider_id,
+            "name": summary.name,
+            "baseUrl": override_url.unwrap_or(&summary.base_url),
+            "hasApiKey": has_key(&provider_id),
+            "modelCount": summary.model_count,
+            "requiresBaseUrl": summary.base_url.contains("YOUR_RESOURCE"),
+        }));
+    }
+
+    let mut custom = provider_entries
+        .into_iter()
+        .flat_map(|providers| providers.iter())
+        .filter(|(provider_id, config)| provider_id.as_str() != "future" && !is_override_only(config))
+        .map(|(provider_id, config)| {
+            let name = config
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or(provider_id);
+            let provider_models = config
+                .get("models")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|model| {
+                    let model_id = model.get("id")?.as_str()?;
+                    let model_name = model
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|name| !name.trim().is_empty())
+                        .unwrap_or(model_id);
+                    let supports_images = model
+                        .get("modalities")
+                        .and_then(serde_json::Value::as_array)
+                        .is_some_and(|items| items.iter().any(|item| item.as_str() == Some("image")));
+                    Some(serde_json::json!({
+                        "id": model_id,
+                        "name": model_name,
+                        "supportsImages": supports_images,
+                    }))
+                })
+                .collect::<Vec<_>>();
+            serde_json::json!({
+                "id": provider_id,
+                "name": name,
+                "api": config.get("api").and_then(serde_json::Value::as_str).unwrap_or_default(),
+                "baseUrl": config.get("baseUrl").and_then(serde_json::Value::as_str).unwrap_or_default(),
+                "hasApiKey": has_key(provider_id),
+                "models": provider_models,
+            })
+        })
+        .collect::<Vec<_>>();
+    custom.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+    Ok(serde_json::json!({ "builtin": builtin, "custom": custom }))
+}
+
 /// Rebuild the shared model registry so provider/models.json changes become
 /// visible to every session, then refresh each live session's cached
 /// credentials. Shared by `reload_auth` and the config-write commands, which
@@ -1059,6 +1196,9 @@ fn refresh_registry_and_credentials(state: &AppState) {
 
 /// Apply one auth.json mutation and refresh live state (see dispatch comment).
 fn cmd_set_auth(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
+    let _provider_guard = PROVIDER_COMMAND_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let Some(mutation) = cmd.auth_update.as_ref() else {
         return RpcResponse::build_fail(id, "set_auth", "missing auth_update payload");
     };
@@ -1078,16 +1218,25 @@ fn cmd_set_auth(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
         return RpcResponse::build_fail(id, "set_auth", &error);
     }
     refresh_registry_and_credentials(state);
+    let revision = crate::rpc::publish_provider_config_changed(
+        &mutation.provider,
+        "auth_updated",
+        true,
+        false,
+    );
     RpcResponse::ok(
         id,
         "set_auth",
-        serde_json::json!({ "provider": mutation.provider }),
+        serde_json::json!({ "provider": mutation.provider, "revision": revision }),
     )
 }
 
 /// Create/update a models.json provider (plus optional auth.json key) and
 /// refresh live state (see dispatch comment).
 fn cmd_upsert_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
+    let _provider_guard = PROVIDER_COMMAND_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let Some(spec) = cmd.provider_config.as_ref() else {
         return RpcResponse::build_fail(id, "upsert_provider", "missing provider_config payload");
     };
@@ -1098,8 +1247,10 @@ fn cmd_upsert_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
         || spec.api.is_some()
         || spec.base_url.is_some()
         || spec.clear_base_url
+        || spec.replace_models
         || !spec.models.is_empty()
-        || spec.api_key.is_some();
+        || spec.api_key.is_some()
+        || spec.clear_api_key;
     if !carries_change {
         return RpcResponse::build_fail(id, "upsert_provider", "provider_config carries no change");
     }
@@ -1111,10 +1262,8 @@ fn cmd_upsert_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
     // here (not only in the GUI) keeps the invariant correct no matter which
     // client issues the write and whether any client-side catalog is stale or
     // temporarily unavailable.
-    let defines_custom_provider = spec.name.is_some()
-        || spec.api.is_some()
-        || !spec.models.is_empty()
-        || spec.api_key.is_some();
+    let defines_custom_provider =
+        spec.name.is_some() || spec.api.is_some() || spec.replace_models || !spec.models.is_empty();
     if defines_custom_provider
         && state
             .model_registry
@@ -1135,12 +1284,29 @@ fn cmd_upsert_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
         return RpcResponse::build_fail(id, "upsert_provider", &error);
     }
     refresh_registry_and_credentials(state);
-    RpcResponse::ok(id, "upsert_provider", serde_json::json!({ "id": spec.id }))
+    let revision = crate::rpc::publish_provider_config_changed(
+        &spec.id,
+        if spec.create_only {
+            "created"
+        } else {
+            "updated"
+        },
+        spec.api_key.is_some() || spec.clear_api_key,
+        true,
+    );
+    RpcResponse::ok(
+        id,
+        "upsert_provider",
+        serde_json::json!({ "id": spec.id, "revision": revision }),
+    )
 }
 
 /// Remove a provider's models.json entry AND auth.json entry, then refresh
 /// live state (see dispatch comment).
 fn cmd_delete_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
+    let _provider_guard = PROVIDER_COMMAND_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let Some(spec) = cmd.provider_config.as_ref() else {
         return RpcResponse::build_fail(id, "delete_provider", "missing provider_config payload");
     };
@@ -1173,10 +1339,11 @@ fn cmd_delete_provider(state: &AppState, id: &str, cmd: &RpcCommand) -> String {
         return RpcResponse::build_fail(id, "delete_provider", &error);
     }
     refresh_registry_and_credentials(state);
+    let revision = crate::rpc::publish_provider_config_changed(provider_id, "deleted", true, true);
     RpcResponse::ok(
         id,
         "delete_provider",
-        serde_json::json!({ "id": provider_id }),
+        serde_json::json!({ "id": provider_id, "revision": revision }),
     )
 }
 

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -14,13 +14,48 @@ pub(crate) use future_rpc::payloads;
 use crate::models::Registry as ModelRegistry;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::{Arc, LazyLock};
 
 pub use approval::{ApprovalDecision, ApprovalDecisionStatus, ApprovalGate};
 pub use commands::handle_command_internal;
 pub use protocol::{RpcCommand, RpcResponse, SseBroadcaster, SseEvent};
 pub use session::ServerSession;
+
+/// Provider/auth configuration is process-wide Agent state, not chat state.
+/// This broadcaster gives every client one authoritative completion stream.
+static GLOBAL_CONFIG_BROADCASTER: LazyLock<Arc<SseBroadcaster>> =
+    LazyLock::new(|| Arc::new(SseBroadcaster::new()));
+static CONFIG_REVISION: AtomicI64 = AtomicI64::new(0);
+
+pub fn global_config_broadcaster() -> Arc<SseBroadcaster> {
+    GLOBAL_CONFIG_BROADCASTER.clone()
+}
+
+pub fn current_config_revision() -> i64 {
+    CONFIG_REVISION.load(Ordering::Acquire)
+}
+
+/// Publish only after the mutation is durable and live Agent state refreshed.
+pub fn publish_provider_config_changed(
+    provider_id: &str,
+    operation: &str,
+    auth_changed: bool,
+    models_changed: bool,
+) -> i64 {
+    let revision = CONFIG_REVISION.fetch_add(1, Ordering::AcqRel) + 1;
+    GLOBAL_CONFIG_BROADCASTER.broadcast(SseEvent::new(
+        "provider_config_changed",
+        serde_json::json!({
+            "revision": revision,
+            "providerId": provider_id,
+            "operation": operation,
+            "authChanged": auth_changed,
+            "modelsChanged": models_changed,
+        }),
+    ));
+    revision
+}
 
 /// Map one broadcaster/journal event into its replay payload carrier. The
 /// wire type lives in the future-rpc crate; the mapping needs the
@@ -207,22 +242,26 @@ impl AppState {
     /// the config-write commands (`set_auth` / `upsert_provider` /
     /// `delete_provider`) after the agent writes its own auth.json/models.json
     /// — FutureGene login/logout, custom-provider key edits — so no running
-    /// session keeps using a stale key. Sessions actively streaming are
-    /// skipped by `reload_credentials` and pick up the new key on their next
-    /// `set_model`.
+    /// session keeps using a stale key. Active runs own independent snapshots;
+    /// the short shared control-plane lock is waited out rather than skipped.
     ///
     /// Sessions that were created before any credentials existed (model is empty)
     /// get a default model resolved and applied, so the user can prompt immediately
     /// after login without switching threads.
     pub fn reload_all_credentials(&self) {
-        let sessions = self.sessions.read();
-        for sess in sessions.values() {
-            let model_is_empty = { sess.read().model.is_empty() };
-            if model_is_empty {
+        let sessions = self.sessions.read().values().cloned().collect::<Vec<_>>();
+        for sess in &sessions {
+            let model_needs_reselection = {
+                let session = sess.read();
+                session.model.is_empty()
+                    || self.model_registry.read().resolve(&session.model).is_none()
+            };
+            if model_needs_reselection {
                 // Session created before login — resolve and apply default model.
                 // Re-check emptiness inside the write lock to avoid TOCTOU: another
                 // thread may have set a model between our read and write locks.
-                if let Some(mut session) = sess.try_write() {
+                {
+                    let mut session = sess.write();
                     #[cfg(test)]
                     {
                         // Id-gated; the hook receives the held write guard so it
@@ -235,20 +274,73 @@ impl AppState {
                             }
                         }
                     }
-                    if session.model.is_empty() {
+                    let still_needs_reselection = session.model.is_empty()
+                        || self.model_registry.read().resolve(&session.model).is_none();
+                    if still_needs_reselection {
                         let registry = self.model_registry.read();
                         let default_model =
                             crate::models::get_default_model_with(&registry).unwrap_or_default();
-                        if !default_model.is_empty() {
-                            let _ = session.set_model(&default_model);
+                        drop(registry);
+                        loop {
+                            match session.set_model(&default_model) {
+                                Ok(()) => break,
+                                Err(error)
+                                    if error
+                                        .to_string()
+                                        .contains("session configuration is busy") =>
+                                {
+                                    // Config writes only complete after every
+                                    // live session observes the new registry.
+                                    // Ordinary /model remains non-blocking,
+                                    // but this control-plane reconciliation
+                                    // waits out its short loop lock.
+                                    std::thread::yield_now();
+                                }
+                                Err(error) => {
+                                    tracing::error!(
+                                        session_id = %session.session_id,
+                                        model = %default_model,
+                                        "failed to persist provider-removal model reconciliation: {error:#}"
+                                    );
+                                    break;
+                                }
+                            }
                         }
+                        if default_model.is_empty() {
+                            reload_credentials_wait(&session);
+                        }
+                        session.broadcaster.broadcast(SseEvent::new(
+                            "model_changed",
+                            serde_json::json!({"model": session.model}),
+                        ));
                     } else {
                         // Model was set concurrently — just refresh credentials
-                        session.reload_credentials();
+                        reload_credentials_wait(&session);
                     }
                 }
             } else {
-                sess.read().reload_credentials();
+                reload_credentials_wait(&sess.read());
+            }
+        }
+    }
+}
+
+/// Provider config commits are synchronization barriers: unlike an ordinary
+/// prompt (which reports a transient busy error), they wait until every live
+/// session has installed the authoritative credential revision.
+fn reload_credentials_wait(session: &ServerSession) {
+    loop {
+        match session.reload_credentials() {
+            Ok(()) => return,
+            Err(error) if error.to_string().contains("configuration is busy") => {
+                std::thread::yield_now();
+            }
+            Err(error) => {
+                tracing::error!(
+                    session_id = %session.session_id,
+                    "failed to refresh live session credentials: {error:#}"
+                );
+                return;
             }
         }
     }
@@ -848,7 +940,7 @@ mod tests {
     }
 
     #[test]
-    fn reload_all_credentials_skips_write_locked_session() {
+    fn reload_all_credentials_waits_for_write_locked_session() {
         let (_dir, state) = bare_app_state();
         let session = crate::rpc::ServerSession::new_with_queue_budget(
             "locked".to_string(),
@@ -864,15 +956,25 @@ mod tests {
             state.queue_budget.clone(),
         );
         state.create_session(session);
+        let state = std::sync::Arc::new(state);
         let session = state.get_session("locked").unwrap();
-        // A held READ guard makes reload's try_write fail without blocking
-        // its own read — the model-less session is skipped entirely.
+        // A held read guard temporarily prevents reconciliation, but the
+        // refresh must wait rather than acknowledge with stale session state.
         let guard = session.read();
-        state.reload_all_credentials();
-        assert!(
-            guard.model.is_empty(),
-            "write-locked session left untouched"
-        );
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let reload_state = state.clone();
+        let worker = std::thread::spawn(move || {
+            reload_state.reload_all_credentials();
+            done_tx.send(()).unwrap();
+        });
+        assert!(done_rx
+            .recv_timeout(std::time::Duration::from_millis(20))
+            .is_err());
+        drop(guard);
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("refresh completes after the session lock is released");
+        worker.join().unwrap();
     }
 
     // ─── coverage batch 16: hydrate/reload/get_state residuals ─────────────
@@ -975,11 +1077,12 @@ mod tests {
     }
 
     #[test]
-    fn reload_all_credentials_refreshes_session_that_gained_a_model_mid_check() {
+    fn reload_all_credentials_reselects_invalid_model_installed_mid_check() {
         let (_dir, state) = bare_app_state();
         // Live session with NO model yet → the outer check takes the
-        // set-default path; the hook then installs a model before the inner
-        // re-check, so only credentials are refreshed.
+        // set-default path; the hook then installs a stale/nonexistent model
+        // before the inner re-check. It must still be reconciled rather than
+        // preserving a model removed by a concurrent provider mutation.
         let session = crate::rpc::ServerSession::new_with_queue_budget(
             "modeless".to_string(),
             std::sync::Arc::new(tokio::sync::RwLock::new(crate::agent::Loop::new(
@@ -1003,7 +1106,9 @@ mod tests {
         state.reload_all_credentials();
         assert!(RELOAD_RACE_HOOK.lock().is_none());
         let session = state.get_session("modeless").unwrap();
-        assert_eq!(session.read().model, "concurrent-model");
+        let selected = session.read().model.clone();
+        assert_ne!(selected, "concurrent-model");
+        assert!(state.model_registry.read().resolve(&selected).is_some());
     }
 
     #[test]

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -878,6 +878,7 @@ fn is_session_scoped_event(event_type: &str) -> bool {
             | "tools_changed"
             | "config_reloaded"
             | "skills_reloaded"
+            | "provider_config_changed"
     )
 }
 

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -520,9 +520,14 @@ impl ServerSession {
     /// Active runs use a provider snapshot, so updating this control plane
     /// affects the next request without mutating headers already sent by an
     /// in-flight request.
-    pub fn reload_credentials(&self) {
+    pub fn reload_credentials(&self) -> Result<()> {
         if self.model.is_empty() {
-            return;
+            let loop_ = self
+                .agent_loop
+                .try_read()
+                .map_err(|_| anyhow::anyhow!("run configuration is busy; retry prompt"))?;
+            loop_.provider.set_api_key("");
+            return Ok(());
         }
         let registry_resolved = self.model_registry.read().resolve(&self.model);
         let provider = registry_resolved
@@ -535,11 +540,25 @@ impl ServerSession {
             .as_ref()
             .map(|m| m.api_key.clone())
             .unwrap_or_default();
+        let base_url = registry_resolved
+            .as_ref()
+            .map(|m| m.base_url.clone())
+            .unwrap_or_default();
         let api_key = resolve_api_key(&auth, &self.model, &provider, &model_key);
 
-        if let Ok(loop_) = self.agent_loop.try_read() {
-            loop_.provider.set_api_key(&api_key);
+        // The shared loop is a short-lived control plane; active runs own
+        // independent snapshots. Wait until the latest credential revision is
+        // installed so config commands cannot acknowledge while a session is
+        // still on the old key.
+        let loop_ = self
+            .agent_loop
+            .try_read()
+            .map_err(|_| anyhow::anyhow!("run configuration is busy; retry prompt"))?;
+        loop_.provider.set_api_key(&api_key);
+        if !base_url.is_empty() {
+            loop_.provider.set_base_url(&base_url);
         }
+        Ok(())
     }
 
     fn strip_image_content_from_messages(&self) {
@@ -920,6 +939,26 @@ mod tests {
         ) -> anyhow::Result<ReceiverStream<StreamEvent>> {
             let (_tx, rx) = mpsc::channel(1);
             Ok(ReceiverStream::new(rx))
+        }
+    }
+
+    struct KeyRecordingProvider(Arc<parking_lot::Mutex<String>>);
+
+    #[async_trait::async_trait]
+    impl LLMProvider for KeyRecordingProvider {
+        async fn stream_chat(
+            &self,
+            _model: String,
+            _messages: Vec<Message>,
+            _tools: Vec<ToolDef>,
+            _system_prompt: String,
+        ) -> anyhow::Result<ReceiverStream<StreamEvent>> {
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(ReceiverStream::new(rx))
+        }
+
+        fn set_api_key(&self, api_key: &str) {
+            *self.0.lock() = api_key.to_string();
         }
     }
 
@@ -2292,7 +2331,38 @@ mod tests {
     #[test]
     fn reload_credentials_no_panic() {
         let session = make_test_session("s1");
-        session.reload_credentials();
+        let _ = session.reload_credentials();
+    }
+
+    #[test]
+    fn reload_credentials_applies_authoritative_provider_key() {
+        let _home = crate::test_support::TestHome::new();
+        let auth_path = crate::config::providers::auth_json_path();
+        std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            auth_path,
+            r#"{"custom":{"type":"api_key","key":"new-key"}}"#,
+        )
+        .unwrap();
+
+        let observed = Arc::new(parking_lot::Mutex::new("old-key".to_string()));
+        let cwd = test_workspace();
+        let mut session = ServerSession::new(
+            "key-refresh".to_string(),
+            Arc::new(tokio::sync::RwLock::new(Loop::new(
+                Arc::new(KeyRecordingProvider(observed.clone())),
+                "model",
+            ))),
+            Arc::new(Manager::new(test_session_dir())),
+            &cwd,
+            Arc::new(SseBroadcaster::new()),
+            ApprovalGate::default(),
+            Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
+        );
+        session.model = "custom/model".to_string();
+
+        session.reload_credentials().unwrap();
+        assert_eq!(&*observed.lock(), "new-key");
     }
 
     #[test]

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -116,6 +116,11 @@ impl ServerSession {
         client_request_id: &str,
         busy_policy: crate::runtime::BusyPolicy,
     ) -> Result<crate::runtime::RunAck> {
+        // auth.json is authoritative. Refresh immediately before freezing the
+        // run snapshot so a UI/catalog view and the actual request can never
+        // disagree about which key is in use. Failure rejects admission rather
+        // than silently running with stale credentials.
+        self.reload_credentials()?;
         if self.deleting {
             return Err(crate::runtime::RunQueueError::Deleting.into());
         }

--- a/agent/src/types/mod.rs
+++ b/agent/src/types/mod.rs
@@ -755,6 +755,11 @@ pub trait LLMProvider: Send + Sync {
     /// endpoint.
     fn set_api_key(&self, _api_key: &str) {}
 
+    /// Refresh the provider endpoint in the same shared runtime client. Run
+    /// snapshots clone the provider Arc, so this also keeps already-accepted
+    /// queued work aligned with a committed provider edit.
+    fn set_base_url(&self, _base_url: &str) {}
+
     /// Update thinking level and budget at runtime (after set_thinking_level / cycle_thinking_level).
     fn update_thinking(&self, _level: &str, _budget: i32) {}
 }

--- a/channels/src/grpc_client.rs
+++ b/channels/src/grpc_client.rs
@@ -500,6 +500,7 @@ impl AgentClient {
             event_types: vec![],
             after_idx: -1,
             atomic_attach: true,
+            global_events: false,
         });
         let inner = self
             .inner

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -6,11 +6,15 @@
 
 use crate::constants::{auth_file, DEFAULT_PLATFORM_URL, FUTURE_AUTH_PROVIDER};
 use crate::output::Output;
+#[cfg(not(test))]
+use crate::rpc::{grpc_addr, RunClient};
 use crate::utils::platform::get_platform_url;
 use crate::utils::string::trim_trailing_slash;
 use crate::utils::time::sleep;
 use serde::Deserialize;
-use serde_json::{json, Map, Value};
+#[cfg(test)]
+use serde_json::Map;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 
 /// `DeviceCodeResponse` from auth.ts.
@@ -70,7 +74,15 @@ fn resolve_login_platform_url(platform_url_override: Option<String>) -> String {
 
 /// `login(platformUrlOverride?)` — device-code OAuth flow.
 pub async fn login(platform_url_override: Option<String>, out: &Output) -> Result<(), String> {
+    #[cfg(not(test))]
+    RunClient::new(&grpc_addr())
+        .get_agent_info()
+        .await
+        .map_err(|error| format!("Future Agent must be running before login: {error}"))?;
+    #[cfg(test)]
     let auth_data = load_auth_file().await?;
+    #[cfg(not(test))]
+    let auth_data = Value::Null;
     // `platformUrlOverride ? platformUrlOverride.replace(/\/+$/, "") : DEFAULT_PLATFORM_URL`
     let platform_url = resolve_login_platform_url(platform_url_override);
 
@@ -227,32 +239,70 @@ pub async fn credential(json: bool, out: &Output) -> Result<(), String> {
 
 /// `logout()` — remove the stored Future API key.
 pub async fn logout(out: &Output) -> Result<(), String> {
-    let auth_file = load_auth_file().await?;
-    let current = get_future_auth_entry(&auth_file);
+    #[cfg(not(test))]
+    {
+        let client = RunClient::new(&grpc_addr());
+        let providers = client
+            .list_providers()
+            .await
+            .map_err(|error| format!("Future Agent must be running before logout: {error}"))?;
+        let logged_in = providers
+            .get("builtin")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .any(|provider| {
+                provider.get("id").and_then(Value::as_str) == Some(FUTURE_AUTH_PROVIDER)
+                    && provider
+                        .get("hasApiKey")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+            });
+        if !logged_in {
+            out.log("Not logged in.");
+            return Ok(());
+        }
+        client
+            .set_auth(future_rpc::proto::AuthUpdate {
+                provider: FUTURE_AUTH_PROVIDER.to_string(),
+                clear_key: true,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| format!("Future Agent did not clear the credential: {error}"))?;
+        out.log("Removed Future API key through Future Agent.");
+        Ok(())
+    }
 
-    let Some(current) = current.filter(|c| c.key.is_some()) else {
-        out.log("Not logged in.");
-        return Ok(());
-    };
-    // `const next = { ...current }; delete next.key;` — the sanitized
-    // entry (type/key/base_url only) minus the key.
-    let mut next = Map::new();
-    if let Some(type_) = current.type_ {
-        next.insert("type".to_string(), Value::String(type_));
+    #[cfg(test)]
+    {
+        let auth_file = load_auth_file().await?;
+        let current = get_future_auth_entry(&auth_file);
+
+        let Some(current) = current.filter(|c| c.key.is_some()) else {
+            out.log("Not logged in.");
+            return Ok(());
+        };
+        // `const next = { ...current }; delete next.key;` — the sanitized
+        // entry (type/key/base_url only) minus the key.
+        let mut next = Map::new();
+        if let Some(type_) = current.type_ {
+            next.insert("type".to_string(), Value::String(type_));
+        }
+        if let Some(base_url) = current.base_url {
+            next.insert("base_url".to_string(), Value::String(base_url));
+        }
+        let mut auth_file = auth_file;
+        if let Some(obj) = auth_file.as_object_mut() {
+            obj.insert(FUTURE_AUTH_PROVIDER.to_string(), Value::Object(next));
+        }
+        write_auth_file(&auth_file).await?;
+        out.log(&format!(
+            "Removed Future API key from {}",
+            auth_file_path().display()
+        ));
+        Ok(())
     }
-    if let Some(base_url) = current.base_url {
-        next.insert("base_url".to_string(), Value::String(base_url));
-    }
-    let mut auth_file = auth_file;
-    if let Some(obj) = auth_file.as_object_mut() {
-        obj.insert(FUTURE_AUTH_PROVIDER.to_string(), Value::Object(next));
-    }
-    write_auth_file(&auth_file).await?;
-    out.log(&format!(
-        "Removed Future API key from {}",
-        auth_file_path().display()
-    ));
-    Ok(())
 }
 
 /// `auth.baseUrl.replace(/\/api\/?$/, "")` — strip a trailing `/api` or
@@ -342,6 +392,7 @@ pub async fn load_auth_file() -> Result<Value, String> {
 }
 
 /// `saveAuth(authFile, token, platformUrl)` — merge into the `future` entry.
+#[cfg(test)]
 async fn save_auth(
     auth_file: &Value,
     token: &DeviceTokenResponse,
@@ -365,7 +416,26 @@ async fn save_auth(
     write_auth_file(&auth_file).await
 }
 
+#[cfg(not(test))]
+async fn save_auth(
+    _auth_file: &Value,
+    token: &DeviceTokenResponse,
+    platform_url: &str,
+) -> Result<(), String> {
+    RunClient::new(&grpc_addr())
+        .set_auth(future_rpc::proto::AuthUpdate {
+            provider: FUTURE_AUTH_PROVIDER.to_string(),
+            key: token.api_key.clone(),
+            base_url: format!("{platform_url}/api"),
+            ..Default::default()
+        })
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("Future Agent did not save the login credential: {error}"))
+}
+
 /// `writeAuthFile(authFile)` — mkdir -p, write pretty JSON + newline, 0600.
+#[cfg(test)]
 async fn write_auth_file(auth_file: &Value) -> Result<(), String> {
     let path = auth_file_path();
     // Invariant: auth_file_path() is always `<home>/.future/agent/auth.json`.

--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -13,7 +13,7 @@
 
 use crate::output::Output;
 use future_rpc::proto::future_agent_client::FutureAgentClient;
-use future_rpc::proto::{RpcCommand, StreamEvent, StreamRequest};
+use future_rpc::proto::{AuthUpdate, RpcCommand, StreamEvent, StreamRequest};
 use serde_json::{json, Map, Value};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -108,6 +108,26 @@ impl RunClient {
     pub async fn list_models(&self) -> Result<Value, String> {
         self.execute_command("list_models", RpcCommand::default(), None, 5)
             .await
+    }
+
+    /// Agent-authoritative, secret-redacted provider snapshot.
+    pub async fn list_providers(&self) -> Result<Value, String> {
+        self.execute_command("list_providers", RpcCommand::default(), None, 5)
+            .await
+    }
+
+    /// Persist one auth mutation through the Agent's sole-writer path.
+    pub async fn set_auth(&self, update: AuthUpdate) -> Result<Value, String> {
+        self.execute_command(
+            "set_auth",
+            RpcCommand {
+                auth_update: Some(update),
+                ..Default::default()
+            },
+            None,
+            10,
+        )
+        .await
     }
 
     /// `getState(sessionId?)` — `get_state` → SessionState JSON.

--- a/desktop/src-tauri/src/agent_bridge/config.rs
+++ b/desktop/src-tauri/src/agent_bridge/config.rs
@@ -7,54 +7,62 @@
 //! and live-session credentials internally, so no follow-up round-trip is
 //! needed on this path.
 //!
-//! Fallback keeps version skew and offline edits working: an unreachable
-//! agent, or one that predates these commands (it answers `success = false`
-//! with "unknown command"), sends the caller back to the GUI's own file
-//! writers plus the best-effort `reload_auth` follow-up — exactly the legacy
-//! behavior. An explicit rejection from an agent that DOES know the command
-//! (validation failure, e.g. a duplicate provider id) is surfaced as an error
-//! instead, never silently re-applied locally.
+//! There is deliberately no local-write fallback. A successful UI response
+//! means the Agent durably committed the mutation and refreshed live state;
+//! an unavailable or outdated Agent is an error. This keeps every client and
+//! every conversation on one authoritative configuration revision.
 
 use crate::agent_proto::{AuthUpdate, RpcCommand};
 use crate::AppError;
 
 use super::client::{base_command, connect_agent};
 
+/// Read the Agent-owned, secret-redacted provider snapshot. This deliberately
+/// does not inspect Desktop's filesystem, so a custom Agent endpoint or HOME
+/// cannot make the displayed state diverge from the process serving prompts.
+pub(crate) async fn list_providers() -> Result<crate::agent_providers::ProvidersView, AppError> {
+    let mut client = connect_agent().await?;
+    let response = client
+        .execute_command(base_command("list_providers", String::new()))
+        .await
+        .map_err(|status| {
+            AppError::Message(format!("Unable to list Future Agent providers: {status}"))
+        })?
+        .into_inner();
+    if !response.success {
+        return Err(if response.error.is_empty() {
+            "Future Agent rejected the provider snapshot request."
+                .to_string()
+                .into()
+        } else {
+            response.error.into()
+        });
+    }
+    serde_json::from_str(&response.data).map_err(|error| {
+        format!("Future Agent returned an invalid provider snapshot: {error}").into()
+    })
+}
+
 /// Send a config-write command to the agent.
 ///
-/// Returns `Ok(true)` when the agent applied the change (its live state is
-/// already refreshed), `Ok(false)` when the caller must fall back to the local
-/// file writers (agent unreachable or too old), and `Err` when the agent
-/// explicitly rejected the change.
+/// Returns only after the Agent applied the change and refreshed live state.
 async fn send_config_write(command: RpcCommand, context: &str) -> Result<bool, AppError> {
-    let mut client = match connect_agent().await {
-        Ok(client) => client,
-        Err(error) => {
-            eprintln!(
-                "FutureOS: agent unavailable for {context} ({error}); falling back to the local config write"
-            );
-            return Ok(false);
-        }
-    };
-    let response = match client.execute_command(command).await {
-        Ok(response) => response.into_inner(),
-        Err(status) => {
-            eprintln!(
-                "FutureOS: {context} failed at transport level ({status}); falling back to the local config write"
-            );
-            return Ok(false);
-        }
-    };
+    let mut client = connect_agent().await.map_err(|error| {
+        AppError::Message(format!(
+            "Future Agent is unavailable; {context} was not saved: {error}"
+        ))
+    })?;
+    let response = client
+        .execute_command(command)
+        .await
+        .map_err(|status| {
+            AppError::Message(format!(
+                "Future Agent did not complete {context}; nothing was saved: {status}"
+            ))
+        })?
+        .into_inner();
     if response.success {
         return Ok(true);
-    }
-    // A pre-item-2 agent answers success=false "unknown command: <type>".
-    // Treat it like an unavailable agent and let the caller fall back.
-    if response.error.contains("unknown command") {
-        eprintln!(
-            "FutureOS: agent does not support {context}; falling back to the local config write"
-        );
-        return Ok(false);
     }
     let message = if response.error.is_empty() {
         format!("Future Agent rejected {context}.")
@@ -146,6 +154,29 @@ pub(crate) async fn set_builtin_provider_base_url(
     .await
 }
 
+/// Atomically update a built-in provider's optional Base URL and API key.
+pub(crate) async fn update_builtin_provider(
+    id: &str,
+    base_url: Option<&str>,
+    api_key: Option<Option<&str>>,
+) -> Result<bool, AppError> {
+    let mut config = crate::agent_proto::ProviderUpsert {
+        id: id.to_string(),
+        ..Default::default()
+    };
+    if let Some(base_url) = base_url {
+        config.base_url = base_url.to_string();
+        config.clear_base_url = base_url.is_empty();
+    }
+    if let Some(api_key) = api_key {
+        match api_key {
+            Some(key) => config.api_key = key.to_string(),
+            None => config.clear_api_key = true,
+        }
+    }
+    upsert_provider(config).await
+}
+
 /// Create/update a `models.json` provider entry (plus optional auth key).
 pub(crate) async fn upsert_provider(
     config: crate::agent_proto::ProviderUpsert,
@@ -190,12 +221,14 @@ mod tests {
         let result = call().await;
         if let Some(prev) = prev {
             std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
+        } else {
+            std::env::remove_var("FUTURE_AGENT_GRPC_ADDR");
         }
         result
     }
 
     #[tokio::test]
-    async fn applied_rejected_and_fallback_outcomes() {
+    async fn applied_and_rejected_outcomes_never_fall_back() {
         let mock = mock_agent();
 
         // Agent applies the change.
@@ -224,25 +257,26 @@ mod tests {
             .expect_err("rejected");
         assert_eq!(error.to_string(), "Future Agent rejected set_auth.");
 
-        // Legacy agent: "unknown command" → caller falls back (Ok(false)).
+        // A legacy Agent cannot become a second authority via local fallback.
         mock.push(
             "set_auth",
             Reply::Reject("unknown command: set_auth".to_string()),
         );
-        assert!(!set_provider_key("future", "sk-1").await.expect("fallback"));
+        assert!(set_provider_key("future", "sk-1").await.is_err());
 
-        // Transport-level failure → fall back too.
+        // Transport failure means nothing is reported as saved.
         mock.push(
             "set_auth",
             Reply::Status(tonic::Code::Unavailable, "connection reset"),
         );
-        assert!(!set_provider_key("future", "sk-1").await.expect("fallback"));
+        let error = set_provider_key("future", "sk-1").await.unwrap_err();
+        assert!(error.to_string().contains("nothing was saved"));
 
-        // Agent unreachable at connect time → fall back.
-        let applied = with_broken_endpoint(|| set_provider_key("future", "sk-1"))
+        // Connect failure also refuses an out-of-band local write.
+        let error = with_broken_endpoint(|| set_provider_key("future", "sk-1"))
             .await
-            .expect("fallback");
-        assert!(!applied);
+            .unwrap_err();
+        assert!(error.to_string().contains("was not saved"));
     }
 
     #[tokio::test]
@@ -332,5 +366,35 @@ mod tests {
             .clone()
             .expect("provider config");
         assert_eq!(config.id, "custom");
+
+        // Built-in Base URL + key are one atomic Agent upsert, not two
+        // independently observable mutations.
+        mock.push("upsert_provider", Reply::Data("{}".to_string()));
+        assert!(update_builtin_provider(
+            "azure-openai-responses",
+            Some("https://tenant.openai.azure.com/openai"),
+            Some(Some("azure-key")),
+        )
+        .await
+        .expect("ok"));
+        let requests = mock.requests_of("upsert_provider");
+        let config = requests.last().unwrap().provider_config.as_ref().unwrap();
+        assert_eq!(config.base_url, "https://tenant.openai.azure.com/openai");
+        assert_eq!(config.api_key, "azure-key");
+        assert!(!config.clear_api_key);
+
+        mock.push("upsert_provider", Reply::Data("{}".to_string()));
+        assert!(update_builtin_provider(
+            "azure-openai-responses",
+            Some("https://other.openai.azure.com/openai"),
+            Some(None),
+        )
+        .await
+        .expect("ok"));
+        let requests = mock.requests_of("upsert_provider");
+        let config = requests.last().unwrap().provider_config.as_ref().unwrap();
+        assert_eq!(config.base_url, "https://other.openai.azure.com/openai");
+        assert!(config.api_key.is_empty());
+        assert!(config.clear_api_key);
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/config_observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/config_observer.rs
@@ -1,0 +1,109 @@
+//! Process-wide provider/auth configuration observer.
+//!
+//! Unlike run streams this subscription is not attached to a chat. It bridges
+//! the Agent's committed config revision to the WebView and remote clients so
+//! every endpoint invalidates provider/model state from the same completion.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::Emitter;
+
+use super::connect_agent;
+
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+pub fn spawn_provider_config_observer() {
+    if STARTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    tauri::async_runtime::spawn(run());
+}
+
+async fn run() {
+    let mut last_revision: Option<i64> = None;
+    let mut backoff = Duration::from_millis(250);
+    loop {
+        let result = observe_once(&mut last_revision, &mut backoff).await;
+        if let Err(error) = result {
+            eprintln!("FutureOS provider config observer reconnecting: {error}");
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(5));
+    }
+}
+
+async fn observe_once(
+    last_revision: &mut Option<i64>,
+    backoff: &mut Duration,
+) -> Result<(), crate::AppError> {
+    let mut client = connect_agent().await?;
+    let mut stream = client
+        .stream_events(crate::agent_proto::StreamRequest {
+            event_types: vec!["ping".to_string(), "provider_config_changed".to_string()],
+            global_events: true,
+            ..Default::default()
+        })
+        .await
+        .map_err(|error| format!("global config stream failed: {error}"))?
+        .into_inner();
+    // A successful attachment proves the Agent is healthy again. If this
+    // stream later closes, reconnect promptly instead of retaining the
+    // maximum delay accumulated during an earlier outage.
+    *backoff = Duration::from_millis(250);
+
+    while let Some(event) = stream
+        .message()
+        .await
+        .map_err(|error| format!("global config stream closed: {error}"))?
+    {
+        let mut payload = serde_json::from_str::<serde_json::Value>(&event.data)
+            .unwrap_or_else(|_| serde_json::json!({}));
+        let revision = payload
+            .get("revision")
+            .or_else(|| payload.get("configRevision"))
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        if event.r#type == "ping" {
+            // Always invalidate on a newly attached stream. Agent revisions
+            // are process-local and reset after restart, so equality alone
+            // cannot prove the underlying config/runtime generation is the
+            // same one we observed before the disconnect.
+            payload = serde_json::json!({
+                "revision": revision,
+                "providerId": "*",
+                "operation": "snapshot",
+                "authChanged": true,
+                "modelsChanged": true,
+            });
+        } else if last_revision.is_some_and(|seen| revision <= seen) {
+            // subscribe-before-snapshot can legitimately queue revision N and
+            // then emit a ping snapshot at N. The snapshot already invalidated
+            // every consumer, so do not trigger a duplicate reload.
+            continue;
+        }
+        if event.r#type != "provider_config_changed" && event.r#type != "ping" {
+            continue;
+        }
+        *last_revision = Some(revision);
+        let data = payload.to_string();
+        if let Some(handle) = crate::APP_HANDLE.get() {
+            let _ = handle.emit("provider-config-changed", &payload);
+        }
+        crate::remote::publish_event(
+            "_global",
+            "provider_config_changed",
+            &data,
+            "",
+            revision,
+            0,
+            &format!("provider-config-{revision}"),
+            "",
+            revision,
+            -1,
+        );
+    }
+    Err(crate::AppError::Message(
+        "global config stream ended".to_string(),
+    ))
+}

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -1,6 +1,7 @@
 mod approval;
 mod client;
 pub(crate) mod config;
+mod config_observer;
 mod headless;
 mod import;
 mod models;
@@ -23,6 +24,7 @@ pub use self::client::{
     prune_run_events_command, set_default_model_command, set_model_command,
     set_session_name_command, set_thinking_level_command, RpcResponseExt,
 };
+pub use self::config_observer::spawn_provider_config_observer;
 pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, PreparedPrompt};
 pub(crate) use self::import::{import_missing_sessions, list_agent_session_ids};
 pub use self::models::{list_agent_models, list_builtin_providers, AgentModelOption};
@@ -407,6 +409,7 @@ pub(crate) async fn provision_agent_session(
 ///
 /// Best-effort: if the agent isn't running there's no in-memory state to
 /// refresh, so an unavailable agent is treated as success.
+#[cfg(test)]
 pub async fn reload_agent_credentials() -> Result<(), crate::AppError> {
     let mut client = match connect_agent().await {
         Ok(client) => client,

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -566,6 +566,7 @@ async fn run_observer(
                     run_id: run_id.clone(),
                     after_idx: cursor,
                     atomic_attach: true,
+                    global_events: false,
                 })
                 .await
             {

--- a/desktop/src-tauri/src/agent_bridge/stream.rs
+++ b/desktop/src-tauri/src/agent_bridge/stream.rs
@@ -185,6 +185,7 @@ pub(super) async fn collect_agent_response(
                     run_id: canonical_run_id.to_string(),
                     after_idx: last_idx,
                     atomic_attach: true,
+                    global_events: false,
                 })
                 .await
                 .map(|response| response.into_inner())

--- a/desktop/src-tauri/src/agent_providers/catalog.rs
+++ b/desktop/src-tauri/src/agent_providers/catalog.rs
@@ -9,11 +9,16 @@
 //! the GUI has no independent id→name map to keep in sync.
 
 use std::collections::BTreeMap;
+#[cfg(test)]
 use std::path::PathBuf;
 
+#[cfg(test)]
 use serde_json::Value;
 
-use crate::auth_store::{agent_dir, FUTURE_PROVIDER_ID};
+#[cfg(test)]
+use crate::auth_store::agent_dir;
+use crate::auth_store::FUTURE_PROVIDER_ID;
+#[cfg(test)]
 use crate::config_io;
 
 #[derive(Debug, Clone)]
@@ -21,7 +26,9 @@ pub(crate) struct CatalogProviderSummary {
     /// Display name as supplied by the agent (single source of truth); falls
     /// back to the provider id for a pre-name agent.
     pub(super) name: String,
+    #[allow(dead_code)]
     pub(super) base_url: String,
+    #[allow(dead_code)]
     pub(super) model_count: usize,
 }
 
@@ -82,14 +89,17 @@ pub(super) fn catalog_unavailable(
     BTreeMap::new()
 }
 
+#[cfg(test)]
 pub(super) fn models_json_path() -> Result<PathBuf, crate::AppError> {
     Ok(agent_dir()?.join("models.json"))
 }
 
+#[cfg(test)]
 pub(super) fn future_models_cache_path() -> Result<PathBuf, crate::AppError> {
     Ok(agent_dir()?.join(".future-models-cache.json"))
 }
 
+#[cfg(test)]
 pub(super) fn future_model_count() -> usize {
     future_models_cache_path()
         .ok()

--- a/desktop/src-tauri/src/agent_providers/mod.rs
+++ b/desktop/src-tauri/src/agent_providers/mod.rs
@@ -14,12 +14,16 @@
 //! `validate` (custom-provider field validation), `write` (the mutating command
 //! paths). This module owns the public DTOs and the read-only `list` view.
 
+#[cfg(test)]
 use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
 use serde_json::Value;
 
+#[cfg(test)]
 use crate::auth_store::FUTURE_PROVIDER_ID;
+#[cfg(test)]
 use crate::config_io;
 
 mod catalog;
@@ -29,13 +33,13 @@ mod validate;
 mod write;
 
 pub use write::{
-    delete_custom_provider, set_builtin_provider_base_url, update_builtin_provider_key,
-    upsert_custom_provider,
+    delete_custom_provider, set_builtin_provider_base_url, update_builtin_provider,
+    update_builtin_provider_key, upsert_custom_provider,
 };
 
-use catalog::{
-    builtin_catalog_providers, future_model_count, models_json_path, CatalogProviderSummary,
-};
+#[cfg(test)]
+use catalog::{future_model_count, models_json_path, CatalogProviderSummary};
+#[cfg(test)]
 use write::{is_override_only, provider_base_url_override};
 
 /// Display name of the built-in Future provider. Shared with `write` so the
@@ -48,14 +52,14 @@ pub(super) const FUTURE_PROVIDER_NAME: &str = "Future";
 /// Base URL in the Providers page, stored as a `models.json` `baseUrl` override.
 pub(super) const BASE_URL_PLACEHOLDER: &str = "YOUR_RESOURCE";
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvidersView {
     pub builtin: Vec<BuiltinProvider>,
     pub custom: Vec<CustomProvider>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BuiltinProvider {
     pub id: String,
@@ -69,7 +73,7 @@ pub struct BuiltinProvider {
     pub requires_base_url: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomProvider {
     pub id: String,
@@ -134,21 +138,28 @@ pub struct SetBuiltinProviderBaseUrlInput {
     pub base_url: String,
 }
 
+/// Atomic built-in provider form submission. Presence is explicit so a single
+/// Agent transaction can update Base URL and set/clear/keep the key.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateBuiltinProviderInput {
+    pub id: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub update_api_key: bool,
+}
+
 pub async fn list_agent_providers() -> Result<ProvidersView, crate::AppError> {
-    // Display path stays lenient: a corrupt models.json shouldn't fail the whole
-    // Providers page — show built-ins and let the user fix the file. Write paths
-    // read strictly (see the upsert/delete functions) so they never clobber it.
-    let models = config_io::read_json_lenient(&models_json_path()?);
-    // Display path: a corrupt auth.json shouldn't blank the providers list, so
-    // fall back to empty (key badges show "Not Configured"); write paths stay strict.
-    let auth = Value::Object(crate::auth_store::read().unwrap_or_default());
-    let catalog = builtin_catalog_providers().await;
-    Ok(build_providers_view(&models, &auth, &catalog))
+    crate::agent_bridge::config::list_providers().await
 }
 
 /// Re-read the config files and rebuild the view with an already-fetched
 /// catalog. Used by the write paths so each command fetches the catalog once
 /// (for validation and for the view) instead of twice.
+#[cfg(test)]
 pub(super) fn refresh_view_with_catalog(
     catalog: &BTreeMap<String, CatalogProviderSummary>,
 ) -> Result<ProvidersView, crate::AppError> {
@@ -161,6 +172,7 @@ pub(super) fn refresh_view_with_catalog(
 /// Pure view assembly over the current config files and the agent-provided
 /// built-in catalog. Split out so the write paths can rebuild the view with
 /// the catalog they already fetched, and so tests can inject a fixture catalog.
+#[cfg(test)]
 fn build_providers_view(
     models: &Value,
     auth: &Value,
@@ -283,6 +295,7 @@ fn build_providers_view(
     ProvidersView { builtin, custom }
 }
 
+#[cfg(test)]
 fn auth_has_key(auth: &Value, id: &str) -> bool {
     auth.get(id)
         .and_then(|entry| entry.get("key"))

--- a/desktop/src-tauri/src/agent_providers/tests.rs
+++ b/desktop/src-tauri/src/agent_providers/tests.rs
@@ -728,31 +728,18 @@ async fn builtin_key_update_applied_by_agent_and_validated() {
 }
 
 #[tokio::test]
-async fn builtin_key_update_falls_back_to_local_writes() {
+async fn builtin_key_update_never_falls_back_to_local_writes() {
     let _lock = mock_agent_lock();
     let _home = HomeGuard::new("wr-key-local");
     let agent = ensure_mock_agent();
-    // A pre-item-2 agent answers "unknown command" → local fallback + reload.
+    // A legacy Agent cannot turn Desktop into a second writer.
     agent.script("set_auth", false, json!(null), "unknown command: set_auth");
-    let view = update_builtin_provider_key(key_input("deepseek", Some("sk-local")))
+    let error = update_builtin_provider_key(key_input("deepseek", Some("sk-local")))
         .await
-        .unwrap();
-    assert!(
-        view.builtin
-            .iter()
-            .find(|p| p.id == "deepseek")
-            .unwrap()
-            .has_api_key
-    );
-    assert_eq!(
-        crate::auth_store::read()
-            .unwrap()
-            .get("deepseek")
-            .and_then(|entry| entry.get("key"))
-            .and_then(Value::as_str),
-        Some("sk-local")
-    );
-    assert!(agent.served("reload_auth", ""));
+        .unwrap_err();
+    assert!(error.to_string().contains("unknown command"));
+    assert!(crate::auth_store::read().unwrap().get("deepseek").is_none());
+    assert!(!agent.served("reload_auth", ""));
 
     // An explicit rejection (NOT "unknown command") surfaces as an error.
     agent.script("set_auth", false, json!(null), "key rejected by policy");
@@ -819,19 +806,22 @@ async fn builtin_base_url_update_paths() {
     .await
     .is_err());
 
-    // Fallback: unknown command → local models.json override + reload.
+    // A legacy Agent error is surfaced and the local catalog remains unchanged.
     agent.script(
         "upsert_provider",
         false,
         json!(null),
         "unknown command: upsert_provider",
     );
-    let view =
+    let error =
         set_builtin_provider_base_url(base_url_input("deepseek", "https://local.example.com/v1"))
             .await
-            .unwrap();
-    let deepseek = view.builtin.iter().find(|p| p.id == "deepseek").unwrap();
-    assert_eq!(deepseek.base_url, "https://local.example.com/v1");
+            .unwrap_err();
+    assert!(error.to_string().contains("unknown command"));
+    assert!(
+        config_io::read_json_lenient(&models_json_path().unwrap())["providers"]["deepseek"]
+            .is_null()
+    );
 
     // Explicit rejection surfaces.
     agent.script("upsert_provider", false, json!(null), "bad base url");
@@ -860,7 +850,7 @@ async fn custom_provider_upsert_paths() {
     upsert_custom_provider(create).await.unwrap();
     assert!(agent.served("upsert_provider", ""));
 
-    // Fallback writes models.json + auth.json locally.
+    // A legacy Agent error must not write models.json or auth.json locally.
     agent.script(
         "upsert_provider",
         false,
@@ -869,18 +859,11 @@ async fn custom_provider_upsert_paths() {
     );
     let mut local = input("localp", "LocalP", true);
     local.api_key = Some("sk-local".to_string());
-    let view = upsert_custom_provider(local).await.unwrap();
-    assert!(view.custom.iter().any(|p| p.id == "localp"));
+    let error = upsert_custom_provider(local).await.unwrap_err();
+    assert!(error.to_string().contains("unknown command"));
     let doc = config_io::read_json_lenient(&models_json_path().unwrap());
-    assert_eq!(doc["providers"]["localp"]["name"], json!("LocalP"));
-    assert_eq!(
-        crate::auth_store::read()
-            .unwrap()
-            .get("localp")
-            .and_then(|entry| entry.get("key"))
-            .and_then(Value::as_str),
-        Some("sk-local")
-    );
+    assert!(doc["providers"]["localp"].is_null());
+    assert!(crate::auth_store::read().unwrap().get("localp").is_none());
 
     // Explicit rejection surfaces.
     agent.script(
@@ -964,7 +947,7 @@ async fn custom_provider_delete_paths() {
         .await
         .is_err());
 
-    // Fallback deletes both local entries.
+    // A legacy Agent error leaves both local entries untouched.
     upsert_custom_provider_with_catalog(input("gone2", "Gone2", true), &fixture_catalog()).unwrap();
     crate::auth_store::set_provider_key("gone2", "sk-g").unwrap();
     agent.script(
@@ -973,9 +956,15 @@ async fn custom_provider_delete_paths() {
         json!(null),
         "unknown command: delete_provider",
     );
-    let view = delete_custom_provider("gone2".to_string()).await.unwrap();
-    assert!(view.custom.iter().all(|p| p.id != "gone2"));
-    assert!(crate::auth_store::read().unwrap().get("gone2").is_none());
+    let error = delete_custom_provider("gone2".to_string())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("unknown command"));
+    assert!(crate::auth_store::read().unwrap().get("gone2").is_some());
+    assert!(
+        config_io::read_json_lenient(&models_json_path().unwrap())["providers"]["gone2"]
+            .is_object()
+    );
 
     // Explicit rejection surfaces.
     agent.script(

--- a/desktop/src-tauri/src/agent_providers/validate.rs
+++ b/desktop/src-tauri/src/agent_providers/validate.rs
@@ -3,6 +3,7 @@
 //! before — and separate from — the locked models.json read-modify-write in
 //! [`super::write`].
 
+#[cfg(test)]
 use serde_json::{json, Value};
 
 use crate::auth_store::FUTURE_PROVIDER_ID;
@@ -33,6 +34,7 @@ pub(super) struct ValidatedModel {
 }
 
 /// Serialize validated models to the models.json entry shape.
+#[cfg(test)]
 pub(super) fn model_json_values(models: &[ValidatedModel]) -> Vec<Value> {
     models
         .iter()

--- a/desktop/src-tauri/src/agent_providers/write.rs
+++ b/desktop/src-tauri/src/agent_providers/write.rs
@@ -1,41 +1,40 @@
 //! Mutating command paths for provider configuration: built-in API key / Base
 //! URL overrides and custom-provider upsert/delete.
 //!
-//! Each operation is RPC-first (audit item 2): the validated change is sent to
-//! the agent via `set_auth` / `upsert_provider` / `delete_provider`, and the
-//! agent writes its own auth.json/models.json and refreshes live sessions. The
-//! locked local read-modify-write remains as the fallback for an unreachable
-//! or pre-item-2 agent (then followed by the best-effort `reload_auth`). The
-//! synchronous `_with_catalog` cores are exactly that local path — validation
-//! plus file writes — which keeps the module tests agent-free.
+//! Production writes are Agent-only: success means the Agent durably wrote its
+//! config and refreshed live state. The synchronous `_with_catalog` helpers
+//! remain only for isolated storage contract tests; production never falls
+//! back to an out-of-band GUI write.
 
 use std::collections::BTreeMap;
 
-use serde_json::{Map, Value};
+#[cfg(test)]
+use serde_json::Map;
+#[cfg(test)]
+use serde_json::Value;
 
 use crate::agent_bridge::config as agent_config;
 use crate::auth_store::FUTURE_PROVIDER_ID;
+#[cfg(test)]
 use crate::config_io;
 use crate::AppError;
 
-use super::catalog::{builtin_catalog_providers, models_json_path, CatalogProviderSummary};
+#[cfg(test)]
+use super::catalog::models_json_path;
+use super::catalog::{builtin_catalog_providers, CatalogProviderSummary};
+#[cfg(test)]
+use super::refresh_view_with_catalog;
+#[cfg(test)]
+use super::validate::model_json_values;
 use super::validate::{
-    is_ascii_no_control, model_json_values, validate_custom_provider, ValidatedCustomProvider,
-    API_KEY_MAX_LEN, BASE_URL_MAX_LEN,
+    is_ascii_no_control, validate_custom_provider, ValidatedCustomProvider, API_KEY_MAX_LEN,
+    BASE_URL_MAX_LEN,
 };
 use super::{
-    refresh_view_with_catalog, ProvidersView, SetBuiltinProviderBaseUrlInput,
+    ProvidersView, SetBuiltinProviderBaseUrlInput, UpdateBuiltinProviderInput,
     UpdateBuiltinProviderKeyInput, UpsertCustomProviderInput, BASE_URL_PLACEHOLDER,
     FUTURE_PROVIDER_NAME,
 };
-
-/// Best-effort `reload_auth` after a LOCAL config write: the agent caches the
-/// resolved credentials per session, so the file change alone leaves live
-/// sessions on the old state. Not needed when the RPC write path was used —
-/// the agent refreshed itself.
-async fn reload_after_local_write() {
-    let _ = crate::agent_bridge::reload_agent_credentials().await;
-}
 
 /// One-shot injected failure for the paired auth.json write of a transactional
 /// local write. models.json and auth.json live in the same directory, so a
@@ -56,6 +55,7 @@ fn injected_auth_write_failure() -> Result<(), AppError> {
 
 /// The auth half of the transactional upsert. A thin wrapper so the test-only
 /// failure injection (see above) shares one line with the real call.
+#[cfg(test)]
 fn paired_key_write(id: &str, key: &str) -> Result<(), AppError> {
     #[cfg(test)]
     injected_auth_write_failure()?;
@@ -97,6 +97,7 @@ fn validate_builtin_key_update<'a>(
 }
 
 /// Local fallback: write the key straight to auth.json.
+#[cfg(test)]
 fn apply_builtin_key_update_local(id: &str, api_key: Option<&str>) -> Result<(), AppError> {
     if let Some(key) = api_key {
         crate::auth_store::set_provider_key(id, key)?;
@@ -113,19 +114,56 @@ pub async fn update_builtin_provider_key(
     // Validate before the RPC so bad input never reaches the agent; the
     // fallback core below re-validates from the same input.
     let (id, api_key) = validate_builtin_key_update(&input, &catalog)?;
-    let applied = match api_key {
+    match api_key {
         Some(key) => agent_config::set_provider_key(id, key).await?,
         None => agent_config::clear_provider_key(id).await?,
     };
-    if applied {
-        // The agent wrote auth.json and refreshed live sessions itself.
-        return refresh_view_with_catalog(&catalog);
-    }
-    let view = update_builtin_provider_key_with_catalog(input, &catalog)?;
-    reload_after_local_write().await;
-    Ok(view)
+    super::list_agent_providers().await
 }
 
+pub async fn update_builtin_provider(
+    input: UpdateBuiltinProviderInput,
+) -> Result<ProvidersView, AppError> {
+    let catalog = builtin_catalog_providers().await;
+    let key_input = UpdateBuiltinProviderKeyInput {
+        id: input.id.clone(),
+        api_key: input.api_key.clone(),
+    };
+    let (id, api_key_change) = if input.update_api_key {
+        let (id, key) = validate_builtin_key_update(&key_input, &catalog)?;
+        (id.to_string(), Some(key.map(str::to_string)))
+    } else {
+        let id = input.id.trim();
+        if id.is_empty() || id == FUTURE_PROVIDER_ID || !catalog.contains_key(id) {
+            return Err("Unknown or unsupported built-in provider."
+                .to_string()
+                .into());
+        }
+        (id.to_string(), None)
+    };
+    let base_url = if let Some(base_url) = input.base_url.as_ref() {
+        let base_input = SetBuiltinProviderBaseUrlInput {
+            id: id.clone(),
+            base_url: base_url.clone(),
+        };
+        let (_, validated) = validate_builtin_base_url_update(&base_input, &catalog)?;
+        Some(validated.to_string())
+    } else {
+        None
+    };
+    if base_url.is_none() && api_key_change.is_none() {
+        return Err("No provider changes were supplied.".to_string().into());
+    }
+    agent_config::update_builtin_provider(
+        &id,
+        base_url.as_deref(),
+        api_key_change.as_ref().map(|key| key.as_deref()),
+    )
+    .await?;
+    super::list_agent_providers().await
+}
+
+#[cfg(test)]
 pub(super) fn update_builtin_provider_key_with_catalog(
     input: UpdateBuiltinProviderKeyInput,
     catalog: &BTreeMap<String, CatalogProviderSummary>,
@@ -176,6 +214,7 @@ fn validate_builtin_base_url_update<'a>(
 
 /// Local fallback: strict, per-path-locked models.json read-modify-write of
 /// the `baseUrl` override.
+#[cfg(test)]
 fn apply_builtin_base_url_local(id: &str, base_url: &str) -> Result<(), AppError> {
     let models_path = models_json_path()?;
     config_io::with_config_lock(&models_path, || {
@@ -222,15 +261,11 @@ pub async fn set_builtin_provider_base_url(
 ) -> Result<ProvidersView, AppError> {
     let catalog = builtin_catalog_providers().await;
     let (id, base_url) = validate_builtin_base_url_update(&input, &catalog)?;
-    let applied = agent_config::set_builtin_provider_base_url(id, base_url).await?;
-    if applied {
-        return refresh_view_with_catalog(&catalog);
-    }
-    let view = set_builtin_provider_base_url_with_catalog(input, &catalog)?;
-    reload_after_local_write().await;
-    Ok(view)
+    agent_config::set_builtin_provider_base_url(id, base_url).await?;
+    super::list_agent_providers().await
 }
 
+#[cfg(test)]
 pub(super) fn set_builtin_provider_base_url_with_catalog(
     input: SetBuiltinProviderBaseUrlInput,
     catalog: &BTreeMap<String, CatalogProviderSummary>,
@@ -311,6 +346,7 @@ fn provider_upsert_message(
                 modalities: model.modalities.clone(),
             })
             .collect(),
+        replace_models: true,
         create_only: validated.create,
         api_key: validated.api_key.clone().unwrap_or_default(),
         ..Default::default()
@@ -323,6 +359,7 @@ fn provider_upsert_message(
 /// on either file never leaves a dangling key or a provider whose models and
 /// key disagree. The models write comes first; if the key write then fails, the
 /// models file is rolled back to its exact pre-call bytes.
+#[cfg(test)]
 fn apply_upsert_local(validated: &ValidatedCustomProvider) -> Result<(), AppError> {
     let models_path = models_json_path()?;
     config_io::with_config_lock(&models_path, || {
@@ -408,16 +445,11 @@ pub async fn upsert_custom_provider(
     // needs it.
     let validated = validate_custom_provider(input.clone())?;
     validate_upsert_against_catalog(&validated, &catalog)?;
-    let applied = agent_config::upsert_provider(provider_upsert_message(&validated)).await?;
-    if applied {
-        // The agent wrote models.json/auth.json and refreshed live sessions.
-        return refresh_view_with_catalog(&catalog);
-    }
-    let view = upsert_custom_provider_with_catalog(input, &catalog)?;
-    reload_after_local_write().await;
-    Ok(view)
+    agent_config::upsert_provider(provider_upsert_message(&validated)).await?;
+    super::list_agent_providers().await
 }
 
+#[cfg(test)]
 pub(super) fn upsert_custom_provider_with_catalog(
     input: UpsertCustomProviderInput,
     catalog: &BTreeMap<String, CatalogProviderSummary>,
@@ -452,6 +484,7 @@ fn validate_delete_id(
 }
 
 /// Local fallback: remove the models.json entry AND the auth.json credentials.
+#[cfg(test)]
 fn apply_delete_local(id: &str) -> Result<(), AppError> {
     let models_path = models_json_path()?;
     config_io::with_config_lock(&models_path, || {
@@ -522,16 +555,11 @@ fn apply_delete_local(id: &str) -> Result<(), AppError> {
 pub async fn delete_custom_provider(id: String) -> Result<ProvidersView, AppError> {
     let catalog = builtin_catalog_providers().await;
     let id = validate_delete_id(&id, &catalog)?;
-    let applied = agent_config::delete_provider(&id).await?;
-    if applied {
-        // The agent removed its models.json + auth.json entries and refreshed.
-        return refresh_view_with_catalog(&catalog);
-    }
-    let view = delete_custom_provider_with_catalog(id, &catalog)?;
-    reload_after_local_write().await;
-    Ok(view)
+    agent_config::delete_provider(&id).await?;
+    super::list_agent_providers().await
 }
 
+#[cfg(test)]
 pub(super) fn delete_custom_provider_with_catalog(
     id: String,
     catalog: &BTreeMap<String, CatalogProviderSummary>,
@@ -546,6 +574,7 @@ pub(super) fn delete_custom_provider_with_catalog(
 /// True when a models.json provider entry only carries overrides (Base URL) for
 /// a built-in provider, i.e. it defines no `name`, `api`, or explicit `models`.
 /// Such entries are surfaced through the built-in list rather than as customs.
+#[cfg(test)]
 pub(super) fn is_override_only(config: &Value) -> bool {
     let has_str = |key: &str| {
         config
@@ -563,6 +592,7 @@ pub(super) fn is_override_only(config: &Value) -> bool {
 }
 
 /// The stored Base URL override for a provider, if any (non-empty).
+#[cfg(test)]
 pub(super) fn provider_base_url_override(models: &Value, id: &str) -> Option<String> {
     models
         .get("providers")

--- a/desktop/src-tauri/src/auth_store.rs
+++ b/desktop/src-tauri/src/auth_store.rs
@@ -86,6 +86,7 @@ fn upsert_provider_entry(
 
 /// Set a provider's API key, preserving any other fields on the entry (e.g. the
 /// FutureGene entry's `base_url`). Defaults `type` to `api_key` when absent.
+#[cfg(test)]
 pub(crate) fn set_provider_key(id: &str, key: &str) -> Result<(), AppError> {
     upsert_provider_entry(id, |object| {
         object.insert("key".to_string(), Value::String(key.to_string()));
@@ -94,6 +95,7 @@ pub(crate) fn set_provider_key(id: &str, key: &str) -> Result<(), AppError> {
 
 /// Remove a provider's API key but keep the rest of the entry (e.g. FutureGene
 /// logout retains `base_url`). Returns whether a key was present.
+#[cfg(test)]
 pub(crate) fn remove_provider_key(id: &str) -> Result<bool, AppError> {
     let path = auth_json_path()?;
     config_io::with_config_lock(&path, || {
@@ -115,6 +117,7 @@ pub(crate) fn remove_provider_key(id: &str) -> Result<bool, AppError> {
 /// `future` entry. Mirrors the CLI's `saveAuth` (which writes
 /// `base_url = {platform}/api`) so a GUI login and a CLI login leave identical
 /// `auth.json` state — and the agent/Providers page resolve the same platform.
+#[cfg(test)]
 pub(crate) fn set_future_login(key: &str, base_url: &str) -> Result<(), AppError> {
     upsert_provider_entry(FUTURE_PROVIDER_ID, |object| {
         object.insert("key".to_string(), Value::String(key.to_string()));
@@ -123,6 +126,7 @@ pub(crate) fn set_future_login(key: &str, base_url: &str) -> Result<(), AppError
 }
 
 /// FutureGene logout: drop the key, keep `base_url`. Returns whether removed.
+#[cfg(test)]
 pub(crate) fn clear_future_key() -> Result<bool, AppError> {
     remove_provider_key(FUTURE_PROVIDER_ID)
 }

--- a/desktop/src-tauri/src/commands/login.rs
+++ b/desktop/src-tauri/src/commands/login.rs
@@ -1,8 +1,8 @@
 //! FutureGene device-code login Tauri commands (see desktop/ER.md §6.9).
 
 use crate::agent_providers::{self, ProvidersView};
+use crate::agent_supervisor;
 use crate::future_login::{self, FutureBalance, FutureLoginPoll, FutureLoginStart, FutureProfile};
-use crate::{agent_supervisor, auth_store};
 
 #[tauri::command]
 pub async fn start_future_login() -> Result<FutureLoginStart, crate::AppError> {
@@ -34,23 +34,15 @@ pub async fn poll_future_login<R: tauri::Runtime>(
         }
         let handle = app.clone();
         std::thread::spawn(move || agent_supervisor::ensure_agent_running(&handle));
-        // Credential persistence + live-session refresh now happen inside
-        // `future_login::poll` (RPC-first via set_auth, with a local-write +
-        // reload_auth fallback), so no separate refresh is needed here.
+        // Credential persistence + live-session refresh completed inside the
+        // Agent before `future_login::poll` reported authorization.
     }
     Ok(result)
 }
 
 #[tauri::command]
 pub async fn logout_future_provider() -> Result<ProvidersView, crate::AppError> {
-    // RPC-first (audit item 2): the agent drops the key from its own auth.json
-    // and refreshes live sessions so the user can't keep prompting with the
-    // stale key after logout. Fallback for an unreachable/pre-item-2 agent:
-    // local file write + best-effort reload_auth (the legacy path).
-    if !crate::agent_bridge::config::future_logout().await? {
-        auth_store::clear_future_key()?;
-        let _ = crate::agent_bridge::reload_agent_credentials().await;
-    }
+    crate::agent_bridge::config::future_logout().await?;
     agent_providers::list_agent_providers().await
 }
 
@@ -132,16 +124,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn logout_future_provider_falls_back_when_the_agent_is_down() {
+    async fn logout_future_provider_keeps_credentials_when_the_agent_is_down() {
         let _lock = mock_agent_lock();
         let _home = HomeGuard::new("cmd-login-logout-fb");
         crate::auth_store::set_future_login("sekret", "https://future-os.cn/api").unwrap();
-        let view = crate::commands::agent_mock::with_broken_endpoint(logout_future_provider)
+        let error = crate::commands::agent_mock::with_broken_endpoint(logout_future_provider)
             .await
-            .expect("logout fallback");
-        assert!(!view.builtin.is_empty());
-        // The local fallback cleared the stored key.
-        assert!(crate::future_login::future_api_key().is_err());
+            .expect_err("logout must fail without the Agent");
+        assert!(error.to_string().contains("not saved"));
+        assert_eq!(crate::future_login::future_api_key().unwrap(), "sekret");
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/commands/providers.rs
+++ b/desktop/src-tauri/src/commands/providers.rs
@@ -28,6 +28,13 @@ pub async fn update_builtin_provider_key(
 }
 
 #[tauri::command]
+pub async fn update_builtin_provider(
+    input: agent_providers::UpdateBuiltinProviderInput,
+) -> Result<agent_providers::ProvidersView, crate::AppError> {
+    agent_providers::update_builtin_provider(input).await
+}
+
+#[tauri::command]
 pub async fn set_builtin_provider_base_url(
     input: agent_providers::SetBuiltinProviderBaseUrlInput,
 ) -> Result<agent_providers::ProvidersView, crate::AppError> {
@@ -54,12 +61,14 @@ mod tests {
             tauri::generate_handler![
                 upsert_custom_provider,
                 update_builtin_provider_key,
+                update_builtin_provider,
                 set_builtin_provider_base_url,
                 delete_custom_provider
             ],
             &[
                 "upsert_custom_provider",
                 "update_builtin_provider_key",
+                "update_builtin_provider",
                 "set_builtin_provider_base_url",
                 "delete_custom_provider",
             ],

--- a/desktop/src-tauri/src/config_io.rs
+++ b/desktop/src-tauri/src/config_io.rs
@@ -86,6 +86,7 @@ pub fn read_json_object(path: &Path) -> Result<Value, AppError> {
 /// Lenient read for best-effort *cache* files where a corrupt file should not
 /// surface an error to the user (e.g. a model-count cache): missing or
 /// unparseable → an empty object.
+#[cfg(test)]
 pub fn read_json_lenient(path: &Path) -> Value {
     std::fs::read_to_string(path)
         .ok()
@@ -154,6 +155,7 @@ pub fn write_bytes_atomic(path: &Path, bytes: &[u8], owner_only: bool) -> Result
 /// it). Any OTHER read error (permission, transient I/O) surfaces as `Err` —
 /// it must never be confused with "did not exist", which would make rollback
 /// DELETE an existing file.
+#[cfg(test)]
 pub fn snapshot_file(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
     match std::fs::read(path) {
         Ok(bytes) => Ok(Some(bytes)),
@@ -165,6 +167,7 @@ pub fn snapshot_file(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
 /// Best-effort restore of a snapshot taken by [`snapshot_file`]. Used only on
 /// the error path, so a failed restore is logged to stderr rather than
 /// shadowing the original error being returned to the caller.
+#[cfg(test)]
 pub fn restore_file(path: &Path, snapshot: Option<&[u8]>, owner_only: bool) {
     let result = match snapshot {
         Some(bytes) => write_bytes_atomic(path, bytes, owner_only),

--- a/desktop/src-tauri/src/future_login.rs
+++ b/desktop/src-tauri/src/future_login.rs
@@ -261,14 +261,10 @@ pub async fn poll(device_code: &str) -> Result<FutureLoginPoll, AppError> {
         // Only report success after the key is durably written. Pin `base_url`
         // to the resolved platform (`{platform}/api`), exactly as the CLI does,
         // so a GUI login and a CLI login leave identical `auth.json` state.
-        // RPC-first (audit item 2): the agent writes its own auth.json and
-        // refreshes live sessions. An unreachable or pre-item-2 agent falls
-        // back to the local file write plus the best-effort reload_auth, so a
-        // login during agent startup still lands (the agent reads auth.json at
-        // boot anyway).
+        // The Agent is the sole writer. Authorization is reported complete
+        // only after it durably stores the key and refreshes live sessions.
         let base_url = format!("{platform}/api");
-        let registered = crate::agent_bridge::config::future_login(key.trim(), &base_url).await?;
-        persist_future_login_if_needed(registered, key.trim(), &base_url).await?;
+        crate::agent_bridge::config::future_login(key.trim(), &base_url).await?;
         return Ok(FutureLoginPoll::of("authorized"));
     }
 
@@ -359,22 +355,6 @@ fn validate_browser_url(target: &str) -> Result<(), AppError> {
         return Err(AppError::Message(
             "Authorization URL scheme is not permitted.".to_string(),
         ));
-    }
-    Ok(())
-}
-
-/// Write the login key to `auth.json` and reload agent credentials when the
-/// RPC-first write did not already persist it (agent unreachable, or a legacy
-/// agent without `set_auth`). Extracted so the already-registered no-op path is
-/// testable without a live mock agent.
-async fn persist_future_login_if_needed(
-    registered: bool,
-    key: &str,
-    base_url: &str,
-) -> Result<(), AppError> {
-    if !registered {
-        crate::auth_store::set_future_login(key, base_url)?;
-        let _ = crate::agent_bridge::reload_agent_credentials().await;
     }
     Ok(())
 }
@@ -520,14 +500,6 @@ mod tests {
     fn open_browser_uses_injected_opener() {
         let _ = BROWSER_OPENER.set(|_| Ok(()));
         open_browser("https://example.com/device");
-    }
-
-    #[tokio::test]
-    async fn persist_future_login_skips_when_already_registered() {
-        // RPC-first path already persisted the key → the local fallback no-ops.
-        persist_future_login_if_needed(true, "key", "https://future-os.cn/api")
-            .await
-            .unwrap();
     }
 
     #[tokio::test]
@@ -892,12 +864,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_authorized_writes_key_via_local_fallback() {
+    async fn poll_does_not_report_authorized_when_agent_write_fails() {
         let _home = crate::auth_store::test_support::HomeGuard::new("fl-poll-ok");
         // Force `connect_agent` to fail deterministically with an unparseable
         // endpoint — `Endpoint::from_shared` fails before the latched channel
-        // is consulted, so the RPC-first write reports "unreachable" and poll
-        // falls back to the local auth.json write. Restore the env var after
+        // is consulted. Restore the env var after
         // instead of re-pointing at the shared mock: starting the mock here
         // would re-order the process-wide agent-channel latch and break the
         // agent_bridge mock tests.
@@ -908,12 +879,15 @@ mod tests {
         )]);
         point_auth(&url);
 
-        let out = with_broken_agent_endpoint(|| poll("dc")).await.unwrap();
+        let error = with_broken_agent_endpoint(|| poll("dc"))
+            .await
+            .expect_err("authorization must wait for the Agent write");
 
-        assert_eq!(out.status, "authorized");
-        assert_eq!(
-            crate::auth_store::read().unwrap()["future"]["key"],
-            "sekret"
-        );
+        assert!(error.to_string().contains("not saved"));
+        assert!(crate::auth_store::read()
+            .unwrap()
+            .get("future")
+            .and_then(|entry| entry.get("key"))
+            .is_none());
     }
 }

--- a/desktop/src-tauri/src/future_platform.rs
+++ b/desktop/src-tauri/src/future_platform.rs
@@ -58,6 +58,7 @@ pub(crate) fn resolve_future_platform_url(auth: &Value) -> String {
 
 /// Resolve the FutureGene **model API** base URL: `{platform}/api/v1`. This is
 /// what the Providers page shows and what model calls use.
+#[cfg(test)]
 pub(crate) fn resolve_future_base_url(auth: &Value) -> String {
     format!("{}/api/v1", resolve_future_platform_url(auth))
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -691,6 +691,9 @@ pub fn run() {
             // pipeline collector owns, NATS mirroring). Attach/retry happens
             // inside each observer task, so a down agent never blocks startup.
             agent_bridge::seed_observers_from_store();
+            // Global provider/auth completion stream. This is independent of
+            // chat observers and fans committed revisions to WebView + Mobile.
+            agent_bridge::spawn_provider_config_observer();
             // Discovery: conversations created by other clients (TUI/CLI) get
             // a thread stub + an observer — streaming ones within ~1s, idle
             // ones on the 60s import pass.
@@ -765,6 +768,7 @@ pub fn run() {
             list_agent_providers,
             upsert_custom_provider,
             update_builtin_provider_key,
+            update_builtin_provider,
             set_builtin_provider_base_url,
             delete_custom_provider,
             start_future_login,

--- a/desktop/src-tauri/src/remote/test_support.rs
+++ b/desktop/src-tauri/src/remote/test_support.rs
@@ -286,6 +286,35 @@ fn default_answer(
                 },
             },
         })),
+        "list_providers" => ok(json!({
+            "builtin": [
+                {
+                    "id": "future",
+                    "name": "Future",
+                    "baseUrl": "https://future-os.cn/api/v1",
+                    "hasApiKey": false,
+                    "modelCount": 9,
+                    "requiresBaseUrl": false
+                },
+                {
+                    "id": "deepseek",
+                    "name": "DeepSeek",
+                    "baseUrl": "https://api.deepseek.com/v1",
+                    "hasApiKey": false,
+                    "modelCount": 3,
+                    "requiresBaseUrl": false
+                },
+                {
+                    "id": "azure-openai-responses",
+                    "name": "Azure OpenAI Responses",
+                    "baseUrl": "https://YOUR_RESOURCE.openai.azure.com/openai",
+                    "hasApiKey": false,
+                    "modelCount": 1,
+                    "requiresBaseUrl": true
+                }
+            ],
+            "custom": []
+        })),
         "get_messages" => ok(json!({
             "messages": [
                 { "role": "user", "content": "hi" },

--- a/desktop/src/components/layout/hooks/useAgentConnection.ts
+++ b/desktop/src/components/layout/hooks/useAgentConnection.ts
@@ -168,6 +168,10 @@ export function useAgentConnection(hiddenModels: string[]): UseAgentConnectionRe
     () => onFutureEvent("future-models-synced", () => void refreshAgentModels()),
     [refreshAgentModels],
   );
+  useEffect(
+    () => onFutureEvent("providers-changed", () => void refreshAgentModels()),
+    [refreshAgentModels],
+  );
 
   const visibleModelOptions = useMemo(
     () => modelOptions.filter(model => !hiddenModels.includes(modelKey(model))),

--- a/desktop/src/components/layout/hooks/useHasProviders.ts
+++ b/desktop/src/components/layout/hooks/useHasProviders.ts
@@ -30,6 +30,7 @@ export function useHasProviders() {
   );
 
   useEffect(() => onFutureEvent("future-auth-changed", reload), [reload]);
+  useEffect(() => onFutureEvent("providers-changed", reload), [reload]);
 
   const [byokMode, setByokMode] = useState(false);
   // True while the post-login init runs (models + skills + agent readiness).

--- a/desktop/src/features/settings/ProvidersPage.tsx
+++ b/desktop/src/features/settings/ProvidersPage.tsx
@@ -7,12 +7,11 @@ import {
   deleteCustomProvider,
   listAgentProviders,
   logoutFutureProvider,
-  setBuiltinProviderBaseUrl,
-  updateBuiltinProviderKey,
+  updateBuiltinProvider,
   upsertCustomProvider,
 } from "../../integrations/agent/providers";
 import { errorMessage } from "../../lib/errors";
-import { emitFutureEvent } from "../../lib/futureEvents";
+import { emitFutureEvent, onFutureEvent } from "../../lib/futureEvents";
 import { useAsyncResource } from "../../lib/useAsyncResource";
 import { BuiltinProviderKeyDialog } from "./BuiltinProviderKeyDialog";
 import { CustomProviderDialog } from "./CustomProviderDialog";
@@ -40,7 +39,7 @@ export function ProvidersPage({
   onProvidersChanged?: () => void;
 } = {}) {
   const { t } = useTranslation("settings");
-  const { data: loadedProviders, loading, error } = useAsyncResource<ProvidersView | null>(
+  const { data: loadedProviders, loading, error, reload } = useAsyncResource<ProvidersView | null>(
     listAgentProviders,
     [],
     null,
@@ -62,6 +61,7 @@ export function ProvidersPage({
     if (loadedProviders)
       setProviders(loadedProviders);
   }, [loadedProviders]);
+  useEffect(() => onFutureEvent("providers-changed", reload), [reload]);
 
   async function handleDelete(id: string) {
     setActionError(null);
@@ -94,14 +94,12 @@ export function ProvidersPage({
     provider: BuiltinProvider,
     payload: { apiKey?: string | null; baseUrl?: string },
   ) {
-    // Base URL first, then key; apply each step's fresh view as it lands so a
-    // failure in the second step can't leave a persisted first step invisible.
-    if (payload.baseUrl !== undefined) {
-      setProviders(await setBuiltinProviderBaseUrl({ baseUrl: payload.baseUrl, id: provider.id }));
-    }
-    if (payload.apiKey !== undefined) {
-      setProviders(await updateBuiltinProviderKey({ apiKey: payload.apiKey, id: provider.id }));
-    }
+    setProviders(await updateBuiltinProvider({
+      apiKey: payload.apiKey,
+      baseUrl: payload.baseUrl,
+      id: provider.id,
+      updateApiKey: payload.apiKey !== undefined,
+    }));
     setEditingBuiltinKey(null);
     const cleared = payload.apiKey === null;
     setHint(

--- a/desktop/src/integrations/agent/agentStateCache.test.ts
+++ b/desktop/src/integrations/agent/agentStateCache.test.ts
@@ -23,11 +23,14 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 type Listener = (event: { payload: Record<string, unknown> | undefined }) => void;
 let agentEventListener: Listener | null = null;
+let providerConfigListener: Listener | null = null;
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: (name: string, handler: Listener) => {
     if (name === "agent-event")
       agentEventListener = handler;
+    if (name === "provider-config-changed")
+      providerConfigListener = handler;
     return Promise.resolve(() => {});
   },
 }));
@@ -59,6 +62,30 @@ describe("agentStateCache fetch/cache", () => {
     installAgentEventListener();
     installAgentEventListener();
     expect(agentEventListener).not.toBeNull();
+  });
+
+  it("bridges Agent provider completion into the typed UI event bus", () => {
+    installAgentEventListener();
+    const handler = vi.fn();
+    window.addEventListener("futureos:providers-changed", handler);
+    act(() => {
+      providerConfigListener?.({
+        payload: {
+          revision: 7,
+          providerId: "custom",
+          operation: "updated",
+          authChanged: true,
+          modelsChanged: true,
+        },
+      });
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0]?.[0] as CustomEvent).detail).toMatchObject({
+      revision: 7,
+      providerId: "custom",
+      operation: "updated",
+    });
+    window.removeEventListener("futureos:providers-changed", handler);
   });
 
   it("fetches and parses session state including activeRun variants", async () => {

--- a/desktop/src/integrations/agent/agentStateCache.ts
+++ b/desktop/src/integrations/agent/agentStateCache.ts
@@ -235,6 +235,17 @@ export function installAgentEventListener() {
     return;
   eventListenerInstalled = true;
 
+  void listen<Record<string, unknown>>("provider-config-changed", (event) => {
+    const p = event.payload ?? {};
+    emitFutureEvent("providers-changed", {
+      revision: typeof p.revision === "number" ? p.revision : 0,
+      providerId: typeof p.providerId === "string" ? p.providerId : "*",
+      operation: typeof p.operation === "string" ? p.operation : "snapshot",
+      authChanged: p.authChanged !== false,
+      modelsChanged: p.modelsChanged !== false,
+    });
+  });
+
   void listen<Record<string, unknown>>("agent-event", (event) => {
     const p = event.payload;
     if (!p)

--- a/desktop/src/integrations/agent/providers.ts
+++ b/desktop/src/integrations/agent/providers.ts
@@ -81,6 +81,15 @@ export async function updateBuiltinProviderKey(input: {
   return view;
 }
 
+export async function updateBuiltinProvider(input: {
+  id: string;
+  baseUrl?: string;
+  apiKey?: string | null;
+  updateApiKey: boolean;
+}) {
+  return invokeCommand<ProvidersView>("update_builtin_provider", { input });
+}
+
 export async function setBuiltinProviderBaseUrl(input: {
   id: string;
   /** Empty string clears the override, reverting to the catalog placeholder. */

--- a/desktop/src/integrations/agent/useProviderNames.ts
+++ b/desktop/src/integrations/agent/useProviderNames.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { onFutureEvent } from "../../lib/futureEvents";
 import { useAsyncResource } from "../../lib/useAsyncResource";
 import { listAgentProviders } from "./providers";
 
@@ -7,7 +9,7 @@ import { listAgentProviders } from "./providers";
  * back to the id. Best-effort: errors leave the map empty.
  */
 export function useProviderNames(): Record<string, string> {
-  const { data } = useAsyncResource<Record<string, string>>(
+  const { data, reload } = useAsyncResource<Record<string, string>>(
     async () => {
       const view = await listAgentProviders();
       const map: Record<string, string> = {};
@@ -19,6 +21,8 @@ export function useProviderNames(): Record<string, string> {
     [],
     {},
   );
+
+  useEffect(() => onFutureEvent("providers-changed", reload), [reload]);
 
   return data;
 }

--- a/desktop/src/lib/futureEvents.ts
+++ b/desktop/src/lib/futureEvents.ts
@@ -38,6 +38,14 @@ export interface FutureEventMap {
    * app-wide login gate reloads so the forced-login overlay appears / clears.
    */
   "future-auth-changed": void;
+  /** Agent-confirmed provider/auth commit, shared by every local UI surface. */
+  "providers-changed": {
+    revision: number;
+    providerId: string;
+    operation: string;
+    authChanged: boolean;
+    modelsChanged: boolean;
+  };
   /** Show the onboarding gate (e.g. when the user clicks "Connect" in Settings). */
   "show-onboarding": void;
   /** Emitted when a conversation finishes (agent_end stream event). */

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -242,6 +242,13 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     (event: StreamEvent, sessionId: string) => {
       const sid = sessionId || "";
       if (!sid) return;
+      if (event.type === "provider_config_changed") {
+        // Process-wide Agent completion mirrored on the `_global` subject.
+        // Re-read the catalogue from the authority; never project this as chat
+        // content or retain an endpoint-local optimistic model list.
+        void refreshModels();
+        return;
+      }
       // Side effects that read event payloads directly (not timeline writes):
       // these stay outside the lane because they don't mutate the session
       // timeline — the lane only receives pure timeline events.
@@ -303,7 +310,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       syncEngineRef.current?.event(sid, event);
       if (event.type === "agent_end") void refreshSessions();
     },
-    [reconcileSession, refreshSessions, setTitleOverrides],
+    [reconcileSession, refreshModels, refreshSessions, setTitleOverrides],
   );
 
   const closeConversation = useCallback(() => {

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -379,6 +379,29 @@ describe("RemoteClient terminal iterator recovery", () => {
     );
   });
 
+  test("the global provider completion subject reaches the control-plane callback", async () => {
+    const { client, callbacks } = recoveryClient();
+    const testClient = client as unknown as {
+      subscribeEvents(connection: unknown, generation: number): void;
+    };
+    async function* events() {
+      yield {
+        subject: "p.pair_1.evt._global",
+        data: new TextEncoder().encode(JSON.stringify({
+          type: "provider_config_changed",
+          data: JSON.stringify({ revision: 9, providerId: "custom" }),
+        })),
+      };
+      await new Promise(() => {});
+    }
+    testClient.subscribeEvents({ subscribe: () => events() }, 0);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(callbacks.onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "provider_config_changed" }),
+      "_global",
+    );
+  });
+
   test.each(["subscribeTransfers", "subscribeLiveness", "subscribeState"] as const)(
     "%s reconnects when its iterator ends independently",
     async method => {

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -343,6 +343,7 @@ impl AgentClient {
                 event_types: vec![],
                 after_idx,
                 atomic_attach: true,
+                global_events: false,
             });
             let mut stream = match self.inner.stream_events(request).await {
                 Ok(resp) => resp.into_inner(),

--- a/rpc/proto/future.proto
+++ b/rpc/proto/future.proto
@@ -293,7 +293,9 @@ message ProviderUpsert {
   // Remove the "baseUrl" override; the entry is dropped if nothing remains.
   bool clear_base_url = 5;
 
-  // Non-empty: replace the "models" list.
+  // Replacement model list. `replace_models` carries presence so an empty
+  // repeated field can explicitly clear every model instead of meaning
+  // "leave unchanged".
   repeated ProviderModel models = 6;
 
   // Fail when the provider already exists (create mode; edits must not
@@ -302,6 +304,13 @@ message ProviderUpsert {
 
   // Non-empty: also store as this provider's auth.json "key".
   string api_key = 8;
+
+  // Apply `models`, including an empty list, as a full replacement.
+  bool replace_models = 9;
+
+  // Remove this provider's auth.json key in the same transaction as the
+  // models.json/baseUrl mutation.
+  bool clear_api_key = 10;
 }
 
 // A model entry under a custom provider, persisted to models.json.
@@ -1070,6 +1079,11 @@ message StreamRequest {
   string run_id = 3;
   int64 after_idx = 4;
   bool atomic_attach = 5;
+
+  // Subscribe to process-wide Agent control-plane events instead of one
+  // session. When true, session_id/run_id must be empty and atomic_attach
+  // false. The initial ping carries the current config revision.
+  bool global_events = 6;
 }
 
 // ── StreamEvent ─────────────────────────────────────────────────────────────
@@ -1092,6 +1106,7 @@ message StreamEvent {
   //   usage                        token accounting
   //   error                        run error
   //   tool_sandboxed / persistence_error / compaction_end   sideband signals
+  //   provider_config_changed  global provider/auth configuration committed
   //
   // Provider-specific aliases are normalized inside the Agent and never cross
   // this RPC boundary.

--- a/rpc/src/generated/proto.rs
+++ b/rpc/src/generated/proto.rs
@@ -202,7 +202,9 @@ pub struct ProviderUpsert {
     /// Remove the "baseUrl" override; the entry is dropped if nothing remains.
     #[prost(bool, tag = "5")]
     pub clear_base_url: bool,
-    /// Non-empty: replace the "models" list.
+    /// Replacement model list. `replace_models` carries presence so an empty
+    /// repeated field can explicitly clear every model instead of meaning
+    /// "leave unchanged".
     #[prost(message, repeated, tag = "6")]
     pub models: ::prost::alloc::vec::Vec<ProviderModel>,
     /// Fail when the provider already exists (create mode; edits must not
@@ -212,6 +214,13 @@ pub struct ProviderUpsert {
     /// Non-empty: also store as this provider's auth.json "key".
     #[prost(string, tag = "8")]
     pub api_key: ::prost::alloc::string::String,
+    /// Apply `models`, including an empty list, as a full replacement.
+    #[prost(bool, tag = "9")]
+    pub replace_models: bool,
+    /// Remove this provider's auth.json key in the same transaction as the
+    /// models.json/baseUrl mutation.
+    #[prost(bool, tag = "10")]
+    pub clear_api_key: bool,
 }
 /// A model entry under a custom provider, persisted to models.json.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1146,6 +1155,11 @@ pub struct StreamRequest {
     pub after_idx: i64,
     #[prost(bool, tag = "5")]
     pub atomic_attach: bool,
+    /// Subscribe to process-wide Agent control-plane events instead of one
+    /// session. When true, session_id/run_id must be empty and atomic_attach
+    /// false. The initial ping carries the current config revision.
+    #[prost(bool, tag = "6")]
+    pub global_events: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamEvent {
@@ -1166,6 +1180,7 @@ pub struct StreamEvent {
     ///    usage                        token accounting
     ///    error                        run error
     ///    tool_sandboxed / persistence_error / compaction_end   sideband signals
+    ///    provider_config_changed  global provider/auth configuration committed
     ///
     /// Provider-specific aliases are normalized inside the Agent and never cross
     /// this RPC boundary.


### PR DESCRIPTION
## Summary

- make Future Agent the sole writer and authoritative reader for provider/auth configuration across Desktop and CLI
- add atomic provider mutations, including explicit empty-model replacement and combined built-in Base URL plus key updates
- reconcile live sessions after provider deletion or credential changes and preserve provider-qualified model identity
- broadcast committed provider revisions to Desktop and Mobile so provider/model views refresh across endpoints

## Fixed review items

- P1.2, P1.3, P1.5, P1.6
- P2.8, P2.9, P2.10

## Validation

- Agent library: 1384 tests passed
- CLI: 697 unit tests plus binary/integration tests passed
- Desktop Rust: 988 tests passed
- Desktop frontend: lint/typecheck/stylelint and 564 tests passed
- Mobile: typecheck/lint and 301 tests passed
- Rust workspace and Desktop clippy passed with warnings denied
- RPC and channel code generation is clean
- rebased onto latest origin/main