### PR TITLE
fix(loop): goal init idempotency + gate resolve validation

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -545,6 +545,13 @@ fn cmd_goal(store: &mut Store, args: &[String]) -> Result<()> {
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default()
     });
+    // Idempotent re-init: an already-registered goal returns its existing
+    // state — re-running `goal init` with the same --goal-id must not
+    // duplicate the onboarding bootstrap todo.
+    if store.registered(&goal_id) {
+        println!("goal {goal_id} already exists — continuing (no duplicate bootstrap)");
+        return Ok(());
+    }
     let mut goal = Goal::new(&goal_id, &objective, &cwd);
     let ts = now_epoch();
     goal.created_at = ts;
@@ -1992,6 +1999,15 @@ fn cmd_gate(store: &mut Store, args: &[String]) -> Result<()> {
     let mut goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    // Fail closed on unknown / non-gate todos — a typo'd id must not write
+    // a phantom GateResolved event (previously the command printed ✔ for
+    // any todo id, silently corrupting the gate audit trail).
+    let t = goal
+        .todo(&todo_id)
+        .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found in goal {goal_id}"))?;
+    if t.class != crate::state::TaskClass::UserGate {
+        bail!("todo {todo_id} is not a user_gate — gate resolve only applies to user_gate todos");
+    }
     store.append(Event::GateResolved {
         goal_id: goal_id.clone(),
         todo_id: todo_id.clone(),

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -38,6 +38,28 @@ fn goal_init_variants_and_errors() {
     let doc = std::path::Path::new(&cr.cwd).join("GOAL.md");
     assert_eq!(std::fs::read_to_string(doc).unwrap(), "# Hello\n");
     let _ = gid;
+
+    // Re-init with the same --goal-id is idempotent: it must NOT append a
+    // duplicate onboarding bootstrap todo.
+    cli_ok(&[
+        "goal",
+        "init",
+        "--objective",
+        "with doc again",
+        "--goal-id",
+        "goal_withdoc",
+    ]);
+    let store = open_store(&cr);
+    let g = store.replay("goal_withdoc").unwrap().unwrap();
+    let onboarding_count = g
+        .todos
+        .iter()
+        .filter(|t| t.action_kind.as_deref() == Some("onboarding_connection_validation"))
+        .count();
+    assert_eq!(
+        onboarding_count, 1,
+        "re-init must not duplicate the onboarding todo"
+    );
 }
 
 #[test]
@@ -968,9 +990,10 @@ fn gate_resolve_errors() {
         "x"
     ])
     .contains("not found"));
-    // Resolving a non-gate todo still records the decision (no class check).
+    // Resolving a non-gate todo is rejected fail-closed (no phantom
+    // GateResolved event); resolving an unknown id also errors.
     let first = first_todo_id(&cr.root, &gid);
-    cli_ok(&[
+    assert!(cli_err(&[
         "gate",
         "resolve",
         "--goal",
@@ -979,10 +1002,53 @@ fn gate_resolve_errors() {
         &first,
         "--decision",
         "fine",
+    ])
+    .contains("not a user_gate"));
+    assert!(cli_err(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        "todo_ghost",
+        "--decision",
+        "fine",
+    ])
+    .contains("not found"));
+    // A real user_gate still resolves.
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "gate q",
+        "--role",
+        "user",
+        "--class",
+        "user_gate",
+    ]);
+    let g2 = open_store(&cr).replay(&gid).unwrap().unwrap();
+    let gate_id = g2
+        .todos
+        .iter()
+        .find(|t| t.class == future_loop::state::TaskClass::UserGate)
+        .unwrap()
+        .id
+        .clone();
+    cli_ok(&[
+        "gate",
+        "resolve",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &gate_id,
+        "--decision",
+        "fine",
     ]);
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
-    let t = g.todos.iter().find(|t| t.id == first).unwrap();
+    let t = g.todos.iter().find(|t| t.id == gate_id).unwrap();
     assert_eq!(t.status, TodoStatus::Done);
     assert_eq!(t.decision.as_deref(), Some("fine"));
 }


### PR DESCRIPTION
## Summary

Two correctness bugs found by comprehensive edge-case testing of the future-loop skill:

1. **`goal init` re-run duplicates the onboarding todo** — `goal_started` was idempotent (event-id dedup) but the onboarding bootstrap was not: every re-init appended another "Run future loop status..." todo. Re-init on an existing goal id now returns "already exists — continuing" with no side effects.
2. **`gate resolve` accepted any todo id** — unknown ids and non-gate todos both printed ✔ and appended a phantom `GateResolved` event. Now fails closed on unknown ids and non-`user_gate` todos.

## Verification

- `cargo test -p future-loop`: 61 test binaries pass (incl. 2 new regression tests)
- clippy / fmt: clean
- `future-loop canary premerge --json`: gate passed, exit 0
- Manual E2E: re-init idempotent; `gate resolve` on ghost/non-gate ids errors; real gate resolves