### PR TITLE
Harden mobile background recovery

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/headless.rs
+++ b/desktop/src-tauri/src/agent_bridge/headless.rs
@@ -26,12 +26,34 @@ pub struct PreparedPrompt {
 
 /// Create the run for `thread`, returning the
 /// identifiers the caller can immediately ack to its client.
+#[cfg(test)]
 pub fn prepare_prompt_persisted(
     thread: &store::ThreadRecord,
     message: String,
     model_id: Option<String>,
     thinking_level: Option<String>,
     attachments: Vec<AttachmentInput>,
+) -> Result<PreparedPrompt, crate::AppError> {
+    prepare_prompt_persisted_with_trigger(
+        thread,
+        message,
+        model_id,
+        thinking_level,
+        attachments,
+        None,
+    )
+}
+
+/// Remote prompts use their persisted command id as the run trigger. Keeping
+/// the regular headless entrypoint above unchanged avoids assigning transport
+/// identities to local GUI prompts.
+pub fn prepare_prompt_persisted_with_trigger(
+    thread: &store::ThreadRecord,
+    message: String,
+    model_id: Option<String>,
+    thinking_level: Option<String>,
+    attachments: Vec<AttachmentInput>,
+    trigger_message_id: Option<String>,
 ) -> Result<PreparedPrompt, crate::AppError> {
     let session_id = thread
         .agent_session_id
@@ -41,7 +63,7 @@ pub fn prepare_prompt_persisted(
     let run = store::create_run(store::CreateRunInput {
         id: None,
         thread_id: thread.id.clone(),
-        trigger_message_id: None,
+        trigger_message_id,
         model_provider: None,
         model_id: None,
     })?;

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -25,7 +25,9 @@ pub use self::client::{
     set_session_name_command, set_thinking_level_command, RpcResponseExt,
 };
 pub use self::config_observer::spawn_provider_config_observer;
-pub use self::headless::{prepare_prompt_persisted, run_prepared_prompt, PreparedPrompt};
+pub use self::headless::{
+    prepare_prompt_persisted_with_trigger, run_prepared_prompt, PreparedPrompt,
+};
 pub(crate) use self::import::{import_missing_sessions, list_agent_session_ids};
 pub use self::models::{list_agent_models, list_builtin_providers, AgentModelOption};
 pub use self::observer::{

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -108,6 +108,7 @@ struct IncomingCmd {
     mode: String,
     // get_events_since (P1c backfill)
     run_id: String,
+    prompt_id: String,
     since_idx: i64,
     // get_messages pagination (NATS payload-limit guard)
     offset: i64,
@@ -156,6 +157,7 @@ impl Default for IncomingCmd {
             entry_id: String::new(),
             mode: String::new(),
             run_id: String::new(),
+            prompt_id: String::new(),
             since_idx: -1,
             offset: 0,
             limit: 0,
@@ -589,6 +591,21 @@ async fn handle_command(
             reply(client, &msg, true, json!({}), None).await;
         }
         "prompt" => {
+            // The command id is persisted on the run. This lookup survives the
+            // in-memory reply cache, mobile process death, and desktop restart.
+            // A retry therefore returns the original receipt without executing
+            // the user's prompt twice.
+            match remote_prompt_receipt(&cmd.id) {
+                Ok(Some(ack)) => {
+                    reply(client, &msg, true, ack, None).await;
+                    return;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    reply(client, &msg, false, Value::Null, Some(&error.to_string())).await;
+                    return;
+                }
+            }
             // Lazy creation (matches the GUI new-chat flow): the web client's
             // "new" button only stages a local draft and sends the first message
             // with an empty `session_id`. Here an empty/unknown id creates the
@@ -602,11 +619,14 @@ async fn handle_command(
             match prepare_remote_prompt(
                 &cmd.session_id,
                 cmd.message.clone(),
-                model_id,
-                thinking_level,
-                cmd.mode.clone(),
-                cmd.workspace_id.clone(),
-                cmd.attachments.clone(),
+                RemotePromptOptions {
+                    model_id,
+                    thinking_level,
+                    mode: cmd.mode.clone(),
+                    workspace_id: cmd.workspace_id.clone(),
+                    upload_references: cmd.attachments.clone(),
+                    command_id: cmd.id.clone(),
+                },
             )
             .await
             {
@@ -629,6 +649,10 @@ async fn handle_command(
                 Err(e) => reply(client, &msg, false, Value::Null, Some(&e.to_string())).await,
             }
         }
+        "get_prompt_receipt" => match remote_prompt_receipt(&cmd.prompt_id) {
+            Ok(receipt) => reply(client, &msg, true, receipt.unwrap_or(Value::Null), None).await,
+            Err(error) => reply(client, &msg, false, Value::Null, Some(&error.to_string())).await,
+        },
         "abort" => {
             reply_unit(
                 client,
@@ -645,11 +669,14 @@ async fn handle_command(
             match prepare_remote_prompt(
                 &cmd.session_id,
                 prompt,
-                None,
-                None,
-                "chat".to_string(),
-                String::new(),
-                Vec::new(),
+                RemotePromptOptions {
+                    model_id: None,
+                    thinking_level: None,
+                    mode: "chat".to_string(),
+                    workspace_id: String::new(),
+                    upload_references: Vec::new(),
+                    command_id: cmd.id.clone(),
+                },
             )
             .await
             {
@@ -1029,7 +1056,7 @@ async fn handle_pair_handshake_confirm(
             "bridgeInstanceId": state.bridge_instance_id,
             "deviceId": cmd.device_id,
             "desktopNonce": cmd.desktop_nonce,
-            "features": ["file_transfer_v1", "file_download_v2", "approval_tier_v1", "continue_run_v1"],
+            "features": ["file_transfer_v1", "file_download_v2", "approval_tier_v1", "continue_run_v1", "prompt_receipt_v1"],
             "presence": super::build_presence_payload(
                 &state.creds.pair_id,
                 &state.bridge_instance_id,
@@ -1113,17 +1140,48 @@ fn build_continue_prompt(run_id: &str) -> String {
     lines.join("\n")
 }
 
-/// Find the thread for `session_id` (create a new chat thread when unknown —
-/// remote policy), then persist user message + run via `agent_bridge::headless`.
-async fn prepare_remote_prompt(
-    session_id: &str,
-    message: String,
+fn remote_prompt_receipt(command_id: &str) -> Result<Option<Value>, crate::AppError> {
+    let Some(run) = crate::store::find_run_by_trigger_message_id(command_id)? else {
+        return Ok(None);
+    };
+    let Some(thread) = crate::store::get_thread(&run.thread_id)? else {
+        return Ok(None);
+    };
+    let session_id = thread
+        .agent_session_id
+        .clone()
+        .unwrap_or_else(|| thread.id.clone());
+    Ok(Some(json!({
+        "sessionId": session_id,
+        "threadId": thread.id,
+        "runId": run.id,
+    })))
+}
+
+struct RemotePromptOptions {
     model_id: Option<String>,
     thinking_level: Option<String>,
     mode: String,
     workspace_id: String,
     upload_references: Vec<super::transfer::UploadReference>,
+    command_id: String,
+}
+
+/// Find the thread for `session_id` (create a new chat thread when unknown —
+/// remote policy), then persist user message + run via `agent_bridge::headless`.
+async fn prepare_remote_prompt(
+    session_id: &str,
+    message: String,
+    options: RemotePromptOptions,
 ) -> Result<crate::agent_bridge::PreparedPrompt, crate::AppError> {
+    let RemotePromptOptions {
+        model_id,
+        thinking_level,
+        mode,
+        workspace_id,
+        upload_references,
+        command_id,
+    } = options;
     let thread = match crate::store::find_thread_by_agent_session(session_id)? {
         Some(thread) => thread,
         None => {
@@ -1188,12 +1246,13 @@ async fn prepare_remote_prompt(
         ));
     }
     let attachments = super::transfer::claim_uploads(&upload_references, &thread.id)?;
-    let prepared = crate::agent_bridge::prepare_prompt_persisted(
+    let prepared = crate::agent_bridge::prepare_prompt_persisted_with_trigger(
         &thread,
         message,
         model_id,
         thinking_level,
         attachments.clone(),
+        (!command_id.trim().is_empty()).then_some(command_id),
     );
     #[cfg(test)]
     let prepared = prepared.and_then(|prepared| injected_prepare_failure().map(|()| prepared));
@@ -2096,7 +2155,8 @@ mod bridge_tests {
                 "file_transfer_v1",
                 "file_download_v2",
                 "approval_tier_v1",
-                "continue_run_v1"
+                "continue_run_v1",
+                "prompt_receipt_v1"
             ])
         );
         assert!(bridge.handshake.active_flag().load(Ordering::Acquire));
@@ -2501,8 +2561,9 @@ mod bridge_tests {
             .contains("Select a workspace"));
 
         // Chat mode with an empty session id → lazy thread + agent session.
+        let prompt_id = unique("cmd");
         let reply = bridge
-            .call(json!({ "id": unique("cmd"), "type": "prompt", "message": "hello there", "modelId": "m1", "providerId": "p1", "level": "high" }))
+            .call(json!({ "id": prompt_id, "type": "prompt", "message": "hello there", "modelId": "m1", "providerId": "p1", "level": "high" }))
             .await;
         assert_eq!(reply["success"], json!(true), "got: {reply}");
         let session = reply["data"]["sessionId"].as_str().unwrap().to_string();
@@ -2521,6 +2582,21 @@ mod bridge_tests {
             assert!(std::time::Instant::now() < deadline, "run never settled");
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
+
+        // The run id is a durable receipt keyed by the mobile command id. It
+        // remains queryable after the in-memory single-flight cache expires,
+        // and resending the prompt returns the same ack without a second run.
+        let receipt = bridge
+            .call(
+                json!({ "id": unique("cmd"), "type": "get_prompt_receipt", "promptId": prompt_id }),
+            )
+            .await;
+        assert_eq!(receipt["data"]["runId"], json!(run_id));
+        tokio::time::sleep(Duration::from_millis(650)).await;
+        let retried = bridge
+            .call(json!({ "id": prompt_id, "type": "prompt", "message": "hello there" }))
+            .await;
+        assert_eq!(retried["data"]["runId"], json!(run_id));
 
         // A follow-up prompt on the idle session reuses the thread.
         let reply = bridge

--- a/desktop/src-tauri/src/store.rs
+++ b/desktop/src-tauri/src/store.rs
@@ -53,9 +53,10 @@ pub use review_snapshots::{
 pub use runs::{
     active_run_sessions, advance_tool_projection, clear_all_run_events_files,
     clear_run_event_buffer, create_run, delete_run_events_file, fail_run_if_active,
-    get_tool_call_input, latest_run, latest_run_infos, list_run_events, list_run_events_since,
-    list_runs, project_tool_outputs, tool_projection_cursor, update_run_status_if_active,
-    LatestRunInfo, RunEventRecord, RunRecord, ToolCallRecord, ToolOutputRecord,
+    find_run_by_trigger_message_id, get_tool_call_input, latest_run, latest_run_infos,
+    list_run_events, list_run_events_since, list_runs, project_tool_outputs,
+    tool_projection_cursor, update_run_status_if_active, LatestRunInfo, RunEventRecord, RunRecord,
+    ToolCallRecord, ToolOutputRecord,
 };
 #[cfg(test)]
 pub(crate) use runs::{append_run_event, flush_run_event_log_for_test};

--- a/desktop/src-tauri/src/store/runs.rs
+++ b/desktop/src-tauri/src/store/runs.rs
@@ -135,6 +135,31 @@ pub fn list_runs(thread_id: &str) -> Result<Vec<RunRecord>, crate::AppError> {
         .map_err(crate::AppError::from)
 }
 
+/// Find the run created for a durable remote command id. Mobile persists this
+/// id before sending a prompt, so a retry after either process restarts can
+/// recover the original acknowledgement instead of creating a duplicate run.
+pub fn find_run_by_trigger_message_id(
+    trigger_message_id: &str,
+) -> Result<Option<RunRecord>, crate::AppError> {
+    if trigger_message_id.trim().is_empty() {
+        return Ok(None);
+    }
+    let conn = connect()?;
+    conn.query_row(
+        &format!(
+            "SELECT {RUN_COLUMNS}
+                 FROM runs
+                 WHERE trigger_message_id = ?1
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1"
+        ),
+        params![trigger_message_id],
+        run_from_row,
+    )
+    .optional()
+    .map_err(crate::AppError::from)
+}
+
 /// The thread's single most recent run (same ordering/tiebreak as
 /// [`latest_run_infos`]). Used by initial loads and pushed terminal
 /// reconciliation without transferring the thread's entire run history.

--- a/desktop/src-tauri/src/store/schema.rs
+++ b/desktop/src-tauri/src/store/schema.rs
@@ -232,6 +232,7 @@ CREATE INDEX IF NOT EXISTS idx_threads_workspace ON threads(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_threads_recent ON threads(status, pinned, last_message_at, updated_at);
 -- idx_messages_thread removed with messages table
 CREATE INDEX IF NOT EXISTS idx_runs_thread ON runs(thread_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_runs_trigger_message ON runs(trigger_message_id);
 CREATE INDEX IF NOT EXISTS idx_reference_targets_scope ON reference_targets(scope, workspace_id, target_type);
 CREATE INDEX IF NOT EXISTS idx_review_snapshots_run ON review_snapshots(run_id, phase);
 CREATE INDEX IF NOT EXISTS idx_review_snapshots_workspace ON review_snapshots(workspace_id, created_at);

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -18,8 +18,8 @@ import {
   timelineFromHistory,
   type TimelineState,
 } from "./timeline";
-import { RemoteClient } from "./client";
-import { MAX_PROMPT_MESSAGE_BYTES, utf8Bytes } from "./codec";
+import { isTransientNatsRequestError, RemoteClient } from "./client";
+import { MAX_PROMPT_MESSAGE_BYTES, randomId, utf8Bytes } from "./codec";
 import type { ConnectionState } from "./connectionState";
 import { classifyError } from "./connectionState";
 import { attemptPendingRevoke, claimPairingCode, serverRevoke } from "./pairing";
@@ -32,6 +32,13 @@ import {
 import { type RunCursor } from "./runCursor";
 import { SyncEngine, type ReconcileReason } from "./syncEngine";
 import { fetchEventsSince } from "./replay";
+import {
+  clearPendingPrompt,
+  loadPendingPrompt,
+  savePendingPrompt,
+  type PendingPrompt,
+} from "./pendingPromptStorage";
+import { clearSessionDraftIfMatches } from "./draftStorage";
 import { useSessionCatalog } from "./useSessionCatalog";
 import {
   clearCredentials,
@@ -139,6 +146,71 @@ interface RemoteContextValue {
 
 const RemoteContext = createContext<RemoteContextValue | null>(null);
 
+function samePendingPrompt(
+  pending: PendingPrompt,
+  candidate: Omit<PendingPrompt, "version" | "commandId" | "createdAt">,
+): boolean {
+  const attachmentKey = (items: MobileAttachment[]) =>
+    items.map(item => `${item.localUri}\u0000${item.name}\u0000${item.transferSize}`).sort();
+  return (
+    pending.draftKey === candidate.draftKey &&
+    pending.sessionId === candidate.sessionId &&
+    pending.text.trim() === candidate.text.trim() &&
+    pending.modelId === candidate.modelId &&
+    pending.thinkingLevel === candidate.thinkingLevel &&
+    pending.mode === candidate.mode &&
+    pending.workspaceId === candidate.workspaceId &&
+    JSON.stringify(attachmentKey(pending.attachments)) ===
+      JSON.stringify(attachmentKey(candidate.attachments))
+  );
+}
+
+async function pendingPromptReceipt(
+  client: RemoteClient,
+  commandId: string,
+): Promise<PromptAck | null> {
+  return (
+    await client.requestRetry<PromptAck | null>(
+      { type: "get_prompt_receipt", promptId: commandId },
+      "list",
+    )
+  ).data;
+}
+
+async function deliverPendingPrompt(
+  client: RemoteClient,
+  pending: PendingPrompt,
+  checkReceipt: boolean,
+  receiptSupported: boolean,
+  onUploadProgress?: (completedBytes: number, totalBytes: number) => void,
+): Promise<PromptAck> {
+  if (checkReceipt && receiptSupported) {
+    const receipt = await pendingPromptReceipt(client, pending.commandId);
+    if (receipt) return receipt;
+  }
+  const uploaded = await uploadAttachments(client, pending.attachments, onUploadProgress);
+  return (
+    await client.requestRetry<PromptAck>(
+      {
+        id: pending.commandId,
+        type: "prompt",
+        sessionId: pending.sessionId,
+        message: pending.text.trim(),
+        modelId: pending.modelId,
+        providerId: modelProviderFromReference(pending.modelId),
+        level: pending.thinkingLevel,
+        ...(uploaded.length
+          ? { attachments: uploaded.map(attachment => ({ uploadId: attachment.uploadId! })) }
+          : {}),
+        ...(pending.mode === "workspace"
+          ? { mode: "workspace", workspaceId: pending.workspaceId }
+          : {}),
+      },
+      pending.sessionId,
+    )
+  ).data;
+}
+
 /**
  * Compares each session's status against the previously seen status map and
  * returns the ids whose run just finished (running/queued/waiting_approval →
@@ -156,9 +228,12 @@ export function RemoteProvider({ children }: PropsWithChildren) {
   const [modelId, setModelId] = useState("");
   const [thinkingLevel, setThinkingLevelState] = useState<ThinkingLevel>("off");
   const [sending, setSending] = useState(false);
+  const sendingRef = useRef(false);
+  const pendingRecoveryRef = useRef<Promise<void> | null>(null);
   const [openingSession, setOpeningSession] = useState(false);
   const [capabilities, setCapabilities] = useState<Set<string>>(() => new Set());
   const fileTransferSupported = capabilities.has("file_transfer_v1");
+  const promptReceiptSupported = capabilities.has("prompt_receipt_v1");
   const [clock, setClock] = useState(Date.now());
   // Relative-heartbeat state (L7): the desktop-presence check judges staleness
   // by clock-offset drift, so the running baseline survives recomputes. Reset
@@ -566,6 +641,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
         },
       });
       clientRef.current = client;
+      if (AppState.currentState === "background") client.pauseForBackground();
       if (networkAvailableRef.current === false) client.setNetworkAvailable(false);
       // The sync engine is created ONCE and survives client generations —
       // reconcileAll (reconnect recovery) must keep working across a client
@@ -656,7 +732,9 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     let previous: AppStateStatus = AppState.currentState;
     const subscription = AppState.addEventListener("change", next => {
       const returnedToForeground = next === "active" && previous !== "active";
+      const enteredBackground = next === "background" && previous !== "background";
       previous = next;
+      if (enteredBackground) clientRef.current?.pauseForBackground();
       if (returnedToForeground) void recoverLifecycle("foreground");
     });
     return () => subscription.remove();
@@ -790,6 +868,8 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       }
     }
     await clearCredentials();
+    const pendingPrompt = await loadPendingPrompt();
+    if (pendingPrompt) await clearPendingPrompt(pendingPrompt.commandId);
     setCredentials(null);
     setPresence(null);
     resetCatalog();
@@ -916,7 +996,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       // Nothing to send is a no-op, not an error — the composer guards this too.
       if (!text.trim() && attachments.length === 0) return;
       if (!client) throw new Error("not_connected");
-      if (sending) throw new Error("send_busy");
+      if (sendingRef.current) throw new Error("send_busy");
       if (attachments.length > 0 && !fileTransferSupported) {
         throw new Error("attachment_unsupported_desktop");
       }
@@ -932,26 +1012,64 @@ export function RemoteProvider({ children }: PropsWithChildren) {
       const targetDraftWorkspaceId = draftWorkspaceId;
       const conversationEpoch = conversationEpochRef.current;
       const engine = syncEngineRef.current;
+      const candidate = {
+        draftKey: targetSessionId || "draft:new",
+        sessionId: targetSessionId,
+        text,
+        attachments,
+        modelId,
+        thinkingLevel,
+        mode: targetDraft ? targetDraftMode : ("chat" as const),
+        workspaceId: targetDraft ? targetDraftWorkspaceId : "",
+      };
       // A run may have started (on this device or another) after the composer
       // cleared the input — a silent return here would swallow the user's
       // message. Throw so the UI restores the draft instead. Reads the live
       // mirror so the check reflects the latest lane snapshot even before the
       // subscriber re-renders.
       if (streamingRef.current[targetSessionId] ?? false) throw new Error("send_streaming");
+      let pending = await loadPendingPrompt();
+      let checkReceipt = false;
+      if (pending && samePendingPrompt(pending, candidate)) {
+        checkReceipt = true;
+      } else {
+        if (pending) {
+          // Resolve the previous intent before replacing it. If the desktop
+          // accepted it, clear only its matching draft; if it did not, the
+          // newly edited composer supersedes that unsent intent.
+          const previousReceipt = promptReceiptSupported
+            ? await pendingPromptReceipt(client, pending.commandId)
+            : null;
+          if (previousReceipt) {
+            await clearSessionDraftIfMatches(pending.draftKey, pending);
+          }
+          await clearPendingPrompt(pending.commandId);
+        }
+        pending = {
+          version: 1,
+          commandId: randomId("prompt"),
+          ...candidate,
+          createdAt: Date.now(),
+        };
+        // This write is the commit point for the user's send intent. Do it
+        // before clearing any UI or starting attachment uploads.
+        await savePendingPrompt(pending);
+      }
+      sendingRef.current = true;
       setSending(true);
       try {
-        const uploaded = await uploadAttachments(client, attachments, onUploadProgress);
         // The optimistic bubble is a lane instruction (append to the current
         // snapshot), not a whole-cache overwrite — events that landed during
         // the upload stay (M8).
         engine?.mutate(targetSessionId, timeline => {
           const base = timeline ?? emptyTimeline();
+          if (base.items.some(item => item.id === `local:${pending.commandId}`)) return base;
           return {
             ...base,
             items: [
               ...base.items,
               {
-                id: `local:${Date.now()}:${base.items.length}`,
+                id: `local:${pending.commandId}`,
                 kind: "message",
                 role: "user",
                 text: text.trim(),
@@ -969,24 +1087,16 @@ export function RemoteProvider({ children }: PropsWithChildren) {
             ],
           };
         });
-        const response = await client.requestRetry<PromptAck>(
-          {
-            type: "prompt",
-            sessionId: targetSessionId,
-            message: text.trim(),
-            modelId,
-            providerId: modelProviderFromReference(modelId),
-            level: thinkingLevel,
-            ...(uploaded.length
-              ? { attachments: uploaded.map(attachment => ({ uploadId: attachment.uploadId! })) }
-              : {}),
-            ...(targetDraft && targetDraftMode === "workspace"
-              ? { mode: "workspace", workspaceId: targetDraftWorkspaceId }
-              : {}),
-          },
-          targetSessionId,
+        const response = await deliverPendingPrompt(
+          client,
+          pending,
+          checkReceipt,
+          promptReceiptSupported,
+          onUploadProgress,
         );
-        const nextSessionId = response.data.sessionId;
+        await clearPendingPrompt(pending.commandId);
+        await clearSessionDraftIfMatches(pending.draftKey, pending);
+        const nextSessionId = response.sessionId;
         if (nextSessionId && nextSessionId !== targetSessionId) {
           // A draft just got bound to a real session. Migrate the optimistic
           // bubble from the "" placeholder lane into the real session's lane —
@@ -1028,21 +1138,71 @@ export function RemoteProvider({ children }: PropsWithChildren) {
             void refreshSessions();
           }
         }
+      } catch (sendError) {
+        // Business/auth failures are definitive and leave the regular draft in
+        // place. Transport failures keep the outbox record for foreground or
+        // cold-start recovery with the same durable command id.
+        if (!isTransientNatsRequestError(sendError)) {
+          await clearPendingPrompt(pending.commandId);
+        }
+        throw sendError;
       } finally {
+        sendingRef.current = false;
         setSending(false);
       }
     },
     [
-      sending,
       draft,
       draftMode,
       draftWorkspaceId,
       fileTransferSupported,
       modelId,
+      promptReceiptSupported,
       refreshSessions,
       thinkingLevel,
     ],
   );
+
+  const recoverPendingPrompt = useCallback(async () => {
+    if (sendingRef.current) return;
+    if (pendingRecoveryRef.current) return pendingRecoveryRef.current;
+    const recovery = (async () => {
+      const client = clientRef.current;
+      if (!client || !credentialsRef.current) return;
+      const pending = await loadPendingPrompt();
+      if (!pending) return;
+      sendingRef.current = true;
+      setSending(true);
+      try {
+        const receipt = await deliverPendingPrompt(client, pending, true, promptReceiptSupported);
+        await clearPendingPrompt(pending.commandId);
+        await clearSessionDraftIfMatches(pending.draftKey, pending);
+        void refreshSessions();
+        reconcileSession(receipt.sessionId, "reconnect");
+      } catch (recoveryError) {
+        if (!isTransientNatsRequestError(recoveryError)) {
+          await clearPendingPrompt(pending.commandId);
+          recordError(recoveryError);
+        }
+      } finally {
+        sendingRef.current = false;
+        setSending(false);
+      }
+    })().finally(() => {
+      pendingRecoveryRef.current = null;
+    });
+    pendingRecoveryRef.current = recovery;
+    return recovery;
+  }, [promptReceiptSupported, reconcileSession, recordError, refreshSessions]);
+
+  // A cold start lands on the session list. Resume a staged send there; when
+  // ChatScreen is still mounted after a brief background trip, leave its draft
+  // visible and let the user's next tap reuse the same durable command id.
+  useEffect(() => {
+    if (phase === "connected" && !selectedRef.current && !draft) {
+      void recoverPendingPrompt();
+    }
+  }, [draft, phase, recoverPendingPrompt]);
 
   const prepareAttachment = useCallback(
     async (

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -534,6 +534,26 @@ describe("RemoteClient request retry classification", () => {
 });
 
 describe("RemoteClient OS lifecycle recovery", () => {
+  test("backgrounding closes the live socket and foregrounding opens a new generation", async () => {
+    const { client, callbacks } = recoveryClient();
+    const close = jest.fn().mockResolvedValue(undefined);
+    const testClient = client as unknown as {
+      connection: { close(): Promise<void> } | null;
+      state: string;
+    };
+    testClient.connection = { close };
+    testClient.state = "ready";
+
+    client.pauseForBackground();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(testClient.connection).toBeNull();
+    expect(callbacks.onConnectionState).toHaveBeenCalledWith("reconnecting");
+
+    const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    await client.recoverNow("foreground");
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
   test("foreground validates a healthy socket without replacing it", async () => {
     const { client } = recoveryClient();
     const flush = jest.fn().mockResolvedValue(undefined);

--- a/mobile/src/remote/__tests__/draftStorage.test.ts
+++ b/mobile/src/remote/__tests__/draftStorage.test.ts
@@ -1,5 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { clearSessionDraft, loadSessionDraft, saveSessionDraft } from "../draftStorage";
+import {
+  clearSessionDraft,
+  clearSessionDraftIfMatches,
+  loadSessionDraft,
+  saveSessionDraft,
+} from "../draftStorage";
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
@@ -111,5 +116,20 @@ describe("session draft storage", () => {
   test("clearSessionDraft removes the stored slot", async () => {
     await clearSessionDraft("s1");
     expect(mockedAsync.removeItem).toHaveBeenCalledWith("futureos.remote.draft.v1:s1");
+  });
+
+  test("cold acknowledgement clears only the draft that produced it", async () => {
+    mockedAsync.getItem.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, text: "hello", attachments: [attachment] }),
+    );
+    await clearSessionDraftIfMatches("s1", { text: "hello", attachments: [attachment] });
+    expect(mockedAsync.removeItem).toHaveBeenCalledWith("futureos.remote.draft.v1:s1");
+
+    jest.clearAllMocks();
+    mockedAsync.getItem.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, text: "newer edit", attachments: [attachment] }),
+    );
+    await clearSessionDraftIfMatches("s1", { text: "hello", attachments: [attachment] });
+    expect(mockedAsync.removeItem).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  clearPendingPrompt,
+  loadPendingPrompt,
+  savePendingPrompt,
+  type PendingPrompt,
+} from "../pendingPromptStorage";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockedAsync = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const pending: PendingPrompt = {
+  version: 1,
+  commandId: "prompt_1",
+  draftKey: "s1",
+  sessionId: "s1",
+  text: "hello",
+  attachments: [],
+  modelId: "provider/model",
+  thinkingLevel: "medium",
+  mode: "chat",
+  workspaceId: "",
+  createdAt: 1,
+};
+
+describe("pending prompt storage", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("round-trips a staged prompt", async () => {
+    await savePendingPrompt(pending);
+    expect(mockedAsync.setItem).toHaveBeenCalledWith(
+      "futureos.remote.pending-prompt.v1",
+      JSON.stringify(pending),
+    );
+    mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify(pending));
+    await expect(loadPendingPrompt()).resolves.toEqual(pending);
+  });
+
+  test("a stale completion cannot clear a newer prompt", async () => {
+    mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify(pending));
+    await clearPendingPrompt("prompt_old");
+    expect(mockedAsync.removeItem).not.toHaveBeenCalled();
+  });
+
+  test("the matching completion clears its record", async () => {
+    mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify(pending));
+    await clearPendingPrompt("prompt_1");
+    expect(mockedAsync.removeItem).toHaveBeenCalledWith("futureos.remote.pending-prompt.v1");
+  });
+});

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -82,6 +82,7 @@ export class RemoteClient {
   private authRetryCount = 0;
   private generation = 0;
   private stopped = false;
+  private appActive = true;
   private networkAvailable = true;
   private recoveryPromise: Promise<void> | null = null;
   private failedGeneration: number | null = null;
@@ -122,7 +123,7 @@ export class RemoteClient {
    * the retry timer is owned by exactly one place, here).
    */
   async open(): Promise<void> {
-    if (this.stopped || !this.networkAvailable) return;
+    if (this.stopped || !this.appActive || !this.networkAvailable) return;
     this.signal({ type: "open_started" });
     const generation = ++this.generation;
     try {
@@ -131,7 +132,13 @@ export class RemoteClient {
       this.credentials = fresh;
       this.callbacks.onCredentials(fresh);
       await this.connectSocket(generation);
-      if (this.stopped || !this.networkAvailable || generation !== this.generation) return;
+      if (
+        this.stopped ||
+        !this.appActive ||
+        !this.networkAvailable ||
+        generation !== this.generation
+      )
+        return;
       this.scheduleRefresh();
     } catch (error) {
       if (this.stopped || generation !== this.generation) return;
@@ -159,9 +166,25 @@ export class RemoteClient {
     this.disposeConnection("network_unavailable");
   }
 
+  /**
+   * Ordinary WebSockets are not a background execution mechanism on either
+   * mobile OS. Close deliberately before JavaScript is suspended so foreground
+   * recovery starts from a known state instead of inheriting a half-open WSS.
+   */
+  pauseForBackground(): void {
+    if (this.stopped || !this.appActive) return;
+    this.appActive = false;
+    this.generation += 1;
+    this.clearTimers();
+    this.signal({ type: "transport_disconnect" });
+    this.disposeConnection("background");
+  }
+
   /** Validate after foregrounding, or immediately rebuild after a path change. */
   recoverNow(reason: RecoveryReason): Promise<void> {
     if (this.stopped) return Promise.resolve();
+    if (reason === "foreground") this.appActive = true;
+    if (!this.appActive) return Promise.resolve();
     if (reason !== "foreground") this.networkAvailable = true;
     if (!this.networkAvailable) return Promise.resolve();
     if (this.recoveryPromise) return this.recoveryPromise;
@@ -201,7 +224,7 @@ export class RemoteClient {
         // Rebuild below without waiting for NATS's ping budget to expire.
       }
     }
-    if (this.stopped || !this.networkAvailable) return;
+    if (this.stopped || !this.appActive || !this.networkAvailable) return;
     this.generation += 1;
     this.clearTimers();
     this.signal({ type: "transport_disconnect" });
@@ -212,7 +235,7 @@ export class RemoteClient {
 
   /** Rotate the JWT in place and resume the connection (M1's refreshable class). */
   private async refreshToken(): Promise<void> {
-    if (this.refreshInFlight) return;
+    if (this.refreshInFlight || !this.appActive) return;
     this.refreshInFlight = true;
     try {
       this.signal({ type: "auth_failed" }); // moves to refreshing
@@ -347,13 +370,13 @@ export class RemoteClient {
 
   private scheduleRetry(): void {
     this.signal({ type: "open_failed", error: new Error("transport_failed") });
-    if (this.stopped || !this.networkAvailable) return;
+    if (this.stopped || !this.appActive || !this.networkAvailable) return;
     if (this.retryTimer) clearTimeout(this.retryTimer);
     const delay = backoffDelayMs(this.retryAttempt);
     this.retryAttempt += 1;
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
-      if (this.stopped || !this.networkAvailable) return;
+      if (this.stopped || !this.appActive || !this.networkAvailable) return;
       void this.open();
     }, delay);
   }
@@ -855,7 +878,7 @@ class RemoteResponseError extends Error {
   }
 }
 
-function isTransientNatsRequestError(error: unknown): boolean {
+export function isTransientNatsRequestError(error: unknown): boolean {
   if (error instanceof RemoteResponseError) return false;
   if (error instanceof Error && error.message === "not_connected") return true;
   const code =

--- a/mobile/src/remote/draftStorage.ts
+++ b/mobile/src/remote/draftStorage.ts
@@ -97,3 +97,25 @@ export async function clearSessionDraft(sessionId: string): Promise<void> {
     // Ignore — storage unavailable.
   }
 }
+
+/**
+ * A cold-start outbox acknowledgement may arrive after the user has already
+ * edited the composer again. Remove only the exact draft that produced the
+ * acknowledged prompt; never erase newer local work.
+ */
+export async function clearSessionDraftIfMatches(
+  sessionId: string,
+  expected: Pick<SessionDraft, "text" | "attachments">,
+): Promise<void> {
+  const current = await loadSessionDraft(sessionId);
+  if (!current || current.text.trim() !== expected.text.trim()) return;
+  const identities = (items: MobileAttachment[]) =>
+    items.map(item => `${item.localUri}\u0000${item.name}\u0000${item.transferSize}`).sort();
+  if (
+    JSON.stringify(identities(current.attachments)) !==
+    JSON.stringify(identities(expected.attachments))
+  ) {
+    return;
+  }
+  await clearSessionDraft(sessionId);
+}

--- a/mobile/src/remote/pendingPromptStorage.ts
+++ b/mobile/src/remote/pendingPromptStorage.ts
@@ -1,0 +1,55 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { MobileAttachment, ThinkingLevel } from "./types";
+
+export interface PendingPrompt {
+  version: 1;
+  commandId: string;
+  draftKey: string;
+  sessionId: string;
+  text: string;
+  attachments: MobileAttachment[];
+  modelId: string;
+  thinkingLevel: ThinkingLevel;
+  mode: "chat" | "workspace";
+  workspaceId: string;
+  createdAt: number;
+}
+
+const KEY = "futureos.remote.pending-prompt.v1";
+
+export async function loadPendingPrompt(): Promise<PendingPrompt | null> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as Partial<PendingPrompt>;
+    if (
+      value.version !== 1 ||
+      typeof value.commandId !== "string" ||
+      !value.commandId ||
+      typeof value.draftKey !== "string" ||
+      typeof value.sessionId !== "string" ||
+      typeof value.text !== "string" ||
+      !Array.isArray(value.attachments) ||
+      typeof value.modelId !== "string" ||
+      typeof value.thinkingLevel !== "string" ||
+      (value.mode !== "chat" && value.mode !== "workspace") ||
+      typeof value.workspaceId !== "string" ||
+      typeof value.createdAt !== "number"
+    ) {
+      return null;
+    }
+    return value as PendingPrompt;
+  } catch {
+    return null;
+  }
+}
+
+export async function savePendingPrompt(prompt: PendingPrompt): Promise<void> {
+  await AsyncStorage.setItem(KEY, JSON.stringify(prompt));
+}
+
+/** Clear only the record this caller completed; a newer send must survive. */
+export async function clearPendingPrompt(commandId: string): Promise<void> {
+  const current = await loadPendingPrompt();
+  if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+}

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -307,6 +307,7 @@ export interface RemoteCommand {
   entryId?: string;
   mode?: string;
   runId?: string;
+  promptId?: string;
   sinceIdx?: number;
   offset?: number;
   limit?: number;

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -678,12 +678,12 @@ export function ChatScreen() {
     const value = message.trim();
     if (!value && attachments.length === 0) return;
     const pendingAttachments = attachments;
-    setMessage("");
     setTransferProgress(pendingAttachments.length ? 0 : null);
     try {
       await remote.sendMessage(value, pendingAttachments, (done, total) =>
         setTransferProgress(total > 0 ? done / total : null),
       );
+      setMessage("");
       setAttachments([]);
     } catch (error) {
       // M9: sendMessage now throws for busy/streaming/disconnected instead of


### PR DESCRIPTION
## Summary
- close mobile NATS transport before background suspension and reconnect cleanly on foreground
- persist a pending send intent and use durable desktop prompt receipts to prevent duplicate runs after app or desktop restart
- preserve the composer until desktop acknowledgement succeeds

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchman=false (25 suites, 356 tests)
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- cargo test --manifest-path desktop/src-tauri/Cargo.toml remote::commands::bridge_tests -- --nocapture (20 tests)