### PR TITLE
docs: drop standalone Mobile Apps row from README feature tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ phone in your pocket.
 | Category | Details |
 |---|---|
 | **Multi-Interface** | Terminal UI (TUI), desktop app (GUI), mobile apps (Android & iOS), CLI, IM bots — one agent, everywhere |
-| **Mobile Apps (Android & iOS)** | A phone-native agent experience — most agent runtimes are desktop-only; FutureOS ships Android (APK) and iOS (TestFlight) builds from CI, driven by the same gRPC agent service |
 | **Model Flexibility** | 3800+ built-in models across 140+ providers ([catalog](docs/wiki/en/Models.md)); custom providers via `models.json`; scoped model lists |
 | **Agent Service** | The agent runs as a standalone gRPC service — the runtime is decoupled from the TUI, desktop app, mobile app, channel bridge, and loop control plane, leaving room for new clients and extensions |
 | **Minimalist Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt) — Pi-style minimalism: a lean tool set, no prompt bloat |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,6 @@ FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应�
 | 类别 | 说明 |
 |---|---|
 | **多端统一** | 终端界面 (TUI)、桌面应用 (GUI)、移动端 App（Android · iOS）、命令行 (CLI)、IM 机器人——一个 Agent，无处不在 |
-| **移动端 App（Android · iOS）** | 真正手机原生的 Agent 体验——多数 Agent 运行时只有桌面端；FutureOS 通过 CI 交付 Android（APK）与 iOS（TestFlight）构建，由同一个 gRPC Agent 服务驱动 |
 | **模型灵活** | 内置 3800+ 模型，覆盖 140+ Provider（[目录](docs/wiki/zh/Models.md)）；通过 `models.json` 自定义 Provider；支持模型范围限定 |
 | **Agent 服务** | Agent 以独立 gRPC 服务运行——运行时与 TUI、桌面端、移动端、IM 渠道桥、loop 控制面解耦，为新的客户端与扩展留足空间 |
 | **极简工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt）——Pi 式极简主义：工具集精简，杜绝 prompt 膨胀 |


### PR DESCRIPTION
移动端已在多端统一行体现，独立行删除。