### PR TITLE
fix(agent): list user-configured models.json models without API keys

### DIFF
--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -735,6 +735,16 @@ impl Registry {
         }
     }
 
+    /// Whether the model was explicitly configured by the user in
+    /// models.json (as opposed to coming from the builtin catalog). Used by
+    /// `list_models` to keep user-configured models listed even when they
+    /// carry no API key (e.g. local endpoints like `http://127.0.0.1:8000`).
+    pub fn is_user_defined(&self, model: &Model) -> bool {
+        self.user
+            .iter()
+            .any(|u| u.provider == model.provider && u.id == model.id)
+    }
+
     /// Get all available models (user models override built-in with same ID).
     /// Models with `hide: true` are excluded from the listing but remain callable via `resolve()`.
     pub fn all_models(&self) -> Vec<Model> {

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -1004,10 +1004,19 @@ fn list_models_response(
     let auth = crate::AuthStore::load();
 
     // Always return all available models.  Scoping / defaults are client-side.
+    // Builtin catalog models are only listed when they are credential-reachable
+    // (an API key inline or in auth.json) — otherwise the picker would drown
+    // under ~900 unusable entries.  Models the user explicitly configured in
+    // models.json are always listed: they are intentional even when keyless
+    // (e.g. a local Ollama-style endpoint that needs no key at all).
     let mut models: Vec<crate::models::Model> = registry
         .all_models()
         .into_iter()
-        .filter(|model| !model.api_key.is_empty() || auth.get(&model.provider).is_some())
+        .filter(|model| {
+            registry.is_user_defined(model)
+                || !model.api_key.is_empty()
+                || auth.get(&model.provider).is_some()
+        })
         .filter(|model| model.output.iter().any(|o| o == "text"))
         .collect();
 
@@ -5219,6 +5228,39 @@ mod tests {
             .find(|m| m["id"] == "unnamed-model")
             .expect("unnamed model listed");
         assert_eq!(model["label"], "unnamed-model");
+    }
+
+    #[test]
+    fn list_models_lists_keyless_user_models() {
+        // A user model from models.json with no apiKey (e.g. a local endpoint)
+        // must still appear in list_models — the credential filter only
+        // applies to builtin catalog entries.
+        let home = TestHome::new();
+        std::fs::create_dir_all(home.models_path().parent().unwrap()).unwrap();
+        std::fs::write(
+            home.models_path(),
+            r#"{
+              "providers": {
+                "local": {
+                  "api": "openai-completions",
+                  "baseUrl": "http://127.0.0.1:8000/v1",
+                  "models": [
+                    {"id": "local-model", "modalities": ["text"]}
+                  ]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        let state = make_app_state();
+        let resp = parse_response(&handle_command_internal(&state, make_cmd("list_models")));
+        let models = resp["data"]["models"].as_array().unwrap();
+        let model = models
+            .iter()
+            .find(|m| m["id"] == "local-model")
+            .expect("keyless user model listed");
+        assert_eq!(model["provider"], "local");
+        assert_eq!(model["label"], "local-model");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`/model`, `/scoped-models` (TUI) and the GUI model picker never showed models from custom providers defined in `~/.future/agent/models.json` unless the provider carried an API key inline or in `auth.json`.

Root cause: `list_models_response` filtered every model with

```rust
.filter(|model| !model.api_key.is_empty() || auth.get(&model.provider).is_some())
```

Custom providers like a local Ollama-style endpoint (`http://127.0.0.1:8000/v1`) need no key at all, so their models were silently dropped — while `list_providers` (GUI settings page) lists the same keyless providers. The TUI itself needed no change: it only parses the `list_models` response.

## Fix

- `Registry::is_user_defined()` — whether a model came from the user's models.json.
- `list_models_response` now always lists user-configured models; the credential filter applies only to builtin catalog models (so the picker isn't flooded with ~900 unusable entries).
- Regression test: keyless models.json model appears in `list_models` with provider + label intact.

## Verification

`future models` with `azure`, `realapi` (no keys), `omlx` (local, no key) in models.json:

```
Provider: azure  (1 models)   gpt-5.6-sol
Provider: future (13 models)  ...
Provider: omlx  (1 models)    Qwen3.8-27B-oQ4
Provider: realapi (1 models)  claude-opus-4-8
16 models, 4 providers
```

`cargo test -p future-agent --lib`: 1386 passed, 0 failed. Clippy clean.