### PR TITLE
Fix iOS download share handoff

### DIFF
--- a/mobile/src/components/JsonPreview.tsx
+++ b/mobile/src/components/JsonPreview.tsx
@@ -1,8 +1,4 @@
-import {
-  formatJsonForPreview,
-  rawJsonLines,
-  tokenizeJsonLine,
-} from "@future-os/json-preview";
+import { formatJsonForPreview, rawJsonLines, tokenizeJsonLine } from "@future-os/json-preview";
 import { useMemo } from "react";
 import { FlatList, StyleSheet, Text, View } from "react-native";
 import { colors, spacing } from "../theme/tokens";

--- a/mobile/src/components/MarkdownText.tsx
+++ b/mobile/src/components/MarkdownText.tsx
@@ -67,13 +67,7 @@ function renderInline(nodes: InlineNode[], openTarget: OpenTarget, parentKey: st
         const remoteUrl = remoteMarkdownImageUrl(node.src);
         const label = node.alt || (path ? basename(path) : node.src);
         if (remoteUrl) {
-          return (
-            <RemoteMarkdownImage
-              alt={node.alt}
-              key={key}
-              url={remoteUrl}
-            />
-          );
+          return <RemoteMarkdownImage alt={node.alt} key={key} url={remoteUrl} />;
         }
         if (!path) return label;
         return (
@@ -87,11 +81,7 @@ function renderInline(nodes: InlineNode[], openTarget: OpenTarget, parentKey: st
         const label = reference.label || basename(reference.targetId);
         if (reference.targetType !== "file") return label;
         return (
-          <Text
-            key={key}
-            onPress={() => openTarget(reference.targetId)}
-            style={styles.link}
-          >
+          <Text key={key} onPress={() => openTarget(reference.targetId)} style={styles.link}>
             {label}
           </Text>
         );
@@ -256,7 +246,11 @@ function renderBlock(
   }
 }
 
-function renderBlocks(nodes: MarkdownNode[], openTarget: OpenTarget, parentKey: string): ReactNode[] {
+function renderBlocks(
+  nodes: MarkdownNode[],
+  openTarget: OpenTarget,
+  parentKey: string,
+): ReactNode[] {
   return nodes.map((node, index) =>
     renderBlock(node, openTarget, `${parentKey}:b${index}`, index === nodes.length - 1),
   );
@@ -265,7 +259,7 @@ function renderBlocks(nodes: MarkdownNode[], openTarget: OpenTarget, parentKey: 
 export function MarkdownText({ text, onOpenFile, mode = "message" }: MarkdownTextProps) {
   const { t } = useTranslation();
   const document = parseFutureMarkdown(text);
-  const openTarget: OpenTarget = (rawTarget) => {
+  const openTarget: OpenTarget = rawTarget => {
     const target = classifyMarkdownTarget(rawTarget);
     if (target.kind === "local-file") {
       if (mode === "file-preview") {

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -240,19 +240,31 @@ describe("classifyError", () => {
   test("terminal auth errors → authTerminal", () => {
     // Server revocation is read from the machine code (never the message).
     expect(
-      classifyError(new RemoteApiError("Remote credential is invalid or revoked.", "invalid_remote_credential", 401)),
+      classifyError(
+        new RemoteApiError(
+          "Remote credential is invalid or revoked.",
+          "invalid_remote_credential",
+          401,
+        ),
+      ),
     ).toBe("authTerminal");
-    expect(classifyError(new RemoteApiError("gone", "credentials_revoked", 401))).toBe("authTerminal");
+    expect(classifyError(new RemoteApiError("gone", "credentials_revoked", 401))).toBe(
+      "authTerminal",
+    );
     // A locally-corrupt JWT is terminal regardless of source.
     expect(classifyError(new Error("invalid_jwt"))).toBe("authTerminal");
   });
   test("refreshable auth errors → auth", () => {
-    expect(classifyError(new RemoteApiError("bad signature", "pairing_signature_invalid", 400))).toBe("auth");
+    expect(
+      classifyError(new RemoteApiError("bad signature", "pairing_signature_invalid", 400)),
+    ).toBe("auth");
     expect(classifyError(new Error("pairing_signature_invalid"))).toBe("auth");
     expect(classifyError(new Error("pairing_confirmation_mismatch"))).toBe("auth");
   });
   test("service permission errors → fatal", () => {
-    expect(classifyError(new RemoteApiError("misconfigured", "remote_service_misconfigured", 500))).toBe("fatal");
+    expect(
+      classifyError(new RemoteApiError("misconfigured", "remote_service_misconfigured", 500)),
+    ).toBe("fatal");
     expect(classifyError(new Error("PERMISSIONS_VIOLATION"))).toBe("fatal");
     expect(classifyError(new Error("remote_service_misconfigured"))).toBe("fatal");
   });
@@ -260,7 +272,9 @@ describe("classifyError", () => {
     // A revocation-shaped message with no machine code is NOT sniffed — it
     // stays transport (mirrors the desktop's generic "server" category).
     expect(classifyError(new Error("invalid_remote_credential"))).toBe("transport");
-    expect(classifyError(new RemoteApiError("something went wrong", "unknown_code", 500))).toBe("transport");
+    expect(classifyError(new RemoteApiError("something went wrong", "unknown_code", 500))).toBe(
+      "transport",
+    );
     expect(classifyError(new Error("nats_connect_failed"))).toBe("transport");
     expect(classifyError(new Error("ETIMEDOUT"))).toBe("transport");
     expect(classifyError("boom")).toBe("transport");

--- a/mobile/src/remote/connectionState.ts
+++ b/mobile/src/remote/connectionState.ts
@@ -95,7 +95,10 @@ export function classifyError(error: unknown): "authTerminal" | "auth" | "fatal"
     if (error.code === "invalid_remote_credential" || error.code === "credentials_revoked") {
       return "authTerminal";
     }
-    if (error.code === "pairing_signature_invalid" || error.code === "pairing_confirmation_mismatch") {
+    if (
+      error.code === "pairing_signature_invalid" ||
+      error.code === "pairing_confirmation_mismatch"
+    ) {
       return "auth";
     }
     if (error.code === "remote_service_misconfigured") {

--- a/mobile/src/remote/pairing.ts
+++ b/mobile/src/remote/pairing.ts
@@ -32,12 +32,19 @@ function assertSecureNatsUrl(url: string): void {
 }
 
 async function responseJson<T>(response: Response): Promise<T> {
-  const body = (await response.json().catch(() => ({}))) as { error?: string; message?: string } & T;
+  const body = (await response.json().catch(() => ({}))) as {
+    error?: string;
+    message?: string;
+  } & T;
   if (!response.ok) {
     // Preserve the server's machine-readable `error` code alongside the human
     // message, so a revocation (`invalid_remote_credential`) is distinguishable
     // from a transient failure instead of being sniffed from prose.
-    throw new RemoteApiError(body.message ?? `HTTP ${response.status}`, body.error, response.status);
+    throw new RemoteApiError(
+      body.message ?? `HTTP ${response.status}`,
+      body.error,
+      response.status,
+    );
   }
   return body;
 }

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -812,6 +812,19 @@ export function ChatScreen() {
         }
         updateDownload(handle, { phase: save ? "saving" : "opening" });
         const namedFile = await namedExternalFile(file, info.name);
+        if (Platform.OS === "ios") {
+          // UIActivityViewController cannot be presented reliably while the
+          // React Native download Modal is still on screen. Dismiss it first
+          // and wait for Modal.onDismiss before handing the file to UIKit.
+          // Once handed off, the system share sheet owns cancellation.
+          handoffDownloadModal(handle, () => {
+            void Sharing.shareAsync(namedFile.uri, {
+              mimeType: save ? info.mimeType : openMimeType,
+              dialogTitle: save ? t("attachment.save") : t("attachment.open"),
+            }).catch(() => Alert.alert(t("attachment.title"), t("attachment.downloadFailed")));
+          });
+          return;
+        }
         await Sharing.shareAsync(namedFile.uri, {
           mimeType: save ? info.mimeType : openMimeType,
           dialogTitle: save ? t("attachment.save") : t("attachment.open"),
@@ -823,7 +836,7 @@ export function ChatScreen() {
         finishDownload(handle);
       }
     },
-    [beginDownload, fetchDownload, finishDownload, t, updateDownload],
+    [beginDownload, fetchDownload, finishDownload, handoffDownloadModal, t, updateDownload],
   );
 
   const downloadOriginal = useCallback(


### PR DESCRIPTION
## Summary

- dismiss the React Native download progress modal before presenting the iOS system share sheet
- hand native presentation off through the existing Modal.onDismiss path so UIKit is never asked to present over an active modal
- let the system share sheet own cancellation after download completion
- normalize the mobile files that were failing the repository Prettier check

## Root cause

The download reached 100%, then called Sharing.shareAsync while the progress modal was still presented. UIKit could fail to present UIActivityViewController, leaving the Expo promise unresolved. The progress modal cleanup therefore never ran, and its AbortController could no longer cancel the native sharing phase.

## Validation

- cargo fmt --check --all
- cargo clippy --workspace --all-targets --manifest-path Cargo.toml -- -D warnings
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- cd mobile and npm run check: 344 tests passed; lint has 2 pre-existing warnings and 0 errors
- git diff --check

Physical iPhone verification was not available in this environment.