### PR TITLE
Fix attachment queue snapshots

### DIFF
--- a/agent/src/rpc/commands/run_control.rs
+++ b/agent/src/rpc/commands/run_control.rs
@@ -80,11 +80,14 @@ pub(crate) fn handle_prompt(
                     | crate::runtime::RunQueueError::GlobalQueueFull { limit } => {
                         ("queue_full", serde_json::json!({"limit": limit}))
                     }
-                    crate::runtime::RunQueueError::RequestTooLarge { actual, limit }
-                    | crate::runtime::RunQueueError::QueueBytesExceeded { actual, limit }
+                    crate::runtime::RunQueueError::RequestTooLarge { actual, limit } => (
+                        "request_too_large",
+                        serde_json::json!({"actual_bytes": actual, "limit_bytes": limit}),
+                    ),
+                    crate::runtime::RunQueueError::QueueBytesExceeded { actual, limit }
                     | crate::runtime::RunQueueError::GlobalQueueBytesExceeded { actual, limit } => {
                         (
-                            "attachment_too_large",
+                            "queue_memory_limit",
                             serde_json::json!({"actual_bytes": actual, "limit_bytes": limit}),
                         )
                     }
@@ -96,9 +99,6 @@ pub(crate) fn handle_prompt(
                         "persistence_unavailable",
                         serde_json::json!({"reason": reason}),
                     ),
-                    crate::runtime::RunQueueError::AttachmentUnavailable { path, .. } => {
-                        ("attachment_unavailable", serde_json::json!({"path": path}))
-                    }
                     crate::runtime::RunQueueError::InvalidRunId(run_id) => {
                         ("invalid_run_id", serde_json::json!({"run_id": run_id}))
                     }

--- a/agent/src/rpc/commands/run_control_tests.rs
+++ b/agent/src/rpc/commands/run_control_tests.rs
@@ -441,8 +441,15 @@ fn prompt_duplicate_run_id_maps_to_scheduler_error() {
 }
 
 #[test]
-fn prompt_reports_attachment_unavailable() {
+fn prompt_accepts_attachment_as_a_live_path_reference() {
     let state = make_app_state();
+    state
+        .get_session("default")
+        .unwrap()
+        .read()
+        .runtime
+        .begin(Some("run-active"), Some("request-active"))
+        .unwrap();
     let mut cmd = make_cmd("prompt");
     cmd.message = "with attachment".to_string();
     cmd.busy_policy = "enqueue_if_busy".to_string();
@@ -452,12 +459,7 @@ fn prompt_reports_attachment_unavailable() {
         ..Default::default()
     }];
     let resp = parse_response(&handle_command_internal(&state, cmd));
-    assert_eq!(resp["success"], false);
-    assert_eq!(resp["error_code"], "attachment_unavailable");
-    assert_eq!(
-        resp["error_data"]["path"],
-        "/definitely/not/a/real/file.pdf"
-    );
+    assert_eq!(resp["success"], true, "response: {resp}");
 }
 
 #[test]
@@ -515,7 +517,7 @@ fn prompt_reports_request_too_large() {
     cmd.busy_policy = "enqueue_if_busy".to_string();
     let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], false);
-    assert_eq!(resp["error_code"], "attachment_too_large");
+    assert_eq!(resp["error_code"], "request_too_large");
 }
 
 #[test]
@@ -543,7 +545,7 @@ fn prompt_reports_global_queue_bytes_exceeded() {
     cmd.busy_policy = "enqueue_if_busy".to_string();
     let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], false);
-    assert_eq!(resp["error_code"], "attachment_too_large");
+    assert_eq!(resp["error_code"], "queue_memory_limit");
 }
 
 #[test]
@@ -662,7 +664,7 @@ fn prompt_reports_session_queue_bytes_exceeded() {
     cmd.busy_policy = "enqueue_if_busy".to_string();
     let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], false);
-    assert_eq!(resp["error_code"], "attachment_too_large");
+    assert_eq!(resp["error_code"], "queue_memory_limit");
 }
 
 #[test]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -1780,15 +1780,14 @@ mod tests {
     }
 
     #[test]
-    fn queued_attachment_is_an_immutable_memory_snapshot() {
-        let mut session = make_test_session("attachment-snapshot");
+    fn queued_attachment_remains_a_live_path_reference() {
+        let mut session = make_test_session("attachment-reference");
         session
             .runtime
             .begin(Some("run-active"), Some("request-active"))
             .unwrap();
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("note.txt");
-        std::fs::write(&path, b"accepted bytes").unwrap();
         let attachment = crate::types::Attachment {
             path: path.to_string_lossy().into_owned(),
             kind: "file".to_string(),
@@ -1799,17 +1798,24 @@ mod tests {
             .enqueue_prompt(
                 "queued",
                 &[],
-                &[attachment],
+                std::slice::from_ref(&attachment),
                 Some("run-queued"),
                 "request-queued",
                 crate::runtime::BusyPolicy::EnqueueIfBusy,
             )
             .unwrap();
+        // Admission neither reads nor freezes the target. It may be created,
+        // replaced, or removed while the run waits; execution resolves the
+        // same path and therefore observes whichever contents are current.
         std::fs::write(&path, b"changed after ack").unwrap();
-        std::fs::remove_file(path).unwrap();
+        let queued = session.scheduled_attachments("run-queued").unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].path, attachment.path);
+        assert_eq!(queued[0].kind, attachment.kind);
+        assert_eq!(queued[0].name, attachment.name);
         assert_eq!(
-            session.scheduled_attachment_bytes("run-queued").unwrap(),
-            vec![b"accepted bytes".to_vec()]
+            std::fs::read(&queued[0].path).unwrap(),
+            b"changed after ack"
         );
     }
 

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -17,14 +16,8 @@ struct ScheduledPromptPayload {
     #[serde(default)]
     model_context: String,
     images: Vec<crate::types::ImageContent>,
-    attachments: Vec<QueuedAttachmentSnapshot>,
+    attachments: Vec<crate::types::Attachment>,
     settings: ScheduledSettingsSnapshot,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct QueuedAttachmentSnapshot {
-    attachment: crate::types::Attachment,
-    bytes_base64: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,22 +107,17 @@ impl ServerSession {
     }
 
     #[cfg(test)]
-    pub(super) fn scheduled_attachment_bytes(&self, run_id: &str) -> Option<Vec<Vec<u8>>> {
+    pub(super) fn scheduled_attachments(
+        &self,
+        run_id: &str,
+    ) -> Option<Vec<crate::types::Attachment>> {
         let request = self
             .scheduler
             .queued()
             .into_iter()
             .find(|run| run.run_id == run_id)?;
         let payload: ScheduledPromptPayload = serde_json::from_value(request.payload).ok()?;
-        payload
-            .attachments
-            .iter()
-            .map(|snapshot| {
-                base64::engine::general_purpose::STANDARD
-                    .decode(&snapshot.bytes_base64)
-                    .ok()
-            })
-            .collect()
+        Some(payload.attachments)
     }
 
     pub fn enqueue_prompt(
@@ -209,21 +197,6 @@ impl ServerSession {
         {
             return Err(crate::runtime::RunQueueError::Busy.into());
         }
-        let attachment_snapshots = attachments
-            .iter()
-            .map(|attachment| {
-                let bytes = std::fs::read(&attachment.path).map_err(|error| {
-                    crate::runtime::RunQueueError::AttachmentUnavailable {
-                        path: attachment.path.clone(),
-                        reason: error.to_string(),
-                    }
-                })?;
-                Ok(QueuedAttachmentSnapshot {
-                    attachment: attachment.clone(),
-                    bytes_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
-                })
-            })
-            .collect::<std::result::Result<Vec<_>, crate::runtime::RunQueueError>>()?;
         let settings = ScheduledSettingsSnapshot {
             settings_schema_version: 1,
             model: self.model.clone(),
@@ -249,7 +222,11 @@ impl ServerSession {
             message: prompt.message.to_string(),
             model_context: prompt.model_context.to_string(),
             images: images.to_vec(),
-            attachments: attachment_snapshots,
+            // Attachments are live filesystem references. Configuration is
+            // frozen at admission, but file contents are deliberately resolved
+            // only when the run starts (images) or when a tool reads them
+            // (ordinary files), so queued work observes the latest contents.
+            attachments: attachments.to_vec(),
             settings: settings.clone(),
         })?;
         let (ack, superseded, superseded_active) = if busy_policy
@@ -344,12 +321,10 @@ impl ServerSession {
                 }
             }
         }
-        let materialized_attachments =
-            self.materialize_queued_attachments(&request.run_id, &payload.attachments)?;
         let lease = self.prompt_internal(
             PromptText::new(&payload.message, &payload.model_context),
             &payload.images,
-            &materialized_attachments,
+            &payload.attachments,
             Some(&request.run_id),
             Some(&request.client_request_id),
             Some(&request),
@@ -362,46 +337,6 @@ impl ServerSession {
             run_sequence: lease.run_sequence,
             queue_position: None,
         })
-    }
-
-    fn materialize_queued_attachments(
-        &self,
-        run_id: &str,
-        snapshots: &[QueuedAttachmentSnapshot],
-    ) -> Result<Vec<crate::types::Attachment>> {
-        if snapshots.is_empty() {
-            return Ok(Vec::new());
-        }
-        let directory = self
-            .session_manager
-            .run_data_path(&self.session_id)
-            .join("attachments")
-            .join(run_id);
-        std::fs::create_dir_all(&directory)?;
-        snapshots
-            .iter()
-            .enumerate()
-            .map(|(index, snapshot)| {
-                let bytes =
-                    base64::engine::general_purpose::STANDARD.decode(&snapshot.bytes_base64)?;
-                let extension = std::path::Path::new(&snapshot.attachment.name)
-                    .extension()
-                    .and_then(|value| value.to_str())
-                    .filter(|value| {
-                        !value.is_empty()
-                            && value.len() <= 16
-                            && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
-                    });
-                let file_name = extension
-                    .map(|extension| format!("{index:04}.{extension}"))
-                    .unwrap_or_else(|| format!("{index:04}.bin"));
-                let path = directory.join(file_name);
-                std::fs::write(&path, bytes)?;
-                let mut attachment = snapshot.attachment.clone();
-                attachment.path = path.to_string_lossy().to_string();
-                Ok(attachment)
-            })
-            .collect()
     }
 
     pub fn prompt(

--- a/agent/src/rpc/session_prompt/tests.rs
+++ b/agent/src/rpc/session_prompt/tests.rs
@@ -714,10 +714,13 @@ async fn prompt_ephemeral_session_skips_persistence() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn enqueue_prompt_starts_immediately_and_materializes_attachments() {
+async fn enqueue_prompt_starts_immediately_with_a_large_live_attachment_reference() {
     let fixture = run_fixture(ScriptedProvider::new(vec![text_turn("got it")]), "enqueue");
     let attachment_path = fixture.workspace().join("note.txt");
-    std::fs::write(&attachment_path, "attachment body").unwrap();
+    std::fs::File::create(&attachment_path)
+        .unwrap()
+        .set_len(20 * 1024 * 1024)
+        .unwrap();
 
     let mut session = fixture.session;
     let ack = session
@@ -744,6 +747,10 @@ async fn enqueue_prompt_starts_immediately_and_materializes_attachments() {
     assert_eq!(messages.last().unwrap().text(), "got it");
     // The attachment became part of the user message context.
     assert!(messages[0].text().contains("read this"));
+    assert_eq!(
+        messages[0].metadata.as_ref().unwrap()["attachments"][0]["path"],
+        attachment_path.to_string_lossy().as_ref()
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/agent/src/runtime/scheduler_queue.rs
+++ b/agent/src/runtime/scheduler_queue.rs
@@ -59,8 +59,6 @@ pub enum RunQueueError {
     Deleting,
     #[error("session persistence is unavailable: {0}")]
     PersistenceUnavailable(String),
-    #[error("attachment `{path}` is unavailable: {reason}")]
-    AttachmentUnavailable { path: String, reason: String },
     #[error("run_id `{0}` contains unsafe characters")]
     InvalidRunId(String),
     #[error("client_request_id must not be empty")]
@@ -275,8 +273,9 @@ impl InMemoryRunQueue {
         }
     }
 
-    /// Accept a request into the process-local FIFO. The payload must already
-    /// contain an immutable snapshot of any path-backed attachment.
+    /// Accept a request into the process-local FIFO. The payload freezes run
+    /// configuration and attachment metadata; path-backed attachment contents
+    /// remain live and are resolved only when the run consumes them.
     pub fn accept(
         &self,
         client_request_id: &str,

--- a/agent/src/types/mod.rs
+++ b/agent/src/types/mod.rs
@@ -681,9 +681,10 @@ pub struct TextContent {
     pub text: String,
 }
 
-/// A local file attached to a prompt (GUI). Files are referenced by their
-/// original absolute path — never copied — and read on demand by the agent's
-/// tools. Images additionally carry base64 for an image_url block.
+/// A local file attached to a prompt (GUI). The Agent preserves the absolute
+/// path supplied by the caller and reads it on demand instead of copying it.
+/// Images are read from this path when a run starts and converted to an
+/// image_url block only for the model request; their bytes are not queued.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Attachment {
     #[serde(default)]

--- a/desktop/src/features/agent/Composer.tsx
+++ b/desktop/src/features/agent/Composer.tsx
@@ -323,7 +323,7 @@ function ComposerImpl({
     clearComposer();
   }
 
-  const addAttachmentPaths = useCallback(async (paths: string[]) => {
+  const addAttachmentPaths = useCallback(async (paths: string[], temporary = false) => {
     const classified = await Promise.all(
       paths.map(async path => ({ path, result: await classifyAttachment(path) })),
     );
@@ -353,7 +353,7 @@ function ComposerImpl({
           continue;
         }
       }
-      next.push({ kind: result.kind, name: fileNameFromPath(path), path });
+      next.push({ kind: result.kind, name: fileNameFromPath(path), path, ...(temporary ? { temporary: true } : {}) });
     }
     attachmentsRef.current = next;
     setAttachments(next);
@@ -389,7 +389,7 @@ function ComposerImpl({
       }
     }
     if (saved.length > 0) {
-      await addAttachmentPaths(saved);
+      await addAttachmentPaths(saved, true);
       const accepted = new Set(attachmentsRef.current.map(attachment => attachment.path));
       // Files written for this paste but rejected by classification/model limits
       // are no longer referenced by the draft and can be reclaimed immediately.
@@ -416,10 +416,11 @@ function ComposerImpl({
   }
 
   function removeAttachment(path: string) {
+    const removed = attachmentsRef.current.find(attachment => attachment.path === path);
     const next = attachmentsRef.current.filter(attachment => attachment.path !== path);
     attachmentsRef.current = next;
     setAttachments(next);
-    if (path.includes("futureos-attachments"))
+    if (removed?.temporary)
       void deleteTempAttachment(path).catch(() => {});
   }
 

--- a/desktop/src/features/agent/sendPipeline.test.ts
+++ b/desktop/src/features/agent/sendPipeline.test.ts
@@ -6,6 +6,7 @@ import { sendPromptToFutureAgent } from "../../integrations/agent/agentClient";
 import { createRun, getRun, listRunEvents, updateRunStatus } from "../../integrations/storage/threadStore";
 import { buildReferenceContext } from "./buildReferencePrompt";
 import { runSendPipeline } from "./sendPipeline";
+import { finalizeTemporaryAttachmentSources } from "./threadAttachments";
 
 vi.mock("../../integrations/storage/threadStore", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../integrations/storage/threadStore")>();
@@ -25,7 +26,8 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(async () => () => {}),
 }));
 vi.mock("./threadAttachments", () => ({
-  persistImageAttachments: vi.fn(async () => []),
+  finalizeTemporaryAttachmentSources: vi.fn(async () => {}),
+  persistImageAttachments: vi.fn(async () => ({ attachments: [], temporarySources: [] })),
 }));
 vi.mock("./buildReferencePrompt", () => ({
   buildReferenceContext: vi.fn(async () => ""),
@@ -127,6 +129,7 @@ describe("runSendPipeline terminal-status handling", () => {
     await runSendPipeline(makeDeps(setMessages), { content: "hello", attachments: [] });
 
     expect(updateRunStatus).not.toHaveBeenCalled();
+    expect(finalizeTemporaryAttachmentSources).toHaveBeenCalledWith([]);
     const assistant = foldMessages(setMessages).filter(m => m.role === "assistant").pop();
     expect(assistant?.status).toBe("complete");
     expect(assistant?.content).toBe("final answer");
@@ -248,6 +251,7 @@ describe("runSendPipeline stream/failure edges", () => {
     vi.mocked(sendPromptToFutureAgent).mockRejectedValue(new Error("transport down"));
     const setMessages = vi.fn();
     await runSendPipeline(makeDeps(setMessages), { content: "hello", attachments: [] });
+    expect(finalizeTemporaryAttachmentSources).not.toHaveBeenCalled();
     expect(updateRunStatus).toHaveBeenCalledWith(
       expect.objectContaining({ runId: "run-1", status: "failed" }),
     );

--- a/desktop/src/features/agent/sendPipeline.ts
+++ b/desktop/src/features/agent/sendPipeline.ts
@@ -15,7 +15,7 @@ import {
 } from "./agentMessageFormatters";
 import { buildReferenceContext } from "./buildReferencePrompt";
 import { attachmentInputs } from "./messageContent";
-import { persistImageAttachments } from "./threadAttachments";
+import { finalizeTemporaryAttachmentSources, persistImageAttachments } from "./threadAttachments";
 import {
   clientId,
   deriveRenderFields,
@@ -56,7 +56,8 @@ export async function runSendPipeline(
   // Validate and prepare images before adding optimistic messages. A failed
   // decode rejects the send, leaves the composer draft intact, and surfaces a
   // concrete error instead of showing an attachment the model never received.
-  const importedAttachments = await persistImageAttachments(attachments, thread.id);
+  const preparedAttachments = await persistImageAttachments(attachments, thread.id);
+  const importedAttachments = preparedAttachments.attachments;
 
   let stopStreamUpdates: (() => void) | null = null;
   const clearStreamUpdates = () => {
@@ -144,13 +145,14 @@ export async function runSendPipeline(
       sessionId: agentSessionId,
       runId: run.id,
       modelId,
-      // All attachments (images + files) travel by original path. The agent
+      // All attachments (images + files) travel by their current local path. The agent
       // decides per attachment: an image goes inline (image_url) when the model
       // accepts image input, otherwise — and for every non-image file — the path
       // is surfaced for the agent's own tools to read.
       attachments: attachmentInputs(importedAttachments),
       thinkingLevel,
     });
+    await finalizeTemporaryAttachmentSources(preparedAttachments.temporarySources);
     clearStreamUpdates();
 
     if (reply.sessionRecreated) {
@@ -164,9 +166,9 @@ export async function runSendPipeline(
       });
     }
 
-    // No cleanup here: non-image files were never copied, and pasted/downloaded
-    // images already had their temp original moved into the thread's origin dir
-    // by persistImageAttachments (which deletes the temp copy).
+    // Non-image files remain live references. Pasted/downloaded images now use
+    // their promoted thread-owned path, and their temp source was deleted only
+    // after the successful agent response above.
 
     const currentRun = await loadCurrentRun(run.id);
     // A terminal row while this send still awaits the agent means someone else

--- a/desktop/src/features/agent/threadAttachments.test.ts
+++ b/desktop/src/features/agent/threadAttachments.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { persistImageAttachments } from "./threadAttachments";
+import { finalizeTemporaryAttachmentSources, persistImageAttachments } from "./threadAttachments";
 
 const deleteTempAttachment = vi.fn();
 const generateImageThumbnail = vi.fn();
@@ -45,11 +45,18 @@ describe("persistImageAttachments", () => {
     // A thumbnail write failure must not reject the send: the image validated,
     // so it is persisted (durable path) and returned without a thumbnail.
     await expect(persistImageAttachments([
-      { kind: "image", name: "ok.png", path: "/tmp/futureos-attachments/ok.png" },
-    ], "thread-1")).resolves.toEqual([
-      { kind: "image", name: "ok.png", path: "/origin/ok.png" },
-    ]);
+      { kind: "image", name: "ok.png", path: "/tmp/futureos-attachments/ok.png", temporary: true },
+    ], "thread-1")).resolves.toEqual({
+      attachments: [{
+        kind: "image",
+        name: "ok.png",
+        path: "/origin/ok.png",
+        temporary: false,
+      }],
+      temporarySources: ["/tmp/futureos-attachments/ok.png"],
+    });
     expect(importEphemeralImage).toHaveBeenCalledTimes(1);
+    expect(deleteTempAttachment).not.toHaveBeenCalled();
   });
 
   it("rewrites a pasted image only after validation succeeds", async () => {
@@ -58,10 +65,23 @@ describe("persistImageAttachments", () => {
     deleteTempAttachment.mockResolvedValue(undefined);
 
     await expect(persistImageAttachments([
-      { kind: "image", name: "ok.png", path: "/tmp/futureos-attachments/ok.png" },
-    ], "thread-1")).resolves.toEqual([
-      { kind: "image", name: "ok.png", path: "/origin/ok.png", thumbnail: "/thumb/ok.jpg" },
-    ]);
+      { kind: "image", name: "ok.png", path: "/tmp/futureos-attachments/ok.png", temporary: true },
+    ], "thread-1")).resolves.toEqual({
+      attachments: [{
+        kind: "image",
+        name: "ok.png",
+        path: "/origin/ok.png",
+        temporary: false,
+        thumbnail: "/thumb/ok.jpg",
+      }],
+      temporarySources: ["/tmp/futureos-attachments/ok.png"],
+    });
+  });
+
+  it("deletes a promoted temp source only when the caller finalizes it", async () => {
+    deleteTempAttachment.mockResolvedValue(undefined);
+    await finalizeTemporaryAttachmentSources(["/tmp/futureos-attachments/ok.png"]);
+    expect(deleteTempAttachment).toHaveBeenCalledWith("/tmp/futureos-attachments/ok.png");
   });
 });
 
@@ -73,7 +93,7 @@ describe("persistImageAttachments non-image passthrough", () => {
   it("passes non-image attachments through both phases untouched", async () => {
     const file = { kind: "file" as const, path: "/a/b.pdf", name: "b.pdf" };
     const result = await persistImageAttachments([file], "t1");
-    expect(result).toEqual([file]);
+    expect(result).toEqual({ attachments: [file], temporarySources: [] });
     expect(validateImageAttachment).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/features/agent/threadAttachments.ts
+++ b/desktop/src/features/agent/threadAttachments.ts
@@ -3,13 +3,12 @@ import i18n from "../../i18n";
 import { deleteTempAttachment, generateImageThumbnail, importEphemeralImage, validateImageAttachment } from "../../integrations/storage/files";
 
 /**
- * A pasted/downloaded image lives in our temp dir (`futureos-attachments`) and
- * has no durable filesystem original; a picked/dragged image has a real path the
- * user owns. We key off the temp marker to decide whether the origin must be
- * persisted. Matches the Rust `delete_temp_attachment` guard's dir.
+ * New composer entries carry an explicit temporary bit. The path fallback is
+ * only for drafts written by older FutureOS versions before that bit existed.
  */
-function isEphemeralImagePath(path: string) {
-  return path.includes("futureos-attachments");
+function isEphemeralImage(attachment: MessageAttachment) {
+  return attachment.temporary === true
+    || (attachment.temporary === undefined && attachment.path.includes("futureos-attachments"));
 }
 
 /**
@@ -17,14 +16,15 @@ function isEphemeralImagePath(path: string) {
  * (for the bubble). Pasted/downloaded images — which only ever existed in the
  * temp dir — are additionally copied into `~/.future/app/images/<tid>/origin`
  * and their path rewritten there, so the reference survives after the temp file
- * is cleaned; the temp copy is then removed. Local (picked/dragged) images keep
- * their original path and are not copied. Non-image files are untouched — they
- * are referenced by their original path and read by the agent on demand.
+ * is cleaned. The source is retained until the agent call succeeds, so an
+ * early failure cannot invalidate the attachment path. Local (picked/dragged)
+ * images keep their original path and are not copied. Non-image files are
+ * untouched.
  */
 export async function persistImageAttachments(attachments: MessageAttachment[], threadId: string) {
-  // Phase 1 is read-only: every image must validate before phase 2 moves or
-  // deletes any pasted temp original. This keeps a rejected multi-image draft
-  // fully retryable instead of leaving some of its paths stale.
+  // Phase 1 is read-only: every image must validate before phase 2 writes any
+  // promoted original. This keeps a rejected multi-image draft
+  // internally consistent instead of leaving some of its paths stale.
   const prepared = await Promise.all(
     attachments.map(async (attachment) => {
       if (attachment.kind !== "image") {
@@ -50,22 +50,38 @@ export async function persistImageAttachments(attachments: MessageAttachment[], 
   // Phase 2 may persist ephemeral originals now that the whole batch is valid.
   // A missing thumbnail no longer skips persistence — the image is valid and
   // must still get a durable path before its temp original is reclaimed.
-  return Promise.all(
+  const persisted = await Promise.all(
     prepared.map(async ({ attachment, thumbnail }) => {
       if (attachment.kind !== "image")
-        return attachment;
+        return { attachment, temporarySource: null };
       let path = attachment.path;
-      if (isEphemeralImagePath(path)) {
+      if (isEphemeralImage(attachment)) {
         try {
           const origin = await importEphemeralImage({ name: attachment.name, path, threadId });
-          await deleteTempAttachment(path).catch(() => {});
+          const temporarySource = path;
           path = origin;
+          const promoted = thumbnail
+            ? { ...attachment, path, thumbnail, temporary: false }
+            : { ...attachment, path, temporary: false };
+          return { attachment: promoted, temporarySource };
         }
         catch {
           // Best-effort: keep the temp path if the durable copy fails.
         }
       }
-      return thumbnail ? { ...attachment, path, thumbnail } : { ...attachment, path };
+      const current = thumbnail ? { ...attachment, path, thumbnail } : { ...attachment, path };
+      return { attachment: current, temporarySource: null };
     }),
   );
+  return {
+    attachments: persisted.map(item => item.attachment),
+    temporarySources: persisted
+      .map(item => item.temporarySource)
+      .filter((path): path is string => Boolean(path)),
+  };
+}
+
+/** Delete promoted temp sources only after the agent call has succeeded. */
+export async function finalizeTemporaryAttachmentSources(paths: string[]) {
+  await Promise.all([...new Set(paths)].map(path => deleteTempAttachment(path).catch(() => {})));
 }

--- a/packages/thread-projection/src/model.ts
+++ b/packages/thread-projection/src/model.ts
@@ -49,12 +49,14 @@ export type MessageSegment
 
 export interface MessageAttachment {
   name: string;
-  /** Original absolute local path — never copied; the agent reads it on demand. */
+  /** Absolute path read by the agent on demand. */
   path: string;
   /** image | file — images send inline (when supported); files send as a path. */
   kind?: "image" | "file" | null;
   /** Absolute path to a cached thumbnail (images only), rendered via convertFileSrc. */
   thumbnail?: string | null;
+  /** Composer-owned temporary input that must be promoted before sending. */
+  temporary?: boolean;
 }
 
 export interface AgentMessage {


### PR DESCRIPTION
## Summary
- keep queued attachments as live filesystem references instead of embedding Base64 bytes in request snapshots
- preserve only composer-owned temporary pasted images until a successful agent call
- add regressions for large attachments and live queued paths

## Validation
- cargo fmt --check --manifest-path agent/Cargo.toml
- cargo clippy --all-targets --manifest-path agent/Cargo.toml -- -D warnings
- npm --prefix desktop test
- npm --prefix desktop run lint