### PR TITLE
Fix remote attachment preview resilience

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -261,7 +261,6 @@ async fn handle_command_singleflight(
             }
         }
     };
-
     if inserted {
         let slots = reply_slots.clone();
         let id = command_id.clone();
@@ -563,12 +562,8 @@ async fn handle_command(
             .await
         }
         "download_prepare" => {
-            match super::transfer::prepare_download_variant(
-                &cmd.session_id,
-                &cmd.file_path,
-                &cmd.mode,
-            )
-            .await
+            match super::transfer::prepare_download_variant(&cmd.session_id, &cmd.file_path, &cmd.mode)
+                .await
             {
                 Ok(data) => {
                     reply(

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -562,8 +562,12 @@ async fn handle_command(
             .await
         }
         "download_prepare" => {
-            match super::transfer::prepare_download_variant(&cmd.session_id, &cmd.file_path, &cmd.mode)
-                .await
+            match super::transfer::prepare_download_variant(
+                &cmd.session_id,
+                &cmd.file_path,
+                &cmd.mode,
+            )
+            .await
             {
                 Ok(data) => {
                     reply(

--- a/desktop/src-tauri/src/remote/mod.rs
+++ b/desktop/src-tauri/src/remote/mod.rs
@@ -727,6 +727,7 @@ pub async fn unpair() -> Result<RemoteStatus, crate::AppError> {
         pairing::revoke_pairing(&creds).await?;
     }
     let status = stop();
+    transfer::clear_preview_cache();
     pairing::clear_creds()?;
     Ok(status)
 }
@@ -825,7 +826,10 @@ fn stop_runtime() -> RemoteStatus {
         if let Some(web_task) = state.web_task {
             web_task.abort();
         }
-        transfer::clear_all();
+        // In-flight transfers are generation-scoped, but prepared previews are
+        // safe content-derived artifacts. Preserve them across bridge restarts
+        // so a transient NATS reconnect cannot force an expensive re-encode.
+        transfer::clear_transfers();
     }
     empty()
 }

--- a/desktop/src-tauri/src/remote/transfer.rs
+++ b/desktop/src-tauri/src/remote/transfer.rs
@@ -25,6 +25,8 @@ pub const MAX_MESSAGE_BYTES: u64 = 20 * 1024 * 1024;
 pub const MAX_ATTACHMENTS: usize = 10;
 pub const MAX_IMAGES: usize = 4;
 const MOBILE_PREVIEW_MAX_EDGE: u32 = 1600;
+const PREVIEW_CACHE_VERSION: &[u8] = b"futureos-mobile-preview-v1";
+const MAX_PREVIEW_CACHE_BYTES: u64 = 100 * 1024 * 1024;
 pub const CHUNK_BYTES: u64 = 512 * 1024;
 const TRANSFER_TTL: Duration = Duration::from_secs(30 * 60);
 
@@ -93,6 +95,76 @@ fn transfer_root() -> PathBuf {
         .join("mobile")
 }
 
+fn preview_cache_dir() -> PathBuf {
+    transfer_root().join("preview-cache")
+}
+
+fn image_preview_extension(source: &Path) -> Option<&'static str> {
+    match source
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "jpg" | "jpeg" | "bmp" => Some("jpg"),
+        "png" | "webp" => Some("png"),
+        _ => None,
+    }
+}
+
+fn preview_cache_path(source: &Path) -> Result<Option<PathBuf>, crate::AppError> {
+    let Some(output_extension) = image_preview_extension(source) else {
+        return Ok(None);
+    };
+    let metadata = std::fs::metadata(source)?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|value| value.as_nanos())
+        .unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(PREVIEW_CACHE_VERSION);
+    hasher.update([0]);
+    hasher.update(source.to_string_lossy().as_bytes());
+    hasher.update([0]);
+    hasher.update(metadata.len().to_le_bytes());
+    hasher.update(modified.to_le_bytes());
+    let key = format!("{:x}", hasher.finalize());
+    Ok(Some(
+        preview_cache_dir().join(format!("{key}.{output_extension}")),
+    ))
+}
+
+fn prune_preview_cache() {
+    let dir = preview_cache_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    let mut files = entries
+        .flatten()
+        .filter_map(|entry| {
+            let metadata = entry.metadata().ok()?;
+            metadata
+                .is_file()
+                .then_some((entry.path(), metadata.len(), metadata.modified().ok()))
+        })
+        .collect::<Vec<_>>();
+    files.sort_by_key(|(_, _, modified)| *modified);
+    let mut total = files.iter().map(|(_, size, _)| *size).sum::<u64>();
+    for (path, size, modified) in files {
+        let expired = modified
+            .and_then(|value| value.elapsed().ok())
+            .is_some_and(|age| age > TRANSFER_TTL);
+        if (expired || total > MAX_PREVIEW_CACHE_BYTES)
+            && std::fs::remove_file(path).is_ok()
+        {
+            total = total.saturating_sub(size);
+        }
+    }
+}
+
 /// Create a staging directory with owner-only permissions (0700 on unix).
 /// Attachment bytes (uploaded `.part` files and downloaded previews) sit here
 /// until claimed or TTL'd — on a multi-user machine the default `/tmp` mode
@@ -143,6 +215,7 @@ fn safe_disk_name(name: &str, fallback: &str) -> String {
 }
 
 fn prune_expired() {
+    prune_preview_cache();
     let expired = |created: SystemTime| created.elapsed().unwrap_or_default() > TRANSFER_TTL;
     let mut uploads = UPLOADS.lock().unwrap();
     uploads.retain(|_, item| {
@@ -428,7 +501,7 @@ pub async fn prepare_download(
     prepare_download_variant(session_id, requested_path, "preview").await
 }
 
-pub async fn prepare_download_variant(
+pub(super) async fn prepare_download_variant(
     session_id: &str,
     requested_path: &str,
     requested_variant: &str,
@@ -465,15 +538,30 @@ pub async fn prepare_download_variant(
                 .into(),
         );
     }
-    let prepared = match requested_variant {
-        "original" => prepare_original(&source, &display_name)?,
-        "" | "preview" => prepare_preview(&source, &display_name)
-            .or_else(|_| prepare_original(&source, &display_name))?,
-        _ => return Err("Unsupported download variant.".to_string().into()),
-    };
-    let size = std::fs::metadata(&prepared.path)?.len();
+    let source_for_prepare = source.clone();
+    let display_name_for_prepare = display_name.clone();
+    let variant_for_prepare = requested_variant.to_string();
+    let prepared = tokio::task::spawn_blocking(move || {
+        match variant_for_prepare.as_str() {
+            "original" => prepare_original(&source_for_prepare, &display_name_for_prepare),
+            "" | "preview" => prepare_preview_cached(&source_for_prepare, &display_name_for_prepare)
+            .or_else(|_| prepare_original(&source_for_prepare, &display_name_for_prepare)),
+            _ => Err("Unsupported download variant.".to_string().into()),
+        }
+    })
+    .await
+    .map_err(|error| format!("Preview preparation task failed: {error}"))??;
+    let prepared_path = prepared.path.clone();
+    let (size, content_hash) = tokio::task::spawn_blocking(
+        move || -> Result<(u64, String), crate::AppError> {
+            let size = std::fs::metadata(&prepared_path)?.len();
+            let content_hash = sha256_file(&prepared_path)?;
+            Ok((size, content_hash))
+        },
+    )
+    .await
+    .map_err(|error| format!("Preview hashing task failed: {error}"))??;
     let transfer_id = new_transfer_id("download");
-    let content_hash = sha256_file(&prepared.path)?;
     let info = DownloadInfo {
         transfer_id: transfer_id.clone(),
         name: prepared.name.clone(),
@@ -733,7 +821,6 @@ fn prepare_preview(
             variant: "preview".to_string(),
         });
     }
-
     let size = std::fs::metadata(source)?.len();
     if size > MAX_FILE_BYTES {
         return Err("The file is larger than 10 MiB; view it on desktop."
@@ -784,6 +871,101 @@ fn prepare_preview(
     })
 }
 
+fn cached_image_preview(
+    requested_display_name: &str,
+    cache_path: &Path,
+) -> Result<Option<PreparedPreview>, crate::AppError> {
+    let metadata = match std::fs::metadata(cache_path) {
+        Ok(metadata) if metadata.is_file() && metadata.len() > 0 => metadata,
+        Ok(_) => {
+            let _ = std::fs::remove_file(cache_path);
+            return Ok(None);
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let valid_dimensions = image::ImageReader::open(cache_path)
+        .ok()
+        .and_then(|reader| reader.with_guessed_format().ok())
+        .and_then(|reader| reader.into_dimensions().ok())
+        .is_some_and(|(width, height)| {
+            width > 0 && height > 0 && width.max(height) <= MOBILE_PREVIEW_MAX_EDGE
+        });
+    if !valid_dimensions {
+        let _ = std::fs::remove_file(cache_path);
+        return Ok(None);
+    }
+    let output_extension = cache_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("jpg");
+    let dir = transfer_root().join("download");
+    ensure_private_dir(&dir)?;
+    let transfer_path = dir.join(format!(
+        "{}.{}",
+        new_transfer_id("preview-cache"),
+        output_extension
+    ));
+    if std::fs::hard_link(cache_path, &transfer_path).is_err() {
+        std::fs::copy(cache_path, &transfer_path)?;
+    }
+    debug_assert_eq!(std::fs::metadata(&transfer_path)?.len(), metadata.len());
+    let original_name = display_name(requested_display_name, "attachment");
+    Ok(Some(PreparedPreview {
+        path: transfer_path,
+        name: format!(
+            "{}.{}",
+            Path::new(&original_name)
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .unwrap_or("image"),
+            output_extension
+        ),
+        mime_type: if output_extension == "png" {
+            "image/png"
+        } else {
+            "image/jpeg"
+        }
+        .to_string(),
+        preview_kind: "image".to_string(),
+        variant: "preview".to_string(),
+    }))
+}
+
+fn persist_image_preview_cache(prepared: &PreparedPreview, cache_path: &Path) {
+    let Some(parent) = cache_path.parent() else {
+        return;
+    };
+    if ensure_private_dir(parent).is_err() || cache_path.exists() {
+        return;
+    }
+    let temporary = parent.join(format!("{}.tmp", new_transfer_id("preview-cache")));
+    if std::fs::copy(&prepared.path, &temporary).is_err() {
+        let _ = std::fs::remove_file(temporary);
+        return;
+    }
+    if std::fs::rename(&temporary, cache_path).is_err() {
+        let _ = std::fs::remove_file(temporary);
+    }
+}
+
+fn prepare_preview_cached(
+    source: &Path,
+    requested_display_name: &str,
+) -> Result<PreparedPreview, crate::AppError> {
+    let cache_path = preview_cache_path(source)?;
+    if let Some(path) = cache_path.as_deref() {
+        if let Some(prepared) = cached_image_preview(requested_display_name, path)? {
+            return Ok(prepared);
+        }
+    }
+    let prepared = prepare_preview(source, requested_display_name)?;
+    if let Some(path) = cache_path.as_deref() {
+        persist_image_preview_cache(&prepared, path);
+    }
+    Ok(prepared)
+}
+
 fn is_plain_utf8_text(path: &Path) -> Result<bool, crate::AppError> {
     let bytes = std::fs::read(path)?;
     let Ok(text) = std::str::from_utf8(&bytes) else {
@@ -800,13 +982,23 @@ pub fn cancel_download(transfer_id: &str) {
     }
 }
 
-pub fn clear_all() {
+pub fn clear_transfers() {
     for (_, item) in UPLOADS.lock().unwrap().drain() {
         let _ = std::fs::remove_file(item.path);
     }
     for (_, item) in DOWNLOADS.lock().unwrap().drain() {
         let _ = std::fs::remove_file(item.path);
     }
+}
+
+pub fn clear_preview_cache() {
+    let _ = std::fs::remove_dir_all(preview_cache_dir());
+}
+
+#[cfg(test)]
+pub fn clear_all() {
+    clear_transfers();
+    clear_preview_cache();
 }
 
 /// First resubscribe delay after a failed subscribe / ended stream (doubles up
@@ -1533,6 +1725,38 @@ mod flow_tests {
         assert!(!download_path.exists());
         // Idempotent on empty maps.
         clear_all();
+    }
+
+    #[test]
+    fn preview_cache_survives_transfer_cleanup_and_invalidates_on_source_change() {
+        let _lock = mock_agent_lock();
+        let _home = HomeGuard::new("xfer-preview-cache");
+        let dir = std::env::temp_dir().join(unique("futureos-preview-cache-source"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("photo.jpg");
+        image::DynamicImage::new_rgb8(64, 32).save(&source).unwrap();
+        let first_cache_path = preview_cache_path(&source).unwrap().unwrap();
+        let _ = std::fs::remove_file(&first_cache_path);
+
+        let first = prepare_preview_cached(&source, "photo.jpg").unwrap();
+        let expected = std::fs::read(&first.path).unwrap();
+        assert!(first_cache_path.exists());
+        std::fs::remove_file(&first.path).unwrap();
+        clear_transfers();
+        assert!(first_cache_path.exists());
+
+        let second = prepare_preview_cached(&source, "photo.jpg").unwrap();
+        assert_eq!(std::fs::read(&second.path).unwrap(), expected);
+        assert!(first_cache_path.exists());
+
+        image::DynamicImage::new_rgb8(65, 32).save(&source).unwrap();
+        let changed_cache_path = preview_cache_path(&source).unwrap().unwrap();
+        assert_ne!(changed_cache_path, first_cache_path);
+
+        std::fs::remove_file(second.path).unwrap();
+        clear_preview_cache();
+        assert!(!first_cache_path.exists());
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/desktop/src-tauri/src/remote/transfer.rs
+++ b/desktop/src-tauri/src/remote/transfer.rs
@@ -157,9 +157,7 @@ fn prune_preview_cache() {
         let expired = modified
             .and_then(|value| value.elapsed().ok())
             .is_some_and(|age| age > TRANSFER_TTL);
-        if (expired || total > MAX_PREVIEW_CACHE_BYTES)
-            && std::fs::remove_file(path).is_ok()
-        {
+        if (expired || total > MAX_PREVIEW_CACHE_BYTES) && std::fs::remove_file(path).is_ok() {
             total = total.saturating_sub(size);
         }
     }
@@ -541,26 +539,23 @@ pub(super) async fn prepare_download_variant(
     let source_for_prepare = source.clone();
     let display_name_for_prepare = display_name.clone();
     let variant_for_prepare = requested_variant.to_string();
-    let prepared = tokio::task::spawn_blocking(move || {
-        match variant_for_prepare.as_str() {
-            "original" => prepare_original(&source_for_prepare, &display_name_for_prepare),
-            "" | "preview" => prepare_preview_cached(&source_for_prepare, &display_name_for_prepare)
+    let prepared = tokio::task::spawn_blocking(move || match variant_for_prepare.as_str() {
+        "original" => prepare_original(&source_for_prepare, &display_name_for_prepare),
+        "" | "preview" => prepare_preview_cached(&source_for_prepare, &display_name_for_prepare)
             .or_else(|_| prepare_original(&source_for_prepare, &display_name_for_prepare)),
-            _ => Err("Unsupported download variant.".to_string().into()),
-        }
+        _ => Err("Unsupported download variant.".to_string().into()),
     })
     .await
     .map_err(|error| format!("Preview preparation task failed: {error}"))??;
     let prepared_path = prepared.path.clone();
-    let (size, content_hash) = tokio::task::spawn_blocking(
-        move || -> Result<(u64, String), crate::AppError> {
+    let (size, content_hash) =
+        tokio::task::spawn_blocking(move || -> Result<(u64, String), crate::AppError> {
             let size = std::fs::metadata(&prepared_path)?.len();
             let content_hash = sha256_file(&prepared_path)?;
             Ok((size, content_hash))
-        },
-    )
-    .await
-    .map_err(|error| format!("Preview hashing task failed: {error}"))??;
+        })
+        .await
+        .map_err(|error| format!("Preview hashing task failed: {error}"))??;
     let transfer_id = new_transfer_id("download");
     let info = DownloadInfo {
         transfer_id: transfer_id.clone(),

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -506,6 +506,31 @@ describe("RemoteClient request retry classification", () => {
     );
     expect(request).toHaveBeenCalledTimes(1);
   });
+
+  test("recovers only transient request failures", async () => {
+    const { client } = recoveryClient();
+    const recoverNow = jest.spyOn(client, "recoverNow").mockResolvedValue(undefined);
+
+    await expect(
+      client.recoverAfterTransientRequest(new NatsError("timeout", ErrorCode.Timeout)),
+    ).resolves.toBe(true);
+    await expect(client.recoverAfterTransientRequest(new Error("business_error"))).resolves.toBe(
+      false,
+    );
+    expect(recoverNow).toHaveBeenCalledTimes(1);
+    expect(recoverNow).toHaveBeenCalledWith("request-failure");
+  });
+
+  test("passes a command-specific timeout to NATS", async () => {
+    const { client } = recoveryClient();
+    const request = jest.fn().mockResolvedValue({
+      data: response({ success: true, data: { ok: true } }),
+    });
+    (client as unknown as { connection: { request: jest.Mock } | null }).connection = { request };
+
+    await client.request({ type: "list_sessions" }, "list", 20_000);
+    expect(request.mock.calls[0]?.[2]).toEqual({ timeout: 20_000 });
+  });
 });
 
 describe("RemoteClient OS lifecycle recovery", () => {

--- a/mobile/src/remote/__tests__/files.test.ts
+++ b/mobile/src/remote/__tests__/files.test.ts
@@ -212,12 +212,14 @@ function fsFile(
 function mockClient(): {
   request: jest.Mock;
   requestRetry: jest.Mock;
+  recoverAfterTransientRequest: jest.Mock;
   uploadChunk: jest.Mock;
   downloadChunk: jest.Mock;
 } {
   return {
     request: jest.fn(),
     requestRetry: jest.fn(),
+    recoverAfterTransientRequest: jest.fn().mockResolvedValue(true),
     uploadChunk: jest.fn(),
     downloadChunk: jest.fn(),
   };
@@ -736,6 +738,7 @@ describe("download & preview cache", () => {
         mode: "preview",
       }),
       "s1",
+      10_000,
     );
   });
 
@@ -755,6 +758,7 @@ describe("download & preview cache", () => {
         mode: "original",
       }),
       "s1",
+      10_000,
     );
   });
 
@@ -790,6 +794,23 @@ describe("download & preview cache", () => {
     expect(waiting).toHaveBeenCalledTimes(1);
     expect(client.request).toHaveBeenCalledTimes(2);
     expect(client.request.mock.calls[0]![0].id).toBe(client.request.mock.calls[1]![0].id);
+    expect(client.request.mock.calls[0]![2]).toBe(10_000);
+    expect(client.request.mock.calls[1]![2]).toBe(20_000);
+    expect(client.recoverAfterTransientRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("prepareDownload does not retry a non-transient failure", async () => {
+    const client = mockClient();
+    client.request.mockRejectedValue(new Error("not an attachment"));
+    client.recoverAfterTransientRequest.mockResolvedValue(false);
+
+    await expect(
+      prepareDownload(client as unknown as RemoteClient, "s1", {
+        path: "/tmp/a.jpg",
+        name: "a.jpg",
+      }),
+    ).rejects.toThrow("not an attachment");
+    expect(client.request).toHaveBeenCalledTimes(1);
   });
 
   test("cachedDownload returns only a present size-matching cache candidate", () => {

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -20,7 +20,8 @@ const decoder = new TextDecoder();
 const HANDSHAKE_PROTOCOL_VERSION = 1;
 const FOREGROUND_PROBE_TIMEOUT_MS = 4_000;
 
-export type RecoveryReason = "foreground" | "network-restored" | "network-changed";
+export type RecoveryReason =
+  "foreground" | "network-restored" | "network-changed" | "request-failure";
 
 interface HandshakeConfirmation {
   confirmed: boolean;
@@ -174,9 +175,20 @@ export class RemoteClient {
   private async runRecovery(reason: RecoveryReason): Promise<void> {
     const connection = this.connection;
     const generation = this.generation;
-    if (reason === "foreground" && connection && !connection.isClosed()) {
+    if (
+      (reason === "foreground" || reason === "request-failure") &&
+      connection &&
+      !connection.isClosed()
+    ) {
       try {
-        await withTimeout(connection.flush(), FOREGROUND_PROBE_TIMEOUT_MS);
+        // A command timeout can be a slow desktop handler or a half-open WSS.
+        // Probe briefly: keep a healthy socket (the stable command id will
+        // retrieve the singleflight result), but rebuild a half-open one before
+        // the only prepare retry is spent on the same dead path.
+        await withTimeout(
+          connection.flush(),
+          reason === "request-failure" ? 1_000 : FOREGROUND_PROBE_TIMEOUT_MS,
+        );
         if (
           !this.stopped &&
           this.networkAvailable &&
@@ -657,10 +669,22 @@ export class RemoteClient {
   async request<T>(
     command: RemoteCommand,
     sessionId = command.sessionId ?? "list",
+    timeoutMs = 10_000,
   ): Promise<RpcResponse<T>> {
     const connection = this.connection;
     if (!connection) throw new Error("not_connected");
-    return this.requestWithConnection(connection, command, sessionId);
+    return this.requestWithConnection(connection, command, sessionId, timeoutMs);
+  }
+
+  /** Recover a stale request path only for transport failures. Business errors
+   * must surface immediately and must never enter the transfer retry loop. */
+  async recoverAfterTransientRequest(error: unknown): Promise<boolean> {
+    if (!isTransientNatsRequestError(error)) return false;
+    // The retry itself remains the source of truth. Recovery is best-effort:
+    // if reconnecting fails, let the bounded retry report its own transport
+    // error instead of replacing it with an internal recovery exception.
+    await this.recoverNow("request-failure").catch(() => undefined);
+    return true;
   }
 
   /**
@@ -736,12 +760,13 @@ export class RemoteClient {
     connection: NatsConnection,
     command: RemoteCommand,
     sessionId = command.sessionId ?? "list",
+    timeoutMs = 10_000,
   ): Promise<RpcResponse<T>> {
     const payload = { ...command, id: command.id ?? randomId("cmd") };
     const message = await connection.request(
       `p.${this.credentials.pairId}.cmd.${sessionId || "new"}`,
       encoder.encode(JSON.stringify(payload)),
-      { timeout: 10_000 },
+      { timeout: timeoutMs },
     );
     const response = decodeJson<RpcResponse<T>>(message.data);
     if (!response.success) {
@@ -832,6 +857,7 @@ class RemoteResponseError extends Error {
 
 function isTransientNatsRequestError(error: unknown): boolean {
   if (error instanceof RemoteResponseError) return false;
+  if (error instanceof Error && error.message === "not_connected") return true;
   const code =
     typeof error === "object" && error !== null && "code" in error
       ? (error as { code?: unknown }).code

--- a/mobile/src/remote/files.ts
+++ b/mobile/src/remote/files.ts
@@ -4,7 +4,7 @@ import * as ImagePicker from "expo-image-picker";
 import * as Crypto from "expo-crypto";
 import { Image } from "react-native";
 import type { RemoteClient } from "./client";
-import type { DownloadInfo, HistoryAttachment, MobileAttachment } from "./types";
+import type { DownloadInfo, HistoryAttachment, MobileAttachment, RpcResponse } from "./types";
 import { mobileFileType } from "./fileTypes";
 import { basename } from "./localPath";
 
@@ -371,6 +371,12 @@ function cancelDownload(client: RemoteClient, transferId: string): void {
 }
 
 const TRANSFER_RETRY_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000, 15_000, 15_000];
+// Metadata preparation has a different failure profile from byte chunks. One
+// retry with the same command id is enough to retrieve a desktop singleflight
+// result or recover a half-open socket; the second attempt gets extra time for
+// an uncached image pipeline without multiplying silence for minutes.
+const PREPARE_RPC_TIMEOUTS_MS = [10_000, 20_000] as const;
+const PREPARE_RETRY_DELAY_MS = 500;
 
 export class TransferCancelledError extends Error {
   constructor() {
@@ -537,11 +543,26 @@ export async function prepareDownload(
     filePath: attachment.path,
     mode: variant,
   };
-  const response = await withTransferRetry(
-    () => client.request<DownloadInfo>(command, sessionId),
-    signal,
-    onWaiting,
-  );
+  let attempt = 0;
+  let response: RpcResponse<DownloadInfo> | null = null;
+  for (const timeoutMs of PREPARE_RPC_TIMEOUTS_MS) {
+    attempt += 1;
+    try {
+      response = await abortable(
+        client.request<DownloadInfo>(command, sessionId, timeoutMs),
+        signal,
+      );
+      break;
+    } catch (error) {
+      if (error instanceof TransferCancelledError) throw error;
+      if (attempt >= PREPARE_RPC_TIMEOUTS_MS.length) throw error;
+      const retryable = await abortable(client.recoverAfterTransientRequest(error), signal);
+      if (!retryable) throw error;
+      onWaiting?.();
+      await retryDelay(PREPARE_RETRY_DELAY_MS, signal);
+    }
+  }
+  if (!response) throw new Error("download_prepare_failed");
   // Older desktops do not return `variant`; their preview behavior remains
   // compatible, so normalize the response to the variant we requested.
   const info = response.data.variant ? response.data : { ...response.data, variant };
@@ -550,7 +571,8 @@ export async function prepareDownload(
     throw new TransferCancelledError();
   }
   try {
-    if (await verifiedCachedDownload(info, signal)) {
+    const cached = await verifiedCachedDownload(info, signal);
+    if (cached) {
       cancelDownload(client, info.transferId);
     }
   } catch (error) {

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -119,6 +119,7 @@ interface DownloadHandle {
   fileName: string;
   visible: boolean;
   controller: AbortController;
+  handoffPending: boolean;
 }
 
 interface FileAction {
@@ -205,14 +206,23 @@ function plainText(bytes: Uint8Array): string | null {
 
 function confirmDownload(title: string, message: string, cancel: string, download: string) {
   return new Promise<boolean>(resolve => {
+    let settled = false;
+    const settleAfterDismissal = (accepted: boolean) => {
+      if (settled) return;
+      settled = true;
+      // Alert button callbacks can run before UIKit has released its
+      // presentation controller. Continue only after the dismissal window so
+      // the progress Modal never competes with the cellular-confirmation alert.
+      deferPresentation(() => resolve(accepted));
+    };
     Alert.alert(
       title,
       message,
       [
-        { text: cancel, style: "cancel", onPress: () => resolve(false) },
-        { text: download, onPress: () => resolve(true) },
+        { text: cancel, style: "cancel", onPress: () => settleAfterDismissal(false) },
+        { text: download, onPress: () => settleAfterDismissal(true) },
       ],
-      { cancelable: true, onDismiss: () => resolve(false) },
+      { cancelable: true, onDismiss: () => settleAfterDismissal(false) },
     );
   });
 }
@@ -233,6 +243,8 @@ export function ChatScreen() {
   // download-progress Modal is still dismissing. Keep the next presentation
   // out of render state until `onDismiss` confirms that first Modal is gone.
   const pendingDownloadModalRef = useRef<(() => void) | null>(null);
+  const pendingDownloadHandleRef = useRef<DownloadHandle | null>(null);
+  const pendingPreviewActionRef = useRef<(() => void) | null>(null);
   const [preview, setPreview] = useState<{
     attachment: HistoryAttachment;
     info: DownloadInfo;
@@ -283,6 +295,7 @@ export function ChatScreen() {
         fileName,
         visible,
         controller: new AbortController(),
+        handoffPending: false,
       };
       activeDownloadRef.current = handle;
       if (visible) {
@@ -325,7 +338,11 @@ export function ChatScreen() {
     [],
   );
 
-  const finishDownload = useCallback((handle: DownloadHandle) => {
+  const finishDownload = useCallback((handle: DownloadHandle, force = false) => {
+    // An iOS handoff requested before Modal.onShow must keep the progress
+    // Modal mounted until UIKit confirms presentation. onShow then forces the
+    // state clear, and only onDismiss is allowed to present the next surface.
+    if (handle.handoffPending && !force) return;
     if (activeDownloadRef.current?.id !== handle.id) return;
     activeDownloadRef.current = null;
     setActiveDownload(null);
@@ -333,6 +350,11 @@ export function ChatScreen() {
 
   const flushPendingDownloadModal = useCallback(() => {
     downloadModalPresentedRef.current = false;
+    const handle = pendingDownloadHandleRef.current;
+    if (handle) {
+      handle.handoffPending = false;
+    }
+    pendingDownloadHandleRef.current = null;
     const present = pendingDownloadModalRef.current;
     pendingDownloadModalRef.current = null;
     present?.();
@@ -346,18 +368,18 @@ export function ChatScreen() {
         return;
       }
       pendingDownloadModalRef.current = present;
-      finishDownload(handle);
-      // `onDismiss` is iOS-only. Android continues after the state commit. On
-      // iOS, normally wait for Modal.onDismiss; only use the timer if the
-      // progress modal never reached onShow at all.
+      pendingDownloadHandleRef.current = handle;
+      // `onDismiss` is iOS-only. Android continues after the state commit.
+      // On iOS, if the work finishes before onShow, keep the Modal visible
+      // until onShow and then dismiss it. This avoids the invalid state where
+      // UIKit is still presenting the progress controller while a timer tries
+      // to present the preview/share controller on top of it.
       if (Platform.OS !== "ios") {
+        finishDownload(handle, true);
         deferPresentation(flushPendingDownloadModal);
-      } else if (!downloadModalPresentedRef.current) {
-        setTimeout(() => {
-          if (!downloadModalPresentedRef.current && pendingDownloadModalRef.current === present) {
-            flushPendingDownloadModal();
-          }
-        }, 500);
+      } else {
+        handle.handoffPending = true;
+        if (downloadModalPresentedRef.current) finishDownload(handle, true);
       }
     },
     [finishDownload, flushPendingDownloadModal],
@@ -373,12 +395,46 @@ export function ChatScreen() {
   const cancelActiveDownload = useCallback(() => {
     const handle = activeDownloadRef.current;
     if (!handle) return;
+    pendingDownloadModalRef.current = null;
+    pendingDownloadHandleRef.current = null;
+    handle.handoffPending = false;
     handle.controller.abort();
     // Local cancellation must be immediate even while an underlying NATS
     // request is waiting for its transport timeout. Late callbacks are scoped
     // to this handle and are ignored once it has been released.
-    finishDownload(handle);
+    finishDownload(handle, true);
   }, [finishDownload]);
+
+  const closePreview = useCallback(() => {
+    pendingPreviewActionRef.current = null;
+    setPreview(null);
+  }, []);
+
+  const dismissPreviewThen = useCallback(
+    (action: () => void) => {
+      if (!preview) {
+        action();
+        return;
+      }
+      pendingPreviewActionRef.current = action;
+      setPreview(null);
+      if (Platform.OS !== "ios") {
+        deferPresentation(() => {
+          if (pendingPreviewActionRef.current !== action) return;
+          pendingPreviewActionRef.current = null;
+          action();
+        });
+      }
+    },
+    [preview],
+  );
+
+  const flushPendingPreviewAction = useCallback(() => {
+    if (Platform.OS !== "ios") return;
+    const action = pendingPreviewActionRef.current;
+    pendingPreviewActionRef.current = null;
+    action?.();
+  }, []);
 
   // Approvals live docked above the composer (not inline in the transcript), and
   // only while undecided — once a decision lands the card disappears.
@@ -509,6 +565,9 @@ export function ChatScreen() {
   useEffect(
     () => () => {
       activeDownloadRef.current?.controller.abort();
+      pendingDownloadModalRef.current = null;
+      pendingDownloadHandleRef.current = null;
+      pendingPreviewActionRef.current = null;
     },
     [],
   );
@@ -781,7 +840,7 @@ export function ChatScreen() {
           return;
         }
         const variant = fileType.route === "external" ? "original" : "preview";
-        const cachedPreview = remote.cachedAttachment(attachment, variant);
+        let cachedPreview = remote.cachedAttachment(attachment, variant);
         const info =
           cachedPreview?.info ??
           (await remote.prepareAttachment(
@@ -790,6 +849,11 @@ export function ChatScreen() {
             handle.controller.signal,
             () => handle && updateDownload(handle, { phase: "waiting_network" }),
           ));
+        // prepareAttachment records the returned content identity before it
+        // resolves. Re-read the index so a persistent disk-cache hit is used
+        // immediately instead of showing a progress Modal and verifying the
+        // same file a second time in downloadAttachment.
+        cachedPreview ??= remote.cachedAttachment(attachment, variant);
         if (info.size > MAX_FILE_BYTES) {
           handoffDownloadAlert(handle, t("attachment.tooLarge"));
           return;
@@ -828,28 +892,32 @@ export function ChatScreen() {
             totalBytes: info.size,
           });
         }
-        file = await remote.downloadAttachment(
-          info,
-          (done, total) => {
-            if (!handle) return;
-            const patch = {
-              phase: done >= total ? "verifying" : "downloading",
-              completedBytes: done,
-              totalBytes: total,
-            } as const;
-            if (handle.visible) updateDownload(handle, patch);
-            else showDownload(handle, patch);
-          },
-          handle.controller.signal,
-          () => {
-            if (!handle) return;
-            const patch = { phase: "waiting_network" } as const;
-            if (handle.visible) updateDownload(handle, patch);
-            else showDownload(handle, patch);
-          },
-        );
+        if (!file) {
+          file = await remote.downloadAttachment(
+            info,
+            (done, total) => {
+              if (!handle) return;
+              const patch = {
+                phase: done >= total ? "verifying" : "downloading",
+                completedBytes: done,
+                totalBytes: total,
+              } as const;
+              if (handle.visible) updateDownload(handle, patch);
+              else showDownload(handle, patch);
+            },
+            handle.controller.signal,
+            () => {
+              if (!handle) return;
+              const patch = { phase: "waiting_network" } as const;
+              if (handle.visible) updateDownload(handle, patch);
+              else showDownload(handle, patch);
+            },
+          );
+        }
         if (info.previewKind === "image") {
-          handoffDownloadModal(handle, () => setPreview({ attachment, info, uri: file.uri }));
+          handoffDownloadModal(handle, () => {
+            setPreview({ attachment, info, uri: file.uri });
+          });
         } else {
           const bytes = await file.bytes();
           const visible = bytes.slice(0, MARKDOWN_RENDER_BYTES);
@@ -902,7 +970,7 @@ export function ChatScreen() {
       cachedFile: File | null,
       handle?: DownloadHandle,
     ): Promise<File | null> => {
-      if (info.transferId === "local" && cachedFile) return cachedFile;
+      if (cachedFile) return cachedFile;
       const network = await Network.getNetworkStateAsync();
       if (
         network.type === Network.NetworkStateType.CELLULAR ||
@@ -1067,12 +1135,13 @@ export function ChatScreen() {
         return;
       }
       try {
-        const cached = remote.cachedAttachment(attachment, "original");
+        let cached = remote.cachedAttachment(attachment, "original");
         const info =
           cached?.info ??
           (await remote.prepareAttachment(attachment, "original", handle.controller.signal, () =>
             updateDownload(handle, { phase: "waiting_network" }),
           ));
+        cached ??= remote.cachedAttachment(attachment, "original");
         await openOrShare(info, cached?.file ?? null, true, handle);
       } catch (error) {
         if (error instanceof TransferCancelledError) return;
@@ -1106,12 +1175,13 @@ export function ChatScreen() {
       }
       try {
         const variant = fileType.route === "external" ? "original" : "preview";
-        const cachedPreview = remote.cachedAttachment(attachment, variant);
+        let cachedPreview = remote.cachedAttachment(attachment, variant);
         const info =
           cachedPreview?.info ??
           (await remote.prepareAttachment(attachment, variant, handle.controller.signal, () =>
             updateDownload(handle, { phase: "waiting_network" }),
           ));
+        cachedPreview ??= remote.cachedAttachment(attachment, variant);
         if (info.size > MAX_FILE_BYTES) {
           handoffDownloadAlert(handle, t("attachment.tooLarge"));
           return;
@@ -1567,7 +1637,8 @@ export function ChatScreen() {
 
         <Modal
           animationType="slide"
-          onRequestClose={() => setPreview(null)}
+          onDismiss={flushPendingPreviewAction}
+          onRequestClose={closePreview}
           presentationStyle="pageSheet"
           visible={preview !== null}
         >
@@ -1580,7 +1651,10 @@ export function ChatScreen() {
                 accessibilityLabel={t("attachment.save")}
                 disabled={activeDownload !== null}
                 onPress={() => {
-                  if (preview) void downloadOriginal(preview.attachment);
+                  if (preview) {
+                    const attachment = preview.attachment;
+                    dismissPreviewThen(() => void downloadOriginal(attachment));
+                  }
                 }}
               >
                 {activeDownload !== null ? (
@@ -1589,7 +1663,7 @@ export function ChatScreen() {
                   <Download color={colors.ink} size={21} />
                 )}
               </Pressable>
-              <Pressable accessibilityLabel={t("common.close")} onPress={() => setPreview(null)}>
+              <Pressable accessibilityLabel={t("common.close")} onPress={closePreview}>
                 <X color={colors.ink} size={22} />
               </Pressable>
             </View>
@@ -1633,6 +1707,10 @@ export function ChatScreen() {
           onRequestClose={cancelActiveDownload}
           onShow={() => {
             downloadModalPresentedRef.current = true;
+            const handle = pendingDownloadHandleRef.current ?? activeDownloadRef.current;
+            if (handle) {
+              if (handle.handoffPending) finishDownload(handle, true);
+            }
           }}
           transparent
           visible={activeDownload !== null}

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -10,7 +10,7 @@ import {
   Unplug,
   X,
 } from "lucide-react-native";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { showActionSheet as showAndroidActionSheet } from "future-native-ui";
 import {
@@ -118,6 +118,7 @@ export function SessionsScreen() {
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [renameTarget, setRenameTarget] = useState<RemoteSession | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const pendingNewConversationRef = useRef<(() => void) | null>(null);
 
   const chats = useMemo(
     () => remote.sessions.filter(session => session.mode !== "workspace"),
@@ -212,8 +213,30 @@ export function SessionsScreen() {
 
   const startConversation = () => {
     if (newMode === "workspace" && !workspaceId) return;
+    const mode = newMode;
+    const selectedWorkspaceId = workspaceId;
+    const start = () => void remote.newConversation(mode, selectedWorkspaceId);
     setNewOpen(false);
-    void remote.newConversation(newMode, workspaceId);
+    if (Platform.OS === "ios") {
+      // Do not switch screens while the creation Modal still owns UIKit's
+      // presentation controller. The destination screen may immediately need
+      // to present another native surface.
+      pendingNewConversationRef.current = start;
+    } else {
+      deferPresentation(start);
+    }
+  };
+
+  const closeNew = () => {
+    pendingNewConversationRef.current = null;
+    setNewOpen(false);
+  };
+
+  const flushPendingNewConversation = () => {
+    if (Platform.OS !== "ios") return;
+    const start = pendingNewConversationRef.current;
+    pendingNewConversationRef.current = null;
+    start?.();
   };
 
   const renameSession = async (session: RemoteSession, rawName: string) => {
@@ -497,7 +520,8 @@ export function SessionsScreen() {
 
         <Modal
           animationType="fade"
-          onRequestClose={() => setNewOpen(false)}
+          onDismiss={flushPendingNewConversation}
+          onRequestClose={closeNew}
           transparent
           visible={newOpen}
         >
@@ -505,7 +529,7 @@ export function SessionsScreen() {
             <View style={styles.dialog}>
               <View style={styles.dialogHeader}>
                 <Text style={styles.dialogTitle}>{t("sessions.new")}</Text>
-                <Pressable accessibilityLabel={t("common.close")} onPress={() => setNewOpen(false)}>
+                <Pressable accessibilityLabel={t("common.close")} onPress={closeNew}>
                   <X color={colors.inkMuted} size={20} />
                 </Pressable>
               </View>


### PR DESCRIPTION
## Summary
- add persistent desktop preview caching while keeping preview and original transfers separate
- move desktop preview preparation and hashing off Tokio workers, and recover one transient prepare request with a longer retry window
- serialize iOS modal handoffs and keep cancellation immediately responsive

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml remote::transfer --lib`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --watchman=false`