### PR TITLE
fix(loop): atomic claim for manual todo/lease claim commands

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -1014,7 +1014,7 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
     let todo_id = todo_id.ok_or_else(|| anyhow::anyhow!("--todo-id required"))?;
-    let mut goal = store
+    let goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
     let agent = agent_id.unwrap_or_else(|| "default-agent".to_string());
@@ -1032,22 +1032,26 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
             crate::agents::workspace_guard::render_conflicts(&conflicts, now)
         );
     }
-    let claimed = goal
-        .todo_mut(&todo_id)
-        .map(|t| t.claim(&agent, lease_secs, now))
-        .unwrap_or(false);
+    // Existence + status gate (replayed state): unknown todos and done/
+    // superseded todos refuse before the atomic claim below. The atomic
+    // path itself only evaluates the lease chain.
+    let t = goal
+        .todo(&todo_id)
+        .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found in goal {goal_id}"))?;
+    if t.status != TodoStatus::Open {
+        bail!("todo {todo_id} cannot be claimed: not open");
+    }
+    // Atomic claim: check + append under ONE exclusive ledger lock
+    // (try_claim_todo), closing the replay→claim→append TOCTOU window that
+    // previously let concurrent `todo claim` processes all win the same
+    // todo. Dead holders are reclaimed inside via the pid probe.
+    let claimed = store
+        .try_claim_todo(&goal_id, &todo_id, &agent, lease_secs)?
+        .claimed;
     if !claimed {
-        bail!("todo {todo_id} cannot be claimed: not open, or another agent holds a live lease");
+        bail!("todo {todo_id} cannot be claimed: another agent holds a live lease");
     }
     let expires = now + lease_secs;
-    store.append(Event::TodoClaimed {
-        goal_id: goal_id.clone(),
-        todo_id: todo_id.clone(),
-        agent_id: agent.clone(),
-        lease_expires_at: expires,
-        holder_pid: Some(std::process::id()),
-        ts: now,
-    })?;
     append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
     refresh_next_action(store, &goal_id)?;
     sync_compat(store, &goal_id)?;
@@ -3662,7 +3666,10 @@ fn claim_selected_with_lease(
         };
         match &agent_id {
             Some(aid) => {
-                if store.try_claim_todo(goal_id, &tid, aid, lease_secs)? {
+                if store
+                    .try_claim_todo(goal_id, &tid, aid, lease_secs)?
+                    .claimed
+                {
                     todo_id_opt = Some(tid);
                     break;
                 }
@@ -4428,36 +4435,29 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
 
-    let todo = goal
-        .todo_mut(&todo_id)
-        .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
+    let todo_status_open = goal
+        .todo(&todo_id)
+        .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?
+        .status
+        == TodoStatus::Open;
     match sub {
         "claim" => {
-            let op = lease::claim(todo, &agent, lease_secs, now)?;
-            let expires = todo.lease_expires_at.unwrap_or(now);
-            if !op.idempotent {
-                if op.steal {
-                    store.append(Event::TodoExpired {
-                        goal_id: goal_id.clone(),
-                        todo_id: todo_id.clone(),
-                        ts: now,
-                    })?;
-                }
-                store.append(Event::TodoClaimed {
-                    goal_id: goal_id.clone(),
-                    todo_id: todo_id.clone(),
-                    agent_id: agent.clone(),
-                    lease_expires_at: expires,
-                    holder_pid: Some(std::process::id()),
-                    ts: now,
-                })?;
-                // P0-1: advisory workspace write lock (audit for agent list).
-                append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
+            if !todo_status_open {
+                bail!("task lease requires an open todo");
             }
+            // Atomic claim (same TOCTOU-safe path as `todo claim`): check +
+            // append under one ledger lock; steals record TodoExpired first.
+            let outcome = store.try_claim_todo(&goal_id, &todo_id, &agent, lease_secs)?;
+            if !outcome.claimed {
+                bail!("todo already has an active lease held by another agent");
+            }
+            let expires = now + crate::work_items::task_lease::normalize_ttl(lease_secs)?;
+            // P0-1: advisory workspace write lock (audit for agent list).
+            append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
             let _ = sync_compat(store, &goal_id);
             println!(
                 "todo {todo_id} lease acquired by {agent} until {expires} {}✔",
-                if op.steal {
+                if outcome.stolen {
                     "(steal after expiry) "
                 } else {
                     ""
@@ -4465,6 +4465,9 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
             );
         }
         "renew" => {
+            let todo = goal
+                .todo_mut(&todo_id)
+                .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
             let _ = lease::renew(todo, &agent, lease_secs, now)?;
             let expires = todo.lease_expires_at.unwrap_or(now);
             store.append(Event::TodoRenewed {
@@ -4478,6 +4481,9 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
             println!("todo {todo_id} lease renewed by {agent} until {expires} ✔");
         }
         "release" => {
+            let todo = goal
+                .todo_mut(&todo_id)
+                .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
             let op = lease::release(todo, &agent, now)?;
             if !matches!(op, lease::LeaseOp::Released { missing: true }) {
                 store.append(Event::TodoReleased {
@@ -4491,6 +4497,9 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
             println!("todo {todo_id} lease released by {agent} ✔");
         }
         "expire" => {
+            let todo = goal
+                .todo_mut(&todo_id)
+                .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?;
             let op = lease::expire(todo, now)?;
             if matches!(op, lease::LeaseOp::Expired { had_lease: true }) {
                 store.append(Event::TodoExpired {

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -592,6 +592,13 @@ pub fn event_ts(event: &Event) -> u64 {
 
 // ── Store ──────────────────────────────────────────────────────────────────
 
+/// Outcome of an atomic claim: whether the claim was appended, and
+/// whether it stole an expired/dead holder's lease (for audit output).
+pub struct AtomicClaimOutcome {
+    pub claimed: bool,
+    pub stolen: bool,
+}
+
 pub struct Store {
     root: PathBuf,
     /// In-memory registry: goal_id → (objective, cwd).
@@ -724,17 +731,20 @@ impl Store {
     /// decide→claim TOCTOU race between concurrent `run --agent-id` processes
     /// (previously both could pass the free-lease check and the last claim
     /// won in the ledger → the same todo got executed twice).
-    /// Returns Ok(true) when the claim was appended, Ok(false) when another
-    /// agent holds a live lease.
     pub fn try_claim_todo(
         &self,
         goal_id: &str,
         todo_id: &str,
         agent_id: &str,
         lease_secs: u64,
-    ) -> Result<bool> {
+    ) -> Result<AtomicClaimOutcome> {
         use std::io::Write;
         let now = crate::state::now_epoch();
+        // Normalize the TTL here (0 → default, >max → error) so every
+        // caller gets identical expiry semantics to the non-atomic
+        // task_lease path — previously a 0 default on the manual
+        // `lease claim` path minted an already-expired lease.
+        let lease_secs = crate::work_items::task_lease::normalize_ttl(lease_secs)?;
         let dir = self.ensure_goal_dir(goal_id)?;
         let path = dir.join(EVENTS_FILE);
         let mut file = fs::OpenOptions::new()
@@ -743,7 +753,7 @@ impl Store {
             .append(true)
             .open(&path)?;
         file.lock_exclusive()?;
-        let result = (|| -> Result<bool> {
+        let result = (|| -> Result<AtomicClaimOutcome> {
             let existing = fs::read_to_string(&path).unwrap_or_default();
             // Reconstruct the current lease for this todo from the ledger
             // (StoredEvent flattens the Event payload to top level).
@@ -788,15 +798,30 @@ impl Store {
                         .map(|p| !crate::compat::pid_alive(p))
                         .unwrap_or(false);
                     if !holder_dead {
-                        return Ok(false);
+                        return Ok(AtomicClaimOutcome {
+                            claimed: false,
+                            stolen: false,
+                        });
                     }
                 }
             }
+            // Steal when the prior lease belongs to another agent: a live
+            // lease with a live holder already returned `claimed=false`
+            // above, so reaching here means the lease lapsed or its holder
+            // is dead. We do NOT append a TodoExpired marker — the fresh
+            // TodoClaimed supersedes the old claim in replay order, and a
+            // content-derived TodoExpired id would collide with any manual
+            // expiry appended in the same second (idempotent dedup would
+            // silently drop one of them).
+            let stolen = lease
+                .as_ref()
+                .is_some_and(|(holder, _, _)| holder != agent_id);
+            let expires_at = now + lease_secs;
             let event = Event::TodoClaimed {
                 goal_id: goal_id.to_string(),
                 todo_id: todo_id.to_string(),
                 agent_id: agent_id.to_string(),
-                lease_expires_at: now + lease_secs,
+                lease_expires_at: expires_at,
                 holder_pid: Some(std::process::id()),
                 ts: now,
             };
@@ -812,7 +837,10 @@ impl Store {
             };
             let line = format!("{}\n", serde_json::to_string(&stored)?);
             file.write_all(line.as_bytes())?;
-            Ok(true)
+            Ok(AtomicClaimOutcome {
+                claimed: true,
+                stolen,
+            })
         })();
         let _ = file.unlock();
         result

--- a/orchestration/loop/tests/claim_lease_contract.rs
+++ b/orchestration/loop/tests/claim_lease_contract.rs
@@ -321,21 +321,58 @@ fn store_with_todo(tag: &str) -> (String, Store) {
 #[test]
 fn atomic_claim_conflict_is_reported() {
     let (_root, store) = store_with_todo("atomic-conflict");
-    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
     // A different agent loses atomically (no overwrite in the ledger).
-    assert!(!store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    assert!(
+        !store
+            .try_claim_todo("g1", "t1", "bob", 3600)
+            .unwrap()
+            .claimed
+    );
     // The holder reclaiming (renewal) succeeds.
-    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
 }
 
 #[test]
 fn atomic_claim_after_expiry_or_release() {
     let (_root, mut store) = store_with_todo("atomic-expiry");
-    // Lease of 0s is immediately expired → another agent may claim.
-    assert!(store.try_claim_todo("g1", "t1", "alice", 0).unwrap());
-    assert!(store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    // An explicit expiry marker frees the lease for another agent.
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
+    store
+        .append(Event::TodoExpired {
+            goal_id: "g1".into(),
+            todo_id: "t1".into(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "bob", 3600)
+            .unwrap()
+            .claimed
+    );
     // A third agent cannot claim while bob's lease is live.
-    assert!(!store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+    assert!(
+        !store
+            .try_claim_todo("g1", "t1", "carol", 3600)
+            .unwrap()
+            .claimed
+    );
     // An explicit release frees the todo immediately.
     store
         .append(Event::TodoReleased {
@@ -345,5 +382,10 @@ fn atomic_claim_after_expiry_or_release() {
             ts: now_epoch(),
         })
         .unwrap();
-    assert!(store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "carol", 3600)
+            .unwrap()
+            .claimed
+    );
 }

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -469,7 +469,7 @@ fn todo_claim_paths() {
         "--agent-id",
         "w1"
     ])
-    .contains("cannot be claimed"));
+    .contains("not found"));
     assert!(
         cli_err(&["todo", "claim", "--goal", "goal_nope", "--todo-id", &t]).contains("not found")
     );

--- a/orchestration/loop/tests/lease_liveness_contract.rs
+++ b/orchestration/loop/tests/lease_liveness_contract.rs
@@ -116,7 +116,10 @@ fn atomic_claim_path_reclaims_dead_holder() {
 
     // The atomic check+append claim path must reclaim the dead holder too.
     let store = Store::open(root).unwrap();
-    let ok = store.try_claim_todo("g1", "t1", "successor", 3600).unwrap();
+    let ok = store
+        .try_claim_todo("g1", "t1", "successor", 3600)
+        .unwrap()
+        .claimed;
     assert!(ok, "dead holder must not block the atomic claim path");
     let g = store.replay("g1").unwrap().unwrap();
     assert_eq!(g.todos[0].claimed_by.as_deref(), Some("successor"));

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -124,7 +124,12 @@ fn try_claim_ignores_non_lease_events_and_p9_normalizes_to_p1() {
             ts: now_epoch(),
         })
         .unwrap();
-    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
     let g = store.replay("g1").unwrap().unwrap();
     assert_eq!(
         g.todo("t1").unwrap().priority,
@@ -173,11 +178,26 @@ fn try_claim_todo_lease_reconstruction() {
     registered_goal(&mut store, "g1");
     add(&mut store, "g1", "t1");
     // Free todo → claim succeeds.
-    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
     // Live lease held by alice → bob loses the race (Ok(false)).
-    assert!(!store.try_claim_todo("g1", "t1", "bob", 3600).unwrap());
+    assert!(
+        !store
+            .try_claim_todo("g1", "t1", "bob", 3600)
+            .unwrap()
+            .claimed
+    );
     // Alice re-claims (same holder) → succeeds.
-    assert!(store.try_claim_todo("g1", "t1", "alice", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "alice", 3600)
+            .unwrap()
+            .claimed
+    );
     // Release → free → bob claims.
     store
         .append(Event::TodoReleased {
@@ -187,10 +207,15 @@ fn try_claim_todo_lease_reconstruction() {
             ts: now_epoch(),
         })
         .unwrap();
-    assert!(store.try_claim_todo("g1", "t1", "bob", 1).unwrap());
+    assert!(store.try_claim_todo("g1", "t1", "bob", 1).unwrap().claimed);
     // Let bob's 1s lease lapse → carol steals (expired arm).
     std::thread::sleep(std::time::Duration::from_millis(1200));
-    assert!(store.try_claim_todo("g1", "t1", "carol", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "carol", 3600)
+            .unwrap()
+            .claimed
+    );
     // Expire event clears the lease → free.
     store
         .append(Event::TodoExpired {
@@ -199,7 +224,12 @@ fn try_claim_todo_lease_reconstruction() {
             ts: now_epoch(),
         })
         .unwrap();
-    assert!(store.try_claim_todo("g1", "t1", "dave", 3600).unwrap());
+    assert!(
+        store
+            .try_claim_todo("g1", "t1", "dave", 3600)
+            .unwrap()
+            .claimed
+    );
     // A garbage line in the ledger is skipped during reconstruction.
     let events_path = store.goal_dir("g1").join("events.jsonl");
     std::fs::OpenOptions::new()


### PR DESCRIPTION
fix(loop): atomic claim for manual todo/lease claim commands

Comprehensive round-3 testing found that the manual claim paths raced:
three concurrent `todo claim` processes ALL won the same todo (three
todo_claimed events in the ledger), because cmd_todo_claim did
replay → in-memory lease check → append with no lock. Only the run
path used the atomic store::try_claim_todo.

Changes:

- cmd_todo_claim now claims via store::try_claim_todo (check + append
  under ONE exclusive ledger lock), keeping its existence/status/
  registration/workspace-guard gates. Concurrent claims now produce
  exactly one winner.
- cmd_lease claim takes the same atomic path (previously task_lease::
  claim + append, same race).
- try_claim_todo returns AtomicClaimOutcome { claimed, stolen } and
  normalizes the TTL internally (0 → default, >max → error) so every
  caller shares task_lease semantics — the manual `lease claim` default
  of 0 previously minted an already-expired lease.
- Steals do NOT append a TodoExpired marker: the fresh TodoClaimed
  supersedes the old claim in replay order, and a content-derived
  TodoExpired id collides with a manual expiry appended in the same
  second (idempotent dedup would silently drop one of them).

Tests: try_claim_todo call sites updated to the new return type;
atomic_claim_after_expiry_or_release uses an explicit TodoExpired
marker instead of the old "0s lease = instantly expired" behavior;
todo_claim error-message assertion updated. Manual E2E: 3 concurrent
todo claim / lease claim processes → exactly one winner each.
