### PR TITLE
fix(loop): reclaim dead-holder leases on manual claim; reject bare --blocks

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -797,6 +797,13 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let text = text.ok_or_else(|| anyhow::anyhow!("--text required"))?;
+    // Bare `--blocks` at end-of-line is parsed as the literal "true" by
+    // parse_pairs' value-less flag convention; no generated todo id is ever
+    // "true", so reject it loudly instead of writing a dangling dependency
+    // that later fails task-graph with "references unknown todo `true`".
+    if blocks.iter().any(|b| b == "true") {
+        bail!("--blocks requires a comma-separated todo id list (bare `--blocks` reads as `true`)");
+    }
     // O4: advisory hint — code-like todos without a validator can be marked
     // done by an agent even when the code does not compile. Computed before
     // `verify` is moved into the todo below.
@@ -6547,6 +6554,13 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let todo_id = todo_id.ok_or_else(|| anyhow::anyhow!("--todo-id required"))?;
+    // Same bare-flag trap as todo add: a value-less `--blocks` parses as
+    // the literal "true" — never a real todo id, so reject it loudly.
+    if let Some(ids) = &blocks {
+        if ids.iter().any(|b| b == "true") {
+            bail!("--blocks requires a comma-separated todo id list (bare `--blocks` reads as `true`)");
+        }
+    }
     let goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -395,13 +395,23 @@ impl Todo {
     /// Claim a slice: succeeds only when open AND (unclaimed OR the previous
     /// lease expired). Returns false if another agent holds a live lease
     /// (LoopX: claim is not ownership; lease is the bounded execution window).
+    ///
+    /// Lease liveness: a live lease held by a DEAD holder is reclaimed
+    /// automatically (kill -0 probe on the recorded holder pid, mirroring
+    /// the run-path claim in `work_items::task_lease`). A lease from a
+    /// pre-liveness ledger (no pid) keeps the old hard error.
     pub fn claim(&mut self, agent_id: &str, lease_secs: u64, now_epoch: u64) -> bool {
         if self.status != TodoStatus::Open {
             return false;
         }
         if let Some(expires) = self.lease_expires_at {
             if expires > now_epoch && self.claimed_by.as_deref() != Some(agent_id) {
-                return false;
+                // Dead holder → reclaim instead of refusing (killed runs
+                // leave orphaned leases behind; pid probe recycles them).
+                match self.holder_pid {
+                    Some(pid) if !crate::compat::pid_alive(pid) => {}
+                    _ => return false,
+                }
             }
         }
         self.claimed_by = Some(agent_id.to_string());

--- a/orchestration/loop/tests/claim_lease_contract.rs
+++ b/orchestration/loop/tests/claim_lease_contract.rs
@@ -98,6 +98,41 @@ fn claim_rejects_live_lease_from_other_agent() {
     assert_eq!(g.todo("t1").unwrap().claimed_by.as_deref(), Some("alice"));
 }
 
+// ── Lease liveness on the manual `todo claim` path (state::Todo::claim) ────
+// A killed run leaves a live lease whose holder pid no longer exists; the
+// next manual claim must reclaim it (mirrors the run-path task_lease steal),
+// while a live pid keeps the hard error and a pre-liveness ledger (no pid)
+// keeps the old refusal.
+#[test]
+fn claim_reclaims_dead_holder_lease() {
+    let mut g = goal_with_todo(&["alice", "bob"]);
+    let now = now_epoch();
+    {
+        let t = g.todo_mut("t1").unwrap();
+        t.claimed_by = Some("alice".to_string());
+        t.lease_expires_at = Some(now + 3600);
+        t.holder_pid = Some(4_000_000_000); // far outside the pid range
+    }
+    let claimed = g.todo_mut("t1").unwrap().claim("bob", 3600, now);
+    assert!(claimed, "dead holder's lease must be reclaimed");
+    assert_eq!(g.todo("t1").unwrap().claimed_by.as_deref(), Some("bob"));
+}
+
+#[test]
+fn claim_refuses_live_holder_pid() {
+    let mut g = goal_with_todo(&["alice", "bob"]);
+    let now = now_epoch();
+    {
+        let t = g.todo_mut("t1").unwrap();
+        t.claimed_by = Some("alice".to_string());
+        t.lease_expires_at = Some(now + 3600);
+        t.holder_pid = Some(std::process::id()); // the test process is alive
+    }
+    let claimed = g.todo_mut("t1").unwrap().claim("bob", 3600, now);
+    assert!(!claimed, "a live holder's lease must not be stolen");
+    assert_eq!(g.todo("t1").unwrap().claimed_by.as_deref(), Some("alice"));
+}
+
 // ── Contract (P0-1): workspace declarations survive replay and drive the
 //    guard — a peer holding a live lease in an overlapping workspace
 //    conflicts; idle or disjoint peers do not. ─────────────────────────────

--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -423,8 +423,12 @@ fn two_agent_sessions_hold_disjoint_frontiers() {
             "agent-b",
         ],
     );
-    // claim is exclusive: A cannot claim B's slice.
-    let (_, err, code) = run(
+    // claim is exclusive while the holder is ALIVE; the CLI subprocess that
+    // claimed for agent-b has exited, so its dead holder's lease is reclaimed
+    // by the next claim (lease liveness — killed runs must not wedge the
+    // frontier). The live-holder refusal is covered in-process by
+    // claim_lease_contract::claim_refuses_live_holder_pid.
+    let (out, err, code) = run(
         &root,
         &[
             "todo",
@@ -437,8 +441,8 @@ fn two_agent_sessions_hold_disjoint_frontiers() {
             "agent-a",
         ],
     );
-    assert_ne!(code, 0, "A must not be able to claim B's live lease");
-    assert!(err.contains("another agent"), "stderr: {err}");
+    assert_eq!(code, 0, "dead holder's lease must be reclaimed: {err}");
+    assert!(out.contains("claimed"), "reclaim: {out}");
 }
 
 /// ── P4: version / doctor / history / turn / todo-event / evidence-log ────


### PR DESCRIPTION
## Summary

Two gaps found while end-to-end testing the future-loop skill against the real CLI:

1. **`todo claim` refused dead-holder leases** — the pid-probe reclaim (kill -0) existed only on the run path (`work_items::task_lease`) and the store's atomic claim, so the SKILL.md promise "leases auto-reclaim on the next claim" held for `run` but not for the manual `todo claim` command. A killed run's lease wedged manual claiming until expiry.
2. **Bare `--blocks` wrote literal `true`** — a value-less `--blocks` at end-of-line is parsed as `"true"` by parse_pairs' flag convention, silently creating `blocked_by_gate=true`, which later fails task-graph with "references unknown todo `true`".

## Changes

- `state::Todo::claim`: add the dead-holder pid probe (pre-liveness ledgers without a pid keep the old hard error)
- `todo add` / `todo update`: reject `--blocks` resolving to the literal `true`
- Tests: `claim_reclaims_dead_holder_lease` + `claim_refuses_live_holder_pid`; update `two_agent_sessions_hold_disjoint_frontiers` (subprocess holder is dead → reclaim is now the correct behavior)

## Verification

- `cargo test -p future-loop`: 61 test binaries pass
- `cargo clippy --all-targets` / `fmt --check`: clean
- `future-loop canary premerge --json`: gate passed
- Manual E2E on a scratch goal: bare `--blocks` errors loudly; dead lease reclaimed by next manual claim