### PR TITLE
feat(ci): release Linux arm64 alongside x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,30 @@ jobs:
 
   # Linux packages are unsigned (no code-signing equivalent), so the build is
   # inlined here instead of a reusable workflow: .deb for Debian/Ubuntu plus
-  # the portable tarball for every other distro.
+  # the portable tarball for every other distro, on both architectures. The
+  # matrix mirrors build.yml's tested Linux jobs exactly: x86_64 on
+  # ubuntu-latest and native aarch64 on ubuntu-24.04-arm (cross-compiling the
+  # WebKit-heavy GUI from x86_64 would need a full aarch64 sysroot).
   linux:
-    name: Build Linux
+    name: Build Linux (${{ matrix.arch }})
     needs: version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            os: ubuntu-latest
+            deb_arch: amd64
+            artifact_name: futureos-linux-release
+            # x86_64 keeps its historical arch-less filename; ARM assets get an
+            # -arm64 suffix so both can live in the same release directory.
+            portable_name: FutureOS-portable-linux.tar.gz
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+            deb_arch: arm64
+            artifact_name: futureos-linux-arm64-release
+            portable_name: FutureOS-portable-linux-arm64.tar.gz
     env:
       FUTURE_VERSION: ${{ needs.version.outputs.version }}
     steps:
@@ -90,7 +109,7 @@ jobs:
           cache-on-failure: true
           cache-all-crates: true
 
-      # Same package set as build.yml's tested Linux job.
+      # Same package set as build.yml's tested Linux jobs (both architectures).
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
@@ -105,6 +124,7 @@ jobs:
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
+            musl-tools \
             patchelf \
             wget
 
@@ -113,15 +133,27 @@ jobs:
         run: npm ci
 
      
-      - name: Build CLI binary
+      # Identical to build.yml's Linux CLI step: a FULLY STATIC musl binary,
+      # not glibc-linked. The glibc build would only run on distros with a
+      # glibc at least as new as the runner image; the static binary runs on
+      # any Linux of this arch (old distros, Alpine, bare containers).
+      - name: Build CLI binary (Linux, static musl)
         working-directory: cli
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
         run: |
-          cargo build --release
+          set -euo pipefail
+          target="${{ matrix.arch }}-unknown-linux-musl"
+          rustup target add "$target"
+          cargo build --release --target "$target"
           # Stage it as a Tauri sidecar too (bundle.externalBin) so the CLI ships
-          # inside the .deb, not just the portable tarball.
+          # inside the .deb, not just the portable tarball. The sidecar filename
+          # uses the host (glibc) triple; Tauri only copies the file and doesn't
+          # care how the binary is linked.
           triple=$(rustc -Vv | sed -n 's/^host: //p')
           mkdir -p ../desktop/src-tauri/binaries
-          cp ../target/release/future "../desktop/src-tauri/binaries/future-$triple"
+          cp "../target/$target/release/future" "../desktop/src-tauri/binaries/future-$triple"
 
       - name: Set Tauri bundle version
         run: node scripts/version.mjs --set-bundle
@@ -137,10 +169,11 @@ jobs:
           dir="futureos-portable-linux"
           mkdir -p "$dir"
           cp "desktop/src-tauri/target/release/futureos" "$dir/futureos"
-          cp "target/release/future" "$dir/future"
+          # The static musl CLI build — see the CLI build step above.
+          cp "target/${{ matrix.arch }}-unknown-linux-musl/release/future" "$dir/future"
           chmod +x "$dir"/*
           cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
-          tar -czf FutureOS-portable-linux.tar.gz -C "$dir" .
+          tar -czf "${{ matrix.portable_name }}" -C "$dir" .
 
       - name: Stage release assets
         run: |
@@ -151,13 +184,13 @@ jobs:
             echo "Tauri produced no .deb bundle" >&2
             exit 1
           }
-          cp "$deb" "release-assets/FutureOS_${FUTURE_VERSION}_amd64.deb"
-          cp FutureOS-portable-linux.tar.gz "release-assets/"
+          cp "$deb" "release-assets/FutureOS_${FUTURE_VERSION}_${{ matrix.deb_arch }}.deb"
+          cp "${{ matrix.portable_name }}" "release-assets/"
 
       - name: Upload Linux release assets
         uses: actions/upload-artifact@v7
         with:
-          name: futureos-linux-release
+          name: ${{ matrix.artifact_name }}
           if-no-files-found: error
           overwrite: true
           path: release-assets/
@@ -466,7 +499,9 @@ jobs:
           mac_intel_updater="FutureOS_${VERSION}_x64.app.tar.gz"
           windows="FutureOS_${VERSION}_x64-setup-sign.exe"
           linux_deb="FutureOS_${VERSION}_amd64.deb"
+          linux_deb_arm="FutureOS_${VERSION}_arm64.deb"
           linux_portable="FutureOS-portable-linux.tar.gz"
+          linux_portable_arm="FutureOS-portable-linux-arm64.tar.gz"
           android_apk="FutureOS_${VERSION}.apk"
 
           for name in \
@@ -479,7 +514,9 @@ jobs:
             "$windows" \
             "$windows.sig" \
             "$linux_deb" \
+            "$linux_deb_arm" \
             "$linux_portable" \
+            "$linux_portable_arm" \
             "$android_apk"
           do
             source="$(find release-assets -type f -name "$name" -print -quit)"
@@ -499,8 +536,8 @@ jobs:
           cp -v "publish/$windows" "publish/FutureOS_${VERSION}_x64-setup.exe"
 
           count="$(find publish -type f | wc -l | tr -d ' ')"
-          [[ "$count" == "14" ]] || {
-            echo "Expected exactly fourteen public release assets, found $count." >&2
+          [[ "$count" == "16" ]] || {
+            echo "Expected exactly sixteen public release assets, found $count." >&2
             exit 1
           }
 
@@ -517,7 +554,9 @@ jobs:
           export MAC_INTEL_UPDATER_FILE="FutureOS_${VERSION}_x64.app.tar.gz"
           export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup-sign.exe"
           export LINUX_DEB_FILE="FutureOS_${VERSION}_amd64.deb"
+          export LINUX_DEB_ARM_FILE="FutureOS_${VERSION}_arm64.deb"
           export LINUX_PORTABLE_FILE="FutureOS-portable-linux.tar.gz"
+          export LINUX_PORTABLE_ARM_FILE="FutureOS-portable-linux-arm64.tar.gz"
           export ANDROID_APK_FILE="FutureOS_${VERSION}.apk"
 
           node <<'NODE'
@@ -543,11 +582,13 @@ jobs:
               "darwin-aarch64": asset(process.env.MAC_ARM_FILE),
               "darwin-x86_64": asset(process.env.MAC_INTEL_FILE),
               "windows-x86_64": asset(process.env.WINDOWS_FILE),
-              // install.sh keys on these: linux-x86_64 (.deb) for Debian systems,
-              // linux-x86_64-portable for every other distro. No `platforms`
-              // entry — Linux has no Tauri updater signing key.
+              // install.sh keys on these: linux-<arch> (.deb) for Debian
+              // systems, linux-<arch>-portable for every other distro. No
+              // `platforms` entries — Linux has no Tauri updater signing key.
               "linux-x86_64": asset(process.env.LINUX_DEB_FILE),
               "linux-x86_64-portable": asset(process.env.LINUX_PORTABLE_FILE),
+              "linux-aarch64": asset(process.env.LINUX_DEB_ARM_FILE),
+              "linux-aarch64-portable": asset(process.env.LINUX_PORTABLE_ARM_FILE),
               "android": asset(process.env.ANDROID_APK_FILE),
             },
           };
@@ -591,7 +632,9 @@ jobs:
             "FutureOS_${VERSION}_x64-setup.exe" \
             "FutureOS_${VERSION}_x64-setup-sign.exe.sig" \
             "FutureOS_${VERSION}_amd64.deb" \
+            "FutureOS_${VERSION}_arm64.deb" \
             "FutureOS-portable-linux.tar.gz" \
+            "FutureOS-portable-linux-arm64.tar.gz" \
             "FutureOS_${VERSION}.apk"
           do
             ossutil stat "$target/$name"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -157,7 +157,13 @@ install_linux() {
   else
     pkg_type="portable"
     key="linux-$ARCH-portable"
-    filename="FutureOS-portable-linux.tar.gz"
+    # x86_64 keeps its historical arch-less filename; aarch64 tarballs carry
+    # the -arm64 suffix (see release.yml's linux matrix).
+    case "$ARCH" in
+      x86_64)  filename="FutureOS-portable-linux.tar.gz" ;;
+      aarch64) filename="FutureOS-portable-linux-arm64.tar.gz" ;;
+      *) die "unsupported architecture: $ARCH" ;;
+    esac
     say "Non-Debian system detected — installing the portable tarball"
   fi
 


### PR DESCRIPTION
## 问题

release action 的 Linux 产物与 build action 不一致，且缺 ARM：

| | build.yml（CI 验证） | release.yml（发布） |
|---|---|---|
| 架构 | x86_64（ubuntu-latest）+ aarch64（ubuntu-24.04-arm） | 仅 x86_64 |
| CLI | 全静态 musl（任何同架构 Linux 可跑） | glibc 链接（受 runner glibc 版本限制） |
| latest.json | — | 仅 `linux-x86_64` / `linux-x86_64-portable` |

另外 `scripts/install.sh` 的 ARM 分支已存在，但 portable 文件名写死为 `FutureOS-portable-linux.tar.gz`，aarch64 机器会装到 x86_64 的包。

## 改动

- **release.yml**：`linux` job 改为与 build.yml 完全一致的 matrix（x86_64 / aarch64 原生 runner），CLI 改为相同的静态 musl 构建（含 `musl-tools` 依赖），产出 `FutureOS_<v>_amd64.deb` + `FutureOS_<v>_arm64.deb`、`FutureOS-portable-linux.tar.gz` + `FutureOS-portable-linux-arm64.tar.gz`（x86_64 保留历史无后缀文件名）。
- **publish job**：必需资产校验加入两个 ARM 文件（13→16 计数随 android 已更新为 14→16），OSS 上传后的 `ossutil stat` 验证清单同步补全。
- **latest.json**：`assets` 增加 `linux-aarch64`（.deb）与 `linux-aarch64-portable`（tarball）条目；Linux 无 Tauri updater 签名密钥，故不进 `platforms`。
- **install.sh**：portable 文件名按架构选择（aarch64 → `-arm64.tar.gz`）。

## 验证

- YAML 语法解析通过；`bash -n` 通过
- 用与 publish job 相同的 node 脚本模拟生成 latest.json：4 个 linux 条目（含 sha256）齐全
- 用与 install.sh 相同的 awk 匹配逻辑对新布局 latest.json 做四路查找（amd64/arm64 deb、x86_64/arm64 portable），均命中正确条目、无交叉误匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)