### PR TITLE
Fix mobile native UI handoffs

### DIFF
--- a/mobile/modules/future-native-ui/android/build.gradle
+++ b/mobile/modules/future-native-ui/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'cn.future_os'
+version = '1.0.0'
+
+android {
+  namespace "cn.future_os.nativeui"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+}

--- a/mobile/modules/future-native-ui/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/future-native-ui/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/mobile/modules/future-native-ui/android/src/main/java/cn/future_os/nativeui/NativeUiModule.kt
+++ b/mobile/modules/future-native-ui/android/src/main/java/cn/future_os/nativeui/NativeUiModule.kt
@@ -1,0 +1,34 @@
+package cn.future_os.nativeui
+
+import android.app.AlertDialog
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class NativeUiModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("FutureNativeUi")
+
+    AsyncFunction("showActionSheet") { title: String?, options: List<String>, promise: Promise ->
+      require(options.isNotEmpty()) { "Action sheet options cannot be empty" }
+      val activity = appContext.currentActivity ?: error("Current activity is unavailable")
+      activity.runOnUiThread {
+        var selectedIndex: Int? = null
+        var settled = false
+        fun resolveAfterDismiss() {
+          if (settled) return
+          settled = true
+          promise.resolve(selectedIndex)
+        }
+
+        val builder = AlertDialog.Builder(activity)
+        if (!title.isNullOrBlank()) builder.setTitle(title)
+        val dialog = builder
+          .setItems(options.toTypedArray()) { _, index -> selectedIndex = index }
+          .create()
+        dialog.setOnDismissListener { resolveAfterDismiss() }
+        dialog.show()
+      }
+    }
+  }
+}

--- a/mobile/modules/future-native-ui/expo-module.config.json
+++ b/mobile/modules/future-native-ui/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["cn.future_os.nativeui.NativeUiModule"]
+  }
+}

--- a/mobile/modules/future-native-ui/index.ts
+++ b/mobile/modules/future-native-ui/index.ts
@@ -1,0 +1,12 @@
+import { requireOptionalNativeModule } from "expo-modules-core";
+
+interface NativeUiModule {
+  showActionSheet(title: string | null, options: string[]): Promise<number | null>;
+}
+
+const nativeModule = requireOptionalNativeModule<NativeUiModule>("FutureNativeUi");
+
+export async function showActionSheet(options: string[], title?: string): Promise<number | null> {
+  if (!nativeModule) throw new Error("Native UI module is unavailable");
+  return nativeModule.showActionSheet(title ?? null, options);
+}

--- a/mobile/modules/future-native-ui/package.json
+++ b/mobile/modules/future-native-ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "future-native-ui",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "peerDependencies": {
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,6 +26,7 @@
     "expo-system-ui": "~57.0.1",
     "fast-text-encoding": "^1.0.6",
     "future-file-handler": "file:modules/future-file-handler",
+    "future-native-ui": "file:modules/future-native-ui",
     "i18next": "^26.3.6",
     "lucide-react-native": "^1.27.0",
     "nats.ws": "^1.30.3",

--- a/mobile/src/remote/__tests__/files.test.ts
+++ b/mobile/src/remote/__tests__/files.test.ts
@@ -15,6 +15,7 @@ import {
   pickAttachments,
   pickFromAlbum,
   prepareDownload,
+  recoverPendingImagePickerAttachments,
   rememberPreparedPreview,
   takePhoto,
   uploadAttachments,
@@ -145,6 +146,7 @@ jest.mock("expo-image-picker", () => ({
   launchCameraAsync: jest.fn(),
   requestMediaLibraryPermissionsAsync: jest.fn(),
   launchImageLibraryAsync: jest.fn(),
+  getPendingResultAsync: jest.fn(),
 }));
 
 jest.mock("expo-crypto", () => ({
@@ -195,6 +197,7 @@ const mockedRequestCamera = ImagePicker.requestCameraPermissionsAsync as jest.Mo
 const mockedLaunchCamera = ImagePicker.launchCameraAsync as jest.Mock;
 const mockedRequestLibrary = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
 const mockedLaunchLibrary = ImagePicker.launchImageLibraryAsync as jest.Mock;
+const mockedPendingResult = ImagePicker.getPendingResultAsync as jest.Mock;
 const mockedDigest = Crypto.digest as jest.Mock;
 const mockedGetSize = Image.getSize as jest.Mock;
 
@@ -588,6 +591,34 @@ describe("pickFromAlbum", () => {
       mimeType: "image/png",
       name: "photo.png",
     });
+  });
+});
+
+describe("recoverPendingImagePickerAttachments", () => {
+  test("returns existing attachments when Android has no pending result", async () => {
+    mockedPendingResult.mockResolvedValue(null);
+    const existing = [attachment()];
+    expect(await recoverPendingImagePickerAttachments(existing)).toBe(existing);
+  });
+
+  test("prepares a pending image after MainActivity reconstruction", async () => {
+    mockedPendingResult.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: "file:///pending/photo.png", mimeType: "image/png" }],
+    });
+    mockFS.__set("file:///pending/photo.png", { bytes: new Uint8Array(10), type: "image/png" });
+
+    const result = await recoverPendingImagePickerAttachments([]);
+    expect(result[0]).toMatchObject({
+      kind: "image",
+      mimeType: "image/png",
+      name: "photo.png",
+    });
+  });
+
+  test("surfaces a pending native picker error", async () => {
+    mockedPendingResult.mockResolvedValue({ code: "E_PICKER", message: "picker failed" });
+    await expect(recoverPendingImagePickerAttachments([])).rejects.toThrow("attachment_failed");
   });
 });
 

--- a/mobile/src/remote/files.ts
+++ b/mobile/src/remote/files.ts
@@ -312,17 +312,11 @@ export async function takePhoto(existing: MobileAttachment[]): Promise<MobileAtt
   return combined;
 }
 
-export async function pickFromAlbum(existing: MobileAttachment[]): Promise<MobileAttachment[]> {
-  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
-  if (!permission.granted) throw new Error("attachment_album_permission");
-  const result = await ImagePicker.launchImageLibraryAsync({
-    mediaTypes: ["images"],
-    allowsMultipleSelection: true,
-    quality: 1,
-    exif: false,
-  });
-  if (result.canceled || result.assets.length === 0) return existing;
-  const selected = result.assets.map(asset => ({
+async function prepareImagePickerAssets(
+  existing: MobileAttachment[],
+  assets: ImagePicker.ImagePickerAsset[],
+): Promise<MobileAttachment[]> {
+  const selected = assets.map(asset => ({
     file: new File(asset.uri),
     mimeType: asset.mimeType ?? "image/jpeg",
   }));
@@ -333,6 +327,30 @@ export async function pickFromAlbum(existing: MobileAttachment[]): Promise<Mobil
   const combined = [...existing, ...prepared];
   validateBatch(combined);
   return combined;
+}
+
+export async function pickFromAlbum(existing: MobileAttachment[]): Promise<MobileAttachment[]> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) throw new Error("attachment_album_permission");
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ["images"],
+    allowsMultipleSelection: true,
+    quality: 1,
+    exif: false,
+  });
+  if (result.canceled || result.assets.length === 0) return existing;
+  return prepareImagePickerAssets(existing, result.assets);
+}
+
+/** Recover a camera/library result after Android reconstructs MainActivity. */
+export async function recoverPendingImagePickerAttachments(
+  existing: MobileAttachment[],
+): Promise<MobileAttachment[]> {
+  const result = await ImagePicker.getPendingResultAsync();
+  if (!result) return existing;
+  if ("code" in result) throw new Error("attachment_failed");
+  if (result.canceled || result.assets.length === 0) return existing;
+  return prepareImagePickerAssets(existing, result.assets);
 }
 
 interface UploadInit {

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -1,13 +1,11 @@
 import {
   ArrowDown,
   ArrowLeft,
-  Camera,
   Check,
   ChevronDown,
   CircleAlert,
   Download,
   FileText,
-  Images,
   Paperclip,
   Pencil,
   Send,
@@ -39,6 +37,7 @@ import {
 import * as Network from "expo-network";
 import * as Sharing from "expo-sharing";
 import { openFile as openAndroidFile } from "future-file-handler";
+import { showActionSheet as showAndroidActionSheet } from "future-native-ui";
 import { File } from "expo-file-system";
 import * as LegacyFileSystem from "expo-file-system/legacy";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
@@ -56,6 +55,7 @@ import {
   mimeFor,
   pickAttachments,
   pickFromAlbum,
+  recoverPendingImagePickerAttachments,
   takePhoto,
   TransferCancelledError,
   namedExternalFile,
@@ -116,7 +116,73 @@ interface ActiveDownload {
 
 interface DownloadHandle {
   id: string;
+  fileName: string;
+  visible: boolean;
   controller: AbortController;
+}
+
+interface FileAction {
+  info: DownloadInfo;
+  cachedFile: File | null;
+  openMimeType: string;
+}
+
+function deferPresentation(action: () => void): void {
+  // UIKit invokes action-sheet callbacks before the dismissal animation has
+  // fully released its presentation controller. A short delay avoids racing
+  // the next native controller. InteractionManager is deliberately avoided:
+  // it can remain pending while a Modal is itself transitioning.
+  setTimeout(action, Platform.OS === "ios" ? 350 : 0);
+}
+
+function NativeFileActionSheet({
+  action,
+  cancelLabel,
+  openLabel,
+  saveLabel,
+  onClose,
+  onSelect,
+}: {
+  action: FileAction | null;
+  cancelLabel: string;
+  openLabel: string;
+  saveLabel: string;
+  onClose: () => void;
+  onSelect: (action: FileAction, save: boolean) => void;
+}) {
+  const shownActionRef = useRef<FileAction | null>(null);
+
+  useEffect(() => {
+    if (!action || shownActionRef.current === action) return;
+    shownActionRef.current = action;
+    const close = () => {
+      shownActionRef.current = null;
+      onClose();
+    };
+    const select = (save: boolean) => {
+      close();
+      deferPresentation(() => onSelect(action, save));
+    };
+    if (Platform.OS === "ios") {
+      // iOS uses the same system share sheet for both "open" and "save".
+      // Present it directly instead of asking the user to choose between two
+      // actions that lead to the same native surface.
+      select(false);
+      return;
+    }
+    Alert.alert(
+      action.info.name,
+      undefined,
+      [
+        { text: openLabel, onPress: () => select(false) },
+        { text: cancelLabel, style: "cancel", onPress: close },
+        { text: saveLabel, onPress: () => select(true) },
+      ],
+      { cancelable: true, onDismiss: close },
+    );
+  }, [action, cancelLabel, onClose, onSelect, openLabel, saveLabel]);
+
+  return null;
 }
 
 function formatBytes(bytes: number): string {
@@ -159,10 +225,10 @@ export function ChatScreen() {
   const listRef = useRef<FlatList<TimelineItem>>(null);
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<MobileAttachment[]>([]);
-  const [attachmentMenu, setAttachmentMenu] = useState(false);
   const [transferProgress, setTransferProgress] = useState<number | null>(null);
   const [activeDownload, setActiveDownload] = useState<ActiveDownload | null>(null);
   const activeDownloadRef = useRef<DownloadHandle | null>(null);
+  const downloadModalPresentedRef = useRef(false);
   // UIKit cannot reliably present a second React Native Modal while the
   // download-progress Modal is still dismissing. Keep the next presentation
   // out of render state until `onDismiss` confirms that first Modal is gone.
@@ -175,13 +241,9 @@ export function ChatScreen() {
     text?: string;
     truncated?: boolean;
   } | null>(null);
-  // Prepared non-previewable download awaiting an "open"/"save" choice (Android
-  // bottom sheet; iOS drives the same choice through the native action sheet).
-  const [fileAction, setFileAction] = useState<{
-    info: DownloadInfo;
-    cachedFile: File | null;
-    openMimeType: string;
-  } | null>(null);
+  // Prepared non-previewable attachment awaiting an Android open/save choice;
+  // iOS immediately continues to its system share sheet.
+  const [fileAction, setFileAction] = useState<FileAction | null>(null);
   const [selector, setSelector] = useState<"model" | "thinking" | null>(null);
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameValue, setRenameValue] = useState("");
@@ -214,28 +276,48 @@ export function ChatScreen() {
     : 0;
 
   const beginDownload = useCallback(
-    (key: string, fileName: string, totalBytes = 0): DownloadHandle | null => {
+    (key: string, fileName: string, totalBytes = 0, visible = true): DownloadHandle | null => {
       if (activeDownloadRef.current) return null;
       const handle = {
         id: `${key}:${Date.now().toString(36)}`,
+        fileName,
+        visible,
         controller: new AbortController(),
       };
       activeDownloadRef.current = handle;
+      if (visible) {
+        setActiveDownload({
+          id: handle.id,
+          fileName,
+          phase: "preparing",
+          completedBytes: 0,
+          totalBytes,
+        });
+      }
+      return handle;
+    },
+    [],
+  );
+
+  const showDownload = useCallback(
+    (handle: DownloadHandle, patch: Partial<Omit<ActiveDownload, "id" | "fileName">> = {}) => {
+      if (activeDownloadRef.current?.id !== handle.id) return;
+      handle.visible = true;
       setActiveDownload({
         id: handle.id,
-        fileName,
+        fileName: handle.fileName,
         phase: "preparing",
         completedBytes: 0,
-        totalBytes,
+        totalBytes: 0,
+        ...patch,
       });
-      return handle;
     },
     [],
   );
 
   const updateDownload = useCallback(
     (handle: DownloadHandle, patch: Partial<Omit<ActiveDownload, "id" | "fileName">>) => {
-      if (activeDownloadRef.current?.id !== handle.id) return;
+      if (activeDownloadRef.current?.id !== handle.id || !handle.visible) return;
       setActiveDownload(current =>
         current?.id === handle.id ? { ...current, ...patch } : current,
       );
@@ -250,6 +332,7 @@ export function ChatScreen() {
   }, []);
 
   const flushPendingDownloadModal = useCallback(() => {
+    downloadModalPresentedRef.current = false;
     const present = pendingDownloadModalRef.current;
     pendingDownloadModalRef.current = null;
     present?.();
@@ -257,13 +340,34 @@ export function ChatScreen() {
 
   const handoffDownloadModal = useCallback(
     (handle: DownloadHandle, present: () => void) => {
+      if (!handle.visible) {
+        finishDownload(handle);
+        present();
+        return;
+      }
       pendingDownloadModalRef.current = present;
       finishDownload(handle);
-      // `onDismiss` is iOS-only. Android supports stacking these modals, so
-      // hand off on its next event-loop turn instead of leaving it pending.
-      if (Platform.OS !== "ios") setTimeout(flushPendingDownloadModal, 0);
+      // `onDismiss` is iOS-only. Android continues after the state commit. On
+      // iOS, normally wait for Modal.onDismiss; only use the timer if the
+      // progress modal never reached onShow at all.
+      if (Platform.OS !== "ios") {
+        deferPresentation(flushPendingDownloadModal);
+      } else if (!downloadModalPresentedRef.current) {
+        setTimeout(() => {
+          if (!downloadModalPresentedRef.current && pendingDownloadModalRef.current === present) {
+            flushPendingDownloadModal();
+          }
+        }, 500);
+      }
     },
     [finishDownload, flushPendingDownloadModal],
+  );
+
+  const handoffDownloadAlert = useCallback(
+    (handle: DownloadHandle, message: string) => {
+      handoffDownloadModal(handle, () => Alert.alert(t("attachment.title"), message));
+    },
+    [handoffDownloadModal, t],
   );
 
   const cancelActiveDownload = useCallback(() => {
@@ -319,9 +423,38 @@ export function ChatScreen() {
     [remote, t],
   );
 
+  const renameConversation = async (rawName: string) => {
+    const name = rawName.trim();
+    if (!name) return;
+    try {
+      await remote.rename(remote.selectedSessionId, name);
+    } catch {
+      Alert.alert(t("common.error"));
+    }
+  };
+
   const openRename = () => {
-    // Pre-fill the current title so the user can edit in place.
-    setRenameValue(remote.selectedTitle || "");
+    const currentTitle = remote.selectedTitle || "";
+    if (Platform.OS === "ios") {
+      Alert.prompt(
+        t("chat.renameTitle"),
+        undefined,
+        [
+          { text: t("chat.cancel"), style: "cancel" },
+          {
+            text: t("chat.save"),
+            onPress: (value?: string) => {
+              if (value?.trim()) void renameConversation(value);
+            },
+          },
+        ],
+        "plain-text",
+        currentTitle,
+      );
+      return;
+    }
+    // Android has no native React Native text-input alert.
+    setRenameValue(currentTitle);
     setRenameOpen(true);
   };
 
@@ -329,11 +462,7 @@ export function ChatScreen() {
     const name = renameValue.trim();
     if (!name) return;
     setRenameOpen(false);
-    try {
-      await remote.rename(remote.selectedSessionId, name);
-    } catch {
-      Alert.alert(t("common.error"));
-    }
+    await renameConversation(name);
   };
 
   useEffect(() => {
@@ -383,15 +512,26 @@ export function ChatScreen() {
     restoringDraftRef.current = true;
     activeDraftKeyRef.current = draftKey;
     const key = draftKey;
-    void loadSessionDraft(key).then(draft => {
-      // Guard against a conversation switch racing the async load.
+    void (async () => {
+      const draft = await loadSessionDraft(key);
+      let restoredAttachments = draft?.attachments ?? [];
+      if (Platform.OS === "android") {
+        try {
+          restoredAttachments = await recoverPendingImagePickerAttachments(restoredAttachments);
+        } catch (error) {
+          const errorKey = error instanceof Error ? error.message : "attachment_failed";
+          showToast(t(`attachment.errors.${errorKey}`));
+        }
+      }
+      // Guard against a conversation switch racing the async load or Android
+      // pending-result recovery after MainActivity reconstruction.
       if (restoringDraftRef.current && activeDraftKeyRef.current === key) {
         setMessage(draft?.text ?? "");
-        setAttachments(draft?.attachments ?? []);
+        setAttachments(restoredAttachments);
         restoringDraftRef.current = false;
       }
-    });
-  }, [draftKey]);
+    })();
+  }, [draftKey, t]);
 
   // Persist edits. The restore-driven update is skipped (the effect above
   // already loaded the draft), and temporary camera/cache files are released
@@ -402,12 +542,7 @@ export function ChatScreen() {
   }, [attachments, draftKey, message]);
 
   const chooseFiles = async () => {
-    setAttachmentMenu(false);
     try {
-      // Android's fallback sheet must finish dismissing before UIKit/Android
-      // presents another native controller. Otherwise the picker can be
-      // rejected as a concurrent presentation and looks like a no-op.
-      if (attachmentMenu) await new Promise(resolve => setTimeout(resolve, 200));
       setAttachments(await pickAttachments(attachments));
     } catch (error) {
       const key = error instanceof Error ? error.message : "attachment_failed";
@@ -416,9 +551,7 @@ export function ChatScreen() {
   };
 
   const capturePhoto = async () => {
-    setAttachmentMenu(false);
     try {
-      if (attachmentMenu) await new Promise(resolve => setTimeout(resolve, 200));
       setAttachments(await takePhoto(attachments));
     } catch (error) {
       const key = error instanceof Error ? error.message : "attachment_failed";
@@ -427,9 +560,7 @@ export function ChatScreen() {
   };
 
   const chooseFromAlbum = async () => {
-    setAttachmentMenu(false);
     try {
-      if (attachmentMenu) await new Promise(resolve => setTimeout(resolve, 200));
       setAttachments(await pickFromAlbum(attachments));
     } catch (error) {
       const key = error instanceof Error ? error.message : "attachment_failed";
@@ -450,16 +581,30 @@ export function ChatScreen() {
           cancelButtonIndex: 3,
         },
         index => {
-          // Schedule after the action sheet's dismissal animation, so the
-          // document/camera controller always gets a presentable view host.
-          if (index === 0) setTimeout(() => void capturePhoto(), 0);
-          if (index === 1) setTimeout(() => void chooseFromAlbum(), 0);
-          if (index === 2) setTimeout(() => void chooseFiles(), 0);
+          // Run after native presentation work has settled so the picker never
+          // competes with the action sheet for the current view controller.
+          if (index === 0) deferPresentation(() => void capturePhoto());
+          if (index === 1) deferPresentation(() => void chooseFromAlbum());
+          if (index === 2) deferPresentation(() => void chooseFiles());
         },
       );
       return;
     }
-    setAttachmentMenu(true);
+    void showAndroidActionSheet(
+      [
+        t("attachment.takePhoto"),
+        t("attachment.chooseFromAlbum"),
+        t("attachment.chooseFiles"),
+        t("chat.cancel"),
+      ],
+      t("attachment.title"),
+    )
+      .then(index => {
+        if (index === 0) deferPresentation(() => void capturePhoto());
+        if (index === 1) deferPresentation(() => void chooseFromAlbum());
+        if (index === 2) deferPresentation(() => void chooseFiles());
+      })
+      .catch(() => showToast(t("attachment.errors.attachment_failed")));
   };
 
   const send = async () => {
@@ -622,7 +767,7 @@ export function ChatScreen() {
           }
           return;
         }
-        handle = beginDownload(attachment.path, attachment.name);
+        handle = beginDownload(attachment.path, attachment.name, 0, false);
         if (!handle) {
           showToast(t("attachment.downloadInProgress"));
           return;
@@ -637,9 +782,13 @@ export function ChatScreen() {
             handle.controller.signal,
             () => handle && updateDownload(handle, { phase: "waiting_network" }),
           ));
+        if (info.size > MAX_FILE_BYTES) {
+          handoffDownloadAlert(handle, t("attachment.tooLarge"));
+          return;
+        }
         if (info.previewKind === "file") {
           if (!openMimeType) {
-            Alert.alert(t("attachment.title"), t("attachment.noHandler"));
+            handoffDownloadAlert(handle, t("attachment.noHandler"));
             return;
           }
           handoffDownloadModal(handle, () =>
@@ -663,18 +812,25 @@ export function ChatScreen() {
             if (!accepted) return;
           }
         }
-        updateDownload(handle, { phase: "downloading", totalBytes: info.size });
         file = await remote.downloadAttachment(
           info,
-          (done, total) =>
-            handle &&
-            updateDownload(handle, {
+          (done, total) => {
+            if (!handle) return;
+            const patch = {
               phase: done >= total ? "verifying" : "downloading",
               completedBytes: done,
               totalBytes: total,
-            }),
+            } as const;
+            if (handle.visible) updateDownload(handle, patch);
+            else showDownload(handle, patch);
+          },
           handle.controller.signal,
-          () => handle && updateDownload(handle, { phase: "waiting_network" }),
+          () => {
+            if (!handle) return;
+            const patch = { phase: "waiting_network" } as const;
+            if (handle.visible) updateDownload(handle, patch);
+            else showDownload(handle, patch);
+          },
         );
         if (info.previewKind === "image") {
           handoffDownloadModal(handle, () => setPreview({ attachment, info, uri: file.uri }));
@@ -701,12 +857,25 @@ export function ChatScreen() {
           detail.includes("view it on desktop") || detail.includes("GIF preview")
             ? t("attachment.previewOnDesktop")
             : t("attachment.downloadFailed");
-        Alert.alert(t("attachment.title"), message);
+        if (handle) {
+          handoffDownloadAlert(handle, message);
+        } else {
+          Alert.alert(t("attachment.title"), message);
+        }
       } finally {
         if (handle) finishDownload(handle);
       }
     },
-    [beginDownload, finishDownload, handoffDownloadModal, remote, t, updateDownload],
+    [
+      beginDownload,
+      finishDownload,
+      handoffDownloadAlert,
+      handoffDownloadModal,
+      remote,
+      showDownload,
+      t,
+      updateDownload,
+    ],
   );
 
   // Download `info` to a cached File, prompting on cellular. Returns the file,
@@ -731,33 +900,32 @@ export function ChatScreen() {
         );
         if (!accepted) return null;
       }
-      if (handle) {
-        updateDownload(handle, {
-          phase: "downloading",
-          completedBytes: 0,
-          totalBytes: info.size,
-        });
-      }
       return remote.downloadAttachment(
         info,
         (done, total) => {
           if (handle) {
-            updateDownload(handle, {
+            const patch = {
               phase: done >= total ? "verifying" : "downloading",
               completedBytes: done,
               totalBytes: total,
-            });
+            } as const;
+            if (handle.visible) updateDownload(handle, patch);
+            else showDownload(handle, patch);
           } else {
             setTransferProgress(total > 0 ? done / total : null);
           }
         },
         handle?.controller.signal,
         () => {
-          if (handle) updateDownload(handle, { phase: "waiting_network" });
+          if (handle) {
+            const patch = { phase: "waiting_network" } as const;
+            if (handle.visible) updateDownload(handle, patch);
+            else showDownload(handle, patch);
+          }
         },
       );
     },
-    [remote, t, updateDownload],
+    [remote, showDownload, t, updateDownload],
   );
 
   // Non-previewable file: download then hand it to the OS share sheet, which is
@@ -771,7 +939,7 @@ export function ChatScreen() {
       openMimeType = info.mimeType,
     ) => {
       const handle =
-        existingHandle ?? beginDownload(info.transferId || info.name, info.name, info.size);
+        existingHandle ?? beginDownload(info.transferId || info.name, info.name, info.size, false);
       if (!handle) {
         showToast(t("attachment.downloadInProgress"));
         return;
@@ -807,7 +975,7 @@ export function ChatScreen() {
           return;
         }
         if (!(await Sharing.isAvailableAsync())) {
-          Alert.alert(t("attachment.title"), t("attachment.shareUnavailable"));
+          handoffDownloadAlert(handle, t("attachment.shareUnavailable"));
           return;
         }
         updateDownload(handle, { phase: save ? "saving" : "opening" });
@@ -831,17 +999,25 @@ export function ChatScreen() {
         });
       } catch (error) {
         if (error instanceof TransferCancelledError) return;
-        Alert.alert(t("attachment.title"), t("attachment.downloadFailed"));
+        handoffDownloadAlert(handle, t("attachment.downloadFailed"));
       } finally {
         finishDownload(handle);
       }
     },
-    [beginDownload, fetchDownload, finishDownload, handoffDownloadModal, t, updateDownload],
+    [
+      beginDownload,
+      fetchDownload,
+      finishDownload,
+      handoffDownloadAlert,
+      handoffDownloadModal,
+      t,
+      updateDownload,
+    ],
   );
 
   const downloadOriginal = useCallback(
     async (attachment: HistoryAttachment) => {
-      const handle = beginDownload(attachment.path, attachment.name);
+      const handle = beginDownload(attachment.path, attachment.name, 0, false);
       if (!handle) {
         showToast(t("attachment.downloadInProgress"));
         return;
@@ -874,12 +1050,11 @@ export function ChatScreen() {
           ));
         await openOrShare(info, cached?.file ?? null, true, handle);
       } catch (error) {
-        finishDownload(handle);
         if (error instanceof TransferCancelledError) return;
-        Alert.alert(t("attachment.title"), t("attachment.downloadFailed"));
+        handoffDownloadAlert(handle, t("attachment.downloadFailed"));
       }
     },
-    [beginDownload, finishDownload, openOrShare, remote, t, updateDownload],
+    [beginDownload, handoffDownloadAlert, openOrShare, remote, t, updateDownload],
   );
 
   // A local-file markdown link/image target: prepare, then dispatch by size and
@@ -899,7 +1074,7 @@ export function ChatScreen() {
         Alert.alert(t("attachment.title"), t("attachment.noHandler"));
         return;
       }
-      const handle = beginDownload(path, attachment.name);
+      const handle = beginDownload(path, attachment.name, 0, false);
       if (!handle) {
         showToast(t("attachment.downloadInProgress"));
         return;
@@ -913,7 +1088,7 @@ export function ChatScreen() {
             updateDownload(handle, { phase: "waiting_network" }),
           ));
         if (info.size > MAX_FILE_BYTES) {
-          Alert.alert(t("attachment.title"), t("attachment.tooLarge"));
+          handoffDownloadAlert(handle, t("attachment.tooLarge"));
           return;
         }
         const previewable =
@@ -923,7 +1098,7 @@ export function ChatScreen() {
           info.previewKind === "json";
         if (!previewable) {
           if (!openMimeType) {
-            Alert.alert(t("attachment.title"), t("attachment.noHandler"));
+            handoffDownloadAlert(handle, t("attachment.noHandler"));
             return;
           }
           handoffDownloadModal(handle, () =>
@@ -958,12 +1133,21 @@ export function ChatScreen() {
           detail.includes("view it on desktop") || detail.includes("GIF preview")
             ? t("attachment.previewOnDesktop")
             : t("attachment.downloadFailed");
-        Alert.alert(t("attachment.title"), message);
+        handoffDownloadAlert(handle, message);
       } finally {
         finishDownload(handle);
       }
     },
-    [beginDownload, fetchDownload, finishDownload, handoffDownloadModal, remote, t, updateDownload],
+    [
+      beginDownload,
+      fetchDownload,
+      finishDownload,
+      handoffDownloadAlert,
+      handoffDownloadModal,
+      remote,
+      t,
+      updateDownload,
+    ],
   );
 
   // The bottom-most scroll offset: full content height minus the viewport,
@@ -1292,84 +1476,16 @@ export function ChatScreen() {
           )}
         </View>
 
-        <Modal
-          animationType="fade"
-          onRequestClose={() => setAttachmentMenu(false)}
-          transparent
-          visible={attachmentMenu}
-        >
-          <TouchableWithoutFeedback onPress={() => setAttachmentMenu(false)}>
-            <View style={styles.attachmentOverlay}>
-              <TouchableWithoutFeedback>
-                <View style={styles.attachmentMenu}>
-                  <Pressable
-                    onPress={() => void capturePhoto()}
-                    style={styles.attachmentMenuOption}
-                  >
-                    <Camera color={colors.ink} size={20} />
-                    <Text style={styles.attachmentMenuText}>{t("attachment.takePhoto")}</Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => void chooseFromAlbum()}
-                    style={styles.attachmentMenuOption}
-                  >
-                    <Images color={colors.ink} size={20} />
-                    <Text style={styles.attachmentMenuText}>{t("attachment.chooseFromAlbum")}</Text>
-                  </Pressable>
-                  <Pressable onPress={() => void chooseFiles()} style={styles.attachmentMenuOption}>
-                    <FileText color={colors.ink} size={20} />
-                    <Text style={styles.attachmentMenuText}>{t("attachment.chooseFiles")}</Text>
-                  </Pressable>
-                </View>
-              </TouchableWithoutFeedback>
-            </View>
-          </TouchableWithoutFeedback>
-        </Modal>
-
-        <Modal
-          animationType="fade"
-          onRequestClose={() => setFileAction(null)}
-          transparent
-          visible={fileAction !== null}
-        >
-          <TouchableWithoutFeedback onPress={() => setFileAction(null)}>
-            <View style={styles.attachmentOverlay}>
-              <TouchableWithoutFeedback>
-                <View style={styles.attachmentMenu}>
-                  <Pressable
-                    onPress={() => {
-                      const action = fileAction;
-                      setFileAction(null);
-                      if (action)
-                        void openOrShare(
-                          action.info,
-                          action.cachedFile,
-                          false,
-                          undefined,
-                          action.openMimeType,
-                        );
-                    }}
-                    style={styles.attachmentMenuOption}
-                  >
-                    <FileText color={colors.ink} size={20} />
-                    <Text style={styles.attachmentMenuText}>{t("attachment.open")}</Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => {
-                      const action = fileAction;
-                      setFileAction(null);
-                      if (action) void openOrShare(action.info, action.cachedFile, true);
-                    }}
-                    style={styles.attachmentMenuOption}
-                  >
-                    <Download color={colors.ink} size={20} />
-                    <Text style={styles.attachmentMenuText}>{t("attachment.save")}</Text>
-                  </Pressable>
-                </View>
-              </TouchableWithoutFeedback>
-            </View>
-          </TouchableWithoutFeedback>
-        </Modal>
+        <NativeFileActionSheet
+          action={fileAction}
+          cancelLabel={t("chat.cancel")}
+          onClose={() => setFileAction(null)}
+          onSelect={(action, save) => {
+            void openOrShare(action.info, action.cachedFile, save, undefined, action.openMimeType);
+          }}
+          openLabel={t("attachment.open")}
+          saveLabel={t("attachment.save")}
+        />
 
         <Modal
           animationType="slide"
@@ -1437,6 +1553,9 @@ export function ChatScreen() {
           animationType="fade"
           onDismiss={flushPendingDownloadModal}
           onRequestClose={cancelActiveDownload}
+          onShow={() => {
+            downloadModalPresentedRef.current = true;
+          }}
           transparent
           visible={activeDownload !== null}
         >
@@ -1557,7 +1676,7 @@ export function ChatScreen() {
           animationType="fade"
           onRequestClose={() => setRenameOpen(false)}
           transparent
-          visible={renameOpen}
+          visible={Platform.OS !== "ios" && renameOpen}
         >
           <View style={styles.overlay}>
             <View style={styles.dialog}>
@@ -1789,28 +1908,6 @@ const styles = StyleSheet.create({
     paddingBottom: spacing.xl,
     backgroundColor: colors.overlay,
   },
-  attachmentOverlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: colors.overlay,
-  },
-  attachmentMenu: {
-    width: "100%",
-    overflow: "hidden",
-    borderTopLeftRadius: radius.lg,
-    borderTopRightRadius: radius.lg,
-    backgroundColor: colors.surface,
-  },
-  attachmentMenuOption: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.md,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.lg,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.lineSoft,
-  },
-  attachmentMenuText: { color: colors.ink, fontSize: 15, fontWeight: "600" },
   downloadOverlay: {
     flex: 1,
     alignItems: "center",

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -1,32 +1,30 @@
 import {
-  Check,
   ChevronDown,
   CircleAlert,
   Folder,
   LogOut,
   MessageCircle,
-  Pencil,
   Pin,
-  PinOff,
   Plus,
   Settings,
-  Trash2,
   Unplug,
   X,
 } from "lucide-react-native";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { showActionSheet as showAndroidActionSheet } from "future-native-ui";
 import {
   ActivityIndicator,
+  ActionSheetIOS,
   Alert,
   FlatList,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
-  TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -46,6 +44,12 @@ type Tab = "workspace" | "chat";
 // Persist the selected tab across screen transitions (SessionsScreen is
 // unmounted when entering a chat and remounted when returning).
 let lastTab: Tab = "chat";
+
+function deferPresentation(action: () => void): void {
+  // Let the native action sheet finish dismissing before presenting another
+  // alert. InteractionManager can remain pending during native transitions.
+  setTimeout(action, Platform.OS === "ios" ? 350 : 0);
+}
 
 function SessionStatusIndicator({
   status,
@@ -110,10 +114,8 @@ export function SessionsScreen() {
   const [newMode, setNewMode] = useState<Tab>("chat");
   const [workspaceId, setWorkspaceId] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [approvalMenuOpen, setApprovalMenuOpen] = useState(false);
   const [approvalSaving, setApprovalSaving] = useState(false);
   const [checkingUpdate, setCheckingUpdate] = useState(false);
-  const [menuSession, setMenuSession] = useState<RemoteSession | null>(null);
   const [renameTarget, setRenameTarget] = useState<RemoteSession | null>(null);
   const [renameValue, setRenameValue] = useState("");
 
@@ -170,16 +172,8 @@ export function SessionsScreen() {
   );
   const approvalDisabled = !remote.desktopOnline || approvalSaving;
 
-  useEffect(() => {
-    // Connection state is external to this screen; transient menus must close
-    // immediately when that external state invalidates their actions.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!remote.desktopOnline) setApprovalMenuOpen(false);
-  }, [remote.desktopOnline]);
-
   const selectApprovalTier = async (tier: (typeof approvalTiers)[number]) => {
     if (approvalDisabled) return;
-    setApprovalMenuOpen(false);
     if (tier === remote.approvalTier) return;
     setApprovalSaving(true);
     try {
@@ -191,13 +185,66 @@ export function SessionsScreen() {
     }
   };
 
+  const openApprovalMenu = () => {
+    if (approvalDisabled) return;
+    const options = [...approvalTiers.map(tier => t(`approvalTier.${tier}`)), t("chat.cancel")];
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: t("approvalTier.title"),
+          options,
+          cancelButtonIndex: approvalTiers.length,
+        },
+        index => {
+          const tier = approvalTiers[index];
+          if (tier) deferPresentation(() => void selectApprovalTier(tier));
+        },
+      );
+      return;
+    }
+    void showAndroidActionSheet(options, t("approvalTier.title"))
+      .then(index => {
+        const tier = index === null ? undefined : approvalTiers[index];
+        if (tier) deferPresentation(() => void selectApprovalTier(tier));
+      })
+      .catch(() => Alert.alert(t("common.error")));
+  };
+
   const startConversation = () => {
     if (newMode === "workspace" && !workspaceId) return;
     setNewOpen(false);
     void remote.newConversation(newMode, workspaceId);
   };
 
+  const renameSession = async (session: RemoteSession, rawName: string) => {
+    const name = rawName.trim();
+    if (!name) return;
+    try {
+      await remote.rename(session.sessionId, name);
+    } catch {
+      Alert.alert(t("common.error"));
+    }
+  };
+
   const openRename = (session: RemoteSession) => {
+    if (Platform.OS === "ios") {
+      Alert.prompt(
+        t("chat.renameTitle"),
+        undefined,
+        [
+          { text: t("chat.cancel"), style: "cancel" },
+          {
+            text: t("chat.save"),
+            onPress: (value?: string) => {
+              if (value?.trim()) void renameSession(session, value);
+            },
+          },
+        ],
+        "plain-text",
+        session.title || "",
+      );
+      return;
+    }
     setRenameTarget(session);
     setRenameValue(session.title || "");
   };
@@ -207,22 +254,16 @@ export function SessionsScreen() {
     const name = renameValue.trim();
     if (!session || !name) return;
     setRenameTarget(null);
-    try {
-      await remote.rename(session.sessionId, name);
-    } catch {
-      Alert.alert(t("common.error"));
-    }
+    await renameSession(session, name);
   };
 
   const togglePin = (session: RemoteSession) => {
-    setMenuSession(null);
     void remote
       .setSessionPinned(session.sessionId, session.threadId, !session.pinned)
       .catch(() => Alert.alert(t("common.error")));
   };
 
   const confirmDelete = (session: RemoteSession) => {
-    setMenuSession(null);
     Alert.alert(
       t("sessions.delete"),
       t("sessions.deleteConfirm", {
@@ -243,6 +284,36 @@ export function SessionsScreen() {
     );
   };
 
+  const openSessionMenu = (session: RemoteSession) => {
+    const options = [
+      session.pinned ? t("sessions.unpin") : t("sessions.pin"),
+      t("chat.rename"),
+      t("sessions.delete"),
+      t("chat.cancel"),
+    ];
+    const title = session.title || t("sessions.unnamed");
+    const handleSelection = (index: number | null) => {
+      if (index === 0) deferPresentation(() => togglePin(session));
+      if (index === 1) deferPresentation(() => openRename(session));
+      if (index === 2) deferPresentation(() => confirmDelete(session));
+    };
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title,
+          options,
+          destructiveButtonIndex: 2,
+          cancelButtonIndex: 3,
+        },
+        handleSelection,
+      );
+      return;
+    }
+    void showAndroidActionSheet(options, title)
+      .then(handleSelection)
+      .catch(() => Alert.alert(t("common.error")));
+  };
+
   const renderSession = (item: RemoteSession, inWorkspace = false) => (
     <Pressable
       accessibilityRole="button"
@@ -250,7 +321,7 @@ export function SessionsScreen() {
       onLongPress={() => {
         // Session management goes through the desktop bridge — with the link
         // down every action would just fail, so don't offer the menu.
-        if (remote.desktopOnline) setMenuSession(item);
+        if (remote.desktopOnline) openSessionMenu(item);
       }}
       onPress={() => {
         // Opening a conversation needs the desktop for state/history — a tap
@@ -493,10 +564,7 @@ export function SessionsScreen() {
 
         <Modal
           animationType="fade"
-          onRequestClose={() => {
-            setApprovalMenuOpen(false);
-            setSettingsOpen(false);
-          }}
+          onRequestClose={() => setSettingsOpen(false)}
           transparent
           visible={settingsOpen}
         >
@@ -506,10 +574,7 @@ export function SessionsScreen() {
                 <Text style={styles.dialogTitle}>{t("sessions.settings")}</Text>
                 <Pressable
                   accessibilityLabel={t("common.close")}
-                  onPress={() => {
-                    setApprovalMenuOpen(false);
-                    setSettingsOpen(false);
-                  }}
+                  onPress={() => setSettingsOpen(false)}
                 >
                   <X color={colors.inkMuted} size={20} />
                 </Pressable>
@@ -518,9 +583,9 @@ export function SessionsScreen() {
               <View style={styles.tierDropdown}>
                 <Pressable
                   accessibilityRole="button"
-                  accessibilityState={{ disabled: approvalDisabled, expanded: approvalMenuOpen }}
+                  accessibilityState={{ disabled: approvalDisabled }}
                   disabled={approvalDisabled}
-                  onPress={() => setApprovalMenuOpen(open => !open)}
+                  onPress={openApprovalMenu}
                   style={({ pressed }) => [
                     styles.tierTrigger,
                     approvalDisabled && styles.tierTriggerDisabled,
@@ -541,35 +606,6 @@ export function SessionsScreen() {
                     <ChevronDown color={colors.inkMuted} size={18} />
                   )}
                 </Pressable>
-                {approvalMenuOpen && !approvalDisabled && (
-                  <View style={styles.tierMenu}>
-                    {approvalTiers.map(tier => {
-                      const active = remote.approvalTier === tier;
-                      return (
-                        <Pressable
-                          accessibilityRole="button"
-                          key={tier}
-                          onPress={() => void selectApprovalTier(tier)}
-                          style={({ pressed }) => [
-                            styles.tierMenuOption,
-                            active && styles.tierMenuOptionActive,
-                            pressed && styles.pressed,
-                          ]}
-                        >
-                          <Text
-                            style={[
-                              styles.tierMenuOptionText,
-                              active && styles.tierMenuOptionTextActive,
-                            ]}
-                          >
-                            {t(`approvalTier.${tier}`)}
-                          </Text>
-                          {active && <Check color={colors.accent} size={17} />}
-                        </Pressable>
-                      );
-                    })}
-                  </View>
-                )}
               </View>
               <View style={styles.updateRow}>
                 <Text style={styles.updateVersion}>
@@ -595,80 +631,9 @@ export function SessionsScreen() {
 
         <Modal
           animationType="fade"
-          onRequestClose={() => setMenuSession(null)}
-          transparent
-          visible={menuSession !== null}
-        >
-          <TouchableWithoutFeedback onPress={() => setMenuSession(null)}>
-            <View style={styles.menuOverlay}>
-              <TouchableWithoutFeedback>
-                <View style={styles.menu}>
-                  <Text numberOfLines={1} style={styles.menuTitle}>
-                    {menuSession?.title || t("sessions.unnamed")}
-                  </Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => {
-                      if (menuSession) togglePin(menuSession);
-                    }}
-                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
-                  >
-                    {menuSession?.pinned ? (
-                      <PinOff color={colors.ink} size={18} />
-                    ) : (
-                      <Pin color={colors.ink} size={18} />
-                    )}
-                    <Text style={styles.menuOptionText}>
-                      {menuSession?.pinned ? t("sessions.unpin") : t("sessions.pin")}
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => {
-                      if (menuSession) {
-                        openRename(menuSession);
-                        setMenuSession(null);
-                      }
-                    }}
-                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
-                  >
-                    <Pencil color={colors.ink} size={18} />
-                    <Text style={styles.menuOptionText}>{t("chat.rename")}</Text>
-                  </Pressable>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => {
-                      if (menuSession) confirmDelete(menuSession);
-                    }}
-                    style={({ pressed }) => [styles.menuOption, pressed && styles.pressed]}
-                  >
-                    <Trash2 color={colors.danger} size={18} />
-                    <Text style={[styles.menuOptionText, styles.menuOptionDanger]}>
-                      {t("sessions.delete")}
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => setMenuSession(null)}
-                    style={({ pressed }) => [
-                      styles.menuOption,
-                      styles.menuOptionCancel,
-                      pressed && styles.pressed,
-                    ]}
-                  >
-                    <Text style={styles.menuOptionCancelText}>{t("chat.cancel")}</Text>
-                  </Pressable>
-                </View>
-              </TouchableWithoutFeedback>
-            </View>
-          </TouchableWithoutFeedback>
-        </Modal>
-
-        <Modal
-          animationType="fade"
           onRequestClose={() => setRenameTarget(null)}
           transparent
-          visible={renameTarget !== null}
+          visible={Platform.OS !== "ios" && renameTarget !== null}
         >
           <View style={styles.overlay}>
             <View style={styles.dialog}>
@@ -913,63 +878,6 @@ const styles = StyleSheet.create({
   tierTriggerDisabled: { backgroundColor: colors.surfaceSubtle, opacity: 0.55 },
   tierTriggerText: { flex: 1, color: colors.ink, fontSize: 14, fontWeight: "600" },
   tierTriggerTextDisabled: { color: colors.inkMuted },
-  tierMenu: {
-    position: "absolute",
-    top: 52,
-    left: 0,
-    right: 0,
-    zIndex: 20,
-    elevation: 6,
-    overflow: "hidden",
-    borderWidth: 1,
-    borderColor: colors.line,
-    borderRadius: radius.md,
-    backgroundColor: colors.surface,
-  },
-  tierMenuOption: {
-    minHeight: 44,
-    paddingHorizontal: spacing.md,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: spacing.md,
-  },
-  tierMenuOptionActive: { backgroundColor: colors.accentSoft },
-  tierMenuOptionText: { flex: 1, color: colors.ink, fontSize: 14, fontWeight: "600" },
-  tierMenuOptionTextActive: { color: colors.accent },
-  menuOverlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: colors.overlay,
-  },
-  menu: {
-    gap: spacing.xs,
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.md,
-    paddingBottom: spacing.xl,
-    backgroundColor: colors.surface,
-    borderTopLeftRadius: radius.lg,
-    borderTopRightRadius: radius.lg,
-  },
-  menuTitle: {
-    color: colors.inkMuted,
-    fontSize: 16,
-    fontWeight: "600",
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.xs,
-    paddingBottom: spacing.sm,
-  },
-  menuOption: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.md,
-    padding: spacing.md,
-    borderRadius: radius.md,
-  },
-  menuOptionText: { color: colors.ink, fontSize: 16, fontWeight: "500" },
-  menuOptionDanger: { color: colors.danger, fontWeight: "600" },
-  menuOptionCancel: { justifyContent: "center" },
-  menuOptionCancelText: { color: colors.inkSoft, fontSize: 16, fontWeight: "600" },
   nameInput: {
     borderWidth: 1,
     borderColor: colors.line,

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "expo-system-ui": "~57.0.1",
         "fast-text-encoding": "^1.0.6",
         "future-file-handler": "file:modules/future-file-handler",
+        "future-native-ui": "file:modules/future-native-ui",
         "i18next": "^26.3.6",
         "lucide-react-native": "^1.27.0",
         "nats.ws": "^1.30.3",
@@ -106,6 +107,14 @@
       }
     },
     "mobile/modules/future-file-handler": {
+      "version": "1.0.0",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "mobile/modules/future-native-ui": {
       "version": "1.0.0",
       "peerDependencies": {
         "expo": "*",
@@ -12056,6 +12065,10 @@
     },
     "node_modules/future-file-handler": {
       "resolved": "mobile/modules/future-file-handler",
+      "link": true
+    },
+    "node_modules/future-native-ui": {
+      "resolved": "mobile/modules/future-native-ui",
       "link": true
     },
     "node_modules/generator-function": {


### PR DESCRIPTION
## Summary
- use native iOS/Android action surfaces for short mobile actions while keeping complex previews and forms custom
- fix iOS modal handoff so attachment previews and share sheets do not stall during native transitions
- make metadata lookup silent and show progress only for actual file transfer; reject files over 10 MiB before download
- restore consistent model and thinking-level selector behavior

## Root cause
Native presentations were competing with React Native modal transitions, and attachment preparation was presented as a download before bytes were transferred.

## Validation
- npm run typecheck
- npm run lint (two pre-existing TimelineCard warnings)
- npm run format:check
- npm test -- --no-watchman (347 tests)
- git diff --check

Android native-module autolinking was verified. Native Android compilation and device testing remain unverified locally because the Android SDK is not installed.