### PR TITLE
ci: remove coverage ratchet gate from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       rust_workspace: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.rust_workspace == 'true' || steps.filter.outputs.ci == 'true' }}
       loop_canary: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.loop_canary == 'true' || steps.filter.outputs.ci == 'true' }}
-      coverage_scripts: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.coverage_scripts == 'true' || steps.filter.outputs.ci == 'true' }}
       desktop_tauri: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.desktop_tauri == 'true' || steps.filter.outputs.ci == 'true' }}
       desktop_frontend: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.desktop_frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       mobile: ${{ steps.force.outputs.all == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ci == 'true' }}
@@ -76,12 +75,6 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
-            # P1-7: the ratchet machinery itself must revalidate the gate (a
-            # baseline-only edit is the ratchet-down approval path).
-            coverage_scripts:
-              - 'scripts/coverage.sh'
-              - 'scripts/coverage_ratchet.py'
-              - 'scripts/coverage-baseline.json'
             desktop_tauri:
               - 'desktop/src-tauri/**'
               - '.cargo/**'
@@ -386,70 +379,6 @@ jobs:
       - name: Canary premerge gate
         run: ./target/debug/future-loop canary premerge --json
 
-  # ─── Coverage ratchet gate (P1-7) ────────────────────────────────────────
-  # Only-up coverage gate: measures workspace line coverage via
-  # scripts/coverage.sh (cargo llvm-cov) and fails if any crate drops below
-  # its floor in scripts/coverage-baseline.json. Rises are always allowed;
-  # an intentional drop is approved by lowering the floor file in the same
-  # PR (that diff is the explicit ratchet-down approval). This deliberately
-  # re-runs the test suite instrumented rather than sharing rust-tests'
-  # run — llvm-cov needs its own build profile.
-  coverage-ratchet:
-    name: Coverage ratchet (workspace lines)
-    needs: changes
-    if: needs.changes.outputs.rust_workspace == 'true' || needs.changes.outputs.coverage_scripts == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Install llvm-tools-preview
-        run: rustup component add llvm-tools-preview
-
-      # Prebuilt binary install (cargo install would compile for minutes).
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-          cache-on-failure: true
-          cache-all-crates: true
-
-      # mold: .cargo/config.toml pins -fuse-ld=mold for Linux targets. No
-      # WebKit/GTK needed — the desktop Tauri backend is not part of the
-      # workspace coverage measurement. libssl for the agent's TLS deps.
-      - name: Install Linux deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential mold pkg-config libssl-dev
-
-      - name: Coverage ratchet gate
-        run: scripts/coverage.sh --check
-
-  # ─── Rust 3-platform compile check ───────────────────────────────────────
-  # The quality gate above only runs on Linux, so platform-conditional code was
-  # never type-checked on Windows/macOS — exactly how the desktop Tauri backend
-  # regressed twice (a macOS-only fix dropped the `windows` crate and broke
-  # Windows, and vice versa) with no PR signal. This matrix runs `cargo check`
-  # on every release target so a missing `cfg`/crate surfaces on the PR.
-  #
-  # Scope: the whole workspace (agent / channels) plus the desktop Tauri
-  # backend. `cargo check` type-checks without linking the final crate, but it
-  # DOES link build scripts / proc-macros, so each OS still needs its linker
-  # story: Linux needs mold (`.cargo/config.toml`'s -fuse-ld=mold) and the
-  # WebKit/GTK libs (the -sys build scripts run pkg-config). No protoc is
-  # needed: proto generation is gated on REGENERATE_PROTO and the generated
-  # code is checked in. The desktop backend's `bundle.externalBin` sidecars don't
-  # exist in a bare check, so we drop empty placeholders (tauri-build only
-  # checks presence; `binaries/` is gitignored).
   rust-build:
     name: Rust build (${{ matrix.name }})
     needs: changes


### PR DESCRIPTION
移除 Coverage ratchet job（非 required，但反复因平台漂移/插桩 flake 失败，浪费 CI 时间）。ci.yml 删 job + path filter + 输出引用；本地 scripts/coverage.sh --check 与 coverage_ratchet.py 保留为可选工具。