### PR TITLE
fix(agent): fail fast on malformed tool args + actionable recovery guidance

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -328,9 +328,16 @@ impl Loop {
         // Stage 2: PrepareToolCall hook
         let raw_args = tc.function.arguments.clone();
         let normalized_args = match &raw_args {
-            serde_json::Value::String(s) => {
-                serde_json::from_str::<serde_json::Value>(s).unwrap_or(raw_args)
-            }
+            serde_json::Value::String(s) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => v,
+                Err(_) => {
+                    return (
+                        String::new(),
+                        Some(format!("Tool {} received malformed (non-JSON) arguments; re-emit with a valid JSON object", tool_name)),
+                        tool_name,
+                    );
+                }
+            },
             _ => raw_args,
         };
         let effective_args = if let Some(ref hook) = config.prepare_tool_call {
@@ -617,6 +624,26 @@ mod tests {
         assert_eq!(name, "nonexistent_tool");
         assert!(err.is_some());
         assert!(err.unwrap().contains("Unknown tool"));
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_malformed_string_args_fails_fast() {
+        let tools = vec![crate::tools::write_tool()];
+        let tc = crate::types::ToolCall {
+            id: "c1".to_string(),
+            call_type: "function".to_string(),
+            function: crate::types::ToolCallFn {
+                name: "write".to_string(),
+                arguments: serde_json::json!("{not valid json"),
+            },
+        };
+        let (result, err, name) =
+            Loop::execute_one_tool_impl_static(&tc, &tools, &crate::types::AgentConfig::default())
+                .await;
+        assert_eq!(name, "write");
+        assert!(err.is_some());
+        assert!(err.unwrap().contains("malformed"));
+        assert!(result.is_empty());
     }
 
     #[tokio::test]

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -399,6 +399,8 @@ fn build_identity_section(opts: &PromptOptions) -> String {
 
 fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
     let has_shell = tool_names.contains(&"shell");
+    let has_write = tool_names.contains(&"write");
+    let has_edit = tool_names.contains(&"edit");
 
     let mut guidelines = vec![];
 
@@ -413,6 +415,13 @@ fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
         #[cfg(target_os = "windows")]
         guidelines.push(
             "Use the shell tool (PowerShell) for command-line exploration such as Get-ChildItem and Select-String; but to read a known file's contents use the read tool, not Get-Content. Prefer write/edit tools for ordinary file writes."
+                .to_string(),
+        );
+    }
+
+    if has_write || has_edit || has_shell {
+        guidelines.push(
+            "If a tool returns a \"malformed (non-JSON) arguments\" error, re-emit that tool call with simpler arguments: split an over-long `content` or `command` into smaller pieces and avoid deeply nested escapes; never resend the identical call unchanged."
                 .to_string(),
         );
     }
@@ -927,6 +936,19 @@ mod tests {
     fn build_dynamic_tool_guidelines_returns_vec() {
         let guidelines = build_dynamic_tool_guidelines(&["shell", "read", "write", "edit"]);
         assert!(!guidelines.is_empty());
+    }
+
+    #[test]
+    fn dynamic_guidelines_include_malformed_args_recovery_when_write_tool_present() {
+        let guidelines = build_dynamic_tool_guidelines(&["read", "write", "edit", "shell"]);
+        assert!(guidelines
+            .iter()
+            .any(|g| g.contains("malformed (non-JSON) arguments")));
+        // With no write/edit/shell tools, the recovery hint is absent.
+        let guidelines = build_dynamic_tool_guidelines(&["read"]);
+        assert!(!guidelines
+            .iter()
+            .any(|g| g.contains("malformed (non-JSON) arguments")));
     }
 
     #[test]

--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -373,7 +373,7 @@ fn edit_handler(args: serde_json::Value) -> Pin<Box<dyn Future<Output = Result<S
 pub fn edit_tool() -> AgentTool {
     make_tool(
         "edit",
-        "Edit a file using exact text replacement. Supports multi-edit via edits array.",
+        "Edit a file using exact text replacement. Single replacement: pass `path` + `oldText` + `newText`. Multiple replacements in one call: pass `path` + `edits` (an array of {oldText, newText}). Never mix both forms, and never pass a bare array or a string in place of the arguments object.",
         edit_schema(),
         edit_handler,
         vec!["Include enough context for unique matching"],


### PR DESCRIPTION
## Problem

Tool-call arguments arriving as a corrupt JSON string (streamed truncation, escaped newlines, or the model emitting a bare array of {oldText,newText} objects) currently fall through silently: the handler then fails with an opaque "invalid type: string, expected struct <X>Params", which the model cannot act on.

Observed 24 times in one real session - the model retried the same call repeatedly, then abandoned write/edit in favour of shell heredocs.

## Change

- agent/src/agent/mod.rs - parse the string arguments; on failure return an actionable error naming the tool and asking for a valid JSON object (fail fast instead of silent fallback). Adds a regression test.
- agent/src/tools/mod.rs - make the edit tool single-vs-multi contract explicit, forbid mixing forms, and forbid passing a bare array/string as arguments.
- agent/src/prompt/mod.rs - add a dynamic guideline (gated on write/edit/shell being present) telling the model how to recover from the now-actionable malformed (non-JSON) arguments error: re-emit with simpler arguments, split over-long content/command, never resend the identical call. Adds a unit test for both the present and absent cases.

## Test plan

- cargo check -p future-agent: PASS
- cargo test -p future-agent --lib execute_one_tool: PASS (11, incl. new regression)
- cargo test -p future-agent --lib dynamic_guidelines: PASS
- cargo fmt --check: PASS
- cargo clippy -p future-agent --lib -- -D warnings: PASS
