### PR TITLE
Improve custom provider model configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For providers with user-specific base URLs (e.g. Azure's `YOUR_RESOURCE`), add a
       "apiKey": "sk-...",
       "baseUrl": "https://my-api.example.com/v1",
       "models": [
-        { "id": "my-model", "name": "My Model", "contextWindow": 128000 }
+        { "id": "my-model", "name": "My Model", "contextWindow": 128000, "maxTokens": 16384 }
       ]
     }
   }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ future auth login
       "apiKey": "sk-...",
       "baseUrl": "https://my-api.example.com/v1",
       "models": [
-        { "id": "my-model", "name": "My Model", "contextWindow": 128000 }
+        { "id": "my-model", "name": "My Model", "contextWindow": 128000, "maxTokens": 16384 }
       ]
     }
   }

--- a/agent/src/config/providers.rs
+++ b/agent/src/config/providers.rs
@@ -46,6 +46,10 @@ pub struct ProviderModelSpec {
     pub name: String,
     /// Input modalities, e.g. `["text"]` or `["text", "image"]`.
     pub modalities: Vec<String>,
+    /// Maximum total context window, in tokens.
+    pub context_window: i32,
+    /// Maximum tokens generated in one response.
+    pub max_tokens: i32,
 }
 
 /// Create/update of a `models.json` `providers` entry, optionally with the
@@ -175,6 +179,12 @@ pub fn validate_provider_upsert(spec: &ProviderUpsertSpec) -> Result<(), String>
                 .any(|modality| !matches!(modality.as_str(), "text" | "image"))
         {
             return Err("provider model modalities are invalid".to_string());
+        }
+        if model.context_window <= 0 || model.max_tokens <= 0 {
+            return Err("provider model token limits must be positive".to_string());
+        }
+        if model.max_tokens > model.context_window {
+            return Err("provider model max tokens cannot exceed its context window".to_string());
         }
     }
     Ok(())
@@ -458,6 +468,8 @@ pub fn apply_provider_upsert(
                     "id": model.id,
                     "name": model.name,
                     "modalities": model.modalities,
+                    "contextWindow": model.context_window,
+                    "maxTokens": model.max_tokens,
                 })
             })
             .collect::<Vec<_>>();
@@ -763,6 +775,8 @@ mod tests {
                 id: "m1".to_string(),
                 name: "Model One".to_string(),
                 modalities: vec!["text".to_string(), "image".to_string()],
+                context_window: 128000,
+                max_tokens: 16384,
             }],
             ..Default::default()
         };
@@ -772,6 +786,8 @@ mod tests {
         assert_eq!(provider["baseUrl"], json!("https://new.example.com"));
         assert_eq!(provider["compat"], json!("strict"), "unmanaged fields kept");
         assert_eq!(provider["models"][0]["modalities"][1], json!("image"));
+        assert_eq!(provider["models"][0]["contextWindow"], json!(128000));
+        assert_eq!(provider["models"][0]["maxTokens"], json!(16384));
     }
 
     #[test]
@@ -990,6 +1006,8 @@ mod tests {
                 id: "m1".to_string(),
                 name: "m1".to_string(),
                 modalities: vec!["text".to_string()],
+                context_window: 128000,
+                max_tokens: 16384,
             }],
             ..Default::default()
         };

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -279,6 +279,8 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                             id: model.id,
                             name: model.name,
                             modalities: model.modalities,
+                            context_window: model.context_window,
+                            max_tokens: model.max_tokens,
                         })
                         .collect(),
                     replace_models: config.replace_models,
@@ -719,6 +721,8 @@ mod tests {
                     id: "m1".to_string(),
                     name: "Model One".to_string(),
                     modalities: vec!["text".to_string()],
+                    context_window: 128000,
+                    max_tokens: 16384,
                 }],
                 replace_models: true,
                 create_only: false,

--- a/agent/src/rpc/commands.rs
+++ b/agent/src/rpc/commands.rs
@@ -2576,6 +2576,8 @@ mod tests {
                 id: "m1".to_string(),
                 name: "Model One".to_string(),
                 modalities: vec!["text".to_string()],
+                context_window: 128000,
+                max_tokens: 16384,
             }],
             ..Default::default()
         });

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -30,6 +30,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
+    "remark-math": "^6.0.0",
     "shiki": "^4.3.0",
     "tailwind-merge": "^3.6.0"
   },

--- a/desktop/src-tauri/src/agent_providers/mod.rs
+++ b/desktop/src-tauri/src/agent_providers/mod.rs
@@ -95,7 +95,16 @@ pub struct CustomProviderModel {
     /// `modalities` array (`["text"]` or `["text","image"]`) that the agent reads.
     #[serde(default)]
     pub supports_images: bool,
+    /// Maximum total context window, in tokens.
+    #[serde(default = "default_context_window")]
+    pub context_window: i32,
+    /// Maximum tokens generated in one response.
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: i32,
 }
+
+const fn default_context_window() -> i32 { 128_000 }
+const fn default_max_tokens() -> i32 { 16_384 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -275,6 +284,16 @@ fn build_providers_view(
                                 id,
                                 name,
                                 supports_images,
+                                context_window: model
+                                    .get("contextWindow")
+                                    .and_then(Value::as_i64)
+                                    .and_then(|value| i32::try_from(value).ok())
+                                    .unwrap_or_else(default_context_window),
+                                max_tokens: model
+                                    .get("maxTokens")
+                                    .and_then(Value::as_i64)
+                                    .and_then(|value| i32::try_from(value).ok())
+                                    .unwrap_or_else(default_max_tokens),
                             })
                         })
                         .collect()

--- a/desktop/src-tauri/src/agent_providers/mod.rs
+++ b/desktop/src-tauri/src/agent_providers/mod.rs
@@ -103,8 +103,12 @@ pub struct CustomProviderModel {
     pub max_tokens: i32,
 }
 
-const fn default_context_window() -> i32 { 128_000 }
-const fn default_max_tokens() -> i32 { 16_384 }
+const fn default_context_window() -> i32 {
+    128_000
+}
+const fn default_max_tokens() -> i32 {
+    16_384
+}
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/desktop/src-tauri/src/agent_providers/tests.rs
+++ b/desktop/src-tauri/src/agent_providers/tests.rs
@@ -57,6 +57,16 @@ fn input(id: &str, name: &str, create: bool) -> UpsertCustomProviderInput {
     }
 }
 
+fn custom_model(id: &str, name: &str, supports_images: bool) -> CustomProviderModel {
+    CustomProviderModel {
+        id: id.to_string(),
+        name: name.to_string(),
+        supports_images,
+        context_window: 128_000,
+        max_tokens: 16_384,
+    }
+}
+
 #[test]
 fn create_rejects_existing_id() {
     let _home = HomeGuard::new("dup-id");
@@ -287,35 +297,19 @@ fn validates_models() {
     let catalog = fixture_catalog();
     // Valid composite model id with `/` and `.`.
     let mut ok = input("p1", "P1", true);
-    ok.models = vec![CustomProviderModel {
-        id: "anthropic/claude-3.5-sonnet".to_string(),
-        name: String::new(),
-        supports_images: false,
-    }];
+    ok.models = vec![custom_model("anthropic/claude-3.5-sonnet", "", false)];
     assert!(upsert_custom_provider_with_catalog(ok, &catalog).is_ok());
 
     // Whitespace in model id is rejected.
     let mut bad = input("p2", "P2", true);
-    bad.models = vec![CustomProviderModel {
-        id: "bad id".to_string(),
-        name: String::new(),
-        supports_images: false,
-    }];
+    bad.models = vec![custom_model("bad id", "", false)];
     assert!(upsert_custom_provider_with_catalog(bad, &catalog).is_err());
 
     // Duplicate model ids are rejected.
     let mut dup = input("p3", "P3", true);
     dup.models = vec![
-        CustomProviderModel {
-            id: "m".to_string(),
-            name: String::new(),
-            supports_images: false,
-        },
-        CustomProviderModel {
-            id: "m".to_string(),
-            name: String::new(),
-            supports_images: false,
-        },
+        custom_model("m", "", false),
+        custom_model("m", "", false),
     ];
     assert!(upsert_custom_provider_with_catalog(dup, &catalog).is_err());
 }
@@ -325,11 +319,7 @@ fn empty_provider_and_model_names_fall_back_to_their_ids() {
     let _home = HomeGuard::new("name-fallbacks");
     let catalog = fixture_catalog();
     let mut input = input("provider-id", "", true);
-    input.models = vec![CustomProviderModel {
-        id: "model-id".to_string(),
-        name: String::new(),
-        supports_images: false,
-    }];
+    input.models = vec![custom_model("model-id", "", false)];
 
     let view = upsert_custom_provider_with_catalog(input, &catalog).unwrap();
 
@@ -348,16 +338,8 @@ fn model_modalities_round_trip() {
     let catalog = fixture_catalog();
     let mut in_ = input("p1", "P1", true);
     in_.models = vec![
-        CustomProviderModel {
-            id: "text-only".to_string(),
-            name: String::new(),
-            supports_images: false,
-        },
-        CustomProviderModel {
-            id: "vision".to_string(),
-            name: String::new(),
-            supports_images: true,
-        },
+        custom_model("text-only", "", false),
+        custom_model("vision", "", true),
     ];
     upsert_custom_provider_with_catalog(in_, &catalog).unwrap();
 
@@ -366,6 +348,8 @@ fn model_modalities_round_trip() {
     let models = doc["providers"]["p1"]["models"].as_array().unwrap();
     let vision = models.iter().find(|m| m["id"] == "vision").unwrap();
     assert_eq!(vision["modalities"], json!(["text", "image"]));
+    assert_eq!(vision["contextWindow"], json!(128000));
+    assert_eq!(vision["maxTokens"], json!(16384));
     let text_only = models.iter().find(|m| m["id"] == "text-only").unwrap();
     assert_eq!(text_only["modalities"], json!(["text"]));
 
@@ -583,11 +567,7 @@ fn validate_api_key_rules() {
 #[test]
 fn validate_model_rules() {
     let _home = HomeGuard::new("val-models");
-    let model = |id: &str, name: &str| CustomProviderModel {
-        id: id.to_string(),
-        name: name.to_string(),
-        supports_images: false,
-    };
+    let model = |id: &str, name: &str| custom_model(id, name, false);
 
     // Empty model ids are skipped, not rejected.
     let mut skipped = valid_input();
@@ -630,16 +610,25 @@ fn validate_model_rules() {
 
     // Image support maps to the modalities pair.
     let mut vision = valid_input();
-    vision.models = vec![CustomProviderModel {
-        id: "v1".to_string(),
-        name: "Vision".to_string(),
-        supports_images: true,
-    }];
+    vision.models = vec![custom_model("v1", "Vision", true)];
     let validated = validate_custom_provider(vision).unwrap();
     assert_eq!(validated.models[0].modalities, ["text", "image"]);
     let values = model_json_values(&validated.models);
     assert_eq!(values[0]["modalities"], json!(["text", "image"]));
     assert_eq!(values[0]["name"], json!("Vision"));
+    assert_eq!(values[0]["contextWindow"], json!(128000));
+    assert_eq!(values[0]["maxTokens"], json!(16384));
+
+    let mut invalid_limits = valid_input();
+    invalid_limits.models = vec![CustomProviderModel {
+        context_window: 4096,
+        max_tokens: 8192,
+        ..custom_model("m1", "", false)
+    }];
+    assert!(validate_custom_provider(invalid_limits)
+        .unwrap_err()
+        .to_string()
+        .contains("cannot exceed"));
 }
 
 // ── catalog.rs ──────────────────────────────────────────────────────────────
@@ -842,11 +831,7 @@ async fn custom_provider_upsert_paths() {
     // does not persist files, so the view simply re-reads the (empty) locals.
     let mut create = valid_input();
     create.api_key = Some("sk-new".to_string());
-    create.models = vec![CustomProviderModel {
-        id: "m1".to_string(),
-        name: String::new(),
-        supports_images: true,
-    }];
+    create.models = vec![custom_model("m1", "", true)];
     upsert_custom_provider(create).await.unwrap();
     assert!(agent.served("upsert_provider", ""));
 

--- a/desktop/src-tauri/src/agent_providers/tests.rs
+++ b/desktop/src-tauri/src/agent_providers/tests.rs
@@ -307,10 +307,7 @@ fn validates_models() {
 
     // Duplicate model ids are rejected.
     let mut dup = input("p3", "P3", true);
-    dup.models = vec![
-        custom_model("m", "", false),
-        custom_model("m", "", false),
-    ];
+    dup.models = vec![custom_model("m", "", false), custom_model("m", "", false)];
     assert!(upsert_custom_provider_with_catalog(dup, &catalog).is_err());
 }
 

--- a/desktop/src-tauri/src/agent_providers/validate.rs
+++ b/desktop/src-tauri/src/agent_providers/validate.rs
@@ -183,10 +183,15 @@ pub(super) fn validate_custom_provider(
             return Err(format!("Model ID `{model_id}` is duplicated.").into());
         }
         if model.context_window <= 0 || model.max_tokens <= 0 {
-            return Err(format!("Model `{model_id}` token limits must be positive integers.").into());
+            return Err(
+                format!("Model `{model_id}` token limits must be positive integers.").into(),
+            );
         }
         if model.max_tokens > model.context_window {
-            return Err(format!("Model `{model_id}` maximum output tokens cannot exceed its context window.").into());
+            return Err(format!(
+                "Model `{model_id}` maximum output tokens cannot exceed its context window."
+            )
+            .into());
         }
         let model_name = model.name.trim();
         let model_name = if model_name.is_empty() {

--- a/desktop/src-tauri/src/agent_providers/validate.rs
+++ b/desktop/src-tauri/src/agent_providers/validate.rs
@@ -31,6 +31,8 @@ pub(super) struct ValidatedModel {
     pub(super) name: String,
     /// Input modalities, e.g. `["text"]` or `["text", "image"]`.
     pub(super) modalities: Vec<String>,
+    pub(super) context_window: i32,
+    pub(super) max_tokens: i32,
 }
 
 /// Serialize validated models to the models.json entry shape.
@@ -43,6 +45,8 @@ pub(super) fn model_json_values(models: &[ValidatedModel]) -> Vec<Value> {
                 "id": model.id,
                 "name": model.name,
                 "modalities": model.modalities,
+                "contextWindow": model.context_window,
+                "maxTokens": model.max_tokens,
             })
         })
         .collect()
@@ -178,6 +182,12 @@ pub(super) fn validate_custom_provider(
         if !seen_model_ids.insert(model_id.to_string()) {
             return Err(format!("Model ID `{model_id}` is duplicated.").into());
         }
+        if model.context_window <= 0 || model.max_tokens <= 0 {
+            return Err(format!("Model `{model_id}` token limits must be positive integers.").into());
+        }
+        if model.max_tokens > model.context_window {
+            return Err(format!("Model `{model_id}` maximum output tokens cannot exceed its context window.").into());
+        }
         let model_name = model.name.trim();
         let model_name = if model_name.is_empty() {
             model_id
@@ -205,6 +215,8 @@ pub(super) fn validate_custom_provider(
             id: model_id.to_string(),
             name: model_name.to_string(),
             modalities,
+            context_window: model.context_window,
+            max_tokens: model.max_tokens,
         });
     }
     if models.len() > MAX_MODELS {

--- a/desktop/src-tauri/src/agent_providers/write.rs
+++ b/desktop/src-tauri/src/agent_providers/write.rs
@@ -344,6 +344,8 @@ fn provider_upsert_message(
                 id: model.id.clone(),
                 name: model.name.clone(),
                 modalities: model.modalities.clone(),
+                context_window: model.context_window,
+                max_tokens: model.max_tokens,
             })
             .collect(),
         replace_models: true,

--- a/desktop/src-tauri/src/remote/mod.rs
+++ b/desktop/src-tauri/src/remote/mod.rs
@@ -193,13 +193,14 @@ struct RemoteState {
     transfer_task: tokio::task::JoinHandle<()>,
     heartbeat_task: tokio::task::JoinHandle<()>,
     refresh_task: tokio::task::JoinHandle<()>,
-    /// `None` when the web server failed to bind (port busy) — the bridge still
-    /// runs, but there's no web client to point at.
+    /// `None` outside the test environment, or when the optional test web
+    /// server failed to bind. The phone bridge remains available either way.
     web_task: Option<tokio::task::JoinHandle<()>>,
-    /// Web client URL for THIS machine (localhost); `None` when bind failed.
+    /// Test-only web client URL for THIS machine; `None` outside the test
+    /// environment or when bind failed.
     web_url: Option<String>,
-    /// Web client URL a phone on the same LAN can reach; `None` when bind
-    /// failed or no LAN route was found.
+    /// Test-only web client URL a phone on the same LAN can reach; `None`
+    /// outside the test environment, when bind failed, or without a LAN route.
     web_lan_url: Option<String>,
     /// The one-shot pairing code issued at start, kept (with its expiry) so the
     /// UI can re-show it after navigation until it expires — no longer a
@@ -265,10 +266,11 @@ pub struct RemoteStatus {
     /// Desktop identity bound into the QR invitation and signed handshake.
     pub desktop_id: String,
     pub desktop_public_key: String,
-    /// Web client URL for this machine (localhost); `None` if the web server
-    /// failed to bind.
+    /// Test-only web client URL for this machine; `None` outside the test
+    /// environment or if the web server failed to bind.
     pub web_url: Option<String>,
-    /// Web client URL a phone on the same LAN can reach; `None` if unavailable.
+    /// Test-only web client URL a phone on the same LAN can reach; `None` if
+    /// unavailable or outside the test environment.
     pub web_lan_url: Option<String>,
     /// Machine-readable reason the bridge isn't healthy (e.g. `network`,
     /// `revoked`, `server`, `service_config`, `reconnect_required`,
@@ -399,22 +401,28 @@ async fn start_once(replace_existing: bool) -> Result<RemoteStatus, crate::AppEr
         pairing_confirmed.clone(),
         handshake_state,
     );
-    // Bind the web server up front so a busy port is reported, not silent. A
-    // failed bind is non-fatal: the bridge still runs, it just has no web UI.
-    let (web_task, web_url, web_lan_url) = match bind_web_listener().await {
-        Ok(listener) => (
-            Some(spawn_web_server(listener)),
-            Some(format!("http://localhost:{WEB_PORT}")),
-            lan_ip().map(|ip| format!("http://{ip}:{WEB_PORT}")),
-        ),
-        Err(error) => {
-            eprintln!("remote: web client bind failed: {error}");
-            (None, None, None)
+    // The browser client is a test-environment-only validation surface. Keep
+    // the NATS/mobile bridge available in every environment, but never expose
+    // the unauthenticated local HTTP listener in production or custom envs.
+    let web_enabled = web_client_enabled();
+    let (web_task, web_url, web_lan_url) = if web_enabled {
+        match bind_web_listener().await {
+            Ok(listener) => (
+                Some(spawn_web_server(listener)),
+                Some(format!("http://localhost:{WEB_PORT}")),
+                lan_ip().map(|ip| format!("http://{ip}:{WEB_PORT}")),
+            ),
+            Err(error) => {
+                eprintln!("remote: web client bind failed: {error}");
+                (None, None, None)
+            }
         }
+    } else {
+        (None, None, None)
     };
     // A failed web bind is non-fatal (the bridge still runs) and is retried
     // silently before the UI is asked to intervene.
-    let web_bind_failed = web_task.is_none();
+    let web_bind_failed = web_enabled && web_task.is_none();
 
     let status = RemoteStatus {
         running: true,
@@ -861,20 +869,20 @@ pub fn status() -> RemoteStatus {
                 && (!generation_unhealthy || reconnect_in_flight || can_auto_reconnect);
             let connected = !generation_unhealthy && !terminal_service_error && !nats_reconnecting;
 
-            // The local Web listener is optional and retries independently so
+            // The local Web listener is test-only and retries independently so
             // a busy port never disrupts the healthy phone bridge.
-            let web_dead = s.web_task.as_ref().is_none_or(|task| task.is_finished());
-            if !web_dead {
+            let web_enabled = web_client_enabled();
+            let web_dead = web_enabled && s.web_task.as_ref().is_none_or(|task| task.is_finished());
+            if web_enabled && !web_dead {
                 WEB_RECONNECT_ATTEMPTS.store(0, Ordering::Release);
             }
-            let web_reconnect_in_flight = WEB_RECONNECT_RUNNING.load(Ordering::Acquire);
-            let can_reconnect_web =
-                WEB_RECONNECT_ATTEMPTS.load(Ordering::Acquire) < MAX_WEB_RECONNECT_ATTEMPTS;
+            let web_reconnect_in_flight = web_enabled && WEB_RECONNECT_RUNNING.load(Ordering::Acquire);
+            let can_reconnect_web = web_enabled
+                && WEB_RECONNECT_ATTEMPTS.load(Ordering::Acquire) < MAX_WEB_RECONNECT_ATTEMPTS;
             if web_dead && can_reconnect_web && !web_reconnect_in_flight {
                 spawn_web_reconnect(s.pair_id.clone());
             }
-            let web_reconnect_exhausted =
-                web_dead && !web_reconnect_in_flight && !can_reconnect_web;
+            let web_reconnect_exhausted = web_dead && !web_reconnect_in_flight && !can_reconnect_web;
             // Re-expose the pairing code until it expires so the UI keeps it
             // after navigating away and back (it's no longer a show-once value).
             let confirmed = s.pairing_confirmed.load(Ordering::Acquire);
@@ -1592,6 +1600,26 @@ fn web_dir() -> std::path::PathBuf {
         .unwrap_or_else(|_| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../web"))
 }
 
+/// The web remote client is intentionally available only against the test
+/// platform. Production and custom platform URLs retain mobile remote control
+/// but never bind the local HTTP listener.
+fn web_client_enabled_for_platform(platform_url: &str) -> bool {
+    platform_url == crate::future_platform::TEST_PLATFORM_URL
+}
+
+fn web_client_enabled() -> bool {
+    // Remote integration tests use local mock platform URLs while exercising
+    // the listener; production code always checks the actual environment.
+    #[cfg(test)]
+    {
+        true
+    }
+    #[cfg(not(test))]
+    {
+        web_client_enabled_for_platform(&crate::future_platform::current_platform_url())
+    }
+}
+
 /// Bind the web-client listener up front (in `start()`) so a busy port surfaces
 /// in the returned status instead of a silent web_url that goes nowhere.
 async fn bind_web_listener() -> Result<tokio::net::TcpListener, crate::AppError> {
@@ -1805,6 +1833,17 @@ mod runtime_tests {
     use super::*;
     use serde_json::json;
     use std::time::Duration;
+
+    #[test]
+    fn web_client_is_limited_to_the_test_platform() {
+        assert!(web_client_enabled_for_platform(
+            crate::future_platform::TEST_PLATFORM_URL
+        ));
+        assert!(!web_client_enabled_for_platform(
+            crate::future_platform::PRODUCTION_PLATFORM_URL
+        ));
+        assert!(!web_client_enabled_for_platform("https://custom.example.com"));
+    }
 
     fn test_creds(pair_id: &str, nats_url: &str, expires_in: i64) -> pairing::PairingCreds {
         let key_pair = nkeys::KeyPair::new_user();

--- a/desktop/src-tauri/src/remote/mod.rs
+++ b/desktop/src-tauri/src/remote/mod.rs
@@ -876,13 +876,15 @@ pub fn status() -> RemoteStatus {
             if web_enabled && !web_dead {
                 WEB_RECONNECT_ATTEMPTS.store(0, Ordering::Release);
             }
-            let web_reconnect_in_flight = web_enabled && WEB_RECONNECT_RUNNING.load(Ordering::Acquire);
+            let web_reconnect_in_flight =
+                web_enabled && WEB_RECONNECT_RUNNING.load(Ordering::Acquire);
             let can_reconnect_web = web_enabled
                 && WEB_RECONNECT_ATTEMPTS.load(Ordering::Acquire) < MAX_WEB_RECONNECT_ATTEMPTS;
             if web_dead && can_reconnect_web && !web_reconnect_in_flight {
                 spawn_web_reconnect(s.pair_id.clone());
             }
-            let web_reconnect_exhausted = web_dead && !web_reconnect_in_flight && !can_reconnect_web;
+            let web_reconnect_exhausted =
+                web_dead && !web_reconnect_in_flight && !can_reconnect_web;
             // Re-expose the pairing code until it expires so the UI keeps it
             // after navigating away and back (it's no longer a show-once value).
             let confirmed = s.pairing_confirmed.load(Ordering::Acquire);
@@ -1842,7 +1844,9 @@ mod runtime_tests {
         assert!(!web_client_enabled_for_platform(
             crate::future_platform::PRODUCTION_PLATFORM_URL
         ));
-        assert!(!web_client_enabled_for_platform("https://custom.example.com"));
+        assert!(!web_client_enabled_for_platform(
+            "https://custom.example.com"
+        ));
     }
 
     fn test_creds(pair_id: &str, nats_url: &str, expires_in: i64) -> pairing::PairingCreds {

--- a/desktop/src/components/ui/Dialog.tsx
+++ b/desktop/src/components/ui/Dialog.tsx
@@ -4,6 +4,8 @@ import { cn } from "../../lib/cn";
 import { Overlay } from "./Overlay";
 
 interface DialogProps {
+  /** Optional layout classes for the scrollable content region. */
+  bodyClassName?: string;
   children: ReactNode;
   className?: string;
   description?: ReactNode;
@@ -14,6 +16,7 @@ interface DialogProps {
 }
 
 export function Dialog({
+  bodyClassName,
   children,
   className,
   description,
@@ -42,7 +45,7 @@ export function Dialog({
           </h2>
           {description ? <div className="text-sm leading-5 text-ink-soft">{description}</div> : null}
         </div>
-        <div className="mt-5">{children}</div>
+        <div className={cn("mt-5", bodyClassName)}>{children}</div>
         {footer ? <div className="mt-5 flex justify-end gap-2">{footer}</div> : null}
       </section>
     </Overlay>

--- a/desktop/src/features/remote/remoteClient.ts
+++ b/desktop/src/features/remote/remoteClient.ts
@@ -14,9 +14,9 @@ export interface RemoteStatus {
   /** Desktop identity authenticated by the signed client/bridge handshake. */
   desktopId: string;
   desktopPublicKey: string;
-  /** Web client URL for this machine (localhost); null if the web server failed to bind. */
+  /** Test-only web client URL for this machine; null outside the test environment or if bind failed. */
   webUrl: string | null;
-  /** Web client URL a phone on the same LAN can reach; null if unavailable. */
+  /** Test-only LAN web client URL; null outside the test environment or if unavailable. */
   webLanUrl: string | null;
   /**
    * Machine-readable reason the bridge isn't healthy (`network` / `revoked` /

--- a/desktop/src/features/settings/CustomProviderDialog.tsx
+++ b/desktop/src/features/settings/CustomProviderDialog.tsx
@@ -227,7 +227,7 @@ export function CustomProviderDialog({
   return (
     <Dialog
       bodyClassName="min-h-0 flex-1 overflow-y-auto pr-2"
-    className="flex h-[min(760px,calc(100vh-3rem))] max-w-lg flex-col"
+      className="flex h-[min(760px,calc(100vh-3rem))] max-w-lg flex-col"
       onClose={onClose}
       open={open}
       title={editing ? t("customProvider.editTitle") : t("customProvider.addTitle")}

--- a/desktop/src/features/settings/CustomProviderDialog.tsx
+++ b/desktop/src/features/settings/CustomProviderDialog.tsx
@@ -162,7 +162,13 @@ export function CustomProviderDialog({
 
     // Models.
     const cleanedModels = models
-      .map(model => ({ id: model.id.trim(), name: model.name.trim(), supportsImages: model.supportsImages }))
+      .map(model => ({
+        id: model.id.trim(),
+        name: model.name.trim(),
+        supportsImages: model.supportsImages,
+        contextWindow: model.contextWindow,
+        maxTokens: model.maxTokens,
+      }))
       .filter(model => model.id.length > 0);
     const seenModelIds = new Set<string>();
     for (const model of cleanedModels) {
@@ -181,6 +187,15 @@ export function CustomProviderDialog({
       seenModelIds.add(model.id);
       if (model.name.length > MODEL_NAME_MAX_LEN) {
         setError(t("customProvider.errors.modelNameLength", { name: model.name }));
+        return;
+      }
+      if (!Number.isSafeInteger(model.contextWindow) || model.contextWindow <= 0
+        || !Number.isSafeInteger(model.maxTokens) || model.maxTokens <= 0) {
+        setError(t("customProvider.errors.tokenLimitsPositive", { id: model.id }));
+        return;
+      }
+      if (model.maxTokens > model.contextWindow) {
+        setError(t("customProvider.errors.maxTokensExceedContext", { id: model.id }));
         return;
       }
     }
@@ -261,7 +276,14 @@ export function CustomProviderDialog({
             <span className="text-sm font-medium text-ink">{t("customProvider.modelsHeading")}</span>
             <button
               className="text-xs font-medium text-accent transition-colors hover:underline"
-              onClick={() => setModels(current => [...current, { id: "", key: crypto.randomUUID(), name: "", supportsImages: false }])}
+              onClick={() => setModels(current => [...current, {
+                id: "",
+                key: crypto.randomUUID(),
+                name: "",
+                supportsImages: false,
+                contextWindow: 128000,
+                maxTokens: 16384,
+              }])}
               type="button"
             >
               {t("customProvider.addModel")}
@@ -272,41 +294,69 @@ export function CustomProviderDialog({
             : (
                 <div className="space-y-2">
                   {models.map((model, index) => (
-                    <div className="space-y-2 rounded-md border border-line-soft p-2" key={model.key}>
-                      <div className="flex items-center gap-2">
-                        <TextInput
-                          onChange={event => updateModel(index, { id: event.target.value })}
-                          placeholder={t("customProvider.modelIdPlaceholder")}
-                          value={model.id}
-                        />
-                        <TextInput
-                          onChange={event => updateModel(index, { name: event.target.value })}
-                          placeholder={t("customProvider.modelNamePlaceholder")}
-                          value={model.name}
-                        />
-                        <IconButton
-                          className="shrink-0 hover:text-danger"
-                          icon={<Trash2 className="size-4" />}
-                          label={t("customProvider.removeModel")}
-                          onClick={() => setModels(current => current.filter((_, modelIndex) => modelIndex !== index))}
-                        />
+                    <div className="flex items-start gap-2" key={model.key}>
+                      <div className="flex-1 space-y-4 rounded-md border border-line-soft p-3">
+                        <div className="grid grid-cols-2 gap-3">
+                          <label className="flex flex-col gap-1.5 text-xs text-ink-muted">
+                            <span><RequiredLabel>{t("customProvider.modelIdLabel")}</RequiredLabel></span>
+                            <TextInput
+                              onChange={event => updateModel(index, { id: event.target.value })}
+                              placeholder={t("customProvider.modelIdPlaceholder")}
+                              value={model.id}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1.5 text-xs text-ink-muted">
+                            <span>{t("customProvider.modelNameLabel")}</span>
+                            <TextInput
+                              onChange={event => updateModel(index, { name: event.target.value })}
+                              placeholder={t("customProvider.modelNamePlaceholder")}
+                              value={model.name}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1.5 text-xs text-ink-muted">
+                            <span><RequiredLabel>{t("customProvider.contextWindowLabel")}</RequiredLabel></span>
+                            <TextInput
+                              min="1"
+                              step="1"
+                              onChange={event => updateModel(index, { contextWindow: Number(event.target.value) })}
+                              type="number"
+                              value={model.contextWindow}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1.5 text-xs text-ink-muted">
+                            <span><RequiredLabel>{t("customProvider.maxTokensLabel")}</RequiredLabel></span>
+                            <TextInput
+                              min="1"
+                              step="1"
+                              onChange={event => updateModel(index, { maxTokens: Number(event.target.value) })}
+                              type="number"
+                              value={model.maxTokens}
+                            />
+                          </label>
+                        </div>
+                        <div className="flex items-center gap-4">
+                          <span className="text-xs text-ink-muted">{t("customProvider.modalityLabel")}</span>
+                          <label className="flex cursor-not-allowed items-center gap-1.5 text-xs text-ink-soft">
+                            <input checked className="size-3.5 accent-accent" disabled type="checkbox" />
+                            {t("customProvider.modalityText")}
+                          </label>
+                          <label className="flex cursor-pointer items-center gap-1.5 text-xs text-ink">
+                            <input
+                              checked={model.supportsImages}
+                              className="size-3.5 accent-accent"
+                              onChange={event => updateModel(index, { supportsImages: event.target.checked })}
+                              type="checkbox"
+                            />
+                            {t("customProvider.modalityImage")}
+                          </label>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-4 pl-0.5">
-                        <span className="text-xs text-ink-muted">{t("customProvider.modalityLabel")}</span>
-                        <label className="flex cursor-not-allowed items-center gap-1.5 text-xs text-ink-soft">
-                          <input checked className="size-3.5 accent-accent" disabled type="checkbox" />
-                          {t("customProvider.modalityText")}
-                        </label>
-                        <label className="flex cursor-pointer items-center gap-1.5 text-xs text-ink">
-                          <input
-                            checked={model.supportsImages}
-                            className="size-3.5 accent-accent"
-                            onChange={event => updateModel(index, { supportsImages: event.target.checked })}
-                            type="checkbox"
-                          />
-                          {t("customProvider.modalityImage")}
-                        </label>
-                      </div>
+                      <IconButton
+                        className="shrink-0 hover:text-danger"
+                        icon={<Trash2 className="size-4" />}
+                        label={t("customProvider.removeModel")}
+                        onClick={() => setModels(current => current.filter((_, modelIndex) => modelIndex !== index))}
+                      />
                     </div>
                   ))}
                 </div>

--- a/desktop/src/features/settings/CustomProviderDialog.tsx
+++ b/desktop/src/features/settings/CustomProviderDialog.tsx
@@ -226,7 +226,8 @@ export function CustomProviderDialog({
 
   return (
     <Dialog
-      className="max-w-lg"
+      bodyClassName="min-h-0 flex-1 overflow-y-auto pr-2"
+    className="flex h-[min(760px,calc(100vh-3rem))] max-w-lg flex-col"
       onClose={onClose}
       open={open}
       title={editing ? t("customProvider.editTitle") : t("customProvider.addTitle")}

--- a/desktop/src/i18n/locales/en/remote.json
+++ b/desktop/src/i18n/locales/en/remote.json
@@ -14,7 +14,7 @@
   "cancel": "Cancel",
   "pairingCodeLabel": "Pairing code",
   "pairingQrLabel": "Scan with FutureOS Mobile",
-  "pairingCodeHint": "Scan the QR code with the phone app, or copy the code into the web client, within 5 minutes. It is single-use and contains only a short-lived credential-claim nonce, never an account key or device private key.",
+  "pairingCodeHint": "Scan the QR code with the FutureOS mobile app within 5 minutes. It is single-use and contains only a short-lived credential-claim nonce, never an account key or device private key.",
   "pairingCodeExpiresIn": "expires in {{time}}",
   "copy": "Copy",
   "copied": "Copied",

--- a/desktop/src/i18n/locales/en/settings.json
+++ b/desktop/src/i18n/locales/en/settings.json
@@ -134,6 +134,8 @@
   },
   "customProvider": {
     "editTitle": "Edit custom provider",
+    "contextWindowLabel": "Maximum context tokens",
+    "maxTokensLabel": "Maximum output tokens",
     "addTitle": "Add custom provider",
     "description": "The provider is written to ~/.future/agent/models.json; the Agent may need a restart to load the new models.",
     "cancel": "Cancel",
@@ -152,8 +154,10 @@
     "modelsHeading": "Models",
     "addModel": "+ Add model",
     "noModels": "No models added yet.",
-    "modelIdPlaceholder": "Model ID",
-    "modelNamePlaceholder": "Display name",
+    "modelIdLabel": "Model ID",
+    "modelIdPlaceholder": "e.g. qwen",
+    "modelNameLabel": "Display name",
+    "modelNamePlaceholder": "Leave blank to use the model ID",
     "removeModel": "Remove model",
     "modalityLabel": "Modality",
     "modalityText": "Text",
@@ -172,6 +176,8 @@
       "modelIdPattern": "Model ID \"{{id}}\" contains invalid characters.",
       "modelIdDuplicate": "Model ID \"{{id}}\" is duplicated.",
       "modelNameLength": "Model name \"{{name}}\" is too long.",
+      "tokenLimitsPositive": "Token limits for model \"{{id}}\" must be positive integers.",
+      "maxTokensExceedContext": "Maximum output tokens for model \"{{id}}\" cannot exceed its context window.",
       "modelsMax": "The number of models cannot exceed {{max}}."
     }
   },

--- a/desktop/src/i18n/locales/zh/remote.json
+++ b/desktop/src/i18n/locales/zh/remote.json
@@ -14,7 +14,7 @@
   "cancel": "取消",
   "pairingCodeLabel": "配对码",
   "pairingQrLabel": "使用 FutureOS 手机端扫描",
-  "pairingCodeHint": "请在 5 分钟内使用手机客户端扫描二维码，或把配对码复制到 Web 客户端。配对码仅可使用一次，只含领取凭证所需的短期 nonce，不含账号密钥或设备私钥。",
+  "pairingCodeHint": "请在 5 分钟内使用 FutureOS 手机端扫描二维码。配对码仅可使用一次，只含领取凭证所需的短期 nonce，不含账号密钥或设备私钥。",
   "pairingCodeExpiresIn": "{{time}} 后过期",
   "copy": "复制",
   "copied": "已复制",

--- a/desktop/src/i18n/locales/zh/settings.json
+++ b/desktop/src/i18n/locales/zh/settings.json
@@ -132,6 +132,8 @@
   },
   "customProvider": {
     "editTitle": "编辑自定义提供商",
+    "contextWindowLabel": "最大上下文 Token",
+    "maxTokensLabel": "最大输出 Token",
     "addTitle": "添加自定义提供商",
     "description": "提供商写入 ~/.future/agent/models.json，Agent 可能需要重启后才能加载新模型。",
     "cancel": "取消",
@@ -150,8 +152,10 @@
     "modelsHeading": "模型",
     "addModel": "+ 添加模型",
     "noModels": "尚未添加模型。",
-    "modelIdPlaceholder": "模型 ID",
-    "modelNamePlaceholder": "显示名称",
+    "modelIdLabel": "模型 ID",
+    "modelIdPlaceholder": "例如 qwen",
+    "modelNameLabel": "显示名称",
+    "modelNamePlaceholder": "留空使用模型 ID",
     "removeModel": "移除模型",
     "modalityLabel": "模态",
     "modalityText": "文本",
@@ -170,6 +174,8 @@
       "modelIdPattern": "模型 ID「{{id}}」含非法字符。",
       "modelIdDuplicate": "模型 ID「{{id}}」重复。",
       "modelNameLength": "模型名称「{{name}}」过长。",
+      "tokenLimitsPositive": "模型「{{id}}」的 Token 上限必须为正整数。",
+      "maxTokensExceedContext": "模型「{{id}}」的最大输出 Token 不能超过上下文窗口。",
       "modelsMax": "模型数量不能超过 {{max}} 个。"
     }
   },

--- a/desktop/src/integrations/agent/providers.ts
+++ b/desktop/src/integrations/agent/providers.ts
@@ -22,6 +22,10 @@ export interface CustomProviderModel {
   name: string;
   /** Whether the model accepts image input. Text input is always implied. */
   supportsImages: boolean;
+  /** Maximum total context window, in tokens. */
+  contextWindow: number;
+  /** Maximum tokens generated in one response. */
+  maxTokens: number;
 }
 
 export interface CustomProvider {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
+        "remark-math": "^6.0.0",
         "shiki": "^4.3.0",
         "tailwind-merge": "^3.6.0"
       },
@@ -19758,7 +19759,7 @@
     },
     "node_modules/remark-math": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/remark-math/-/remark-math-6.0.0.tgz",
       "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
       "license": "MIT",
       "dependencies": {

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -324,6 +324,10 @@ message ProviderModel {
   string name = 2;
   // Input modalities, e.g. ["text"] or ["text", "image"].
   repeated string modalities = 3;
+  // Maximum total context window, in tokens.
+  int32 context_window = 4;
+  // Maximum tokens generated in one response.
+  int32 max_tokens = 5;
 }
 
 // ── ImageContent ───────────────────────────────────────────────────────────

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -237,6 +237,12 @@ pub struct ProviderModel {
     /// Input modalities, e.g. \["text"\] or \["text", "image"\].
     #[prost(string, repeated, tag = "3")]
     pub modalities: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Maximum total context window, in tokens.
+    #[prost(int32, tag = "4")]
+    pub context_window: i32,
+    /// Maximum tokens generated in one response.
+    #[prost(int32, tag = "5")]
+    pub max_tokens: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ImageContent {


### PR DESCRIPTION
Adds per-model context and output token limits to custom providers, preserves them through edits, and improves the settings form layout and validation. Also limits the Remote local web client to the test environment while leaving mobile Remote available in production and custom environments.\n\nValidation: cargo test -p future-agent config::providers; cargo test --manifest-path desktop/src-tauri/Cargo.toml agent_providers; cargo test -p future-rpc; cargo check --manifest-path desktop/src-tauri/Cargo.toml; npm --prefix desktop run lint.