### PR TITLE
fix(agent): heal fallback-stuck loop model in reload_credentials

### DIFF
--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -489,6 +489,13 @@ impl ServerSession {
     /// Active runs use a provider snapshot, so updating this control plane
     /// affects the next request without mutating headers already sent by an
     /// in-flight request.
+    ///
+    /// Also heals the `set_model` fallback: while the registry could not
+    /// resolve this model (catalog unavailable during a logout/broken-auth
+    /// window), `set_model` froze the full `provider/id` literal into the
+    /// loop, and upstream rejects that name ("Model 'provider/id' is not
+    /// configured"). Once the registry resolves the model again, restore the
+    /// bare id so the next request carries a name the server knows.
     pub fn reload_credentials(&self) -> Result<()> {
         if self.model.is_empty() {
             let loop_ = self
@@ -518,14 +525,24 @@ impl ServerSession {
         // The shared loop is a short-lived control plane; active runs own
         // independent snapshots. Wait until the latest credential revision is
         // installed so config commands cannot acknowledge while a session is
-        // still on the old key.
-        let loop_ = self
+        // still on the old key. A write lock is needed (not just for the
+        // interior-mutable provider) because the fallback heal below mutates
+        // `loop_.model`.
+        let mut loop_ = self
             .agent_loop
-            .try_read()
+            .try_write()
             .map_err(|_| anyhow::anyhow!("run configuration is busy; retry prompt"))?;
         loop_.provider.set_api_key(&api_key);
         if !base_url.is_empty() {
             loop_.provider.set_base_url(&base_url);
+        }
+        // Fallback heal: `set_model` only ever stores the bare resolved id
+        // here, so any divergence means the loop still carries the unresolved
+        // literal from a resolve-miss window.
+        if let Some(mc) = registry_resolved.as_ref() {
+            if loop_.model != mc.id {
+                loop_.model = mc.id.clone();
+            }
         }
         Ok(())
     }
@@ -2324,6 +2341,63 @@ mod tests {
 
         session.reload_credentials().unwrap();
         assert_eq!(&*observed.lock(), "new-key");
+    }
+
+    #[test]
+    fn reload_credentials_heals_fallback_model_literal() {
+        let mut session = make_test_session("fallback-heal");
+        session.set_model("gpt-4o").unwrap();
+        let bare = session.agent_loop.try_read().unwrap().model.clone();
+        assert!(!bare.contains('/'), "resolved set_model stores the bare id");
+        // Simulate the resolve-miss window: set_model's fallback froze the
+        // full provider/id literal into the loop.
+        let canonical = session.model.clone();
+        assert!(canonical.contains('/'));
+        session.agent_loop.try_write().unwrap().model = canonical;
+
+        session.reload_credentials().unwrap();
+        assert_eq!(session.agent_loop.try_read().unwrap().model, bare);
+    }
+
+    #[test]
+    fn reload_credentials_keeps_consistent_model_id() {
+        let mut session = make_test_session("consistent-model");
+        session.set_model("gpt-4o").unwrap();
+        let before = session.agent_loop.try_read().unwrap().model.clone();
+
+        session.reload_credentials().unwrap();
+        assert_eq!(session.agent_loop.try_read().unwrap().model, before);
+    }
+
+    #[test]
+    fn reload_credentials_leaves_unresolved_model_literal() {
+        let mut session = make_test_session("unresolved-model");
+        // Resolve miss: the fallback stores the literal, and reload must not
+        // rewrite it while the registry still cannot resolve the model.
+        session.set_model("unknown-provider/unknown-model").unwrap();
+        assert_eq!(
+            session.agent_loop.try_read().unwrap().model,
+            "unknown-provider/unknown-model"
+        );
+
+        session.reload_credentials().unwrap();
+        assert_eq!(
+            session.agent_loop.try_read().unwrap().model,
+            "unknown-provider/unknown-model"
+        );
+    }
+
+    #[test]
+    fn reload_credentials_reports_busy_when_loop_is_read_locked() {
+        let mut session = make_test_session("busy-loop");
+        session.set_model("gpt-4o").unwrap();
+        // A held read guard makes the credential install's try_write fail.
+        let _read_guard = session.agent_loop.try_read().unwrap();
+        let error = session.reload_credentials().unwrap_err();
+        assert!(
+            error.to_string().contains("configuration is busy"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

registry 无法解析会话模型时（退出登录 / auth.json 损坏窗口期，catalog 不可用），`set_model` 的 fallback 分支会把完整的 `provider/id` 字面量冻进 `loop_.model`：

```rust
if let Some(ref mc) = resolved {
    loop_.model = mc.id.clone();      // 正常："kimi-k3"
} else {
    loop_.model = model.to_string();  // fallback：卡住成 "future/kimi-k3"
}
```

之后上游会拒绝每个请求：`Model 'future/kimi-k3' is not configured on this server`。而 `reload_credentials` 只原地刷新 key/base_url，从不修复模型名——会话一直坏到用户手动重选模型为止。

实际事故：`~/.future/agent/auth.json` 被外部进程改写指向本地 mock server 后，已有会话全部报上述错误；重新登录（`set_auth` 广播 `reload_all_credentials`）修好了 key 和端点，但卡住的模型名仍需手动 `set_model` 才能恢复。

## 修复

`reload_credentials` 增加自愈：registry 重新能解析该模型时，把 `loop_.model` 恢复为裸 id。判定条件是可靠的——`set_model` 正常路径只存裸 id，任何不一致必为 fallback 残留。

自愈挂在两条现有路径上，覆盖所有恢复场景：

- **每次 prompt 准入前**的 `reload_credentials()` → 卡住的会话下次提问即自愈；
- **`reload_auth` / 配置写入广播**（`reload_all_credentials` → `reload_credentials_wait`）→ 重新登录当场修复所有存活会话。

凭证安装从 `try_read` 升级为 `try_write`（自愈要改 `loop_.model`），busy 语义与 `set_model` 一致；广播屏障 `reload_credentials_wait` 会自动重试，不会卡死。

## 测试

新增 4 个单测：

- `reload_credentials_heals_fallback_model_literal` — fallback 字面量被恢复为裸 id
- `reload_credentials_keeps_consistent_model_id` — 一致时不改写
- `reload_credentials_leaves_unresolved_model_literal` — registry 仍 miss 时不乱动（登出窗口语义不变）
- `reload_credentials_reports_busy_when_loop_is_read_locked` — 持读锁时正确报 busy

## 验证

- `cargo test -p future-agent --lib`：1317 全过（含全部既有 `reload_auth`/凭证广播测试，确认 `try_write` 升级无回归）
- `cargo test --workspace`：全绿
- `make lint-rust`（fmt + clippy `--all-targets`，含 src-tauri）：全绿

Desktop/mobile JS 套件未本地跑：diff 仅 `agent/**`，CI 路径过滤不会触发对应 job。