### PR TITLE
fix(loop): validate todo add/update inputs; idempotent re-completion

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -804,6 +804,31 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let text = text.ok_or_else(|| anyhow::anyhow!("--text required"))?;
+    // Input validation — previously the CLI silently accepted garbage: empty
+    // text, unknown classes/roles (which fell through to `advancement`), and
+    // bogus priorities (silently remapped to P1). All of that enters the
+    // ledger and only explodes much later.
+    if text.trim().is_empty() {
+        bail!("--text must be non-empty");
+    }
+    let valid_combo = matches!(
+        (role.as_str(), class.as_str()),
+        ("agent", "advancement")
+            | ("agent", "monitor")
+            | ("agent", "blocker")
+            | (_, "user_gate")
+            | ("user", "user_action")
+    );
+    if !valid_combo {
+        bail!(
+            "unknown --role/--class combo `{role}`/`{class}` (agent: advancement|monitor|blocker; user_gate: any role; user: user_action)"
+        );
+    }
+    if let Some(p) = &priority {
+        if !matches!(p.to_uppercase().as_str(), "P0" | "P1" | "P2") {
+            bail!("unknown --priority `{p}` (P0|P1|P2)");
+        }
+    }
     // Bare `--blocks` at end-of-line is parsed as the literal "true" by
     // parse_pairs' value-less flag convention; no generated todo id is ever
     // "true", so reject it loudly instead of writing a dangling dependency
@@ -1872,6 +1897,16 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     let t = goal
         .todo(&todo_id)
         .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
+    // Idempotency: re-completing an already-done todo is a no-op (writes
+    // nothing) — previously each repeat double-appended TodoCompleted +
+    // DeliveryOutcomeRecorded events, silently fattening the ledger.
+    if t.status == TodoStatus::Done {
+        println!("todo {todo_id} is already done — nothing to do");
+        return Ok(());
+    }
+    if t.status == TodoStatus::Superseded {
+        bail!("todo {todo_id} was superseded — nothing to complete");
+    }
     if t.class == TaskClass::Advancement && !no_follow_up && successor.is_none() {
         bail!(
             "agent todo completion must declare --no-follow-up or --successor \
@@ -6575,6 +6610,11 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     if let Some(ids) = &blocks {
         if ids.iter().any(|b| b == "true") {
             bail!("--blocks requires a comma-separated todo id list (bare `--blocks` reads as `true`)");
+        }
+    }
+    if let Some(p) = &priority {
+        if !matches!(p.to_uppercase().as_str(), "P0" | "P1" | "P2") {
+            bail!("unknown --priority `{p}` (P0|P1|P2)");
         }
     }
     let goal = store

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -169,7 +169,9 @@ fn todo_add_class_matrix() {
         "--monitor-policy",
         "exists",
     ]);
-    cli_ok(&[
+    // Unknown class is rejected fail-closed (was: silently fell back to
+    // advancement and polluted the ledger).
+    assert!(cli_err(&[
         "todo",
         "add",
         "--goal",
@@ -178,7 +180,8 @@ fn todo_add_class_matrix() {
         "bogus-class",
         "--text",
         "falls back",
-    ]);
+    ])
+    .contains("unknown --role/--class combo"));
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
     let b = g.todos.iter().find(|t| t.id == blocker).unwrap();
@@ -247,8 +250,8 @@ fn todo_add_flag_matrix() {
         "--title",
         "Custom Title",
     ]);
-    // Bogus priority falls back to P1.
-    cli_ok(&[
+    // Bogus priority is rejected fail-closed (previously remapped to P1).
+    assert!(cli_err(&[
         "todo",
         "add",
         "--goal",
@@ -257,7 +260,8 @@ fn todo_add_flag_matrix() {
         "odd priority",
         "--priority",
         "P9",
-    ]);
+    ])
+    .contains("unknown --priority"));
     // Defer paths: numeric --resume-when, textual --resume-when, --defer-secs.
     cli_ok(&[
         "todo",
@@ -369,12 +373,8 @@ fn todo_add_flag_matrix() {
         .find(|t| t.text.contains("titled P0"))
         .unwrap();
     assert_eq!(titled.title, "Custom Title");
-    let odd = g
-        .todos
-        .iter()
-        .find(|t| t.text.contains("odd priority"))
-        .unwrap();
-    assert_eq!(odd.priority, future_loop::state::Priority::P1);
+    // "odd priority" (P9) is now rejected at the CLI, so it never lands in
+    // the ledger — nothing to assert about its projected state.
     for needle in ["deferred num", "deferred text", "deferred secs"] {
         let t = g.todos.iter().find(|t| t.text.contains(needle)).unwrap();
         assert_eq!(t.status, TodoStatus::Deferred, "{needle}");


### PR DESCRIPTION
fix(loop): validate todo add/update inputs; idempotent re-completion

Two ledger-hygiene fixes found by edge-case testing of the future-loop
skill:

1. `todo add` accepted garbage inputs silently:
   - bogus --priority (e.g. P9) was silently remapped to P1
   - empty/whitespace --text was accepted
   - unknown --class (e.g. bogus) fell back to advancement
   All of that entered the ledger and only exploded later (or never).
   Now rejected fail-closed at the CLI, with the valid role/class
   combos spelled out in the error. `todo update --priority` validated
   the same way. The replay path keeps its lenient normalization
   (historical ledgers must stay readable).

2. Re-completing a done todo appended duplicate TodoCompleted +
   DeliveryOutcomeRecorded events on every repeat. Now a no-op
   ("already done — nothing to do"); completing a superseded todo
   errors.

Tests updated: bogus-class / P9 fallback assertions now assert the
hard errors; two_agent_sessions gate matrix and class matrix updated.
SKILL.md documents the new semantics (future-skills#13).
