### PR TITLE
Harden Ubuntu CI package setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,7 @@ jobs:
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          bash scripts/ci/install-apt-packages.sh \
             build-essential \
             curl \
             file \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,17 @@ jobs:
           cache-on-failure: true
           cache-all-crates: true
 
+      # Run formatting before any package installation: rustfmt only needs the
+      # pinned toolchain, so a formatting failure returns immediately even when
+      # an Ubuntu mirror is unhealthy.
+      - name: rustfmt (workspace)
+        if: needs.changes.outputs.rust_workspace == 'true'
+        run: cargo fmt --check --all
+
+      - name: rustfmt (desktop backend)
+        if: needs.changes.outputs.desktop_tauri == 'true'
+        run: cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
+
       # mold + binutils because .cargo/config.toml pins -fuse-ld=mold and clippy
       # still links build scripts, proc-macros and test binaries. WebKit/GTK for
       # the Tauri -sys build scripts (desktop backend is part of this gate now).
@@ -126,8 +137,7 @@ jobs:
       # REGENERATE_PROTO).
       - name: Install Linux deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          bash scripts/ci/install-apt-packages.sh \
             build-essential \
             binutils \
             mold \
@@ -152,10 +162,6 @@ jobs:
       # ── Workspace crates (agent / channels) ──
       # --all because the root manifest is a virtual workspace (no [package]);
       # --manifest-path would fail with "Failed to find targets".
-      - name: rustfmt (workspace)
-        if: needs.changes.outputs.rust_workspace == 'true'
-        run: cargo fmt --check --all
-
       - name: clippy (workspace)
         if: needs.changes.outputs.rust_workspace == 'true'
         run: cargo clippy --workspace --all-targets --manifest-path Cargo.toml -- -D warnings
@@ -172,10 +178,6 @@ jobs:
           git diff --exit-code packages/rpc/src/generated/proto.rs channels/src/generated/
 
       # ── desktop Tauri backend ──
-      - name: rustfmt (desktop backend)
-        if: needs.changes.outputs.desktop_tauri == 'true'
-        run: cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
-
       - name: clippy (desktop backend)
         if: needs.changes.outputs.desktop_tauri == 'true'
         run: cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
@@ -272,24 +274,27 @@ jobs:
           cache-all-crates: true
 
       # The WebKit/GTK stack is only needed by the desktop backend's -sys
-      # build scripts; workspace groups skip it (~40s of apt each).
+      # build scripts; workspace groups skip it (~40s of apt each). The root
+      # workspace has no openssl-sys dependency, so libssl-dev is unnecessary
+      # for its test groups.
       - name: Install Linux deps
         if: steps.affected.outputs.run == 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          packages=(
             build-essential \
             binutils \
             mold \
-            pkg-config \
-            libssl-dev
+            pkg-config
+          )
           if [ "${{ matrix.desktop }}" = 'true' ]; then
-            sudo apt-get install -y \
+            packages+=(
               libayatana-appindicator3-dev \
               libgtk-3-dev \
               librsvg2-dev \
               libwebkit2gtk-4.1-dev
+            )
           fi
+          bash scripts/ci/install-apt-packages.sh "${packages[@]}"
 
       # tauri-build's build script aborts with `resource path ... doesn't
       # exist` unless every `bundle.externalBin` sidecar is present; empty
@@ -373,8 +378,7 @@ jobs:
       - name: Install Linux system dependencies
         if: (needs.changes.outputs.rust_workspace == 'true' || needs.changes.outputs.desktop_tauri == 'true') && runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          bash scripts/ci/install-apt-packages.sh \
             build-essential \
             binutils \
             mold \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,7 @@ jobs:
       # Same package set as build.yml's tested Linux jobs (both architectures).
       - name: Install Linux system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          bash scripts/ci/install-apt-packages.sh \
             build-essential \
             curl \
             file \

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ desktop/.vite/
 mobile/.expo/
 mobile/android/
 mobile/ios/
+# Generated Gradle output for local Expo native modules.
+mobile/modules/*/android/build/
 node_modules/
 
 # Build-time generated version modules (see scripts/version.mjs)

--- a/scripts/ci/install-apt-packages.sh
+++ b/scripts/ci/install-apt-packages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Install CI-only Ubuntu packages without letting the Azure runner mirror hold
+# a job hostage. GitHub's Ubuntu images normally point x86_64 runners at
+# azure.archive.ubuntu.com and ARM runners at azure.ports.ubuntu.com; Ubuntu's
+# corresponding public archive endpoints are the fallback.
+set -Eeuo pipefail
+
+if (( $# == 0 )); then
+  echo "usage: $0 <apt-package> [...]" >&2
+  exit 2
+fi
+
+# Do not let one unavailable mirror consume the job's entire setup budget. APT
+# otherwise retries individual index downloads for minutes before surfacing an
+# error. The retry count is deliberately zero here: the second attempt is made
+# against the official archive below, rather than the same unhealthy endpoint.
+apt_update_args=(
+  -o Acquire::Retries=0
+  -o Acquire::http::Timeout=15
+  -o Acquire::https::Timeout=15
+  -o Dpkg::Use-Pty=0
+)
+
+if sudo timeout 45s apt-get "${apt_update_args[@]}" update; then
+  :
+else
+  echo "Azure Ubuntu mirror did not update within 45 seconds; switching to Ubuntu's public archive." >&2
+
+  # Ubuntu 24.04 runners use deb822 (*.sources); older images may use classic
+  # *.list files. Only rewrite Azure's x86_64 or ARM archive hostname,
+  # preserving suites, components and any third-party source configuration.
+  while IFS= read -r -d '' source_file; do
+    sudo sed -i \
+      -e 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+      -e 's|azure\.ports\.ubuntu\.com|ports.ubuntu.com|g' \
+      "$source_file"
+  done < <(
+    sudo grep -rElZ --include='*.list' --include='*.sources' \
+      'azure\.(archive|ports)\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true
+  )
+
+  if ! sudo timeout 45s apt-get "${apt_update_args[@]}" update; then
+    echo "APT update also failed after switching to Ubuntu's public archive." >&2
+    exit 1
+  fi
+fi
+
+# CI never needs recommended GUI extras; dependencies declared by the selected
+# packages remain installed. Keep limited download retries for transient package
+# fetches after the index source has been established.
+sudo timeout 180s apt-get \
+  -o Acquire::Retries=2 \
+  -o Acquire::http::Timeout=15 \
+  -o Acquire::https::Timeout=15 \
+  -o Dpkg::Use-Pty=0 \
+  --no-install-recommends \
+  install -y "$@"


### PR DESCRIPTION
## Summary
- Add bounded APT update timeouts and switch Azure-backed Ubuntu sources to the matching official archive when the first update fails.
- Reuse the guarded installer across CI, manual builds, and release workflows.
- Run Rust formatting before APT setup; keep desktop-only GTK/WebKit test dependencies isolated and omit unused libssl-dev from workspace tests.
- Ignore generated Android native-module build directories.

## Validation
- bash -n scripts/ci/install-apt-packages.sh
- YAML parse for the updated workflows
- cargo fmt --check --all
- cargo test -p future-rpc