### PR TITLE
Improve mobile chat history and downloads

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -1257,15 +1257,25 @@ fn entries_vec(data: Value) -> Vec<Value> {
 /// needs this outcome to use the same recovery predicate as the desktop UI.
 /// Failed runs additionally carry `run_error` (the stored raw error) so mobile
 /// can rebuild the same friendly failure bubble the desktop shows on reload.
+/// `run_duration_ms` comes from the same persisted start/end timestamps the
+/// desktop footer uses, including for runs which produced no assistant entry.
 fn entries_with_run_status(session_id: &str, mut entries: Vec<Value>) -> Vec<Value> {
-    let outcomes: HashMap<String, (String, Option<String>)> =
+    let outcomes: HashMap<String, (String, Option<String>, Option<i64>)> =
         crate::store::find_thread_by_agent_session(session_id)
             .ok()
             .flatten()
             .and_then(|thread| crate::store::list_runs(&thread.id).ok())
             .unwrap_or_default()
             .into_iter()
-            .map(|run| (run.id, (run.status, run.error_message)))
+            .map(|run| {
+                let duration_ms = match (run.started_at, run.ended_at) {
+                    (Some(started_at), Some(ended_at)) if ended_at >= started_at => {
+                        Some(ended_at - started_at)
+                    }
+                    _ => None,
+                };
+                (run.id, (run.status, run.error_message, duration_ms))
+            })
             .collect();
     if outcomes.is_empty() {
         return entries;
@@ -1275,8 +1285,13 @@ fn entries_with_run_status(session_id: &str, mut entries: Vec<Value>) -> Vec<Val
             .pointer("/meta/run_id")
             .and_then(Value::as_str)
             .and_then(|run_id| outcomes.get(run_id));
-        if let (Some((status, error_message)), Some(object)) = (outcome, entry.as_object_mut()) {
+        if let (Some((status, error_message, duration_ms)), Some(object)) =
+            (outcome, entry.as_object_mut())
+        {
             object.insert("run_status".to_string(), Value::String(status.clone()));
+            if let Some(duration_ms) = duration_ms {
+                object.insert("run_duration_ms".to_string(), Value::from(*duration_ms));
+            }
             if status == "failed" {
                 if let Some(message) = error_message.as_ref().filter(|m| !m.trim().is_empty()) {
                     object.insert("run_error".to_string(), Value::String(message.clone()));
@@ -2357,6 +2372,7 @@ mod bridge_tests {
         assert_eq!(reply["success"], json!(true));
         assert_eq!(reply["data"]["entries"].as_array().unwrap().len(), 1);
         assert_eq!(reply["data"]["entries"][0]["run_status"], json!("failed"));
+        assert!(reply["data"]["entries"][0]["run_duration_ms"].is_number());
 
         // Entries honor an explicit positive limit too.
         let reply = bridge

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -461,7 +461,6 @@ export function TimelineCard({
   onContinue,
 }: TimelineCardProps) {
   const { t, i18n } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
   const { copied, copy } = useCopyState();
 
   if (item.kind === "message") {

--- a/mobile/src/remote/__tests__/files.test.ts
+++ b/mobile/src/remote/__tests__/files.test.ts
@@ -960,6 +960,36 @@ describe("download & preview cache", () => {
     );
   });
 
+  test("downloadPrepared cancels an in-flight chunk request immediately", async () => {
+    const i: DownloadInfo = { ...info, size: 4, chunkBytes: 4, contentHash: "x" };
+    const client = mockClient();
+    const controller = new AbortController();
+    let resolveChunk: ((value: Uint8Array) => void) | undefined;
+    client.downloadChunk.mockImplementation(
+      () =>
+        new Promise<Uint8Array>(resolve => {
+          resolveChunk = resolve;
+        }),
+    );
+    client.request.mockResolvedValue({ success: true, data: {} });
+
+    const download = downloadPrepared(
+      client as unknown as RemoteClient,
+      i,
+      undefined,
+      controller.signal,
+    );
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(download).rejects.toThrow("transfer_cancelled");
+    expect(client.request).toHaveBeenCalledWith(
+      { type: "download_cancel", transferId: "t1" },
+      "transfer",
+    );
+    resolveChunk?.(new Uint8Array([1, 2, 3, 4]));
+  });
+
   test("downloadPrepared prunes the preview cache when over budget", async () => {
     const fileBytes = new Uint8Array([1, 2, 3, 4]);
     const i: DownloadInfo = { ...info, size: 4, chunkBytes: 4, contentHash: sha256Hex(fileBytes) };

--- a/mobile/src/remote/__tests__/timeline.test.ts
+++ b/mobile/src/remote/__tests__/timeline.test.ts
@@ -988,6 +988,7 @@ describe("run failure parity with the desktop", () => {
         meta: { run_id: "run-1" },
         run_status: "failed",
         run_error: "Authentication failed (401). Check your API key.",
+        run_duration_ms: 15_000,
       },
     ]);
     expect(timeline.items).toEqual([
@@ -998,6 +999,7 @@ describe("run failure parity with the desktop", () => {
         role: "assistant",
         failed: true,
         error: "Authentication failed (401). Check your API key.",
+        durationMs: 15_000,
       }),
     ]);
   });

--- a/mobile/src/remote/files.ts
+++ b/mobile/src/remote/files.ts
@@ -363,8 +363,11 @@ interface UploadComplete {
   contentHash: string;
 }
 
-async function cancelDownload(client: RemoteClient, transferId: string): Promise<void> {
-  await client.request({ type: "download_cancel", transferId }, "transfer").catch(() => {});
+function cancelDownload(client: RemoteClient, transferId: string): void {
+  // Cancellation is best-effort cleanup on the desktop. Never await it: when
+  // the network is down, waiting for this command's timeout would keep the
+  // phone's progress dialog and download lock stuck after the user cancelled.
+  void client.request({ type: "download_cancel", transferId }, "transfer").catch(() => {});
 }
 
 const TRANSFER_RETRY_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000, 15_000, 15_000];
@@ -378,6 +381,33 @@ export class TransferCancelledError extends Error {
 
 function throwIfCancelled(signal?: AbortSignal): void {
   if (signal?.aborted) throw new TransferCancelledError();
+}
+
+/** Race an in-flight NATS request with cancellation. NATS requests themselves
+ * don't accept AbortSignal, so their transport timeout may finish later; this
+ * wrapper releases the UI path immediately while still observing that late
+ * result/rejection. */
+function abortable<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  throwIfCancelled(signal);
+  if (!signal) return operation;
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(new TransferCancelledError());
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      value => {
+        cleanup();
+        resolve(value);
+      },
+      error => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 function isPermanentTransferError(error: unknown): boolean {
@@ -419,7 +449,7 @@ async function withTransferRetry<T>(
   for (let attempt = 0; attempt <= retryDelays.length; attempt += 1) {
     throwIfCancelled(signal);
     try {
-      return await operation();
+      return await abortable(operation(), signal);
     } catch (error) {
       lastError = error;
       if (error instanceof TransferCancelledError || isPermanentTransferError(error)) throw error;
@@ -516,15 +546,15 @@ export async function prepareDownload(
   // compatible, so normalize the response to the variant we requested.
   const info = response.data.variant ? response.data : { ...response.data, variant };
   if (signal?.aborted) {
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw new TransferCancelledError();
   }
   try {
     if (await verifiedCachedDownload(info, signal)) {
-      await cancelDownload(client, info.transferId);
+      cancelDownload(client, info.transferId);
     }
   } catch (error) {
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw error;
   }
   return info;
@@ -639,11 +669,11 @@ export async function downloadPrepared(
   try {
     cached = await verifiedCachedDownload(info, signal);
   } catch (error) {
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw error;
   }
   if (cached) {
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     return cached;
   }
   prunePreviewCache(info.size);
@@ -669,18 +699,18 @@ export async function downloadPrepared(
   } catch (error) {
     handle.close();
     if (file.exists) file.delete();
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw error;
   }
   handle.close();
   if (signal?.aborted) {
     file.delete();
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw new TransferCancelledError();
   }
   if (file.size !== info.size) {
     file.delete();
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw new Error("download_size_mismatch");
   }
   let hash: string;
@@ -689,14 +719,14 @@ export async function downloadPrepared(
     throwIfCancelled(signal);
   } catch (error) {
     file.delete();
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw error;
   }
   if (hash !== info.contentHash) {
     file.delete();
-    await cancelDownload(client, info.transferId);
+    cancelDownload(client, info.transferId);
     throw new Error("download_hash_mismatch");
   }
-  await cancelDownload(client, info.transferId);
+  cancelDownload(client, info.transferId);
   return file;
 }

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -180,6 +180,12 @@ export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
                 typeof entry.run_error === "string" && entry.run_error.trim()
                   ? entry.run_error
                   : undefined,
+              durationMs:
+                typeof entry.run_duration_ms === "number" &&
+                Number.isFinite(entry.run_duration_ms) &&
+                entry.run_duration_ms >= 0
+                  ? entry.run_duration_ms
+                  : undefined,
             },
           ] as const,
       ),
@@ -194,6 +200,9 @@ export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
             ...item,
             ...(outcome.status === "failed" ? { failed: true } : {}),
             ...(outcome.status === "cancelled" ? { stopped: true } : {}),
+            ...(item.durationMs == null && outcome.durationMs != null
+              ? { durationMs: outcome.durationMs }
+              : {}),
           }
         : item,
     );
@@ -214,15 +223,18 @@ export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
   // the shared projection ids them `m_<entry id>` — the same id this file's
   // toSessionEntries assigns — so a failed run's bubble anchors after its user
   // item without re-deriving the exchange grouping.
-  const failuresByAnchor = new Map<string, { runId: string; error?: string }>();
-  const unanchored: { runId: string; error?: string }[] = [];
+  const failuresByAnchor = new Map<
+    string,
+    { runId: string; error?: string; durationMs?: number }
+  >();
+  const unanchored: { runId: string; error?: string; durationMs?: number }[] = [];
   entries.forEach((entry, index) => {
     if (entry.role !== "user") return;
     const runId = typeof entry.meta?.run_id === "string" ? entry.meta.run_id : null;
     if (!runId) return;
     const outcome = runOutcomes.get(runId);
     if (outcome?.status !== "failed" || assistantRunIds.has(runId)) return;
-    const failure = { runId, error: outcome.error };
+    const failure = { runId, error: outcome.error, durationMs: outcome.durationMs };
     const text = typeof entry.content === "string" ? entry.content : "";
     if (text.trim() || (entry.meta?.attachments?.length ?? 0) > 0) {
       failuresByAnchor.set(`m_${entry.id ?? `entry_${index}`}`, failure);
@@ -230,7 +242,11 @@ export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
       unanchored.push(failure);
     }
   });
-  const toFailureBubble = (failure: { runId: string; error?: string }): TimelineItem => ({
+  const toFailureBubble = (failure: {
+    runId: string;
+    error?: string;
+    durationMs?: number;
+  }): TimelineItem => ({
     id: `failed_${failure.runId}`,
     kind: "message",
     role: "assistant",
@@ -238,6 +254,7 @@ export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
     runId: failure.runId,
     failed: true,
     ...(failure.error ? { error: failure.error } : {}),
+    ...(failure.durationMs != null ? { durationMs: failure.durationMs } : {}),
   });
   const items: TimelineItem[] = [];
   for (const item of projected) {

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -175,6 +175,10 @@ export interface HistoryEntry {
   /** Raw run error for `run_status: "failed"` — the bridge pairs it with the
    *  status so a reloaded timeline can rebuild the desktop's failure bubble. */
   run_error?: string;
+  /** Authoritative elapsed run time from the desktop store. This remains
+   * separate from `duration_ms`, which belongs to a persisted assistant entry
+   * and is absent when a run fails before producing one. */
+  run_duration_ms?: number;
   /** RFC3339 entry time; preserved across re-saves so history keeps real times. */
   timestamp?: string;
 }

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -374,8 +374,11 @@ export function ChatScreen() {
     const handle = activeDownloadRef.current;
     if (!handle) return;
     handle.controller.abort();
-    updateDownload(handle, { phase: "cancelling" });
-  }, [updateDownload]);
+    // Local cancellation must be immediate even while an underlying NATS
+    // request is waiting for its transport timeout. Late callbacks are scoped
+    // to this handle and are ignored once it has been released.
+    finishDownload(handle);
+  }, [finishDownload]);
 
   // Approvals live docked above the composer (not inline in the transcript), and
   // only while undecided — once a decision lands the card disappears.
@@ -408,6 +411,11 @@ export function ChatScreen() {
   // The first content render snaps to the end without animation; only later
   // appends (streaming, new messages) scroll animated.
   const landedRef = useRef(false);
+  // A FlatList emits scroll events while iOS/Android are measuring its first
+  // content and viewport. Those are layout side effects, not a user decision
+  // to read earlier messages, so they must not disable the initial snap.
+  const initialScrollPendingRef = useRef(true);
+  const initialScrollFrameRef = useRef<number | null>(null);
   const decideApproval = useCallback(
     async (id: string, decision: "approved" | "rejected") => {
       setApprovalSubmitting(id);
@@ -811,6 +819,14 @@ export function ChatScreen() {
             );
             if (!accepted) return;
           }
+          // Metadata is intentionally silent. Once we know this is a cache
+          // miss and have the real byte size, show 0 / total before the first
+          // (possibly only) chunk arrives.
+          showDownload(handle, {
+            phase: "downloading",
+            completedBytes: 0,
+            totalBytes: info.size,
+          });
         }
         file = await remote.downloadAttachment(
           info,
@@ -899,6 +915,15 @@ export function ChatScreen() {
           t("attachment.download"),
         );
         if (!accepted) return null;
+      }
+      if (handle && !cachedFile) {
+        const patch = {
+          phase: "downloading",
+          completedBytes: 0,
+          totalBytes: info.size,
+        } as const;
+        if (handle.visible) updateDownload(handle, patch);
+        else showDownload(handle, patch);
       }
       return remote.downloadAttachment(
         info,
@@ -1155,6 +1180,51 @@ export function ChatScreen() {
   // composer (bottom padding) and content grow.
   const maxScrollOffset = () => Math.max(0, contentHeightRef.current - layoutHeightRef.current);
 
+  // Opening a conversation may lay out the list, its remote history and the
+  // floating composer in separate commits. Wait one frame, then repeat on the
+  // next frame with the final measurements: this avoids both Android's stale
+  // first content size and iOS applying its safe-area/composer inset late.
+  const scheduleInitialScroll = () => {
+    if (
+      !initialScrollPendingRef.current ||
+      contentHeightRef.current <= 0 ||
+      layoutHeightRef.current <= 0 ||
+      composerHeight <= 0
+    ) {
+      return;
+    }
+    if (initialScrollFrameRef.current != null) return;
+    initialScrollFrameRef.current = requestAnimationFrame(() => {
+      initialScrollFrameRef.current = null;
+      if (!initialScrollPendingRef.current) return;
+      listRef.current?.scrollToOffset({ animated: false, offset: maxScrollOffset() });
+      initialScrollFrameRef.current = requestAnimationFrame(() => {
+        initialScrollFrameRef.current = null;
+        if (!initialScrollPendingRef.current) return;
+        listRef.current?.scrollToOffset({ animated: false, offset: maxScrollOffset() });
+        initialScrollPendingRef.current = false;
+        landedRef.current = true;
+        setAtLatest(true);
+      });
+    });
+  };
+
+  // Reset the opening contract if the mounted screen switches between the
+  // draft and an established session. In the usual navigation path ChatScreen
+  // unmounts, but this also covers a send binding a draft to its new session.
+  useEffect(() => {
+    landedRef.current = false;
+    initialScrollPendingRef.current = true;
+    contentHeightRef.current = 0;
+    layoutHeightRef.current = 0;
+    return () => {
+      if (initialScrollFrameRef.current != null) {
+        cancelAnimationFrame(initialScrollFrameRef.current);
+        initialScrollFrameRef.current = null;
+      }
+    };
+  }, [remote.selectedSessionId]);
+
   // scrollToEnd is unreliable on Android for the first layout of a large
   // history (it can no-op or use a stale content size, leaving a gap). An
   // explicit offset computed from the measured content size is deterministic;
@@ -1237,6 +1307,10 @@ export function ChatScreen() {
             }
             onContentSizeChange={(_w, h) => {
               contentHeightRef.current = h;
+              if (initialScrollPendingRef.current) {
+                scheduleInitialScroll();
+                return;
+              }
               if (!atLatest) return;
               if (!landedRef.current && transcriptItems.length === 0) return;
               listRef.current?.scrollToOffset({
@@ -1247,8 +1321,12 @@ export function ChatScreen() {
             }}
             onLayout={event => {
               layoutHeightRef.current = event.nativeEvent.layout.height;
+              scheduleInitialScroll();
             }}
             onScroll={event => {
+              // Ignore first-layout offsets; the two-frame snap above owns the
+              // initial position on both platforms.
+              if (initialScrollPendingRef.current) return;
               const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
               setAtLatest(
                 contentOffset.y + layoutMeasurement.height >=


### PR DESCRIPTION
## Summary

- show persisted run duration for historical failed messages, matching desktop behavior
- reliably open mobile conversations at the latest message on iOS and Android
- make attachment cancellation immediate and show download progress as soon as a confirmed cache miss has metadata
- remove the unused TimelineCard state so mobile lint is clean

## Validation

- `npm --prefix mobile run format:check`
- `npm --prefix mobile run lint`
- `npm --prefix mobile run typecheck`
- `npm --prefix mobile test -- --watchman=false --runInBand` (348 tests)
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml history_commands_page_and_fail --lib`
