### PR TITLE
docs: skill-driven loop entry section in loop-control-plane (EN+ZH)

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -46,6 +46,31 @@ agent executes one bounded turn (gRPC) → writes evidence → kernel decides th
 | Multi-agent | `agent contract/recipe/succession/collective` | One goal, several workers: contract (backups / handoff rules), named recipes for one-command onboarding, auto back-up promotion on offline timeout, wake roster, collective turn ledger |
 | Frontier | `frontier show` | Outcome segments, structured replan rules, bounded semantic history (N=50), terminal judgement |
 
+## Drive loop via the skill (recommended entry)
+
+In most cases you won't type the CLI below — **use the `/future-loop` skill
+and let the agent drive**:
+
+```
+You say "/future-loop keep an eye on X for a week"
+   │
+   ▼
+Agent loads the future-loop skill (v3.x driving manual)
+   ├─ 1. `future loop status` first — continue an existing goal, never duplicate it
+   ├─ 2. Confirm the plan with you (steps/model/thinking level) — unless your message already carries the full objective + constraints
+   ├─ 3. `goal init` + decompose todos (dependencies via --blocks, hard checks via --verify/--acceptance)
+   ├─ 4. Drive turns: `run --max-turns 1 --agent-id <unique>`, relaunching the moment a turn exits
+   ├─ 5. Steer a drifting worker mid-turn via `todo update --text`
+   ├─ 6. Irreversible/expensive/user-only decisions → open a user gate and wait (gates freeze everything)
+   └─ 7. Close out: acceptance todo copies artifacts to the project root → validated closure (terminal)
+```
+
+**Skill vs CLI**: the skill owns "what to do when, how to decompose, how to
+drive" (the orchestration layer); the CLI is the underlying mechanism (state
+kernel + hard checks + decisions). The skill is a maintained v3.x manual, kept
+in sync with this page; full semantics at
+[future-skills/builtin/future-loop](https://github.com/futuregene/future-skills/tree/main/builtin/future-loop).
+
 ## User workflow (zero to closure)
 
 ```bash

--- a/docs/loop-control-plane.zh-CN.md
+++ b/docs/loop-control-plane.zh-CN.md
@@ -39,6 +39,28 @@ Agent 执行一个有界回合（gRPC）→ 写证据 → 内核据此决定下�
 | 多 agent | `agent contract/recipe/succession/collective` | 一个目标多个 worker：契约（替补关系/交接规则）、命名配方一键上车、离线超时自动替补晋升、唤醒轮值表、集体回合账本 |
 | 前端面 frontier | `frontier show` | 成果连续段（outcome segments）、结构化 replan 规则、有界语义历史（N=50）、终局判定 |
 
+## 用技能驱动 loop（推荐入口）
+
+绝大多数情况下，你不需要手敲下面的 CLI——**用 `/future-loop` 技能让 Agent 自己驾驶**：
+
+```
+你（用户）说 "/future-loop 帮我盯着 X 一周"
+   │
+   ▼
+Agent 加载 future-loop 技能（v3.x 驾驶手册）
+   ├─ 1. 先 `future loop status` 查是否已有同类目标（有则续做，不重复建）
+   ├─ 2. 与你确认计划（步骤/模型/thinking level）——除非你的指令已含完整目标与约束
+   ├─ 3. `goal init` + 拆 todos（依赖 --blocks、硬校验 --verify/--acceptance 一起挂）
+   ├─ 4. 逐回合驱动：`run --max-turns 1 --agent-id <唯一名>`，回合结束立即重启
+   ├─ 5. 用 `todo update --text` 中途 steering 纠正跑偏的 worker
+   ├─ 6. 遇到不可逆/昂贵/用户专属决策 → 挂 user gate 等你拍板（gate 冻结一切）
+   └─ 7. 收尾：验收 todo 拷贝交付物到项目根 → validated closure（terminal）
+```
+
+**技能与 CLI 的分工**：技能负责"何时该做什么、如何拆解、如何驾驶"（编排层）；
+CLI 是底层机制（状态内核 + 硬校验 + 决策）。技能是 v3.x 持续维护的驾驶手册，
+与本页同步更新；完整语义见 [future-skills/builtin/future-loop](https://github.com/futuregene/future-skills/tree/main/builtin/future-loop)。
+
 ## 用户工作流（从零到闭环）
 
 ```bash


### PR DESCRIPTION
把 /future-loop 技能驱动作为推荐入口重点章节（用户→技能→编排→CLI 机制的分工与七步流程），双版同步。