### PR TITLE
docs(agent): guideline that tool arguments must be one valid JSON object

### DIFF
--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -421,6 +421,10 @@ fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
 
     if has_write || has_edit || has_shell {
         guidelines.push(
+            "Tool call arguments must be a single valid JSON object: the value of `arguments` is one complete object such as {\"path\": ..., \"content\": ...}, never a bare fragment like {1,3}, {a:1}, {brace}, or an unquoted trailing chunk. When in doubt, write the arguments as one small, well-formed JSON object and keep `content`/`command` short."
+                .to_string(),
+        );
+        guidelines.push(
             "If a tool returns a \"malformed (non-JSON) arguments\" error, re-emit that tool call with simpler arguments: split an over-long `content` or `command` into smaller pieces and avoid deeply nested escapes; never resend the identical call unchanged."
                 .to_string(),
         );
@@ -949,6 +953,19 @@ mod tests {
         assert!(!guidelines
             .iter()
             .any(|g| g.contains("malformed (non-JSON) arguments")));
+    }
+
+    #[test]
+    fn dynamic_guidelines_include_valid_json_contract_when_write_tool_present() {
+        let guidelines = build_dynamic_tool_guidelines(&["read", "write", "edit", "shell"]);
+        assert!(guidelines
+            .iter()
+            .any(|g| g.contains("single valid JSON object")));
+        // Absent without write/edit/shell tools.
+        let guidelines = build_dynamic_tool_guidelines(&["read"]);
+        assert!(!guidelines
+            .iter()
+            .any(|g| g.contains("single valid JSON object")));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Inspection of a real session showed the malformed-argument errors were not caused by adapter chunk corruption: the model itself generated non-JSON argument fragments ({1,3}, {a:1}, {brace}, unquoted trailing chunks), which the adapter passes through and the handler then rejects.

## Change

Add a dynamic guideline (gated on write/edit/shell being present) telling the model to always emit one small, well-formed JSON object for arguments and to keep content/command short. This targets the actual failure mode (model-generated invalid JSON) rather than the adapter.

- agent/src/prompt/mod.rs - new guideline + unit test for both the present and absent cases.

## Test plan

- cargo fmt --check: PASS
- cargo check -p future-agent: PASS
- cargo clippy -p future-agent --lib -- -D warnings: PASS
- cargo test -p future-agent --lib dynamic_guidelines: PASS (2, incl. new test)
