### PR TITLE
Revert PR #334 and #335 (malformed tool args fail-fast + prompt guidelines)

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -328,16 +328,9 @@ impl Loop {
         // Stage 2: PrepareToolCall hook
         let raw_args = tc.function.arguments.clone();
         let normalized_args = match &raw_args {
-            serde_json::Value::String(s) => match serde_json::from_str::<serde_json::Value>(s) {
-                Ok(v) => v,
-                Err(_) => {
-                    return (
-                        String::new(),
-                        Some(format!("Tool {} received malformed (non-JSON) arguments; re-emit with a valid JSON object", tool_name)),
-                        tool_name,
-                    );
-                }
-            },
+            serde_json::Value::String(s) => {
+                serde_json::from_str::<serde_json::Value>(s).unwrap_or(raw_args)
+            }
             _ => raw_args,
         };
         let effective_args = if let Some(ref hook) = config.prepare_tool_call {
@@ -624,26 +617,6 @@ mod tests {
         assert_eq!(name, "nonexistent_tool");
         assert!(err.is_some());
         assert!(err.unwrap().contains("Unknown tool"));
-    }
-
-    #[tokio::test]
-    async fn execute_one_tool_malformed_string_args_fails_fast() {
-        let tools = vec![crate::tools::write_tool()];
-        let tc = crate::types::ToolCall {
-            id: "c1".to_string(),
-            call_type: "function".to_string(),
-            function: crate::types::ToolCallFn {
-                name: "write".to_string(),
-                arguments: serde_json::json!("{not valid json"),
-            },
-        };
-        let (result, err, name) =
-            Loop::execute_one_tool_impl_static(&tc, &tools, &crate::types::AgentConfig::default())
-                .await;
-        assert_eq!(name, "write");
-        assert!(err.is_some());
-        assert!(err.unwrap().contains("malformed"));
-        assert!(result.is_empty());
     }
 
     #[tokio::test]

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -421,10 +421,6 @@ fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
 
     if has_write || has_edit || has_shell {
         guidelines.push(
-            "Tool call arguments must be a single valid JSON object: the value of `arguments` is one complete object such as {\"path\": ..., \"content\": ...}, never a bare fragment like {1,3}, {a:1}, {brace}, or an unquoted trailing chunk. When in doubt, write the arguments as one small, well-formed JSON object and keep `content`/`command` short."
-                .to_string(),
-        );
-        guidelines.push(
             "If a tool returns a \"malformed (non-JSON) arguments\" error, re-emit that tool call with simpler arguments: split an over-long `content` or `command` into smaller pieces and avoid deeply nested escapes; never resend the identical call unchanged."
                 .to_string(),
         );
@@ -953,19 +949,6 @@ mod tests {
         assert!(!guidelines
             .iter()
             .any(|g| g.contains("malformed (non-JSON) arguments")));
-    }
-
-    #[test]
-    fn dynamic_guidelines_include_valid_json_contract_when_write_tool_present() {
-        let guidelines = build_dynamic_tool_guidelines(&["read", "write", "edit", "shell"]);
-        assert!(guidelines
-            .iter()
-            .any(|g| g.contains("single valid JSON object")));
-        // Absent without write/edit/shell tools.
-        let guidelines = build_dynamic_tool_guidelines(&["read"]);
-        assert!(!guidelines
-            .iter()
-            .any(|g| g.contains("single valid JSON object")));
     }
 
     #[test]

--- a/agent/src/prompt/mod.rs
+++ b/agent/src/prompt/mod.rs
@@ -399,8 +399,6 @@ fn build_identity_section(opts: &PromptOptions) -> String {
 
 fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
     let has_shell = tool_names.contains(&"shell");
-    let has_write = tool_names.contains(&"write");
-    let has_edit = tool_names.contains(&"edit");
 
     let mut guidelines = vec![];
 
@@ -415,13 +413,6 @@ fn build_dynamic_tool_guidelines(tool_names: &[&str]) -> Vec<String> {
         #[cfg(target_os = "windows")]
         guidelines.push(
             "Use the shell tool (PowerShell) for command-line exploration such as Get-ChildItem and Select-String; but to read a known file's contents use the read tool, not Get-Content. Prefer write/edit tools for ordinary file writes."
-                .to_string(),
-        );
-    }
-
-    if has_write || has_edit || has_shell {
-        guidelines.push(
-            "If a tool returns a \"malformed (non-JSON) arguments\" error, re-emit that tool call with simpler arguments: split an over-long `content` or `command` into smaller pieces and avoid deeply nested escapes; never resend the identical call unchanged."
                 .to_string(),
         );
     }
@@ -936,19 +927,6 @@ mod tests {
     fn build_dynamic_tool_guidelines_returns_vec() {
         let guidelines = build_dynamic_tool_guidelines(&["shell", "read", "write", "edit"]);
         assert!(!guidelines.is_empty());
-    }
-
-    #[test]
-    fn dynamic_guidelines_include_malformed_args_recovery_when_write_tool_present() {
-        let guidelines = build_dynamic_tool_guidelines(&["read", "write", "edit", "shell"]);
-        assert!(guidelines
-            .iter()
-            .any(|g| g.contains("malformed (non-JSON) arguments")));
-        // With no write/edit/shell tools, the recovery hint is absent.
-        let guidelines = build_dynamic_tool_guidelines(&["read"]);
-        assert!(!guidelines
-            .iter()
-            .any(|g| g.contains("malformed (non-JSON) arguments")));
     }
 
     #[test]

--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -373,7 +373,7 @@ fn edit_handler(args: serde_json::Value) -> Pin<Box<dyn Future<Output = Result<S
 pub fn edit_tool() -> AgentTool {
     make_tool(
         "edit",
-        "Edit a file using exact text replacement. Single replacement: pass `path` + `oldText` + `newText`. Multiple replacements in one call: pass `path` + `edits` (an array of {oldText, newText}). Never mix both forms, and never pass a bare array or a string in place of the arguments object.",
+        "Edit a file using exact text replacement. Supports multi-edit via edits array.",
         edit_schema(),
         edit_handler,
         vec!["Include enough context for unique matching"],


### PR DESCRIPTION
This reverts:
- #335 docs(agent): add guideline that tool arguments must be one valid JSON object
- #334 fix(agent): fail fast on malformed tool args + actionable recovery guidance

Restores the previous behavior in `agent/src/agent/mod.rs`, `agent/src/prompt/mod.rs`, and `agent/src/tools/mod.rs`. `cargo check -p future-agent` passes.