### PR TITLE
chore(loop): Apache-2.0 attribution for LoopX-derived future-loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,10 @@ jobs:
           hdiutil attach "$work" -mountpoint "$mnt" -nobrowse -noverify
           app=$(ls -d "$mnt"/*.app | head -n1)
           cp "docs/dist/readme-macos.txt" "$mnt/Readme.txt"
+          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
+          mkdir -p "$mnt/licenses/loop"
+          cp LICENSE "$mnt/licenses/"
+          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$mnt/licenses/loop/"
           codesign --force --sign - "$app"
           hdiutil detach "$mnt"
           hdiutil convert "$work" -format UDZO -o "$out"
@@ -265,6 +269,10 @@ jobs:
           Copy-Item "desktop/src-tauri/target/release/futureos.exe" "$dir/FutureOS.exe"
           Copy-Item "target/release/future.exe" "$dir/future.exe"
           Copy-Item "docs/dist/readme-windows.txt" "$dir/Readme.txt"
+          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
+          New-Item -ItemType Directory -Force -Path "$dir/licenses/loop" | Out-Null
+          Copy-Item "LICENSE" "$dir/licenses/"
+          Copy-Item "orchestration/loop/LICENSE", "orchestration/loop/NOTICE", "orchestration/loop/UPSTREAM.md" "$dir/licenses/loop/"
           Compress-Archive -Path "$dir/*" -DestinationPath "FutureOS-portable-windows.zip" -Force
 
       - name: Upload Windows portable
@@ -290,6 +298,10 @@ jobs:
           cp "target/$(uname -m)-unknown-linux-musl/release/future" "$dir/future"
           chmod +x "$dir"/*
           cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
+          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
+          mkdir -p "$dir/licenses/loop"
+          cp LICENSE "$dir/licenses/"
+          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$dir/licenses/loop/"
           tar -czf FutureOS-portable-linux.tar.gz -C "$dir" .
 
       - name: Upload Linux portable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,11 @@ jobs:
           cp "target/${{ matrix.arch }}-unknown-linux-musl/release/future" "$dir/future"
           chmod +x "$dir"/*
           cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
+          # License & attribution notices: root MIT, plus the Apache-2.0
+          # LoopX-derived future-loop component (LICENSE/NOTICE/UPSTREAM).
+          mkdir -p "$dir/licenses/loop"
+          cp LICENSE "$dir/licenses/"
+          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$dir/licenses/loop/"
           tar -czf "${{ matrix.portable_name }}" -C "$dir" .
 
       - name: Stage release assets

--- a/README.md
+++ b/README.md
@@ -161,11 +161,3 @@ future tui       # terminal UI
 | Client exits with a connection / gRPC error | The agent isn't running. Start it (`future agent`) and check nothing else holds the port: `lsof -i :50051`. |
 | Agent replies with an auth / "no model" error | No model configured yet. Run `future auth login`, or add a provider to `models.json` — see [Configure a model](#configure-a-model). |
 | Build / install problems | See [Build & Install](docs/build-and-install.md) (platform toolchains, linker, GUI packaging). |
-
-## License
-
-FutureOS is distributed under the [MIT License](LICENSE), **except**
-[`orchestration/loop/`](orchestration/loop/) (Future Loop), which contains
-code derived from [LoopX](https://github.com/huangruiteng/loopx) and is
-distributed under the Apache License, Version 2.0 — see
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -164,4 +164,14 @@ future tui       # terminal UI
 
 ## License
 
-MIT
+FutureOS is distributed under the [MIT License](LICENSE), **except** the
+Future Loop control plane in [`orchestration/loop/`](orchestration/loop/),
+which contains code derived from [LoopX](https://github.com/huangruiteng/loopx)
+and is distributed under the [Apache License, Version 2.0](orchestration/loop/LICENSE)
+— see [`orchestration/loop/NOTICE`](orchestration/loop/NOTICE),
+[`orchestration/loop/UPSTREAM.md`](orchestration/loop/UPSTREAM.md), and
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
+Future Loop is an independent downstream implementation maintained by
+FutureGene. It is **not** an official LoopX release and has not been
+certified or endorsed by the LoopX project.

--- a/README.md
+++ b/README.md
@@ -164,14 +164,8 @@ future tui       # terminal UI
 
 ## License
 
-FutureOS is distributed under the [MIT License](LICENSE), **except** the
-Future Loop control plane in [`orchestration/loop/`](orchestration/loop/),
-which contains code derived from [LoopX](https://github.com/huangruiteng/loopx)
-and is distributed under the [Apache License, Version 2.0](orchestration/loop/LICENSE)
-— see [`orchestration/loop/NOTICE`](orchestration/loop/NOTICE),
-[`orchestration/loop/UPSTREAM.md`](orchestration/loop/UPSTREAM.md), and
+FutureOS is distributed under the [MIT License](LICENSE), **except**
+[`orchestration/loop/`](orchestration/loop/) (Future Loop), which contains
+code derived from [LoopX](https://github.com/huangruiteng/loopx) and is
+distributed under the Apache License, Version 2.0 — see
 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
-
-Future Loop is an independent downstream implementation maintained by
-FutureGene. It is **not** an official LoopX release and has not been
-certified or endorsed by the LoopX project.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ phone in your pocket.
 | **Minimalist Tool Execution** | read, write, edit, shell with approval gating; sandbox tiers (off / manual / macOS Seatbelt) — Pi-style minimalism: a lean tool set, no prompt bloat |
 | **Forkable Sessions** | Branch any conversation like a repo — fork, clone, and tree navigation over JSONL session history |
 | **Powerful Built-in Skills** | 15+ skills out of the box for everyday agent work — image read & generation, PDF/Word parsing, web search, browser control, slides, software install, and the `/future-loop` long-run goal orchestrator ([builtin](https://github.com/futuregene/future-skills/tree/main/builtin)) |
-| **Loop Engineering** | Durable goals/todos/gates/monitors for long-horizon runs of 24+ hours — deterministic should-run kernel, event-sourced state, hard checks (evidence floor / acceptance contracts / verify gates), lease liveness, multi-agent ([guide](docs/loop-control-plane.md)) — a Rust rewrite of the [loopx](https://github.com/huangruiteng/loopx) control plane, customized for FutureOS |
+| **Loop Engineering** | Durable goals/todos/gates/monitors for long-horizon runs of 24+ hours — deterministic should-run kernel, event-sourced state, hard checks (evidence floor / acceptance contracts / verify gates), lease liveness, multi-agent ([guide](docs/loop-control-plane.md)) |
 | **Rust Core** | Agent, IM channel bridge, loop control plane, CLI, and TUI are all written in Rust — high performance with memory safety |
 
 ## Quick Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,10 +155,3 @@ future tui        # 终端界面
 | 客户端报连接 / gRPC 错误退出 | Agent 没启动。先启动它(`future agent`)，并确认端口没被占用：`lsof -i :50051`。 |
 | Agent 回复鉴权 / "no model" 错误 | 还没配置模型。运行 `future auth login`，或在 `models.json` 里加一个 provider——见 [配置模型](#配置模型)。 |
 | 构建 / 安装问题 | 见 [构建与安装](docs/build-and-install.zh-CN.md)（平台工具链、链接器、GUI 打包）。 |
-
-## License
-
-FutureOS 基于 [MIT License](LICENSE) 发布，**唯一例外**是
-[`orchestration/loop/`](orchestration/loop/)（Future Loop）——该目录包含派生自
-[LoopX](https://github.com/huangruiteng/loopx) 的代码，按 Apache License 2.0 分发——
-见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,12 +159,6 @@ future tui        # 终端界面
 ## License
 
 FutureOS 基于 [MIT License](LICENSE) 发布，**唯一例外**是
-[`orchestration/loop/`](orchestration/loop/) 中的 Future Loop 控制平面——该目录包含派生自
-[LoopX](https://github.com/huangruiteng/loopx) 的代码，按
-[Apache License 2.0](orchestration/loop/LICENSE) 分发——见
-[`orchestration/loop/NOTICE`](orchestration/loop/NOTICE)、
-[`orchestration/loop/UPSTREAM.md`](orchestration/loop/UPSTREAM.md) 与
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
-
-Future Loop 是 FutureGene 独立维护的 downstream 实现，**不是** LoopX 官方发行版，
-也未经 LoopX 项目认证或背书。
+[`orchestration/loop/`](orchestration/loop/)（Future Loop）——该目录包含派生自
+[LoopX](https://github.com/huangruiteng/loopx) 的代码，按 Apache License 2.0 分发——
+见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,4 +158,13 @@ future tui        # 终端界面
 
 ## License
 
-MIT
+FutureOS 基于 [MIT License](LICENSE) 发布，**唯一例外**是
+[`orchestration/loop/`](orchestration/loop/) 中的 Future Loop 控制平面——该目录包含派生自
+[LoopX](https://github.com/huangruiteng/loopx) 的代码，按
+[Apache License 2.0](orchestration/loop/LICENSE) 分发——见
+[`orchestration/loop/NOTICE`](orchestration/loop/NOTICE)、
+[`orchestration/loop/UPSTREAM.md`](orchestration/loop/UPSTREAM.md) 与
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
+
+Future Loop 是 FutureGene 独立维护的 downstream 实现，**不是** LoopX 官方发行版，
+也未经 LoopX 项目认证或背书。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ FutureOS 提供统一的 AI Agent 体验，覆盖终端界面 (TUI)、桌面应�
 | **极简工具执行** | read, write, edit, shell，带审批控制和沙箱保护（关闭 / 手动 / macOS Seatbelt）——Pi 式极简主义：工具集精简，杜绝 prompt 膨胀 |
 | **可分支会话** | 像仓库一样为对话开分支——fork、clone、树形导航，JSONL 存储 |
 | **强大的预设技能** | 内置 15+ 技能开箱即用，覆盖日常 Agent 场景——图片读取与生成、PDF/Word 解析、网页搜索、浏览器控制、幻灯片与软件安装，以及 `/future-loop` 长程目标编排器（[builtin](https://github.com/futuregene/future-skills/tree/main/builtin)） |
-| **Loop 工程** | 持久化目标/todos/门禁/监控，支撑 24+ 小时长程任务连续执行——确定性 should-run 内核、事件溯源状态、硬校验（证据下限/验收契约/verify 闸门）、租约活性自愈、多 agent（[指南](docs/loop-control-plane.zh-CN.md)）——基于 [loopx](https://github.com/huangruiteng/loopx) 的 Rust 改写版，针对 FutureOS 做了定制 |
+| **Loop 工程** | 持久化目标/todos/门禁/监控，支撑 24+ 小时长程任务连续执行——确定性 should-run 内核、事件溯源状态、硬校验（证据下限/验收契约/verify 闸门）、租约活性自愈、多 agent（[指南](docs/loop-control-plane.zh-CN.md)） |
 | **Rust 核心** | Agent、IM 渠道桥、loop 控制面、CLI 与 TUI 均用 Rust 编写——高性能、内存安全 |
 
 ## 快速开始

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,26 @@
+# Third-Party Notices
+
+FutureOS as a whole is distributed under the [MIT License](LICENSE). The
+components below carry their own licenses and attributions, which are
+retained in the locations indicated.
+
+## LoopX — Apache License, Version 2.0
+
+- **Upstream:** <https://github.com/huangruiteng/loopx> — Ruiteng Huang and
+  LoopX contributors
+- **Where:** [`orchestration/loop/`](orchestration/loop/) (crate
+  `future-loop`) — the Future Loop control plane contains code translated,
+  ported, and structurally adapted from LoopX v0.4.x (through v0.4.8).
+- **License:** [Apache License, Version 2.0](orchestration/loop/LICENSE).
+  LoopX releases through v0.4.7 were distributed under the MIT License;
+  v0.4.8 is the first Apache-2.0 release.
+- **Notices:** [`orchestration/loop/NOTICE`](orchestration/loop/NOTICE);
+  the upstream base version, derivation scope, and FutureGene's
+  modifications are documented in
+  [`orchestration/loop/UPSTREAM.md`](orchestration/loop/UPSTREAM.md).
+- **Relationship:** Future Loop is an independent downstream implementation
+  maintained by FutureGene — it is **not** an official LoopX release and
+  has **not** been certified or endorsed by the LoopX project.
+
+Portable release archives and disk images that embed the `future` binary
+include these notices under `licenses/`.

--- a/docs/dist/readme-linux-en.txt
+++ b/docs/dist/readme-linux-en.txt
@@ -25,4 +25,9 @@ you can still use ./future directly (CLI / `future tui`).
 · The background agent stops automatically when you quit the app.
 · The command-line tool future is included in the same directory.
 
+[License]
+FutureOS is distributed under the MIT License; the bundled future loop
+component is derived from LoopX and distributed under Apache-2.0.
+Full license texts and attribution notices: see the licenses/ directory.
+
 If you encounter any issues, please send us a screenshot of the error message.

--- a/docs/dist/readme-linux.txt
+++ b/docs/dist/readme-linux.txt
@@ -21,4 +21,8 @@ GUI 需要系统的 WebKitGTK 运行库。若启动时报缺少库，用包管�
 · 退出应用时后台 agent 会一并关闭。
 · 已附带命令行工具 future（同目录）。
 
+【许可】
+FutureOS 主体按 MIT 许可发布；内置的 future loop 组件派生自 LoopX，
+按 Apache-2.0 许可发布。许可证全文与归属声明见 licenses/ 目录。
+
 如遇问题，请把报错信息截图反馈给我们。

--- a/docs/dist/readme-macos-en.txt
+++ b/docs/dist/readme-macos-en.txt
@@ -21,4 +21,9 @@ automatically when you quit the app.
 · The command-line tool future is included at
   FutureOS.app/Contents/MacOS/future.
 
+[License]
+FutureOS is distributed under the MIT License; the bundled future loop
+component is derived from LoopX and distributed under Apache-2.0.
+Full license texts and attribution notices: see the licenses/ directory.
+
 If you encounter any issues, please send us a screenshot of the error dialog.

--- a/docs/dist/readme-macos.txt
+++ b/docs/dist/readme-macos.txt
@@ -17,4 +17,8 @@ FutureOS 使用说明（macOS）
 · 个人数据保存在 ~/.future ；退出应用时后台 agent 会一并关闭。
 · 已附带命令行工具 future（位于 FutureOS.app/Contents/MacOS/）。
 
+【许可】
+FutureOS 主体按 MIT 许可发布；内置的 future loop 组件派生自 LoopX，
+按 Apache-2.0 许可发布。许可证全文与归属声明见 licenses/ 目录。
+
 如遇问题，请把报错弹窗截图反馈给我们。

--- a/docs/dist/readme-windows-en.txt
+++ b/docs/dist/readme-windows-en.txt
@@ -30,4 +30,9 @@ website and try again.
 · Closing the window quits the app; the background agent stops automatically.
 · The command-line tool future.exe is included in the same directory.
 
+[License]
+FutureOS is distributed under the MIT License; the bundled future loop
+component is derived from LoopX and distributed under Apache-2.0.
+Full license texts and attribution notices: see the licenses/ directory.
+
 If you encounter any issues, please send us a screenshot of the error window.

--- a/docs/dist/readme-windows.txt
+++ b/docs/dist/readme-windows.txt
@@ -23,4 +23,8 @@ Runtime」（Evergreen 版），再重新运行。
 · 关闭窗口即退出，后台 agent 会一并关闭。
 · 已附带命令行工具 future.exe（同目录）。
 
+【许可】
+FutureOS 主体按 MIT 许可发布；内置的 future loop 组件派生自 LoopX，
+按 Apache-2.0 许可发布。许可证全文与归属声明见 licenses/ 目录。
+
 如遇问题，请把报错窗口截图反馈给我们。

--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -5,6 +5,13 @@
 > persist outside the chat; the agent executes one bounded turn at a time and
 > a deterministic kernel decides what happens next.
 
+> **Attribution.** `future loop` contains code derived from
+> [LoopX](https://github.com/huangruiteng/loopx) (Apache-2.0) — see
+> `orchestration/loop/NOTICE` and `orchestration/loop/UPSTREAM.md`. Future
+> Loop is an independent downstream implementation maintained by FutureGene,
+> not an official LoopX release, and not certified or endorsed by the LoopX
+> project.
+
 ## Why it exists
 
 A conversation loses context; a "keep an eye on this for a week" request

--- a/orchestration/loop/Cargo.toml
+++ b/orchestration/loop/Cargo.toml
@@ -2,6 +2,9 @@
 name = "future-loop"
 version = "0.1.0"
 edition = "2021"
+# Contains code derived from LoopX (https://github.com/huangruiteng/loopx),
+# Apache-2.0 — see LICENSE, NOTICE, and UPSTREAM.md in this directory.
+license = "Apache-2.0"
 description = "FutureOS loop control plane: durable goal/todo/gate/quota state, a deterministic should-run decision kernel, and a gRPC executor bridge (LoopX-style, implemented natively)."
 
 [lib]

--- a/orchestration/loop/LICENSE
+++ b/orchestration/loop/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/orchestration/loop/NOTICE
+++ b/orchestration/loop/NOTICE
@@ -1,0 +1,20 @@
+Future Loop (future-loop)
+Copyright 2026 FutureGene
+
+This directory contains code derived from LoopX
+(https://github.com/huangruiteng/loopx), which is licensed under the
+Apache License, Version 2.0. A copy of the Apache License is included
+in this directory (see LICENSE).
+
+The following attribution notice is retained from the upstream LoopX
+project (per Apache License, Version 2.0, section 4(d)):
+
+    LoopX
+    Copyright 2026 LoopX contributors
+
+    LoopX releases through v0.4.7 were distributed under the MIT License.
+    The historical MIT license text and copyright notice are retained in
+    LICENSE-MIT (in the upstream repository).
+
+See UPSTREAM.md for the upstream base version, the scope of derived
+code, and the modifications made by FutureGene.

--- a/orchestration/loop/README.md
+++ b/orchestration/loop/README.md
@@ -1,0 +1,23 @@
+# Future Loop (`future-loop`)
+
+The FutureOS loop control plane: durable goals / todos / gates / quotas, a
+deterministic should-run decision kernel, event-sourced state, and a gRPC
+executor bridge — productized as the `future loop` CLI.
+
+Documentation: [`docs/loop-control-plane.md`](../../docs/loop-control-plane.md).
+
+## License & attribution
+
+This directory contains code derived from
+[LoopX](https://github.com/huangruiteng/loopx) and is distributed under the
+**Apache License, Version 2.0** — see [`LICENSE`](LICENSE), [`NOTICE`](NOTICE),
+and [`UPSTREAM.md`](UPSTREAM.md) for the upstream base version, the scope of
+derived code, and FutureGene's modifications. Original portions
+Copyright 2026 LoopX contributors; modifications and original additions
+Copyright 2026 FutureGene.
+
+Future Loop is an **independent downstream implementation** maintained by
+FutureGene. It is **not** an official LoopX release and has **not** been
+certified or endorsed by the LoopX project.
+
+The rest of FutureOS is MIT-licensed — see the repository root.

--- a/orchestration/loop/UPSTREAM.md
+++ b/orchestration/loop/UPSTREAM.md
@@ -1,0 +1,63 @@
+# Upstream: LoopX
+
+`future-loop` (this directory) contains code translated, ported, and
+structurally adapted from **LoopX**, a control plane for long-running AI
+agent work.
+
+- **Upstream repository:** <https://github.com/huangruiteng/loopx>
+- **Upstream author:** Ruiteng Huang and LoopX contributors
+- **Upstream license:** Apache License, Version 2.0 (see [`LICENSE`](LICENSE)
+  in this directory). LoopX releases through v0.4.7 were distributed under
+  the MIT License; v0.4.8 is the first Apache-2.0 release (see [`NOTICE`](NOTICE)).
+
+## Base version
+
+- The derivation tracks the LoopX **v0.4.x** line, through
+  [`v0.4.8`](https://github.com/huangruiteng/loopx/releases/tag/v0.4.8)
+  (commit `8c103dfecae0f4424ecb0b07bad7cbc5f0797d6d`), per the upstream
+  maintainer's review of this implementation (2026-08).
+- Initial import into FutureOS: 2026-08-06, commit `e2a8fb84` (PR #97).
+
+## Scope of derived code
+
+LoopX is written in Python; `future-loop` is a native Rust
+re-implementation of its control plane. Derived subsystems include:
+
+- the deterministic should-run decision kernel and its decision subdomains
+  (identity / boundary / frontier / monitor / stall / heartbeat /
+  goal-boundary / primary-action);
+- the event-sourced state ledger, event replay, and markdown backfill;
+- quota and slot accounting (run / agent / heartbeat);
+- the scheduler arbitration layer and its dispositions;
+- the markdown workbench and sidecar file formats
+  (`ACTIVE_GOAL_STATE.md`, lockfiles, workbench layout);
+- the `loopx`-style CLI command surface (console commands);
+- agent registry / coordination, claim / lease, gates, monitors, and
+  backup / restore.
+
+Throughout the sources, comments marked `LoopX: ...` or
+`` LoopX `<module>` `` map individual functions and behaviors to the
+corresponding upstream modules.
+
+## FutureGene modifications
+
+FutureGene holds the copyright to its modifications and original
+additions, including:
+
+- the Rust-native implementation itself (type system, storage,
+  concurrency, cross-platform support including Windows);
+- the gRPC executor bridge to the FutureOS agent and the typed-RPC wire
+  contract (`future-rpc` dual-written payloads);
+- the unified `future loop` CLI and integration with the FutureOS TUI,
+  desktop app, and skills;
+- capabilities with no upstream counterpart (explore graph,
+  pr_review_queue, canary smoke, automation liveness, read-model
+  self-healing, pid lockfiles / zombie takeover);
+- project-local state layout and FutureOS directory conventions.
+
+## Relationship
+
+Future Loop is an **independent downstream implementation** maintained by
+FutureGene. It is **not** an official LoopX release and has **not** been
+certified or endorsed by the LoopX project. Compatibility with upstream
+LoopX state files is best-effort.

--- a/orchestration/loop/src/lib.rs
+++ b/orchestration/loop/src/lib.rs
@@ -1,5 +1,11 @@
 //! FutureOS loop control plane — a native, LoopX-style implementation.
 //!
+//! This crate contains code derived from LoopX
+//! (<https://github.com/huangruiteng/loopx>), licensed under the Apache
+//! License, Version 2.0 — see `LICENSE`, `NOTICE`, and `UPSTREAM.md` in
+//! this directory for upstream attribution, the derivation scope, and
+//! FutureGene's modifications.
+//!
 //! Library surface exposes the state kernel, the decision compiler, the
 //! durable store, and the gRPC executor so contract tests can exercise the
 //! deterministic parts without touching gRPC or any LLM.


### PR DESCRIPTION
## Summary

Marks `orchestration/loop` (`future-loop`) as LoopX-derived Apache-2.0 code, per the upstream LoopX maintainer'''s request (LoopX core is Apache-2.0 since v0.4.8):

- **`orchestration/loop/`**: `LICENSE` (Apache-2.0, byte-identical to upstream), `NOTICE` (retains upstream LoopX attribution per §4(d)), `UPSTREAM.md` (base: LoopX v0.4.x through v0.4.8 `8c103dfe`; derivation scope; FutureGene modifications), `README.md`, crate `license = Apache-2.0`, lib.rs doc header
- **Root**: `THIRD_PARTY_NOTICES.md`; README / README.zh-CN License sections — FutureOS remains MIT **except** `orchestration/loop` (Apache-2.0); Future Loop is an independent downstream implementation maintained by FutureGene, **not** an official LoopX release, not certified or endorsed by LoopX
- **Docs**: attribution note in `docs/loop-control-plane.md`; dropped the loopx-rewrite tagline from the README features tables (attribution lives in the License section)
- **Release packaging**: `licenses/` directory (root MIT LICENSE + loop `LICENSE`/`NOTICE`/`UPSTREAM.md`) bundled into the Linux/Windows portable archives and the macOS DMG (`build.yml` + `release.yml`); `docs/dist/readme-*` files point to it

## Test plan

- Docs/metadata-only: no Rust code changes beyond a lib.rs doc comment and crate license metadata
- `cargo metadata --no-deps` OK — `future-loop` reports `license = Apache-2.0`
- `cargo fmt --all --check` OK
- `build.yml` / `release.yml` parse cleanly (YAML load)
- `orchestration/loop/LICENSE` verified byte-identical to upstream LoopX `LICENSE`
- Full lint/test matrix left to CI