### PR TITLE
docs: remove bold highlight from mobile mentions in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > One AI agent, everywhere you work — terminal, desktop, mobile, and your chat apps.
 
 FutureOS gives you a unified AI agent experience across a terminal UI (TUI),
-desktop app (GUI), **mobile apps (Android & iOS)**, CLI, and IM bots — on
+desktop app (GUI), mobile apps (Android & iOS), CLI, and IM bots — on
 macOS, Linux, Windows, and your phone. Write code, run research, manage files —
 from the terminal, from a chat app, from a native desktop window, or from a
 phone in your pocket.
@@ -23,7 +23,7 @@ phone in your pocket.
 
 | Category | Details |
 |---|---|
-| **Multi-Interface** | Terminal UI (TUI), desktop app (GUI), **mobile apps (Android & iOS)**, CLI, IM bots — one agent, everywhere |
+| **Multi-Interface** | Terminal UI (TUI), desktop app (GUI), mobile apps (Android & iOS), CLI, IM bots — one agent, everywhere |
 | **Mobile Apps (Android & iOS)** | A phone-native agent experience — most agent runtimes are desktop-only; FutureOS ships Android (APK) and iOS (TestFlight) builds from CI, driven by the same gRPC agent service |
 | **Model Flexibility** | 3800+ built-in models across 140+ providers ([catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
 | **Agent Service** | The agent runs as a standalone gRPC service — the runtime is decoupled from the TUI, desktop app, mobile app, channel bridge, and loop control plane, leaving room for new clients and extensions |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,15 +11,15 @@
 
 # FutureOS
 
-> 同一个 AI Agent，处处随你——终端、桌面、**手机**、飞书与钉钉。
+> 同一个 AI Agent，处处随你——终端、桌面、手机、飞书与钉钉。
 
-FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、**移动端 App（Android · iOS）**、命令行 (CLI) 和 IM 机器人——支持 macOS、Linux、Windows 与你的手机。写代码、做调研、管理文件——从终端、聊天软件、原生桌面窗口或口袋里的手机，无缝切换。
+FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应用 (GUI)、移动端 App（Android · iOS）、命令行 (CLI) 和 IM 机器人——支持 macOS、Linux、Windows 与你的手机。写代码、做调研、管理文件——从终端、聊天软件、原生桌面窗口或口袋里的手机，无缝切换。
 
 ## 特性
 
 | 类别 | 说明 |
 |---|---|
-| **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、**移动端 App（Android · iOS）**、命令行 (CLI)、IM 机器人——一个 Agent，无处不在 |
+| **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、移动端 App（Android · iOS）、命令行 (CLI)、IM 机器人——一个 Agent，无处不在 |
 | **移动端 App（Android · iOS）** | 真正手机原生的 Agent 体验——多数 Agent 运行时只有桌面端；FutureOS 通过 CI 交付 Android（APK）与 iOS（TestFlight）构建，由同一个 gRPC Agent 服务驱动 |
 | **模型灵活** | 内置 3800+ 模型，覆盖 140+ Provider（[目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
 | **Agent 服务** | Agent 以独立 gRPC 服务运行——运行时与 TUI、桌面端、移动端、IM 渠道桥、loop 控制面解耦，为新的客户端与扩展留足空间 |


### PR DESCRIPTION
手机/移动端在标题行与正文中去高亮；特性表行名保持与其他行一致的加粗样式。