### PR TITLE
refactor(loop): drop post-removal residues — orphan list command + stale comments

### DIFF
--- a/orchestration/loop/src/cli/registry.rs
+++ b/orchestration/loop/src/cli/registry.rs
@@ -65,7 +65,7 @@ impl Journey {
                 "todos, gates, replans, leases, quota — the day-to-day control surface"
             }
             Journey::Driver => "per-turn loop execution: run envelopes, heartbeats, agent lanes",
-            Journey::Setup => "one-time configuration: authority, profiles, extensions, automation",
+            Journey::Setup => "one-time configuration: authority, profiles, automation",
             Journey::Maintainer => {
                 "quality gates (benchmark/canary/replay), retention, introspection"
             }
@@ -146,8 +146,7 @@ impl CommandRegistry {
         usage: &str,
         experimental: bool,
     ) -> &mut Self {
-        // Idempotent: re-registering the same name in the same group is a no-op
-        // (extension install may re-declare a manifest that provides commands).
+        // Idempotent: re-registering the same name in the same group is a no-op.
         let already = self
             .commands
             .iter()

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -169,9 +169,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
 }
 
 /// P1-9: operator journey assignments for the statically registered
-/// commands (`future loop commands` grouped view; LoopX `loopx commands`
-/// five-group presentation). Capability command hooks are not listed here —
-/// they keep the maintainer default as ecosystem/adapter surface. A test
+/// commands (`future loop commands` grouped view). A test
 /// (`journey_assignments_cover_every_static_command`) keeps this table in
 /// sync with `build_cli_registry`.
 const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
@@ -202,7 +200,6 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("turn", Journey::Driver),
     ("heartbeat-prompt", Journey::Driver),
     ("worker-bridge", Journey::Driver),
-    ("list", Journey::Driver),
     ("scope", Journey::Driver),
     ("lane", Journey::Driver),
     ("supervisor", Journey::Driver),
@@ -300,12 +297,6 @@ fn build_cli_registry() -> CommandRegistry {
         "agent",
         "register/onboard agents + multi-agent contract/recipe/succession/collective surface (G12)",
         "agent onboard --goal G --agent-id A [--recipe N] | list|contract|recipe|succession|collective --goal G",
-    );
-    r.command(
-        agent,
-        "list",
-        "registered agents + live execution status (leases)",
-        "agent list --goal G [--format json]",
     );
     r.command(
         agent,

--- a/orchestration/loop/src/decision/goal_frontier/mod.rs
+++ b/orchestration/loop/src/decision/goal_frontier/mod.rs
@@ -11,8 +11,7 @@
 //!     (disposition → replan decision + obligation), an ordered policy
 //!     table with a default rule set and a `ReplanRuleSetUpdated` event;
 //!   - [`semantic_history`]: the goal-level bounded semantic event history
-//!     (recent N=50 semantic summaries folded from the event ledger),
-//!     consumable by the decision-context assembler;
+//!     (recent N=50 semantic summaries folded from the event ledger);
 //!   - [`terminal`]: terminal judgement — closure validation that
 //!     enumerates acceptance-gap semantics and every remaining blocker as
 //!     explicit gap entries, aligned with the existing

--- a/orchestration/loop/src/decision/goal_frontier/semantic_history.rs
+++ b/orchestration/loop/src/decision/goal_frontier/semantic_history.rs
@@ -8,9 +8,9 @@
 //! [`SEMANTIC_HISTORY_CAP`] (oldest dropped) so the projection is a pure,
 //! deterministic function of event order.
 //!
-//! The decision-context assembler consumes it through the
-//! `semantic_history` provider (ids/summaries only — summaries are
-//! truncated at write time so the packet stays public-safe).
+//! The semantic event history is a standalone goal-level projection
+//! (ids/summaries only — summaries are truncated at write time so the
+//! packet stays public-safe).
 
 use serde::{Deserialize, Serialize};
 

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -770,7 +770,7 @@ pub struct Goal {
     /// G13 ③: goal-level bounded semantic event history (recent
     /// [`crate::decision::goal_frontier::semantic_history::SEMANTIC_HISTORY_CAP`]
     /// summaries, oldest dropped) — folded from the event ledger during
-    /// replay; consumable by the decision-context `semantic_history` provider.
+    /// replay; a standalone goal-level projection (public-safe summaries).
     #[serde(default)]
     pub semantic_history: Vec<crate::decision::goal_frontier::semantic_history::SemanticEvent>,
     /// G13 ②: explicit replan rule set (folded from `ReplanRuleSetUpdated`;

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -54,7 +54,7 @@ fn help_lists_all_pre_existing_commands_in_groups() {
         "gate resolve --goal G",
         "── agent ──",
         "agent onboard --goal G",
-        "agent list --goal G",
+        "| list|contract|recipe|succession|collective --goal G",
         "── ops ──",
         "quota should-run --goal G",
         "scheduler tick|show|record-host-failure",

--- a/orchestration/loop/tests/decision_split_regression.rs
+++ b/orchestration/loop/tests/decision_split_regression.rs
@@ -12,11 +12,10 @@
 //!    (goal, now, agent_id) and compare the serialized packets field by
 //!    field (recursive JSON equality, volatile fields masked).
 //! 3. The ONLY intended deltas are the G-2/G-11 `scheduler_arbitration`
-//!    record (new field, observe-only) and the per-tool-quota
-//!    `capability_repair_allowed` predicate (LoopX 对比改进项 ②: was a
-//!    constant `false` pre-split, now computed from the goal's capability
-//!    invocation projection): both asserted, then removed from the
-//!    comparison.
+//!    record (new field, observe-only) and the wire-compat
+//!    `capability_repair_allowed` predicate (constant `false` — the
+//!    capability framework was removed): both asserted, then removed from
+//!    the comparison.
 //!
 //! If this test fails, the split drifted from the baseline: either a helper
 //! subdomain changed a field, or the arbitration layer mutated behavior.


### PR DESCRIPTION
loop-lean-audit.md 10 项残留全部清除：孤儿顶层 list 命令、capability/decision-context 时代陈旧注释、--capability 单数别名。零行为变化；fmt/clippy/68 targets 本地全绿。