### PR TITLE
fix(desktop): stabilize runs panel context

### DIFF
--- a/desktop/DEV_MD/ER.md
+++ b/desktop/DEV_MD/ER.md
@@ -180,6 +180,7 @@ Run 表示一次 Agent 执行，通常由用户消息触发。
 | `ended_at` | 结束时间 |
 | `error_message` | 错误信息 |
 | `error_type` | 结构化错误分类（`stream_interrupted`、`command_failed`、`model_failed`、`abort_requested`、`timeout`、`interrupted`、`unknown` 等；配套 `run_error.rs`，未失败时为 NULL） |
+| `archived_at` | 归档时间；非空时不在右侧「运行」列表展示，但保留记录和 Agent 事件，供中间信息流的命令详情跳转使用 |
 | `created_at` | 创建时间 |
 | `updated_at` | 更新时间 |
 
@@ -199,6 +200,7 @@ Run 表示一次 Agent 执行，通常由用户消息触发。
 - 运行中 Run 可以被用户终止；终止后状态进入 `cancelled`，并同步取消该 Run 下仍然 pending 的 Approval Request。
 - 失败 / 已取消的 Run 支持恢复：『重试』用 `trigger_message_id` 对应的用户消息（含附件）重新发起；『继续』以「继续上一个任务」+ 失败消息摘要（Runs 面板触发时另附已执行内容摘要）发起。两者仅针对最新一轮且未中断的 Run，更早轮次或中断恢复改走 Thread 分叉（见 §4.2）。
 - 长任务恢复时，Thread 可以通过最近 Run 恢复上下文展示。
+- 「归档已结束的程序」只为 Runs 面板隐藏已结束 Run，不删除 SQLite Run 记录、Review 数据或 Agent 的 run-events journal；中间信息流可继续通过 `run_id` 打开命令详情。
 
 ### 4.5 Run Event
 

--- a/desktop/src-tauri/src/agent_bridge/client.rs
+++ b/desktop/src-tauri/src/agent_bridge/client.rs
@@ -216,6 +216,7 @@ pub fn delete_session_command(session_id: String) -> RpcCommand {
     base_command("delete_session", session_id)
 }
 
+#[cfg(test)]
 pub fn prune_run_events_command(session_id: String, run_id: String) -> RpcCommand {
     RpcCommand {
         run_id,

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use self::client::raw_agent_addr;
 pub use self::client::{
     connect_agent, delete_session_command, get_available_models_command, get_run_state_command,
     get_session_entries_command, get_state_command, list_streaming_sessions_command, map_rpc_error,
-    prune_run_events_command, set_default_model_command, set_model_command,
-    set_session_name_command, set_thinking_level_command, RpcResponseExt,
+    set_default_model_command, set_model_command, set_session_name_command,
+    set_thinking_level_command, RpcResponseExt,
 };
 pub use self::config_observer::spawn_provider_config_observer;
 pub use self::headless::{

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -359,32 +359,8 @@ pub async fn get_session_entries(thread_id: String) -> Result<serde_json::Value,
 }
 
 #[tauri::command]
-pub async fn clear_finished_runs(thread_id: String) -> Result<usize, crate::AppError> {
-    let thread =
-        store::get_thread(&thread_id)?.ok_or_else(|| "Thread could not be loaded.".to_string())?;
-    let session_id = thread.agent_session_id.unwrap_or(thread.id);
-    let terminal_runs = store::list_runs(&thread_id)?
-        .into_iter()
-        .filter(|run| matches!(run.status.as_str(), "completed" | "failed" | "cancelled"))
-        .map(|run| run.id)
-        .collect::<Vec<_>>();
-    if !terminal_runs.is_empty() {
-        let mut client = agent_bridge::connect_agent().await?;
-        for run_id in terminal_runs {
-            let response = client
-                .execute_command(agent_bridge::prune_run_events_command(
-                    session_id.clone(),
-                    run_id,
-                ))
-                .await
-                .map_err(|status| agent_bridge::map_rpc_error("Agent event prune failed", status))?
-                .into_inner();
-            if !response.success {
-                return Err(format!("Agent event prune failed: {}", response.error).into());
-            }
-        }
-    }
-    store::clear_finished_runs(&thread_id)
+pub fn archive_finished_runs(thread_id: String) -> Result<usize, crate::AppError> {
+    store::archive_finished_runs(&thread_id)
 }
 
 #[tauri::command]
@@ -468,7 +444,7 @@ mod tests {
                 batch_delete_threads,
                 get_thread_agent_state,
                 get_session_entries,
-                clear_finished_runs,
+                archive_finished_runs,
                 attach_remote_stream
             ],
             &[
@@ -480,7 +456,7 @@ mod tests {
                 "batch_delete_threads",
                 "get_thread_agent_state",
                 "get_session_entries",
-                "clear_finished_runs",
+                "archive_finished_runs",
                 "attach_remote_stream",
             ],
         );
@@ -810,13 +786,12 @@ mod tests {
         assert_eq!(updated.id, thread.id);
     }
 
-    #[tokio::test]
-    async fn clear_finished_runs_without_terminal_runs_skips_the_agent() {
-        let _lock = mock_agent_lock();
-        let _home = init("cmd_clear_runs");
+    #[test]
+    fn archive_finished_runs_without_terminal_runs_returns_zero() {
+        let _home = init("cmd_archive_runs");
         let thread = make_thread(&_home, None);
-        let cleared = clear_finished_runs(thread.id.clone()).await.expect("clear");
-        assert_eq!(cleared, 0);
+        let archived = archive_finished_runs(thread.id).expect("archive");
+        assert_eq!(archived, 0);
     }
 
     #[tokio::test]
@@ -957,10 +932,9 @@ mod tests {
         script_mock_agent(MockScript::default());
     }
 
-    #[tokio::test]
-    async fn clear_finished_runs_prunes_terminal_runs_via_the_agent() {
-        let _lock = mock_agent_lock();
-        let _home = init("cmd_clear_runs_terminal");
+    #[test]
+    fn archive_finished_runs_keeps_terminal_run_for_transcript_inspection() {
+        let _home = init("cmd_archive_runs_terminal");
         let thread = make_thread(&_home, Some("sess_clear"));
         crate::store::create_run(store::CreateRunInput {
             id: Some("run_terminal".into()),
@@ -978,14 +952,12 @@ mod tests {
         })
         .expect("terminal");
 
-        crate::commands::agent_mock::ensure_mock_agent();
-        script_mock_agent(MockScript {
-            data: HashMap::from([("prune_run_events".to_string(), "{}".to_string())]),
-            ..Default::default()
-        });
-        let cleared = clear_finished_runs(thread.id.clone()).await.expect("clear");
-        assert_eq!(cleared, 1);
-        script_mock_agent(MockScript::default());
+        let archived = archive_finished_runs(thread.id).expect("archive");
+        assert_eq!(archived, 1);
+        let run = crate::store::get_run("run_terminal")
+            .expect("get run")
+            .expect("run retained");
+        assert!(run.archived_at.is_some());
     }
 
     #[tokio::test]
@@ -1129,36 +1101,6 @@ mod tests {
             .await
             .expect("missing session is a benign empty history");
         assert_eq!(value["entries"], serde_json::json!([]));
-        script_mock_agent(MockScript::default());
-    }
-
-    #[tokio::test]
-    async fn clear_finished_runs_errors_when_prune_rejected() {
-        let _lock = mock_agent_lock();
-        let _home = init("cmd_clear_runs_rej");
-        let thread = make_thread(&_home, Some("sess_clear_rej"));
-        crate::store::create_run(store::CreateRunInput {
-            id: Some("run_term_rej".into()),
-            thread_id: thread.id.clone(),
-            trigger_message_id: None,
-            model_provider: None,
-            model_id: None,
-        })
-        .expect("create run");
-        crate::store::update_run_status_if_active(store::UpdateRunStatusInput {
-            run_id: "run_term_rej".into(),
-            status: "completed".into(),
-            error_message: None,
-            error_type: None,
-        })
-        .expect("terminal");
-        crate::commands::agent_mock::ensure_mock_agent();
-        script_mock_agent(MockScript {
-            errors: HashMap::from([("prune_run_events".to_string(), "nope".to_string())]),
-            ..Default::default()
-        });
-        let err = clear_finished_runs(thread.id.clone()).await.unwrap_err();
-        assert!(!err.to_string().is_empty());
         script_mock_agent(MockScript::default());
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -776,7 +776,7 @@ pub fn run() {
             logout_future_provider,
             get_future_profile,
             get_future_balance,
-            clear_finished_runs,
+            archive_finished_runs,
             list_threads,
             list_workspaces,
             create_workspace,

--- a/desktop/src-tauri/src/store.rs
+++ b/desktop/src-tauri/src/store.rs
@@ -32,7 +32,7 @@ pub use artifacts::{
     import_attachment_artifact, list_artifacts, ArtifactRecord,
 };
 pub use cleanup::{
-    clear_finished_runs, get_thread_cleanup_summary, list_active_runs, list_interrupted_runs,
+    archive_finished_runs, get_thread_cleanup_summary, list_active_runs, list_interrupted_runs,
     reanimate_run, reconcile_orphan_chat_workspaces, reconcile_orphan_images,
     reconcile_orphan_review_repos, reconcile_orphan_sessions, settle_interrupted_run_from_agent,
     ActiveRun,

--- a/desktop/src-tauri/src/store/cleanup.rs
+++ b/desktop/src-tauri/src/store/cleanup.rs
@@ -5,7 +5,6 @@ use rusqlite::{params, Connection};
 
 use super::db::connect;
 use super::records::ThreadCleanupSummary;
-use super::review_snapshots::delete_run_review_in;
 use super::status::TERMINAL_RUN_STATUSES_SQL;
 
 /// A run that was cancelled by startup convergence after a GUI crash.
@@ -401,73 +400,24 @@ pub fn get_thread_cleanup_summary(
     })
 }
 
-/// Cancel every non-terminal run. Returns the number of runs cancelled.
-pub fn clear_finished_runs(thread_id: &str) -> Result<usize, crate::AppError> {
+/// Hide terminal runs from the Runs panel while retaining their local metadata
+/// and Agent-owned event history for transcript inspection and deep links.
+pub fn archive_finished_runs(thread_id: &str) -> Result<usize, crate::AppError> {
     let mut conn = connect()?;
     let tx = conn.transaction()?;
-    // Terminal runs of this Thread, read once up front so the per-run review
-    // cascade below can reuse `delete_run_review_in` (the FK-safe delete order is
-    // owned by review_snapshots, not restated here). Scoped so the statement is
-    // dropped before the transaction's own `execute` calls borrow it.
-    let terminal_run_ids: Vec<String> = {
-        let mut stmt = tx.prepare(&format!(
-            "SELECT id FROM runs
-             WHERE thread_id = ?1 AND status IN ({TERMINAL_RUN_STATUSES_SQL})"
-        ))?;
-        let rows = stmt.query_map(params![thread_id], |row| row.get::<_, String>(0))?;
-        rows.collect::<rusqlite::Result<Vec<_>>>()?
-    };
-    // messages table dropped — no longer needed
-    tx.execute(
+    let now = now_millis();
+    let archived_runs = tx.execute(
         &format!(
-            "UPDATE artifacts
-         SET run_id = NULL
-         WHERE thread_id = ?1
-           AND run_id IN (
-             SELECT id FROM runs
+            "UPDATE runs
+             SET archived_at = ?2, updated_at = ?2
              WHERE thread_id = ?1
-               AND status IN ({TERMINAL_RUN_STATUSES_SQL})
-           )"
+               AND archived_at IS NULL
+               AND status IN ({TERMINAL_RUN_STATUSES_SQL})"
         ),
-        params![thread_id],
-    )?;
-    // tool_outputs table dropped
-    // run_events table dropped
-    tx.execute(
-        &format!(
-            "DELETE FROM approval_requests
-         WHERE thread_id = ?1
-           AND run_id IN (
-             SELECT id FROM runs
-             WHERE thread_id = ?1
-               AND status IN ({TERMINAL_RUN_STATUSES_SQL})
-           )"
-        ),
-        params![thread_id],
-    )?;
-    // Review data (file changes → changeset → snapshots) for each terminal run,
-    // deleted in the FK-safe order encoded once by `delete_run_review_in`.
-    for run_id in &terminal_run_ids {
-        delete_run_review_in(&tx, run_id)?;
-    }
-    // tool_calls table dropped
-    let deleted_runs = tx.execute(
-        &format!(
-            "DELETE FROM runs
-         WHERE thread_id = ?1
-           AND status IN ({TERMINAL_RUN_STATUSES_SQL})"
-        ),
-        params![thread_id],
+        params![thread_id, now],
     )?;
     tx.commit()?;
-    // Event logs live outside SQLite, so remove them only after the database
-    // transaction commits. Keeping this paired with run deletion prevents the
-    // "clear finished" action from leaving orphaned JSONL files indefinitely.
-    for run_id in &terminal_run_ids {
-        super::delete_run_events_file(run_id);
-        super::clear_run_event_buffer(run_id);
-    }
-    Ok(deleted_runs)
+    Ok(archived_runs)
 }
 
 #[cfg(test)]
@@ -586,8 +536,8 @@ mod tests {
     }
 
     #[test]
-    fn clear_finished_runs_removes_event_log() {
-        let _home = HomeGuard::new("clear-finished-run-events");
+    fn archive_finished_runs_keeps_event_log() {
+        let _home = HomeGuard::new("archive-finished-run-events");
         crate::store::initialize_app_store().expect("initialize store");
         let workspace = crate::store::create_workspace(CreateWorkspaceInput {
             name: Some("test".to_string()),
@@ -636,17 +586,22 @@ mod tests {
         assert!(log_path.exists(), "event log should exist before cleanup");
 
         crate::store::update_run_status_if_active(UpdateRunStatusInput {
-            run_id: run.id,
+            run_id: run.id.clone(),
             status: "completed".to_string(),
             error_message: None,
             error_type: None,
         })
         .expect("complete run");
-        assert_eq!(clear_finished_runs(&thread.id).expect("clear runs"), 1);
+        assert_eq!(archive_finished_runs(&thread.id).expect("archive runs"), 1);
         assert!(
-            !log_path.exists(),
-            "event log should be removed with its run"
+            log_path.exists(),
+            "event log must remain available after archiving"
         );
+        assert!(crate::store::get_run(&run.id)
+            .expect("get run")
+            .expect("run retained")
+            .archived_at
+            .is_some());
     }
 
     #[test]

--- a/desktop/src-tauri/src/store/db.rs
+++ b/desktop/src-tauri/src/store/db.rs
@@ -11,7 +11,9 @@ use super::approvals::{
 use super::runs::{run_from_row, RunRecord, RUN_COLUMNS};
 use super::schema::{
     ADDED_COLUMNS, ADDED_INDEXES, DROPPED_COLUMNS, DROPPED_TABLES, RENAMED_COLUMNS, SCHEMA,
+    VERSIONED_MIGRATIONS,
 };
+use super::util::now_millis;
 
 pub(super) fn app_dir() -> Result<PathBuf, crate::AppError> {
     let home = crate::home_dir().ok_or("HOME/USERPROFILE environment variable is not set.")?;
@@ -165,6 +167,7 @@ pub(super) fn connect() -> Result<PooledConnection, crate::AppError> {
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {
     conn.execute_batch(SCHEMA)?;
+    apply_versioned_migrations(conn)?;
     // Rename columns on databases created before the N-3 rename. `CREATE TABLE
     // IF NOT EXISTS` can't do it, and without this the store reads/writes
     // `artifact_type` against a table that still has the old `type` column —
@@ -211,6 +214,45 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {
                 // DROP COLUMN can fail if the column is referenced by an index
                 // or is the last column — log and continue.
                 eprintln!("FutureOS migration: failed to drop {table}.{column}: {error}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Apply post-release migrations once and record their completion. A fresh
+/// database already has each column from `SCHEMA`, so it records the migration
+/// without re-running its `ALTER`; an upgraded database executes the `ALTER`
+/// and records both steps in one SQLite transaction.
+fn apply_versioned_migrations(conn: &Connection) -> Result<(), crate::AppError> {
+    for (version, table, column, sql) in VERSIONED_MIGRATIONS {
+        let applied = conn
+            .query_row(
+                "SELECT 1 FROM schema_migrations WHERE version = ?1",
+                [version],
+                |_| Ok(()),
+            )
+            .optional()?;
+        if applied.is_some() {
+            continue;
+        }
+
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| {
+            if !column_exists(conn, table, column)? {
+                conn.execute(sql, [])?;
+            }
+            conn.execute(
+                "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, ?2)",
+                params![version, now_millis()],
+            )?;
+            Ok::<(), crate::AppError>(())
+        })();
+        match result {
+            Ok(()) => conn.execute_batch("COMMIT")?,
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(error);
             }
         }
     }
@@ -344,6 +386,41 @@ mod tests {
     fn apply_schema_on_fresh_db_succeeds() {
         let conn = Connection::open_in_memory().unwrap();
         apply_schema(&conn).unwrap();
+    }
+
+    #[test]
+    fn apply_schema_migrates_v1_1_2_runs_with_archive_marker() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE runs (
+                id TEXT PRIMARY KEY,
+                thread_id TEXT NOT NULL,
+                trigger_message_id TEXT,
+                status TEXT NOT NULL,
+                model_provider TEXT,
+                model_id TEXT,
+                started_at INTEGER,
+                ended_at INTEGER,
+                error_message TEXT,
+                error_type TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+
+        apply_schema(&conn).unwrap();
+
+        assert!(column_exists(&conn, "runs", "archived_at").unwrap());
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM schema_migrations WHERE version = 'v1.1.3-runs-archived-at'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1,
+        );
     }
 
     /// A migrated DB holding artifact rows, with FKs off — `dedupe_file_artifacts`

--- a/desktop/src-tauri/src/store/runs.rs
+++ b/desktop/src-tauri/src/store/runs.rs
@@ -28,6 +28,7 @@ pub struct RunRecord {
     /// 'abort_requested', 'timeout', 'unknown'. NULL when the run did not
     /// fail or the error type is unknown.
     pub error_type: Option<String>,
+    pub archived_at: Option<i64>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -69,7 +70,7 @@ pub struct ToolOutputRecord {
 
 sql_record!(pub(super) RUN_COLUMNS, run_from_row -> RunRecord {
     id, thread_id, trigger_message_id, status, model_provider, model_id,
-    started_at, ended_at, error_message, error_type, created_at, updated_at,
+    started_at, ended_at, error_message, error_type, archived_at, created_at, updated_at,
 });
 
 // TOOL_CALL_COLUMNS & tool_call_from_row removed — table dropped; ToolCallRecord

--- a/desktop/src-tauri/src/store/schema.rs
+++ b/desktop/src-tauri/src/store/schema.rs
@@ -53,8 +53,16 @@ CREATE TABLE IF NOT EXISTS runs (
     ended_at INTEGER,
     error_message TEXT,
     error_type TEXT,
+    archived_at INTEGER,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
+);
+
+-- Applied database migrations. Fresh installs record every migration after the
+-- complete schema is created; upgrades apply only the migrations they lack.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version TEXT PRIMARY KEY,
+    applied_at INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS approval_requests (
@@ -301,6 +309,15 @@ pub(super) const ADDED_COLUMNS: &[(&str, &str)] = &[
     // Phase 2 sandbox: suggested rule (JSON) for session/always-allow buttons.
     ("approval_requests", "save_suggestion TEXT"),
 ];
+
+/// Database migrations introduced after the v1.1.2 release. Existing entries
+/// are immutable once released; add a new entry for each future release.
+pub(super) const VERSIONED_MIGRATIONS: &[(&str, &str, &str, &str)] = &[(
+    "v1.1.3-runs-archived-at",
+    "runs",
+    "archived_at",
+    "ALTER TABLE runs ADD COLUMN archived_at INTEGER",
+)];
 
 /// Columns renamed after their table's initial creation (N-3 aligned the DB
 /// `type` columns with the Rust `*_type` fields). `CREATE TABLE IF NOT EXISTS`

--- a/desktop/src/components/layout/ContextPanel.tsx
+++ b/desktop/src/components/layout/ContextPanel.tsx
@@ -13,7 +13,7 @@ import { RunInspectPanel } from "../../features/runs/RunInspectPanel";
 import { RunsPanel } from "../../features/runs/RunsPanel";
 import {
   abortRun,
-  clearFinishedRuns,
+  archiveFinishedRuns,
 } from "../../integrations/storage/threadStore";
 import { onFutureEvent } from "../../lib/futureEvents";
 import { startWindowDrag } from "../../lib/windowDrag";
@@ -97,10 +97,13 @@ export function ContextPanel({
   const seededForOpenRef = useRef(false);
   const activeThreadId = activeThread?.id ?? null;
   const activeThreadMode = activeThread?.mode ?? null;
-  const activeWorkspaceId = activeWorkspace?.id ?? activeThread?.workspaceId ?? null;
+  const activeWorkspaceId = activeThread?.workspaceId ?? null;
+  const workspaceScopeReady = activeThreadId === null || activeWorkspace?.id === activeWorkspaceId;
+  const activeWorkspacePath = workspaceScopeReady ? activeWorkspace?.path ?? null : null;
 
   const {
     runs,
+    runsScope,
     toolsByRun,
     artifacts,
     gitReview,
@@ -111,7 +114,15 @@ export function ContextPanel({
     reviewCustomBase,
     setReviewCustomBase,
     refreshContext,
-  } = useContextData({ activeThreadId, activeThreadMode, activeWorkspaceId, activeTab, expanded });
+  } = useContextData({
+    activeThreadId,
+    activeThreadMode,
+    activeWorkspaceId,
+    activeWorkspacePath,
+    workspaceScopeReady,
+    activeTab,
+    expanded,
+  });
 
   // Workspace-mode threads (git or not) show Review (§14.6); chat keeps Artifacts.
   // Tab choice is driven by capabilities (cheap), not the whole-tree git diff (C3).
@@ -148,19 +159,13 @@ export function ContextPanel({
     }
   }, [activeTab, onTabChange, tabs]);
 
-  async function handleTerminateRun(run: StoredRun) {
-    if (!activeThreadId)
-      return;
-
-    await abortRun({ runId: run.id, threadId: activeThreadId });
+  async function handleTerminateRun(threadId: string, run: StoredRun) {
+    await abortRun({ runId: run.id, threadId });
     await refreshContext();
   }
 
-  async function handleClearFinishedRuns() {
-    if (!activeThreadId)
-      return;
-
-    await clearFinishedRuns(activeThreadId);
+  async function handleArchiveFinishedRuns(threadId: string) {
+    await archiveFinishedRuns(threadId);
     await refreshContext();
   }
 
@@ -336,8 +341,8 @@ export function ContextPanel({
                   <RunsPanel
                     runs={runs}
                     toolsByRun={toolsByRun}
-                    workspacePath={activeWorkspace?.path ?? null}
-                    onClearFinished={handleClearFinishedRuns}
+                    scope={runsScope}
+                    onArchiveFinished={handleArchiveFinishedRuns}
                     onInspectTool={handleSelectTool}
                     onTerminateRun={handleTerminateRun}
                   />

--- a/desktop/src/components/layout/hooks/useContextData.ts
+++ b/desktop/src/components/layout/hooks/useContextData.ts
@@ -27,9 +27,25 @@ interface UseContextDataInput {
   activeThreadId: string | null;
   activeThreadMode: StoredThread["mode"] | null;
   activeWorkspaceId: string | null;
+  activeWorkspacePath: string | null;
+  workspaceScopeReady: boolean;
   activeTab: ContextTab;
   expanded: boolean;
 }
+
+export interface RunsContextScope {
+  threadId: string;
+  workspaceId: string | null;
+  workspacePath: string | null;
+}
+
+interface RunsContextSnapshot {
+  scope: RunsContextScope | null;
+  runs: StoredRun[];
+  toolsByRun: Record<string, StoredToolCall[]>;
+}
+
+const EMPTY_RUNS_SNAPSHOT: RunsContextSnapshot = { scope: null, runs: [], toolsByRun: {} };
 
 /**
  * Owns the right-context data pipeline: fetches runs/tools/artifacts/git-review
@@ -42,11 +58,15 @@ export function useContextData({
   activeThreadId,
   activeThreadMode,
   activeWorkspaceId,
+  activeWorkspacePath,
+  workspaceScopeReady,
   activeTab,
   expanded,
 }: UseContextDataInput) {
-  const [runs, setRuns] = useState<StoredRun[]>([]);
-  const [toolsByRun, setToolsByRun] = useState<Record<string, StoredToolCall[]>>({});
+  // Runs, their projected tool calls, and the workspace root that formats file
+  // targets form one scope-bound snapshot. Keeping them together prevents a
+  // thread switch from rendering stale rows through a newer workspace path.
+  const [runsSnapshot, setRunsSnapshot] = useState<RunsContextSnapshot>(EMPTY_RUNS_SNAPSHOT);
   const [artifacts, setArtifacts] = useState<StoredArtifact[]>([]);
   const [gitReview, setGitReview] = useState<GitReview | null>(null);
   const [reviewCapabilities, setReviewCapabilities] = useState<WorkspaceReviewCapabilities | null>(null);
@@ -64,13 +84,18 @@ export function useContextData({
     const isCurrentRefresh = () => refreshGenerationRef.current === refreshGeneration;
 
     if (!activeThreadId) {
-      setRuns([]);
-      setToolsByRun({});
+      setRunsSnapshot(EMPTY_RUNS_SNAPSHOT);
       setArtifacts([]);
       setGitReview(null);
       setLoading(false);
       return;
     }
+
+    // The store may briefly expose a fallback workspace while the active
+    // thread's actual workspace is still resolving. Keep the previous complete
+    // snapshot until the new thread and root can be committed together.
+    if (!workspaceScopeReady)
+      return;
 
     // Note: blanking + the loading spinner are driven by the thread-switch
     // bootstrap effect (delayed + min-duration), not here — so a fast local
@@ -113,21 +138,27 @@ export function useContextData({
       if (!isCurrentRefresh())
         return;
 
-      setRuns(nextRuns);
-      setToolsByRun(Object.fromEntries(toolEntries));
+      setRunsSnapshot({
+        scope: {
+          threadId: activeThreadId,
+          workspaceId: activeWorkspaceId,
+          workspacePath: activeWorkspacePath,
+        },
+        runs: nextRuns,
+        toolsByRun: Object.fromEntries(toolEntries),
+      });
       setArtifacts(nextArtifacts);
       setGitReview(nextGitReview);
       setReviewCapabilities(nextCapabilities);
     }
     catch {
       if (isCurrentRefresh()) {
-        setRuns([]);
-        setToolsByRun({});
+        setRunsSnapshot(EMPTY_RUNS_SNAPSHOT);
         setArtifacts([]);
         setGitReview(null);
       }
     }
-  }, [activeTab, activeThreadId, activeThreadMode, activeWorkspaceId, reviewBase, debouncedReviewCustomBase]);
+  }, [activeTab, activeThreadId, activeThreadMode, activeWorkspaceId, activeWorkspacePath, workspaceScopeReady, reviewBase, debouncedReviewCustomBase]);
 
   // Always invoke the latest refreshContext through this ref: it closes over
   // activeThreadId/activeTab/reviewBase/… so its identity changes on nearly
@@ -160,8 +191,7 @@ export function useContextData({
       if (cancelled)
         return;
       spinnerShownAt = performance.now();
-      setRuns([]);
-      setToolsByRun({});
+      setRunsSnapshot(EMPTY_RUNS_SNAPSHOT);
       setArtifacts([]);
       setGitReview(null);
       setLoading(true);
@@ -194,7 +224,7 @@ export function useContextData({
       if (minTimer)
         clearTimeout(minTimer);
     };
-  }, [activeThreadId]);
+  }, [activeThreadId, activeWorkspaceId, activeWorkspacePath, workspaceScopeReady]);
 
   // Parameter-driven refresh: re-fetch for the current tab / diff base without
   // blanking already-loaded state.
@@ -207,7 +237,7 @@ export function useContextData({
   // idle-panel data (git review, artifacts) moves rarely, and the expensive
   // queries behind it are already cached/batched. External changes (another
   // client driving the session) surface within the slow tick.
-  const hasActiveRun = runs.some(run => !matchesSettledRun(run.status));
+  const hasActiveRun = runsSnapshot.runs.some(run => !matchesSettledRun(run.status));
   usePolling(() => refreshContextRef.current(), hasActiveRun ? 1500 : 5000, {
     enabled: Boolean(activeThreadId) && expanded,
     // Intentionally no refreshContext dep: the parameter-driven effect above
@@ -216,8 +246,9 @@ export function useContextData({
   });
 
   return {
-    runs,
-    toolsByRun,
+    runs: runsSnapshot.runs,
+    runsScope: runsSnapshot.scope,
+    toolsByRun: runsSnapshot.toolsByRun,
     artifacts,
     gitReview,
     reviewCapabilities,

--- a/desktop/src/features/filetree/FileTreePanel.tsx
+++ b/desktop/src/features/filetree/FileTreePanel.tsx
@@ -173,7 +173,7 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
           size="sm"
           variant="toolbar"
         >
-          {refreshing ? t("refreshing") : t("refresh")}
+          {t("refresh")}
         </Button>
       </div>
 

--- a/desktop/src/features/runs/RunsPanel.tsx
+++ b/desktop/src/features/runs/RunsPanel.tsx
@@ -1,5 +1,6 @@
+import type { RunsContextScope } from "../../components/layout/hooks/useContextData";
 import type { StoredRun, StoredToolCall } from "../../integrations/storage/threadStore";
-import { ChevronRight, CircleStop, Pencil, TerminalSquare, Trash2 } from "lucide-react";
+import { Archive, ChevronRight, CircleStop, Pencil, TerminalSquare } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/ui/Button";
@@ -14,10 +15,10 @@ import { toolCommand, toolTarget } from "./toolInput";
 interface RunsPanelProps {
   runs: StoredRun[];
   toolsByRun: Record<string, StoredToolCall[]>;
-  workspacePath?: string | null;
-  onClearFinished: () => Promise<void>;
+  onArchiveFinished: (threadId: string) => Promise<void>;
   onInspectTool: (toolId: string) => void;
-  onTerminateRun: (run: StoredRun) => Promise<void>;
+  onTerminateRun: (threadId: string, run: StoredRun) => Promise<void>;
+  scope: RunsContextScope | null;
 }
 
 interface ToolEntry {
@@ -28,26 +29,33 @@ interface ToolEntry {
   terminable: boolean;
 }
 
-export function RunsPanel({ onClearFinished, onInspectTool, onTerminateRun, runs, toolsByRun, workspacePath }: RunsPanelProps) {
+export function RunsPanel({ onArchiveFinished, onInspectTool, onTerminateRun, runs, scope, toolsByRun }: RunsPanelProps) {
   const { t } = useTranslation("runs");
   const [confirmRunId, setConfirmRunId] = useState<string | null>(null);
   const [busyRunId, setBusyRunId] = useState<string | null>(null);
   const [actionErrors, setActionErrors] = useState<Record<string, string | undefined>>({});
-  const [clearing, setClearing] = useState(false);
-  const [clearError, setClearError] = useState<string | null>(null);
+  const [archiving, setArchiving] = useState(false);
+  const [archiveError, setArchiveError] = useState<string | null>(null);
 
-  const entries = useMemo(() => buildToolEntries(runs, toolsByRun), [runs, toolsByRun]);
+  const allEntries = useMemo(() => buildToolEntries(runs, toolsByRun), [runs, toolsByRun]);
+  const entries = useMemo(() => allEntries.filter(entry => !entry.run.archivedAt), [allEntries]);
   const { runningCount, finishedCount } = useMemo(() => countEntries(entries), [entries]);
 
   if (entries.length === 0) {
-    return <EmptyState title={t("runsPanel.emptyTitle")} detail={t("runsPanel.emptyDetail")} />;
+    const hasArchivedPrograms = allEntries.some(entry => entry.run.archivedAt);
+    return (
+      <EmptyState
+        detail={t(hasArchivedPrograms ? "runsPanel.emptyDetailArchived" : "runsPanel.emptyDetailNeverRun")}
+        title={t("runsPanel.emptyTitle")}
+      />
+    );
   }
 
   async function terminate(run: StoredRun) {
     setBusyRunId(run.id);
     setActionErrors(current => ({ ...current, [run.id]: undefined }));
     try {
-      await onTerminateRun(run);
+      await onTerminateRun(scope?.threadId ?? run.threadId, run);
       setConfirmRunId(null);
     }
     catch (error) {
@@ -61,20 +69,21 @@ export function RunsPanel({ onClearFinished, onInspectTool, onTerminateRun, runs
     }
   }
 
-  async function clearFinished() {
-    if (clearing || finishedCount === 0)
+  async function archiveFinished() {
+    if (archiving || finishedCount === 0)
       return;
 
-    setClearing(true);
-    setClearError(null);
+    setArchiving(true);
+    setArchiveError(null);
     try {
-      await onClearFinished();
+      if (scope)
+        await onArchiveFinished(scope.threadId);
     }
     catch (error) {
-      setClearError(errorMessage(error));
+      setArchiveError(errorMessage(error));
     }
     finally {
-      setClearing(false);
+      setArchiving(false);
     }
   }
 
@@ -85,17 +94,17 @@ export function RunsPanel({ onClearFinished, onInspectTool, onTerminateRun, runs
           {t("runsPanel.runningFinished", { running: runningCount, finished: finishedCount })}
         </div>
         <Button
-          disabled={clearing || finishedCount === 0}
-          leftIcon={<Trash2 className="size-3.5" />}
-          onClick={() => void clearFinished()}
+          disabled={archiving || finishedCount === 0}
+          leftIcon={<Archive className="size-3.5" />}
+          onClick={() => void archiveFinished()}
           size="xs"
           variant="toolbar"
         >
-          {clearing ? t("runsPanel.clearing") : t("runsPanel.clearFinished")}
+          {t("runsPanel.archiveFinished")}
         </Button>
       </div>
-      {clearError
-        ? <div className="line-clamp-3 text-xs leading-5 text-danger">{clearError}</div>
+      {archiveError
+        ? <div className="line-clamp-3 text-xs leading-5 text-danger">{archiveError}</div>
         : null}
       <div className="space-y-2">
         {entries.map(entry => (
@@ -104,7 +113,7 @@ export function RunsPanel({ onClearFinished, onInspectTool, onTerminateRun, runs
             confirming={confirmRunId === entry.run.id}
             key={entry.tool.id}
             entry={entry}
-            workspacePath={workspacePath}
+            workspacePath={scope?.workspacePath}
             actionError={actionErrors[entry.run.id]}
             onCancelConfirm={() => setConfirmRunId(null)}
             onInspect={() => onInspectTool(entry.tool.id)}

--- a/desktop/src/features/settings/CustomProviderDialog.tsx
+++ b/desktop/src/features/settings/CustomProviderDialog.tsx
@@ -226,7 +226,7 @@ export function CustomProviderDialog({
 
   return (
     <Dialog
-      bodyClassName="-mr-5 min-h-0 flex-1 overflow-y-auto pr-5"
+      bodyClassName="-ml-0.5 -mr-5 min-h-0 flex-1 overflow-y-auto pl-0.5 pr-5"
       className="flex max-h-[min(760px,calc(100vh-3rem))] max-w-lg flex-col"
       onClose={onClose}
       open={open}

--- a/desktop/src/i18n/locales/en/filetree.json
+++ b/desktop/src/i18n/locales/en/filetree.json
@@ -1,6 +1,5 @@
 {
   "refresh": "Refresh",
-  "refreshing": "Refreshing…",
   "openWorkspace": "Open Folder",
   "showHidden": "Hidden files",
   "empty": "This folder is empty",

--- a/desktop/src/i18n/locales/en/runs.json
+++ b/desktop/src/i18n/locales/en/runs.json
@@ -32,10 +32,10 @@
   },
   "runsPanel": {
     "emptyTitle": "No background programs",
-    "emptyDetail": "Agent work will appear here while it is running.",
+    "emptyDetailNeverRun": "No programs have run yet.",
+    "emptyDetailArchived": "Finished programs have been archived.",
     "runningFinished": "{{running}} running / {{finished}} finished",
-    "clearing": "Clearing",
-    "clearFinished": "Clear finished",
+    "archiveFinished": "Archive finished",
     "commands_one": "{{count}} command",
     "commands_other": "{{count}} commands",
     "inspectRun": "Inspect run",

--- a/desktop/src/i18n/locales/zh/filetree.json
+++ b/desktop/src/i18n/locales/zh/filetree.json
@@ -1,6 +1,5 @@
 {
   "refresh": "刷新",
-  "refreshing": "正在刷新…",
   "openWorkspace": "打开文件夹",
   "showHidden": "显示隐藏文件",
   "empty": "此目录为空",

--- a/desktop/src/i18n/locales/zh/runs.json
+++ b/desktop/src/i18n/locales/zh/runs.json
@@ -31,11 +31,11 @@
     "collapse": "收起"
   },
   "runsPanel": {
-    "emptyTitle": "没有后台程序",
-    "emptyDetail": "Agent 运行时的工作会显示在这里。",
+    "emptyTitle": "暂无后台程序",
+    "emptyDetailNeverRun": "还没有运行过程序。",
+    "emptyDetailArchived": "已结束的程序已归档。",
     "runningFinished": "{{running}} 运行中 / {{finished}} 已结束",
-    "clearing": "清理中",
-    "clearFinished": "清除已结束的程序",
+    "archiveFinished": "归档已结束的程序",
     "commands_one": "{{count}} 条命令",
     "commands_other": "{{count}} 条命令",
     "inspectRun": "查看运行",

--- a/desktop/src/integrations/storage/runs.ts
+++ b/desktop/src/integrations/storage/runs.ts
@@ -51,8 +51,8 @@ export async function abortRun(input: { threadId: string; runId: string }) {
   return invokeCommand<StoredRun>("abort_run", { threadId: input.threadId, runId: input.runId });
 }
 
-export async function clearFinishedRuns(threadId: string) {
-  return invokeCommand<number>("clear_finished_runs", { threadId });
+export async function archiveFinishedRuns(threadId: string) {
+  return invokeCommand<number>("archive_finished_runs", { threadId });
 }
 
 export async function listRunEvents(runId: string) {

--- a/desktop/src/integrations/storage/storage.test.ts
+++ b/desktop/src/integrations/storage/storage.test.ts
@@ -32,7 +32,7 @@ import {
 } from "./review";
 import {
   abortRun,
-  clearFinishedRuns,
+  archiveFinishedRuns,
   createRun,
   decideApprovalRequest,
   getLatestRun,
@@ -209,8 +209,8 @@ describe("storage invoke wrappers", () => {
     expect(invokeMock).toHaveBeenLastCalledWith("update_run_status", { input: { runId: "r", status: "completed" } });
     await abortRun({ threadId: "t", runId: "r" });
     expect(invokeMock).toHaveBeenLastCalledWith("abort_run", { threadId: "t", runId: "r" });
-    await clearFinishedRuns("t");
-    expect(invokeMock).toHaveBeenLastCalledWith("clear_finished_runs", { threadId: "t" });
+    await archiveFinishedRuns("t");
+    expect(invokeMock).toHaveBeenLastCalledWith("archive_finished_runs", { threadId: "t" });
     await listRunEvents("r");
     expect(invokeMock).toHaveBeenLastCalledWith("list_run_events", { runId: "r" });
     await listRunEventsSince("r", 5);

--- a/desktop/src/integrations/storage/types.ts
+++ b/desktop/src/integrations/storage/types.ts
@@ -52,6 +52,8 @@ export interface StoredRun {
   endedAt?: number | null;
   errorMessage?: string | null;
   errorType?: "stream_disconnected" | "command_failed" | "model_failed" | "abort_requested" | "timeout" | "unknown" | null;
+  /** Set when hidden from the Runs panel; the record and Agent events remain available. */
+  archivedAt?: number | null;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Summary
- archive completed runs without deleting their history or Agent event data
- atomically scope Runs panel data, tool projections, and workspace paths to prevent path-render flicker during thread switches
- polish custom-provider focus rings and file-panel refresh behavior/copy

## Validation
- npm run lint
- npm run test
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo test --manifest-path desktop/src-tauri/Cargo.toml store::db::tests::apply_schema_migrates_v1_1_2_runs_with_archive_marker
- cargo test --manifest-path desktop/src-tauri/Cargo.toml archive_finished_runs
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings