### PR TITLE
Docs: clarify fresh-clone startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ iex (irm https://dl.future-os.cn/install.ps1)
 Step-by-step installation for every platform (desktop app, toolchains, GUI
 packaging) is in the **[Build & Install](docs/build-and-install.md)** guide.
 
+### Run from source
+
+After installing the platform prerequisites from the build guide, a fresh clone
+can start the desktop app with:
+
+```bash
+git clone https://github.com/futuregene/future-os.git
+cd future-os
+make setup
+make run-desktop
+```
+
+`make setup` installs the JavaScript workspaces, initializes built-in skills,
+and creates the Tauri sidecar placeholder. `make run-desktop` builds the local
+CLI sidecar and starts the desktop app in development mode. Android and iOS
+need their respective SDKs and an emulator or device; see the build guide and
+the [mobile guide](mobile/README.md).
+
 ### Configure a model
 
 The agent needs at least one model with an API key before it can answer.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,6 +72,22 @@ iex (irm https://dl.future-os.cn/install.ps1)
 各平台（桌面应用、工具链、GUI 打包）的分步安装步骤见
 **[构建与安装](docs/build-and-install.zh-CN.md)** 文档。
 
+### 从源码启动
+
+先按构建文档安装所在平台的前置依赖；全新克隆后可按以下步骤启动桌面应用：
+
+```bash
+git clone https://github.com/futuregene/future-os.git
+cd future-os
+make setup
+make run-desktop
+```
+
+`make setup` 会安装 JavaScript workspace、初始化内置技能并创建 Tauri sidecar
+占位文件；`make run-desktop` 会构建本地 CLI sidecar 并以开发模式启动桌面应用。
+Android 与 iOS 还需要各自的 SDK 和模拟器或真机，详见构建文档与
+[移动端指南](mobile/README.md)。
+
 ### 配置模型
 
 Agent 至少需要一个带 API key 的模型才能回复。

--- a/docs/build-and-install.md
+++ b/docs/build-and-install.md
@@ -30,7 +30,8 @@ make setup    # JS deps (desktop/mobile) + skills submodule + sidecar placeholde
 package and the desktop/mobile JavaScript dependencies, initializes the `skills`
 submodule, and creates an empty Tauri sidecar placeholder so `cargo check`/
 `clippy`/`test` under `desktop/src-tauri` run even before the first `cargo
-build`. After it, any `make build-*` / `run-*` / `lint` / `test` target works.
+build`. It prepares the repository-level dependencies; app run targets still
+need the platform SDKs and a suitable emulator or device.
 
 ## macOS
 
@@ -39,6 +40,7 @@ Install dependencies:
 ```bash
 xcode-select --install                                            # system toolchain (Tauri)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Rust
+source "$HOME/.cargo/env"                                         # make cargo/rustc available in this shell
 brew install node                                                 # Node.js 24+ (nvm works too — see .nvmrc)
 brew install protobuf                                             # optional — only for make generate-proto
 ```
@@ -88,6 +90,7 @@ sudo apt update
 sudo apt install -y build-essential mold libssl-dev \
   libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Rust (rust-toolchain.toml pins 1.97.0)
+source "$HOME/.cargo/env"                                         # make cargo/rustc available in this shell
 sudo apt install -y protobuf-compiler                             # optional — only for make generate-proto
 ```
 
@@ -234,7 +237,7 @@ make build          # build GUI + unified CLI (no system install; agent/tui/chan
 make lint           # lint all: agent, channels, TUI, CLI, GUI (+stylelint), mobile
 make fmt            # cargo fmt --all (workspace) + desktop/src-tauri + mobile formatting
 make test           # all 7 suites: agent, channels, CLI, TUI, GUI, GUI Rust, mobile
-make clean          # remove build artifacts + installed binaries
+make clean          # remove build artifacts (use make uninstall for installed binaries)
 ```
 
 ### Proto

--- a/docs/build-and-install.zh-CN.md
+++ b/docs/build-and-install.zh-CN.md
@@ -20,7 +20,13 @@ TUI 与 CLI 均为 Rust（`cargo build`），不再需要 Bun 或 Node。
 ```bash
 git clone https://github.com/futuregene/future-os.git
 cd future-os
+make setup    # 安装 JS 依赖（desktop/mobile）+ 初始化 skills 子模块 + 创建 sidecar 占位文件
 ```
+
+`make setup` 只准备仓库级依赖：安装共享的 `thread-projection`、desktop/mobile
+JavaScript 依赖、初始化 `skills` 子模块，并创建空的 Tauri sidecar 占位文件，
+使 `desktop/src-tauri` 的 `cargo check` / `clippy` / `test` 可在首次 `cargo build`
+前运行。应用启动目标仍需要相应平台的 SDK 与模拟器或真机。
 
 ## macOS
 
@@ -29,6 +35,7 @@ cd future-os
 ```bash
 xcode-select --install                                            # 系统工具链（Tauri）
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Rust
+source "$HOME/.cargo/env"                                         # 使 cargo/rustc 在当前 shell 中可用
 brew install node                                                 # Node.js 24+（也可用 nvm——见 .nvmrc）
 brew install protobuf                                             # 可选 —— 仅用于 make generate-proto
 ```
@@ -72,6 +79,7 @@ sudo apt update
 sudo apt install -y build-essential mold libssl-dev \
   libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Rust（rust-toolchain.toml 锁定 1.97.0）
+source "$HOME/.cargo/env"                                         # 使 cargo/rustc 在当前 shell 中可用
 sudo apt install -y protobuf-compiler                             # 可选 —— 仅用于 make generate-proto
 ```
 
@@ -207,7 +215,7 @@ make build          # 构建 GUI + 统一 CLI（不安装到系统；agent/tui/c
 make lint           # 全量 lint：agent、channels、TUI、CLI、GUI（含 stylelint）、mobile
 make fmt            # cargo fmt --all（workspace）+ desktop/src-tauri + mobile 格式化
 make test           # 全部 7 个套件：agent、channels、CLI、TUI、GUI、GUI Rust、mobile
-make clean          # 清理构建产物与已安装二进制
+make clean          # 清理构建产物（已安装二进制请用 make uninstall 删除）
 ```
 
 ### Proto

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -11,12 +11,14 @@ iOS；业务层、主题、国际化和凭证存储均保持跨平台。
 - 流式展示回复、思考与工具执行；支持审批、停止、模型、思考等级和重命名。
 - 历史分页加载、按 `(runId, idx)` 去重，并在连接恢复后通过
   `get_events_since` 回补实时事件。
+- 支持从相册选择或拍摄图片、添加文件附件；可下载会话附件并在手机预览图片、
+  Markdown、文本和 JSON，其余受支持类型交给系统应用打开或保存。
 - seed、JWT 和刷新 token 分项存入 Android Keystore 支持的 SecureStore；
   明文不会进入 AsyncStorage、日志或二维码。
 
 ## 环境
 
-- Node.js 22.11 或更高版本。
+- Node.js 24 或更高版本（与仓库根目录 `.nvmrc` 和 CI 保持一致）。
 - Android Studio、JDK 17 和 Android SDK / Build Tools 36。
 - 一台启用开发者模式与 USB 调试的 Android 设备，或 Android 模拟器。
 
@@ -131,20 +133,20 @@ npm run ios:device
      Store Connect API Key，与 macOS 公证共用；角色需为 App Manager 或以上）
    - 复用现有 `OSS_*` secrets（上传 IPA 到 `dl.future-os.cn`）
 2. Actions → Build iOS TestFlight → Run workflow。
-3. 构建用 `0.0.<提交数>` 作为 TestFlight 版本号（纯数字，TestFlight 要求），
-   提交数同时作为 CFBundleVersion。
+3. 当前工作流固定使用 TestFlight marketing version `0.0.2`；
+   `github.run_number` 同时作为 CFBundleVersion。若需要重置递增序列或发布正式版，
+   需在工作流中显式调整 marketing version。
 4. 上传成功后，登录 App Store Connect → TestFlight → 添加外部测试者。
    首次外部测试需苹果 Beta 审核（约 1-2 天）。
 5. 测试者手机装 TestFlight App → 接受邀请 → 安装 FutureOS。
 
-> 版本号机制：测试包（dev）版本为 `0.0.<提交数>[-<hash>]`，第一位 `0` 即
-> 测试包；正式版从 `1.0.0` 起，打 `vX.Y.Z` tag 触发 release。iOS 测试包
-> 去掉 `-<hash>` 后缀以通过 TestFlight 校验，但版本号仍是 `0.0.x`，判定规则
-> 不变。
+> 版本号机制：本地测试包由 `scripts/version.mjs` 生成，可带开发后缀；TestFlight
+> 必须使用纯数字的 marketing version，当前为 `0.0.2`。其 build number 来自该
+> 工作流的 `github.run_number`，并且必须在同一 marketing version 内单调递增。
+> 正式版从 `1.0.0` 起，打 `vX.Y.Z` tag 触发 release。
 
 ### iOS 平台注意
 
-- Bundle identifier 不能含下划线，Android 的 `cn.future_os.mobile` 在 iOS 上
-  不合法；本项目统一为 `cn.futureos.mobile`。
+- Bundle identifier 统一为 `cn.futureos.mobile`，供 Android 与 iOS 共用。
 - NATS 一律走 `wss://`，不配置任何明文/cleartext 例外；iOS 依赖系统 ATS
   默认放行 TLS WebSocket，Android 保持 cleartext 禁止。


### PR DESCRIPTION
## What changed

- add concise source-start paths to the English and Chinese root READMEs
- document bootstrap scope and platform runtime prerequisites
- ensure Rust is available in the current shell after installation
- align mobile TestFlight, Node, package-identifier, and attachment documentation with implementation
- correct the documented semantics of make clean

## Why

The previous guides had fresh-clone gaps and stale mobile release details that could prevent or confuse a first local startup.

## Validation

- git diff --check
- reviewed Makefile bootstrap and startup targets against the documentation
- verified workspace npm resolution and CI cold-install setup