### PR TITLE
fix(mobile): configure file handler Android version

### DIFF
--- a/mobile/modules/future-file-handler/android/build.gradle
+++ b/mobile/modules/future-file-handler/android/build.gradle
@@ -8,6 +8,10 @@ version = '1.0.0'
 
 android {
   namespace "cn.future_os.filehandler"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

Adds Android defaultConfig.versionCode and versionName to the local future-file-handler Expo module.

## Root cause

Expo module Gradle configuration requires android.defaultConfig.versionName. The local module only set the Gradle project version, so APK builds failed during Expo autolinking.

## Validation

- :future-file-handler:assembleRelease passed

Expo autolinking now configures future-file-handler (1.0.0) successfully.