### PR TITLE
docs: add optional skills-install step to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ For providers with user-specific base URLs (e.g. Azure's `YOUR_RESOURCE`), add a
 
 </details>
 
+### Install skills (optional)
+
+Skills are add-on capability packs the agent picks up from
+`~/.future/agent/skills/`. Browse the catalog and install what you need —
+this only needs network access, not a running agent:
+
+```bash
+future skills list             # browse the skill catalog
+future skills install <name>   # install one skill
+future skills install          # no name: install every built-in skill
+```
+
+Skip this and the agent still answers fine — skills just add ready-made
+workflows. `uninstall` / `update` and friends are in the
+[CLI reference](docs/wiki/en/CLI.md).
+
 ### Run the agent
 
 The terminal and CLI clients are thin gRPC clients. **The agent must be running

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,6 +137,18 @@ future auth login
 
 </details>
 
+### 安装技能（可选）
+
+技能是按需安装的能力包，agent 会从 `~/.future/agent/skills/` 加载。浏览技能目录并安装需要的技能——只需要网络连接，不要求 agent 在运行：
+
+```bash
+future skills list             # 浏览技能目录
+future skills install <name>   # 安装指定技能
+future skills install          # 不带名字：安装全部内置技能
+```
+
+跳过这一步 agent 也能正常回答——技能只是提供现成的工作流。卸载、升级等用法见 [CLI 参考](docs/wiki/zh/CLI.md)。
+
 ### 启动 Agent
 
 终端与 CLI 客户端都是轻量 gRPC 客户端。**必须先启动 Agent**，监听 `127.0.0.1:50051`：


### PR DESCRIPTION
## Change

Adds an **Install skills (optional)** section to the Quick Start in README (en + zh), placed between *Configure a model* and *Run the agent*:

```bash
future skills list             # browse the skill catalog
future skills install <name>   # install one skill
future skills install          # no name: install every built-in skill
```

## Why here

- `future skills` commands dispatch locally and only talk to the platform over HTTPS (`GET /client/v1/skills`) — **no running agent required**, so the step is valid before *Run the agent*.
- Skills land under `~/.future/agent/skills/`, where the agent picks them up on start.
- Marked optional: the agent answers fine without them; links to the CLI reference for `uninstall` / `update`.

Docs-only change (README.md, README.zh-CN.md).