### PR TITLE
fix(desktop): degrade run archive migration

### DIFF
--- a/desktop/src-tauri/src/store/cleanup.rs
+++ b/desktop/src-tauri/src/store/cleanup.rs
@@ -404,6 +404,12 @@ pub fn get_thread_cleanup_summary(
 /// and Agent-owned event history for transcript inspection and deep links.
 pub fn archive_finished_runs(thread_id: &str) -> Result<usize, crate::AppError> {
     let mut conn = connect()?;
+    if !super::runs::run_archive_supported(&conn)? {
+        return Err(
+            "Run archiving is unavailable because the local database upgrade did not complete."
+                .into(),
+        );
+    }
     let tx = conn.transaction()?;
     let now = now_millis();
     let archived_runs = tx.execute(

--- a/desktop/src-tauri/src/store/db.rs
+++ b/desktop/src-tauri/src/store/db.rs
@@ -8,7 +8,7 @@ use std::{fs, path::PathBuf};
 use super::approvals::{
     approval_request_from_row, ApprovalRequestRecord, APPROVAL_REQUEST_COLUMNS,
 };
-use super::runs::{run_from_row, RunRecord, RUN_COLUMNS};
+use super::runs::{run_from_row, RunRecord};
 use super::schema::{
     ADDED_COLUMNS, ADDED_INDEXES, DROPPED_COLUMNS, DROPPED_TABLES, RENAMED_COLUMNS, SCHEMA,
     VERSIONED_MIGRATIONS,
@@ -167,7 +167,12 @@ pub(super) fn connect() -> Result<PooledConnection, crate::AppError> {
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {
     conn.execute_batch(SCHEMA)?;
-    apply_versioned_migrations(conn)?;
+    // Run archiving is optional UI metadata. A failed upgrade must not block
+    // the Agent/file-tool main flow; read paths project its missing column as
+    // NULL and the archive action reports its own unavailable error.
+    if let Err(error) = apply_versioned_migrations(conn) {
+        eprintln!("FutureOS migration: optional run-archive migration failed: {error}");
+    }
     // Rename columns on databases created before the N-3 rename. `CREATE TABLE
     // IF NOT EXISTS` can't do it, and without this the store reads/writes
     // `artifact_type` against a table that still has the old `type` column —
@@ -310,7 +315,11 @@ fn is_duplicate_column_error(error: &rusqlite::Error) -> bool {
 
 /// Whether `table` has a column named `column`. `table`/`column` come from the
 /// `RENAMED_COLUMNS` constant (never user input), so interpolation is safe.
-fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, crate::AppError> {
+pub(super) fn column_exists(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+) -> Result<bool, crate::AppError> {
     let sql = format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = '{column}'");
     let count: i64 = conn.query_row(&sql, [], |row| row.get(0))?;
     Ok(count > 0)
@@ -318,8 +327,9 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, c
 
 pub fn get_run(id: &str) -> Result<Option<RunRecord>, crate::AppError> {
     let conn = connect()?;
+    let columns = super::runs::run_columns(&conn)?;
     conn.query_row(
-        &format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?1"),
+        &format!("SELECT {columns} FROM runs WHERE id = ?1"),
         params![id],
         run_from_row,
     )

--- a/desktop/src-tauri/src/store/markdown_refs/resolve.rs
+++ b/desktop/src-tauri/src/store/markdown_refs/resolve.rs
@@ -13,7 +13,7 @@ use crate::store::records::*;
 use crate::store::review_snapshots::{
     review_changeset_from_row, ReviewChangesetRecord, REVIEW_CHANGESET_COLUMNS,
 };
-use crate::store::runs::{run_from_row, RunRecord, RUN_COLUMNS};
+use crate::store::runs::{qualified_run_columns, run_from_row, RunRecord};
 use crate::store::util::qualify_columns;
 
 pub fn resolve_markdown_references(
@@ -215,7 +215,7 @@ fn get_run_in_workspace(
     workspace_id: &str,
     id: &str,
 ) -> Result<Option<RunRecord>, crate::AppError> {
-    let cols = qualify_columns("r", RUN_COLUMNS);
+    let cols = qualified_run_columns(conn, "r")?;
     conn.query_row(
         &format!(
             "SELECT {cols} FROM runs r

--- a/desktop/src-tauri/src/store/runs.rs
+++ b/desktop/src-tauri/src/store/runs.rs
@@ -73,6 +73,36 @@ sql_record!(pub(super) RUN_COLUMNS, run_from_row -> RunRecord {
     started_at, ended_at, error_message, error_type, archived_at, created_at, updated_at,
 });
 
+/// Legacy projection used only when the optional archive migration could not
+/// be applied. Keep the result shape stable so normal run reads still work.
+pub(super) const RUN_COLUMNS_WITHOUT_ARCHIVE: &str = "id, thread_id, trigger_message_id, status, model_provider, model_id, started_at, ended_at, error_message, error_type, NULL AS archived_at, created_at, updated_at";
+
+pub(super) fn run_archive_supported(conn: &rusqlite::Connection) -> Result<bool, crate::AppError> {
+    column_exists(conn, "runs", "archived_at")
+}
+
+pub(super) fn run_columns(conn: &rusqlite::Connection) -> Result<&'static str, crate::AppError> {
+    Ok(if run_archive_supported(conn)? {
+        RUN_COLUMNS
+    } else {
+        RUN_COLUMNS_WITHOUT_ARCHIVE
+    })
+}
+
+pub(super) fn qualified_run_columns(
+    conn: &rusqlite::Connection,
+    alias: &str,
+) -> Result<String, crate::AppError> {
+    if run_archive_supported(conn)? {
+        return Ok(super::util::qualify_columns(alias, RUN_COLUMNS));
+    }
+    Ok(format!(
+        "{}, NULL AS archived_at, {}",
+        super::util::qualify_columns(alias, "id, thread_id, trigger_message_id, status, model_provider, model_id, started_at, ended_at, error_message, error_type"),
+        super::util::qualify_columns(alias, "created_at, updated_at"),
+    ))
+}
+
 // TOOL_CALL_COLUMNS & tool_call_from_row removed — table dropped; ToolCallRecord
 // is now reconstructed from run events (`project_tool_calls`).
 // TOOL_OUTPUT_COLUMNS & tool_output_from_row removed — table dropped
@@ -125,8 +155,9 @@ pub fn active_run_sessions() -> Result<Vec<String>, crate::AppError> {
 
 pub fn list_runs(thread_id: &str) -> Result<Vec<RunRecord>, crate::AppError> {
     let conn = connect()?;
+    let columns = run_columns(&conn)?;
     let mut stmt = conn.prepare(&format!(
-        "SELECT {RUN_COLUMNS}
+        "SELECT {columns}
              FROM runs
              WHERE thread_id = ?1
              ORDER BY created_at DESC"
@@ -146,9 +177,10 @@ pub fn find_run_by_trigger_message_id(
         return Ok(None);
     }
     let conn = connect()?;
+    let columns = run_columns(&conn)?;
     conn.query_row(
         &format!(
-            "SELECT {RUN_COLUMNS}
+            "SELECT {columns}
                  FROM runs
                  WHERE trigger_message_id = ?1
                  ORDER BY created_at DESC, id DESC
@@ -166,9 +198,10 @@ pub fn find_run_by_trigger_message_id(
 /// reconciliation without transferring the thread's entire run history.
 pub fn latest_run(thread_id: &str) -> Result<Option<RunRecord>, crate::AppError> {
     let conn = connect()?;
+    let columns = run_columns(&conn)?;
     conn.query_row(
         &format!(
-            "SELECT {RUN_COLUMNS}
+            "SELECT {columns}
                  FROM runs
                  WHERE thread_id = ?1
                  ORDER BY created_at DESC, id DESC


### PR DESCRIPTION
## Summary
- keep normal run reads working when the optional archive-column migration cannot complete
- make only the archive action report unavailable in that fallback state
- preserve run markdown reference resolution against legacy databases

## Validation
- npm run lint
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo test --manifest-path desktop/src-tauri/Cargo.toml archive_finished_runs
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings