### PR TITLE
fix(agent): silence dead-code warnings in Windows sandbox

### DIFF
--- a/agent/src/sandbox/mod.rs
+++ b/agent/src/sandbox/mod.rs
@@ -893,7 +893,7 @@ pub(crate) fn probe_windows_sandbox_host() -> std::io::Result<WindowsSandboxProb
 pub(crate) fn probe_windows_sandbox_product() -> std::io::Result<WindowsSandboxProbe> {
     #[cfg(target_os = "windows")]
     {
-        return Ok(cached_windows_sandbox_probe().clone());
+        Ok(cached_windows_sandbox_probe().clone())
     }
     #[cfg(not(target_os = "windows"))]
     probe_windows_sandbox_host()

--- a/agent/src/sandbox/windows/audit.rs
+++ b/agent/src/sandbox/windows/audit.rs
@@ -4,25 +4,26 @@ use std::io;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
-use windows_sys::Win32::Foundation::{
-    CloseHandle, GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER, HANDLE, INVALID_HANDLE_VALUE,
-};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+#[cfg(test)]
+use windows_sys::Win32::Foundation::{GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER};
+#[cfg(test)]
 use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
 #[cfg(test)]
 use windows_sys::Win32::Security::{
-    AccessCheck, DuplicateTokenEx, SecurityImpersonation, TokenImpersonation, GENERIC_MAPPING,
-    PRIVILEGE_SET, TOKEN_QUERY,
-};
-use windows_sys::Win32::Security::{
-    MakeAbsoluteSD, DACL_SECURITY_INFORMATION, GROUP_SECURITY_INFORMATION,
-    OWNER_SECURITY_INFORMATION,
+    AccessCheck, DuplicateTokenEx, MakeAbsoluteSD, SecurityImpersonation, TokenImpersonation,
+    DACL_SECURITY_INFORMATION, GENERIC_MAPPING, GROUP_SECURITY_INFORMATION,
+    OWNER_SECURITY_INFORMATION, PRIVILEGE_SET, TOKEN_QUERY,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
-    GetVolumeInformationByHandleW, FILE_ALL_ACCESS, FILE_ATTRIBUTE_REPARSE_POINT,
-    FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
-    FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES,
+    GetVolumeInformationByHandleW, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
     FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, READ_CONTROL, WRITE_DAC,
+};
+#[cfg(test)]
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_ALL_ACCESS, FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
 };
 
 #[cfg(test)]
@@ -232,6 +233,7 @@ impl FrozenPath {
 /// `GetSecurityInfo` returns a self-relative descriptor, whereas AccessCheck
 /// requires its absolute form. Keep every backing allocation alive for the
 /// AccessCheck call.
+#[cfg(test)]
 struct AbsoluteSecurityDescriptor {
     descriptor: Vec<u8>,
     dacl: Vec<u8>,
@@ -240,6 +242,7 @@ struct AbsoluteSecurityDescriptor {
     group: Vec<u8>,
 }
 
+#[cfg(test)]
 impl AbsoluteSecurityDescriptor {
     fn from_self_relative(input: *mut core::ffi::c_void) -> io::Result<Self> {
         let mut descriptor_size = 0;
@@ -295,6 +298,7 @@ impl AbsoluteSecurityDescriptor {
     }
 }
 
+#[cfg(test)]
 fn ptr_or_null(bytes: &mut Vec<u8>) -> *mut u8 {
     if bytes.is_empty() {
         std::ptr::null_mut()
@@ -311,16 +315,20 @@ impl Drop for FrozenPath {
     }
 }
 
+#[cfg(test)]
 struct HandleGuard(HANDLE);
 
+#[cfg(test)]
 impl Drop for HandleGuard {
     fn drop(&mut self) {
         unsafe { CloseHandle(self.0) };
     }
 }
 
+#[cfg(test)]
 struct LocalGuard(*mut core::ffi::c_void);
 
+#[cfg(test)]
 impl Drop for LocalGuard {
     fn drop(&mut self) {
         if !self.0.is_null() {

--- a/agent/src/sandbox/windows/process.rs
+++ b/agent/src/sandbox/windows/process.rs
@@ -54,6 +54,7 @@ pub(crate) struct RestrictedChild {
     _desktop: PrivateDesktop,
     stdout: Option<File>,
     stderr: Option<File>,
+    #[cfg(test)]
     pid: u32,
     _capability_lease: Option<CapabilityLease>,
 }
@@ -157,6 +158,7 @@ impl RestrictedChild {
             _desktop: desktop,
             stdout: Some(stdout_read.into_file()),
             stderr: Some(stderr_read.into_file()),
+            #[cfg(test)]
             pid: info.dwProcessId,
             _capability_lease: None,
         })
@@ -467,7 +469,9 @@ fn open_inheritable_null() -> io::Result<OwnedHandle> {
 }
 
 struct AttributeList {
-    storage: Vec<usize>,
+    // Keep the aligned backing allocation alive for the attribute list's
+    // lifetime; `pointer` points into it and the list is torn down in `Drop`.
+    _storage: Vec<usize>,
     pointer: *mut core::ffi::c_void,
 }
 
@@ -487,7 +491,10 @@ impl AttributeList {
         if unsafe { InitializeProcThreadAttributeList(pointer, 1, 0, &mut bytes) } == 0 {
             return Err(io::Error::last_os_error());
         }
-        let list = Self { storage, pointer };
+        let list = Self {
+            _storage: storage,
+            pointer,
+        };
         let ok = unsafe {
             UpdateProcThreadAttribute(
                 list.pointer,


### PR DESCRIPTION
## Summary

\make install\ (and the underlying \cargo build --release -p future-cli\) emitted 10 warnings, all in the Windows sandbox code under \gent/src/sandbox/windows/\.

## Root cause

The sandbox's native access-check machinery (\FrozenPath::access_check\ and its helpers) is test-only (\#[cfg(test)]\), but its supporting imports and types were compiled unconditionally. In release builds they became unused imports and dead code. \RestrictedChild::pid\ is likewise only read by a test, and \AttributeList::storage\ is a keep-alive field never read.

## Changes

- \udit.rs\: gate \GetSecurityInfo\/\SE_FILE_OBJECT\, \MakeAbsoluteSD\/\DACL/GROUP/OWNER_SECURITY_INFORMATION\/\FILE_*\ imports, and the \AbsoluteSecurityDescriptor\/\HandleGuard\/\LocalGuard\/\ptr_or_null\ types behind \#[cfg(test)]\.
- \process.rs\: gate \RestrictedChild::pid\ behind \#[cfg(test)]\; rename \AttributeList::storage\ → \_storage\ with a keep-alive comment.
- \mod.rs\: drop a needless \eturn\ in \probe_windows_sandbox_product\ (clippy \
eedless_return\).

## Verification

- \cargo fmt --check --all\ ✅
- \cargo clippy -p future-agent --all-targets -- -D warnings\ ✅
- \cargo build --release -p future-cli\ ✅ (code warnings eliminated; one benign MSVC linker \linker_messages\ note remains)
- \cargo test -p future-agent --lib sandbox::\ → 94 passed, 10 failed — identical to clean \main\ (pre-existing Windows path/case and sandbox-permission environment failures, unrelated to this change).