### PR TITLE
refactor(loop): agent decides, kernel provides the kanban — weaken rule replans + session retention

### DIFF
--- a/orchestration/loop/ARCHITECTURE-SIMPLIFICATION.md
+++ b/orchestration/loop/ARCHITECTURE-SIMPLIFICATION.md
@@ -1,0 +1,77 @@
+# Future Loop 架构简化：弱化规则型功能，强化 kanban 工具
+
+> 原则：**决策者是大模型（agent），不是 loop 内核。** loop 内核应该是一个
+> 「kanban 工具」——提供 todo 状态、verify 门、acceptance 契约、evidence、
+> lease 这些**确定性工具**，而不是一个「规则引擎」——替 agent 判断「你卡住了，
+> 停下来重新规划」。对 agent 的决策提示应该放在 `future-loop` SKILL.md 里，
+> 由 agent 自己读取、自己决策。
+
+## 一、功能分类
+
+### A. 规则型功能（弱化：从「强制 replan」→「信号 + 继续交付」）
+
+这些是内核「替 agent 判断卡住并强制 replan」的硬编码规则，本质上是把
+「你怎么决策」写死在内核里，违背「决策者是大模型」的原则：
+
+| 规则 | 触发条件 | 弱化后 |
+|---|---|---|
+| outcome floor | `surface_streak >= threshold` | 记录信号，交付时在 reason 里附加提示 |
+| oscillation | A→V→A→V 交替 | 记录信号，交付时在 reason 里附加提示 |
+| repair budget | `failed_attempts > MAX` | 不再过滤失败 todo，交付时提示「已失败 N 次」 |
+| monitor stall | `consecutive_no_change >= 3` | 继续 quiet wait，提示「考虑 watch-lane expiry」 |
+
+### B. 正确性底线（保留：这是 kanban 的确定性语义，不是「替 agent 决策」）
+
+这些是「状态一致性」的硬约束，弱化它们会让 goal 陷入非法状态：
+
+| 底线 | 为什么必须保留 |
+|---|---|
+| succession closure missing | 完成必须声明 successor/no-follow-up，否则 goal 永远无法关闭 |
+| acceptance gap | 硬契约：acceptance token 必须满足 |
+| terminal 判定 | kanban 确定性状态：所有 todo done + gaps 满足才关闭 |
+| user gate | 用户门，冻结工作 |
+| blocker | 阻塞器 |
+| work leased to others | 并发正确性 |
+| verify 门 | 正确性：exit 0 才 complete |
+| lease | 并发互斥 |
+
+### C. 移到 SKILL.md 的提示（agent 决策指引）
+
+内核不再「替 agent 决策」，但要在 SKILL.md 里教 agent **读信号、自主决策**：
+
+- 看到 `surface_streak >= N` → 考虑换策略或 supersede
+- 看到振荡信号 → 考虑换验证方法或拆分 todo
+- 看到 `failed_attempts > 1` → 考虑 supersede 或找 operator
+- 看到 monitor 连续无变化 → 考虑 watch-lane expiry 或写 blocker
+
+## 二、改动清单
+
+1. `decision/mod.rs`：移除规则型 replan 分支（outcome floor / oscillation /
+   repair budget / LLM zombie / monitor stall），交付 reason 附加信号提示
+2. `decision/stall.rs`：检测函数保留为「观察数据」（信号源），不再用于强制 replan
+3. `decision/oscillation.rs`：同上
+4. `console.rs`：run loop 删除 repair-budget break（只留 validation-budget break）
+5. `state.rs` + `agent_client.rs` + `console.rs`：**session retention** —— 同一
+   原则的产物。内核记录「会话为什么中断」（`SessionRetention`）+ 保留会话 id，
+   由调用方（`run --session-policy auto|fresh|resume` / `--resume-session ID`）
+   决定 resume-vs-fresh。内核不替调用方决定是否恢复会话。
+6. SKILL.md：新增「agent 决策指引」+「session retention」章节
+7. 信号暴露：`status` / `diagnose` 输出里保留这些信号（agent 可查询）
+
+## 三、信号仍保留（不删除，只改用途）
+
+`outcome_floor_breach` / `oscillation_replan_reason` / `repair_exhausted` /
+`is_monitor_stalled` 这些检测函数**保留**——它们从「强制 replan 的触发器」变成
+「agent 可读的观察信号」，通过两个渠道暴露：
+1. 交付 reason 里附加提示（agent 在 turn envelope 里直接看到）
+2. `status` / `diagnose` 输出（agent 主动查询）
+
+## 四、session retention（同一原则的延伸）
+
+`resume-vs-fresh` 也是「决策权在调用方」的体现：内核只提供**观察数据**
+（会话为什么中断：`InfraRecoverable` = LLM 状态完好，可 resume；
+`HardError`/`ScienceVerifyFailed` = 推理状态已坏，应 fresh），不替调用方决定。
+调用方通过 `--session-policy` / `--resume-session` 显式决策，默认 `auto` 只
+resume 内核判定「可恢复」的会话。
+
+这样内核依然是「纯工具」——它提供状态和信号，但**不替 agent 做决策**。

--- a/orchestration/loop/snapshots/decision.rs.pre-split
+++ b/orchestration/loop/snapshots/decision.rs.pre-split
@@ -112,27 +112,34 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     }
 
     // ── 2. Runnable advancement. ─────────────────────────────────────────
-    let retryable: Vec<&Todo> = runnable
-        .into_iter()
-        .filter(|t| t.failed_attempts <= MAX_REPAIR_ATTEMPTS)
-        .collect();
-    // ── 2b. Outcome floor (LoopX: surface-only progress loop). ──────────
-    if let Some(todo) = retryable.first() {
+    // ARCHITECTURE-SIMPLIFICATION: a failed todo is STILL runnable — the
+    // kernel does NOT filter by `failed_attempts` (the agent decides).
+    let runnable_todos: Vec<&Todo> = runnable;
+    if let Some(todo) = runnable_todos.first() {
+        let mut advisories: Vec<String> = vec![];
         let threshold = goal.execution_profile.outcome_floor_streak_threshold;
         if threshold > 0 && goal.outcome_streak >= threshold {
-            return replan_packet(
-                goal,
-                &format!(
-                    "outcome floor: {surface_streak} consecutive turns without a material outcome (threshold {threshold})",
-                    surface_streak = goal.outcome_streak
-                ),
-            );
+            advisories.push(format!(
+                "[signal: outcome floor: {surface_streak} consecutive turns without a material outcome (threshold {threshold}) — consider changing strategy or superseding a stale todo]",
+                surface_streak = goal.outcome_streak
+            ));
+        }
+        if todo.failed_attempts > 0 {
+            advisories.push(format!(
+                "[signal: todo {} has {} failed attempt(s) — consider superseding or asking the operator]",
+                todo.id, todo.failed_attempts
+            ));
         }
         let attempt = todo.failed_attempts + 1;
         let reason = if attempt > 1 {
             format!("repair attempt {attempt} for todo {}", todo.id)
         } else {
             format!("runnable todo {}", todo.id)
+        };
+        let reason = if advisories.is_empty() {
+            reason
+        } else {
+            format!("{reason} {}", advisories.join(" "))
         };
         // Non-blocking user actions surface in the user channel alongside
         // delivery (LoopX: user_action never freezes the agent).
@@ -170,12 +177,8 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
             },
         );
     }
-    if goal
-        .open_of(TaskClass::Advancement)
-        .any(|t| t.failed_attempts > MAX_REPAIR_ATTEMPTS)
-    {
-        return replan_packet(goal, "advancement todo(s) exhausted repair budget");
-    }
+    // (repair-budget replan removed — a failed todo stays runnable and the
+    //  failure count is surfaced as an advisory in the delivery reason.)
 
     // ── 2c. Blocked by an external blocker with no fallback: quiet wait. ──
     let blockers: Vec<&Todo> = goal.open_of(TaskClass::Blocker).collect();
@@ -221,12 +224,27 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
         .iter()
         .find(|m| m.consecutive_no_change >= MONITOR_NO_CHANGE_REPLAN_THRESHOLD)
     {
-        return replan_packet(
+        // ARCHITECTURE-SIMPLIFICATION: a stalled monitor is a signal, not a
+        // directive — quiet wait with an advisory, the agent decides.
+        return packet(
             goal,
+            "wait",
+            false,
+            "quiet_wait",
+            TurnMode::WaitMonitor,
             &format!(
-                "monitor {} stalled ({} consecutive no-change polls)",
+                "monitor {} stalled ({} consecutive no-change polls) — signal, not a directive: consider watch-lane expiry, a blocker, or superseding the monitor",
                 stalled.id, stalled.consecutive_no_change
             ),
+            UserChannel::none(),
+            AgentChannel {
+                must_attempt: false,
+                delivery_allowed: false,
+                quiet_noop_allowed: true,
+                primary_action: None,
+                selected_todo: None,
+                fallback_todo: None,
+            },
         );
     }
     let due: Vec<&Todo> = monitors

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -302,6 +302,14 @@ impl AgentClient {
         })
     }
 
+    /// Whether a session still exists and accepts commands (`get_state` is a
+    /// cheap liveness probe). Used by the caller to decide resume-vs-fresh: a
+    /// retained session that no longer exists (agent restarted, session
+    /// expired) must fall back to a fresh session rather than fail the run.
+    pub async fn session_alive(&mut self, session_id: &str) -> bool {
+        self.session_totals(session_id).await.is_ok()
+    }
+
     /// Subscribe to one canonical run from its beginning (atomic attach closes
     /// the prompt-ack -> subscribe loss window) and collect events until
     /// `agent_end` (or the stream closes / errors).

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 
 use crate::agent_client::TurnProgressTracker;
 use crate::cli::registry::{CommandRegistry, Journey};
-use crate::decision::{complete_todo, decide_for, MAX_REPAIR_ATTEMPTS};
+use crate::decision::{complete_todo, decide_for};
 use crate::executor::{execute_turn, writeback};
 use crate::state::{now_epoch, Goal, TaskClass, Todo, TodoStatus};
 use crate::store::{Event, Store};
@@ -3456,6 +3456,15 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut anonymous = false;
     let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
     let mut force_workspace = false;
+    // Session retention: the CALLER decides resume-vs-fresh, never the kernel.
+    // `--resume-session <id>` pins the exact session to resume;
+    // `--session-policy <auto|fresh|resume>` sets the default policy:
+    //   auto   → resume the retained session only when the kernel marked it
+    //            resumable (InfraRecoverable), else fresh (default);
+    //   fresh  → always start a new session (the pre-retention behavior);
+    //   resume → resume the retained session whenever one exists.
+    let mut session_policy = "auto".to_string();
+    let mut resume_session: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
@@ -3467,6 +3476,8 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             "--max-turn-secs",
             "--max-turns",
             "--model",
+            "--resume-session",
+            "--session-policy",
             "--thinking-level",
         ],
     )?;
@@ -3489,8 +3500,15 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             anonymous = true;
         } else if k == "--force-workspace" {
             force_workspace = true;
+        } else if k == "--session-policy" {
+            session_policy = v;
+        } else if k == "--resume-session" {
+            resume_session = Some(v);
         }
     });
+    if !matches!(session_policy.as_str(), "auto" | "fresh" | "resume") {
+        bail!("--session-policy must be auto | fresh | resume");
+    }
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
 
     // Identity gate BEFORE any gRPC/session work — fail fast with a hint
@@ -3502,7 +3520,41 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let goal0 = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    let session_id = client.new_session(&goal0.cwd).await?;
+
+    // ── Session retention: the CALLER decides resume-vs-fresh, never the
+    //    kernel. The kernel only recorded WHY the last session was interrupted
+    //    (`session_retention` on the goal) and kept its id on disk. Resolution
+    //    order:
+    //      1. `--resume-session <id>` (explicit pin) → use it if alive;
+    //      2. `--session-policy resume` → use the retained id if alive;
+    //      3. `--session-policy auto` (default) → use the retained id only
+    //         when the kernel marked it resumable (InfraRecoverable);
+    //      4. `--session-policy fresh` → always new;
+    //      5. a retained id that is no longer alive falls back to new.
+    let retained = goal0.session_retention.clone();
+    let want_session: Option<String> = if let Some(id) = resume_session.clone() {
+        Some(id)
+    } else {
+        match session_policy.as_str() {
+            "resume" => retained.as_ref().map(|r| r.session_id.clone()),
+            "fresh" => None,
+            _ /* auto */ => retained
+                .as_ref()
+                .filter(|r| r.resumable)
+                .map(|r| r.session_id.clone()),
+        }
+    };
+    let session_id = match want_session {
+        Some(id) if client.session_alive(&id).await => {
+            println!("   ⤺ resuming session {id} (policy {session_policy})");
+            id
+        }
+        Some(id) => {
+            println!("   ⚠ retained session {id} is no longer alive — starting fresh");
+            client.new_session(&goal0.cwd).await?
+        }
+        None => client.new_session(&goal0.cwd).await?,
+    };
     if let Some(m) = model {
         client.set_model(&session_id, &m).await?;
     }
@@ -3510,11 +3562,12 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         client.set_thinking_level(&session_id, &l).await?;
     }
 
-    // Run the turn loop, then always delete this run's scratch session — on
-    // every exit path — instead of letting ~/.future/agent/sessions/ pile up
-    // one file per run. The agent session is a per-run workspace: context is
-    // replayed via the turn envelope from the goal events.jsonl, so nothing
-    // durable lives in it.
+    // Run the turn loop. Session lifecycle: the kernel no longer blindly
+    // deletes the session — it records the retention state (id + failure
+    // classification + resumable advisory) on the goal and lets the NEXT
+    // caller decide. Deletion happens only when the session is NOT resumable
+    // (HardError / science failure / zombie — its reasoning state is broken).
+    let mut last_failure_kind: Option<crate::state::FailureKind> = None;
     let result = run_turns(
         &mut client,
         store,
@@ -3525,10 +3578,54 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         agent_id.as_deref(),
         max_turn_secs,
         force_workspace,
+        &mut last_failure_kind,
     )
     .await;
-    if let Err(e) = client.delete_session(&session_id).await {
-        println!("   ⚠ session cleanup failed (best-effort): {e}");
+
+    // Record the retention state (the kernel's advisory, not a directive).
+    let resumable = matches!(
+        last_failure_kind,
+        Some(crate::state::FailureKind::InfraRecoverable)
+    );
+    let reason = match last_failure_kind {
+        None => "turns completed or no turn ran".to_string(),
+        Some(crate::state::FailureKind::InfraRecoverable) => {
+            "interrupted by a recoverable infra event (e.g. HTTP 429 / transient disconnect) — LLM state intact".to_string()
+        }
+        Some(crate::state::FailureKind::ScienceVerifyFailed) => {
+            "verify gate rejected the output — reasoning produced a bad artifact".to_string()
+        }
+        Some(crate::state::FailureKind::HardError) => {
+            "turn ended in a non-recoverable error — reasoning state is broken".to_string()
+        }
+        Some(crate::state::FailureKind::None) => "succeeded".to_string(),
+    };
+    let retention = crate::state::SessionRetention {
+        session_id: session_id.clone(),
+        failure_kind: last_failure_kind.unwrap_or(crate::state::FailureKind::None),
+        resumable,
+        reason,
+        ended_at: now_epoch(),
+    };
+    if let Ok(Some(mut g)) = store.replay(&goal_id) {
+        g.session_retention = Some(retention);
+        let goal_dir = store.goal_dir(&goal_id);
+        if let Err(e) = crate::compat::write_active_state(&goal_dir, &g) {
+            println!("   ⚠ failed to persist session retention (best-effort): {e}");
+        }
+    }
+
+    // Delete the session ONLY when it is not resumable — a resumable session
+    // (infra interruption) is kept on the agent for the next caller to resume,
+    // so its accumulated exploration is not thrown away.
+    if !resumable {
+        if let Err(e) = client.delete_session(&session_id).await {
+            println!("   ⚠ session cleanup failed (best-effort): {e}");
+        }
+    } else {
+        println!(
+            "   ⤺ session {session_id} retained (resumable) — next `run` with default policy will resume it"
+        );
     }
     result
 }
@@ -3698,6 +3795,10 @@ fn claim_selected_with_lease(
 /// One `run` = one bounded turn loop against a fresh agent session. `cmd_run`
 /// owns the session lifecycle (create before, delete after); this function
 /// only executes turns and writes back their ledger effects.
+///
+/// `last_failure_kind`: out-parameter set to the failure classification of the
+/// LAST executed turn (`None` when no turn ran this invocation) — the caller
+/// uses it to decide session retention (resume vs delete), never the kernel.
 #[allow(clippy::too_many_arguments)]
 async fn run_turns(
     client: &mut crate::agent_client::AgentClient,
@@ -3709,6 +3810,7 @@ async fn run_turns(
     agent_id: Option<&str>,
     max_turn_secs: u64,
     force_workspace: bool,
+    last_failure_kind: &mut Option<crate::state::FailureKind>,
 ) -> Result<()> {
     let mut turn = 0u32;
     // P1-2③: read-model self-healing — a drifted run index means run-history
@@ -3885,6 +3987,22 @@ async fn run_turns(
                     .unwrap_or_else(|| "-".to_string())
             );
         }
+        // Rate-limit backoff: an HTTP-429 turn is a throttle event, not a
+        // science result — retrying it immediately re-hits the same overload.
+        // Sleep before the writeback/exit so the orchestrator's relaunch
+        // lands on a cooled-down engine instead of burning another turn.
+        if record.terminal_state == "error"
+            && crate::executor::is_rate_limit_error(record.error.as_deref())
+        {
+            println!(
+                "   ⏳ rate-limited (HTTP 429) — backing off {}s before writeback so a relaunch doesn't re-hit the throttle",
+                crate::executor::RATE_LIMIT_BACKOFF_SECS
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(
+                crate::executor::RATE_LIMIT_BACKOFF_SECS,
+            ))
+            .await;
+        }
         // Writeback: complete with closure intent — remaining open todos
         // become successors; the LAST todo declares no-follow-up (LoopX
         // completion contract, verified against the real control plane).
@@ -3918,6 +4036,10 @@ async fn run_turns(
                 .as_str()
                 .to_string(),
         );
+        // A: stamp the failure classification — the repair budget keys on it,
+        // and the caller (cmd_run) uses it to decide session retention.
+        record.failure_kind = Some(crate::executor::classify_failure(&record));
+        *last_failure_kind = record.failure_kind;
         writeback(&mut g, &record, monitor_changed, completion);
         store.append_run(goal_id, &record)?;
         // Project-local per-run mirror (runs/ under the goal state dir).
@@ -3979,20 +4101,18 @@ async fn run_turns(
             // verification — record the outcome signal at this turn.
             record_delivery_if_advancement(store, &g, goal_id, &todo_id, record.turn)?;
         } else {
-            // A missing todo (deleted mid-turn) carries no budget signal.
+            // ARCHITECTURE-SIMPLIFICATION: the repair budget no longer stops
+            // the run loop — a failed todo stays runnable (the failure count
+            // is surfaced as an advisory in the delivery reason, and the agent
+            // decides whether to supersede / re-split). Only the validation
+            // budget (a `--verify` gate that keeps failing) still bounds the
+            // loop, because that is a correctness floor, not a policy rule.
             let stop = g
                 .todo(&todo_id)
                 .map(|t| {
-                    if t.failed_attempts > MAX_REPAIR_ATTEMPTS {
-                        println!("   ✘ repair budget exhausted — stopping");
-                        return true;
-                    }
-                    // Validation-gated repair: a todo with an attached
-                    // validator stays open until exit 0, bounded by its own
-                    // max_validation_attempts.
                     if t.validator.is_some() && t.failed_attempts >= t.max_validation_attempts {
                         println!(
-                            "   ✘ validation budget exhausted ({}/{}) — replan required; stopping",
+                            "   ✘ validation budget exhausted ({}/{}) — stopping (verify gate keeps failing; fix the gate or supersede)",
                             t.failed_attempts, t.max_validation_attempts
                         );
                         return true;

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -55,7 +55,7 @@ use self::monitor::{monitor_outcome, MonitorOutcome};
 use self::oscillation::oscillation_replan_reason;
 use self::primary_action::agent_channel;
 use self::stall::{
-    is_monitor_stalled, outcome_floor_breach, repair_exhausted, repair_exhausted_reason,
+    is_monitor_stalled, outcome_floor_breach,
 };
 use crate::quota::error_codes::DecisionReasonCode;
 
@@ -173,21 +173,47 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     }
 
     // ── 2. Runnable advancement. ─────────────────────────────────────────
-    let retryable: Vec<&Todo> = runnable
-        .into_iter()
-        .filter(|t| t.failed_attempts <= MAX_REPAIR_ATTEMPTS)
-        .collect();
-    // ── 2b. Outcome floor (LoopX: surface-only progress loop). ──────────
-    if let Some(todo) = retryable.first() {
-        if let Some(reason) = outcome_floor_breach(goal) {
-            return replan_packet(goal, DecisionReasonCode::OutcomeFloorBreach, &reason);
+    // ARCHITECTURE-SIMPLIFICATION: a failed todo is STILL runnable — the
+    // kernel does NOT filter by `failed_attempts` (that would be the kernel
+    // deciding "you are stuck"). The agent (the decision maker) reads the
+    // signals below in the delivery reason and decides whether to supersede /
+    // re-split / ask the operator. The kernel is a kanban tool, not a policy
+    // engine. See ARCHITECTURE-SIMPLIFICATION.md.
+    let runnable_todos: Vec<&Todo> = runnable;
+    // ── 2b. Rule signals become advisories, NOT forced replans. ─────────
+    // Outcome-floor / oscillation / failure-count / LLM-zombie are
+    // observations the agent reads and acts on; the kernel surfaces them in
+    // the delivery reason but never converts them into a `replan`.
+    if let Some(todo) = runnable_todos.first() {
+        let mut advisories: Vec<String> = vec![];
+        if let Some(signal) = outcome_floor_breach(goal) {
+            advisories.push(format!(
+                "[signal: {signal} — consider changing strategy or superseding a stale todo]"
+            ));
         }
-        // Oscillation guard (LoopX 对比改进项 ③): the goal's recent delivery
-        // outcomes strictly alternate accept/reject (A→V→A→V) — the
-        // action/verify flip-flop that burns spend without converging.
-        // Force a frontier-changing replan instead of the next delivery.
-        if let Some(reason) = oscillation_replan_reason(goal) {
-            return replan_packet(goal, DecisionReasonCode::OscillationDetected, &reason);
+        if let Some(signal) = oscillation_replan_reason(goal) {
+            advisories.push(format!(
+                "[signal: {signal} — consider a different validator or splitting the todo]"
+            ));
+        }
+        if todo.failed_attempts > 0 {
+            advisories.push(format!(
+                "[signal: todo {} has {} failed attempt(s) — consider superseding or asking the operator]",
+                todo.id, todo.failed_attempts
+            ));
+        }
+        // LLM-zombie signal (was a forced replan in #343; now an advisory —
+        // the kernel surfaces it, the agent decides whether to restart with a
+        // fresh session).
+        let no_progress_turns = goal
+            .turn_no_progress
+            .iter()
+            .filter(|np| np.todo_id == todo.id)
+            .count() as u32;
+        if no_progress_turns >= LLM_ZOMBIE_TURN_THRESHOLD {
+            advisories.push(format!(
+                "[signal: {no_progress_turns} turns with no write-class tool (write/edit/shell) — the worker may be stuck; consider restarting with a fresh session]"
+            ));
         }
         let attempt = todo.failed_attempts + 1;
         let (reason, code) = if attempt > 1 {
@@ -200,6 +226,11 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
                 format!("runnable todo {}", todo.id),
                 DecisionReasonCode::RunnableTodo,
             )
+        };
+        let reason = if advisories.is_empty() {
+            reason
+        } else {
+            format!("{reason} {}", advisories.join(" "))
         };
         // Non-blocking user actions surface in the user channel alongside
         // delivery (LoopX: user_action never freezes the agent).
@@ -238,38 +269,8 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
             ),
         );
     }
-    if repair_exhausted(goal) {
-        let reason = repair_exhausted_reason(goal)
-            .unwrap_or_else(|| "advancement todo(s) exhausted repair budget".to_string());
-        return replan_packet(goal, DecisionReasonCode::RepairBudgetExhausted, &reason);
-    }
-
-    // ── 2d. B: LLM-health zombie detection — a worker whose recent turns all
-    //       ended with NO write-class tool activity (write/edit/shell) is not
-    //       making material progress; it is either stuck in a silent LLM loop
-    //       or reasoning without ever landing an artifact. Relaunching the
-    //       same session replays the same context and re-hits the same wall.
-    //       Surface a replan so the orchestrator restarts the worker with a
-    //       FRESH session (the durable loop state carries the context via the
-    //       turn envelope — nothing is lost). Counts only turns for this
-    //       todo, not the goal at large. ───────────────────────────────────
-    if let Some(todo) = retryable.first() {
-        let no_progress_turns = goal
-            .turn_no_progress
-            .iter()
-            .filter(|np| np.todo_id == todo.id)
-            .count() as u32;
-        if no_progress_turns >= LLM_ZOMBIE_TURN_THRESHOLD {
-            return replan_packet(
-                goal,
-                DecisionReasonCode::RepairBudgetExhausted,
-                &format!(
-                    "LLM zombie: todo {} produced {} turns with no write-class tool (write/edit/shell) — the worker is stuck without landing an artifact; restart it with a fresh session (context replays from the ledger)",
-                    todo.id, no_progress_turns
-                ),
-            );
-        }
-    }
+    // (repair-budget replan removed — a failed todo stays runnable and the
+    //  failure count is surfaced as an advisory above; the agent decides.)
 
     // ── 2c. Blocked by an external blocker with no fallback: quiet wait. ──
     let blockers: Vec<&Todo> = goal.open_of(TaskClass::Blocker).collect();
@@ -311,13 +312,22 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     // ── 4. Monitors. ────────────────────────────────────────────────────
     match monitor_outcome(goal, now) {
         MonitorOutcome::Stalled(stalled) => {
-            return replan_packet(
+            // ARCHITECTURE-SIMPLIFICATION: a stalled monitor is a signal, not
+            // a directive — quiet wait with an advisory, the agent decides
+            // (watch-lane expiry / blocker / supersede the monitor).
+            return packet(
                 goal,
-                DecisionReasonCode::MonitorStalled,
+                DecisionReasonCode::MonitorBackoff,
+                "wait",
+                false,
+                "quiet_wait",
+                TurnMode::WaitMonitor,
                 &format!(
-                    "monitor {} stalled ({} consecutive no-change polls)",
+                    "monitor {} stalled ({} consecutive no-change polls) — signal, not a directive: consider watch-lane expiry, a blocker, or superseding the monitor",
                     stalled.id, stalled.consecutive_no_change
                 ),
+                UserChannel::none(),
+                agent_channel(None, None, None, false, false, true),
             );
         }
         MonitorOutcome::Due(due) => {

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -54,9 +54,7 @@ use self::identity::identity_gate;
 use self::monitor::{monitor_outcome, MonitorOutcome};
 use self::oscillation::oscillation_replan_reason;
 use self::primary_action::agent_channel;
-use self::stall::{
-    is_monitor_stalled, outcome_floor_breach,
-};
+use self::stall::{is_monitor_stalled, outcome_floor_breach};
 use crate::quota::error_codes::DecisionReasonCode;
 
 pub use self::arbitration::{

--- a/orchestration/loop/src/quota/stall_repair.rs
+++ b/orchestration/loop/src/quota/stall_repair.rs
@@ -9,7 +9,9 @@
 //! `decide_for` remains the single authority that actually flips a packet to
 //! replan (packet output unchanged — plan §5.2 G-7 risk note).
 
-use crate::decision::stall::{is_monitor_stalled, outcome_floor_breach, repair_exhausted};
+use crate::decision::stall::{
+    is_monitor_stalled, outcome_floor_breach, repair_exhausted, repair_exhausted_reason,
+};
 use crate::state::{Goal, TaskClass};
 
 /// A stall-return hint: which guard tripped, why, and what the host should do.
@@ -42,9 +44,11 @@ pub fn detect_stall(goal: &Goal) -> Option<StallRepairHint> {
         });
     }
     if repair_exhausted(goal) {
+        let reason = repair_exhausted_reason(goal)
+            .unwrap_or_else(|| "advancement todo(s) exhausted repair budget".to_string());
         return Some(StallRepairHint {
             kind: "repair_budget_exhausted".to_string(),
-            reason: "advancement todo(s) exhausted repair budget".to_string(),
+            reason,
             replan_hint: "record a frontier-changing replan delta (vision patch / successor / no-follow-up) to clear the stall".to_string(),
             blocked_action_scope: None,
         });

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -819,6 +819,34 @@ pub struct Goal {
     /// latest wins). `None` → the default rule set applies.
     #[serde(default)]
     pub replan_rule_set: Option<crate::decision::goal_frontier::replan_rules::ReplanRuleSet>,
+    /// Session retention: the last run's agent session that MAY be resumable.
+    /// The loop kernel never decides resume-vs-fresh itself — it only records
+    /// WHY the session was interrupted (the failure classification) and keeps
+    /// the session id on disk; the CALLER (orchestrator / `run --session-policy`)
+    /// decides whether to resume it or start fresh. Written at run exit.
+    #[serde(default)]
+    pub session_retention: Option<SessionRetention>,
+}
+
+/// Session-retention record: what the loop kernel knows about the last run's
+/// agent session. The kernel keeps this so the caller can make an informed
+/// resume-vs-fresh decision; it is NOT a directive (the caller may always
+/// choose fresh).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionRetention {
+    /// The agent session id from the last run.
+    pub session_id: String,
+    /// The failure classification of the last turn (`None` = succeeded).
+    pub failure_kind: FailureKind,
+    /// Whether the kernel judges this session resumable (advisory only):
+    /// `true` for `InfraRecoverable` (LLM state intact, e.g. 429 / transient
+    /// disconnect); `false` for `HardError` / `ScienceVerifyFailed` / zombie
+    /// (reasoning state is broken — resume would replay the same failure).
+    pub resumable: bool,
+    /// Human-readable reason (advisory).
+    pub reason: String,
+    /// Epoch secs when the run ended.
+    pub ended_at: u64,
 }
 
 /// P1-3①: one automation-liveness breach alert (LoopX automation_liveness):
@@ -916,6 +944,7 @@ impl Goal {
             frontier_change_ts: vec![],
             semantic_history: vec![],
             replan_rule_set: None,
+            session_retention: None,
         }
     }
 

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -86,7 +86,10 @@ fn session_and_command_happy_paths() {
         assert_eq!(totals.tokens_in, 0);
 
         // session_alive: a live session probes true; a missing one probes false.
-        assert!(client.session_alive(&session).await, "live session must probe alive");
+        assert!(
+            client.session_alive(&session).await,
+            "live session must probe alive"
+        );
         assert!(
             !client.session_alive("missing-session").await,
             "a missing session must probe dead"

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -85,6 +85,13 @@ fn session_and_command_happy_paths() {
         let totals = client.session_totals(&session).await.unwrap();
         assert_eq!(totals.tokens_in, 0);
 
+        // session_alive: a live session probes true; a missing one probes false.
+        assert!(client.session_alive(&session).await, "live session must probe alive");
+        assert!(
+            !client.session_alive("missing-session").await,
+            "a missing session must probe dead"
+        );
+
         let models = client.list_models().await.unwrap();
         assert!(models["models"].is_array());
 

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -227,15 +227,21 @@ fn run_failing_turns_exhaust_repair_budget() {
         .unwrap();
     store.set_next_action(&goal, "keeps failing").unwrap();
     drop(store);
-    // Repair budget exhausted after this turn's failure → graceful stop.
-    // (failed_attempts is not event-sourced — the replayed ledger keeps the
-    // seeded value — so assert the LOOP BEHAVIOR: exactly one prompt, i.e.
-    // the budget break fired instead of the max-turns bail.)
-    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "6"]);
+    // ARCHITECTURE-SIMPLIFICATION: the repair budget no longer stops the run
+    // loop — a failed todo stays runnable and the failure count is surfaced
+    // as an advisory (the agent decides to supersede / re-split). The run
+    // loop keeps delivering until the max-turns bound fires (a budget bail,
+    // not a repair-budget stop). Assert the loop behavior: it runs all the
+    // way to max-turns with the signal in every delivery reason.
+    let err = cli_err(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
+    assert!(
+        err.contains("max-turns"),
+        "a failed todo stays runnable — the run loop runs to max-turns (budget bail), got: {err}"
+    );
     assert_eq!(
         shared.lock().unwrap().prompts,
-        1,
-        "repair budget break after one turn"
+        3,
+        "a failed todo stays runnable — 3 prompts before the max-turns bail"
     );
 }
 

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -33,6 +33,9 @@ pub struct MockState {
     pub tokens_in: u64,
     pub tokens_out: u64,
     pub cost: f64,
+    /// Live session ids (added by new_session, removed by delete_session) —
+    /// lets `session_alive` probe distinguish a live session from a missing one.
+    pub live_sessions: HashSet<String>,
     /// Events replayed by stream_events (any run).
     pub events: Vec<StreamEvent>,
     /// Command types that answer success=false with a mock error.
@@ -129,12 +132,34 @@ impl FutureAgent for MockAgent {
         let data = match cmd.r#type.as_str() {
             "new_session" => {
                 st.sessions_created += 1;
-                format!("{{\"sessionId\":\"mock-session-{}\"}}", st.sessions_created)
+                let id = format!("mock-session-{}", st.sessions_created);
+                st.live_sessions.insert(id.clone());
+                format!("{{\"sessionId\":\"{}\"}}", id)
             }
-            "get_state" => format!(
-                "{{\"tokensIn\":{},\"tokensOut\":{},\"totalCost\":{}}}",
-                st.tokens_in, st.tokens_out, st.cost
-            ),
+            "get_state" => {
+                // A session that was never created (or was deleted) probes
+                // dead — mirror the agent's real get_state behavior so
+                // `session_alive` has a meaningful false path. Only enforced
+                // once at least one session has been created via new_session
+                // (tests that drive `execute_turn` directly with a hardcoded
+                // session id predate session tracking and never create one).
+                if st.sessions_created > 0 && !st.live_sessions.contains(&cmd.session_id) {
+                    return Ok(response(
+                        &cmd,
+                        false,
+                        String::new(),
+                        "session not found".to_string(),
+                    ));
+                }
+                format!(
+                    "{{\"tokensIn\":{},\"tokensOut\":{},\"totalCost\":{}}}",
+                    st.tokens_in, st.tokens_out, st.cost
+                )
+            }
+            "delete_session" => {
+                st.live_sessions.remove(&cmd.session_id);
+                String::new()
+            }
             "prompt" => {
                 st.prompts += 1;
                 format!("{{\"run_id\":\"mock-run-{}\"}}", st.prompts)

--- a/orchestration/loop/tests/decision_contract.rs
+++ b/orchestration/loop/tests/decision_contract.rs
@@ -238,7 +238,7 @@ fn monitor_no_change_never_spends() {
 }
 
 #[test]
-fn stalled_monitor_triggers_replan() {
+fn stalled_monitor_is_a_signal_not_a_directive() {
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(Todo::monitor("M1", "Watch A", Duration::from_millis(10)));
     std::thread::sleep(Duration::from_millis(50));
@@ -246,14 +246,16 @@ fn stalled_monitor_triggers_replan() {
     for _ in 0..MONITOR_NO_CHANGE_REPLAN_THRESHOLD {
         future_loop::executor::writeback(&mut goal, &record, Some(false), None);
     }
+    // ARCHITECTURE-SIMPLIFICATION: a stalled monitor is a signal, not a
+    // directive — quiet wait with an advisory, the agent decides.
     let p = decide(&goal, now());
-    assert_eq!(p.interaction_contract.mode, TurnMode::Replan);
-    assert!(p.reason.contains("stalled"));
+    assert_eq!(p.interaction_contract.mode, TurnMode::WaitMonitor);
+    assert!(p.reason.contains("stalled"), "{}", p.reason);
 }
 
-// ── Contract: repair budget ────────────────────────────────────────────────
+// ── Contract: a failed todo stays runnable (signal, not a forced replan) ───
 #[test]
-fn failed_todo_retries_then_stops() {
+fn failed_todo_stays_runnable_with_a_failure_signal() {
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(Todo::advancement("T1", "Flaky work"));
     let d1 = decide(&goal, now());
@@ -265,10 +267,14 @@ fn failed_todo_retries_then_stops() {
     assert_eq!(d2.interaction_contract.mode, TurnMode::BoundedDelivery);
     assert!(d2.reason.contains("repair attempt"));
 
+    // Even after the failed count exceeds the old MAX_REPAIR_ATTEMPTS, the
+    // todo stays runnable — the failure count is surfaced as an advisory and
+    // the agent (not the kernel) decides whether to supersede / re-split.
     future_loop::executor::writeback(&mut goal, &fail, None, None);
     assert!(goal.todo("T1").unwrap().failed_attempts > MAX_REPAIR_ATTEMPTS);
     let d3 = decide(&goal, now());
-    assert_eq!(d3.interaction_contract.mode, TurnMode::Replan);
+    assert_eq!(d3.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(d3.reason.contains("failed attempt"), "{}", d3.reason);
 }
 
 // ── Contract: gate resolution unlocks the dependent todo ───────────────────

--- a/orchestration/loop/tests/decision_split_regression.rs
+++ b/orchestration/loop/tests/decision_split_regression.rs
@@ -319,22 +319,26 @@ fn repair_attempt_parity() {
 }
 
 #[test]
-fn repair_budget_exhausted_parity() {
+fn repair_budget_exhausted_stays_runnable_parity() {
+    // ARCHITECTURE-SIMPLIFICATION: a failed todo stays runnable (the failure
+    // count is an advisory, not a forced replan).
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(Todo::advancement("T1", "Flaky work"));
     goal.todo_mut("T1").unwrap().failed_attempts = 2; // > MAX_REPAIR_ATTEMPTS (1)
-    let p = check(&goal, now(), None, TurnMode::Replan);
-    assert!(p.reason.contains("exhausted repair budget"));
+    let p = check(&goal, now(), None, TurnMode::BoundedDelivery);
+    assert!(p.reason.contains("failed attempt"), "{}", p.reason);
 }
 
 #[test]
-fn outcome_floor_breach_parity() {
+fn outcome_floor_stays_runnable_parity() {
+    // ARCHITECTURE-SIMPLIFICATION: an outcome-floor breach is a signal in the
+    // delivery reason, not a forced replan.
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(Todo::advancement("T1", "Surface-only loop"));
     goal.execution_profile.outcome_floor_streak_threshold = 3;
     goal.outcome_streak = 3;
-    let p = check(&goal, now(), None, TurnMode::Replan);
-    assert!(p.reason.contains("outcome floor"));
+    let p = check(&goal, now(), None, TurnMode::BoundedDelivery);
+    assert!(p.reason.contains("outcome floor"), "{}", p.reason);
 }
 
 // ── Blockers ───────────────────────────────────────────────────────────────
@@ -357,11 +361,13 @@ fn silent_completion_replan_parity() {
 
 // ── Monitors ───────────────────────────────────────────────────────────────
 #[test]
-fn monitor_stalled_replan_parity() {
+fn monitor_stalled_quiet_wait_parity() {
+    // ARCHITECTURE-SIMPLIFICATION: a stalled monitor is a signal, not a
+    // directive — quiet wait with an advisory.
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.add(Todo::monitor("M1", "Watch CI", Duration::from_secs(3600)));
     goal.todo_mut("M1").unwrap().consecutive_no_change = MONITOR_NO_CHANGE_REPLAN_THRESHOLD;
-    let p = check(&goal, now(), None, TurnMode::Replan);
+    let p = check(&goal, now(), None, TurnMode::WaitMonitor);
     assert!(p.reason.contains("stalled"));
 }
 

--- a/orchestration/loop/tests/legacy/decision_pre_split.rs
+++ b/orchestration/loop/tests/legacy/decision_pre_split.rs
@@ -127,27 +127,34 @@ pub fn legacy_decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -
     }
 
     // ── 2. Runnable advancement. ─────────────────────────────────────────
-    let retryable: Vec<&Todo> = runnable
-        .into_iter()
-        .filter(|t| t.failed_attempts <= MAX_REPAIR_ATTEMPTS)
-        .collect();
-    // ── 2b. Outcome floor (LoopX: surface-only progress loop). ──────────
-    if let Some(todo) = retryable.first() {
+    // ARCHITECTURE-SIMPLIFICATION: a failed todo is STILL runnable — the
+    // kernel does NOT filter by `failed_attempts` (the agent decides).
+    let runnable_todos: Vec<&Todo> = runnable;
+    if let Some(todo) = runnable_todos.first() {
+        let mut advisories: Vec<String> = vec![];
         let threshold = goal.execution_profile.outcome_floor_streak_threshold;
         if threshold > 0 && goal.outcome_streak >= threshold {
-            return legacy_replan_packet(
-                goal,
-                &format!(
-                    "outcome floor: {surface_streak} consecutive turns without a material outcome (threshold {threshold})",
-                    surface_streak = goal.outcome_streak
-                ),
-            );
+            advisories.push(format!(
+                "[signal: outcome floor: {surface_streak} consecutive turns without a material outcome (threshold {threshold}) — consider changing strategy or superseding a stale todo]",
+                surface_streak = goal.outcome_streak
+            ));
+        }
+        if todo.failed_attempts > 0 {
+            advisories.push(format!(
+                "[signal: todo {} has {} failed attempt(s) — consider superseding or asking the operator]",
+                todo.id, todo.failed_attempts
+            ));
         }
         let attempt = todo.failed_attempts + 1;
         let reason = if attempt > 1 {
             format!("repair attempt {attempt} for todo {}", todo.id)
         } else {
             format!("runnable todo {}", todo.id)
+        };
+        let reason = if advisories.is_empty() {
+            reason
+        } else {
+            format!("{reason} {}", advisories.join(" "))
         };
         // Non-blocking user actions surface in the user channel alongside
         // delivery (LoopX: user_action never freezes the agent).
@@ -185,12 +192,8 @@ pub fn legacy_decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -
             },
         );
     }
-    if goal
-        .open_of(TaskClass::Advancement)
-        .any(|t| t.failed_attempts > MAX_REPAIR_ATTEMPTS)
-    {
-        return legacy_replan_packet(goal, "advancement todo(s) exhausted repair budget");
-    }
+    // (repair-budget replan removed — a failed todo stays runnable and the
+    //  failure count is surfaced as an advisory in the delivery reason.)
 
     // ── 2c. Blocked by an external blocker with no fallback: quiet wait. ──
     let blockers: Vec<&Todo> = goal.open_of(TaskClass::Blocker).collect();
@@ -240,12 +243,27 @@ pub fn legacy_decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -
         .iter()
         .find(|m| m.consecutive_no_change >= MONITOR_NO_CHANGE_REPLAN_THRESHOLD)
     {
-        return legacy_replan_packet(
+        // ARCHITECTURE-SIMPLIFICATION: a stalled monitor is a signal, not a
+        // directive — quiet wait with an advisory, the agent decides.
+        return legacy_packet(
             goal,
+            "wait",
+            false,
+            "quiet_wait",
+            TurnMode::WaitMonitor,
             &format!(
-                "monitor {} stalled ({} consecutive no-change polls)",
+                "monitor {} stalled ({} consecutive no-change polls) — signal, not a directive: consider watch-lane expiry, a blocker, or superseding the monitor",
                 stalled.id, stalled.consecutive_no_change
             ),
+            UserChannel::none(),
+            AgentChannel {
+                must_attempt: false,
+                delivery_allowed: false,
+                quiet_noop_allowed: true,
+                primary_action: None,
+                selected_todo: None,
+                fallback_todo: None,
+            },
         );
     }
     let due: Vec<&Todo> = monitors

--- a/orchestration/loop/tests/oscillation_contract.rs
+++ b/orchestration/loop/tests/oscillation_contract.rs
@@ -63,7 +63,9 @@ fn goal_with_history(history: Vec<RunRecord>) -> Goal {
 
 // ── Detection fires on the A→V→A→V pattern ────────────────────────────────
 #[test]
-fn oscillation_forces_replan_instead_of_delivery() {
+fn oscillation_surfaces_as_a_signal_not_a_replan() {
+    // ARCHITECTURE-SIMPLIFICATION: oscillation is a signal the agent reads,
+    // surfaced in the delivery reason — NOT a kernel-forced replan.
     let goal = goal_with_history(vec![
         accepted(1, 1),
         rejected(2, 2),
@@ -73,17 +75,16 @@ fn oscillation_forces_replan_instead_of_delivery() {
     let p = decide(&goal, SystemTime::now());
     assert_eq!(
         p.interaction_contract.mode,
-        TurnMode::Replan,
-        "A→V→A→V must convert the next delivery into a replan"
+        TurnMode::BoundedDelivery,
+        "A→V→A→V surfaces as an advisory, delivery continues"
     );
-    assert!(p.reason.contains("oscillation detected"));
-    assert!(p.reason.contains("A→V→A→V"));
-    assert!(!p.normal_delivery_allowed);
-    assert!(p.self_repair_allowed, "the repair lane stays open");
+    assert!(p.reason.contains("oscillation"), "{}", p.reason);
+    assert!(p.reason.contains("A→V→A→V"), "{}", p.reason);
+    assert!(p.normal_delivery_allowed);
 }
 
 #[test]
-fn v_first_alternation_also_fires() {
+fn v_first_alternation_also_surfaces() {
     let goal = goal_with_history(vec![
         rejected(1, 1),
         accepted(2, 2),
@@ -91,23 +92,23 @@ fn v_first_alternation_also_fires() {
         accepted(4, 4),
     ]);
     let p = decide(&goal, SystemTime::now());
-    assert_eq!(p.interaction_contract.mode, TurnMode::Replan);
-    assert!(p.reason.contains("V→A→V→A"));
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(p.reason.contains("V→A→V→A"), "{}", p.reason);
 }
 
 // ── Below the pattern length the guard stays silent ───────────────────────
 #[test]
 fn shorter_alternation_still_delivers() {
-    // One pair plus a lead-in (len 3 < OSCILLATION_PATTERN_LEN): no fire.
+    // One pair plus a lead-in (len 3 < OSCILLATION_PATTERN_LEN): no signal.
     let goal = goal_with_history(vec![accepted(1, 1), rejected(2, 2), accepted(3, 3)]);
     let p = decide(&goal, SystemTime::now());
     assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(!p.reason.contains("oscillation"), "{}", p.reason);
 }
 
 #[test]
 fn consecutive_rejects_break_the_pattern() {
-    // A,V,A,V,V — the same-symbol pair at the tail ends the alternation
-    // (consecutive rejects are the repair budget's domain, not this guard's).
+    // A,V,A,V,V — the same-symbol pair at the tail ends the alternation.
     let goal = goal_with_history(vec![
         accepted(1, 1),
         rejected(2, 2),
@@ -117,6 +118,7 @@ fn consecutive_rejects_break_the_pattern() {
     ]);
     let p = decide(&goal, SystemTime::now());
     assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(!p.reason.contains("oscillation"), "{}", p.reason);
 }
 
 #[test]
@@ -132,6 +134,7 @@ fn stabilized_tail_clears_an_earlier_pattern() {
     ]);
     let p = decide(&goal, SystemTime::now());
     assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(!p.reason.contains("oscillation"), "{}", p.reason);
 }
 
 // ── Non-delivery records are transparent to the detector ──────────────────
@@ -151,43 +154,41 @@ fn monitor_polls_and_failed_turns_neither_fabricate_nor_break() {
         rejected(6, 6),
     ]);
     let p = decide(&goal, SystemTime::now());
-    assert_eq!(
-        p.interaction_contract.mode,
-        TurnMode::Replan,
-        "heartbeat polls and crashed turns must be transparent: A,_,V,_,A,V still alternates"
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(
+        p.reason.contains("oscillation"),
+        "heartbeat polls and crashed turns must be transparent: A,_,V,_,A,V still alternates — {}",
+        p.reason
     );
 }
 
 // ── The replan ACK consumes the pattern (liveness) ─────────────────────────
 #[test]
-fn replan_ack_consumes_the_pattern_and_delivery_resumes() {
+fn replan_ack_consumes_the_pattern_and_signal_clears() {
     let mut goal = goal_with_history(vec![
         accepted(1, 1),
         rejected(2, 2),
         accepted(3, 3),
         rejected(4, 4),
     ]);
-    assert_eq!(
-        decide(&goal, SystemTime::now()).interaction_contract.mode,
-        TurnMode::Replan
-    );
+    assert!(decide(&goal, SystemTime::now())
+        .reason
+        .contains("oscillation"));
     // The agent records a frontier-changing delta (ACK at ts=10); every
-    // alternating record predates the ACK, so the pattern is consumed.
+    // alternating record predates the ACK, so the pattern is consumed and the
+    // oscillation signal clears from the delivery reason.
     goal.replan_ack = Some(ReplanAck {
         recorded: true,
         delta_kinds: vec!["vision_patch".to_string()],
         at: 10,
     });
     let p = decide(&goal, SystemTime::now());
-    assert_eq!(
-        p.interaction_contract.mode,
-        TurnMode::BoundedDelivery,
-        "post-ACK the goal must be allowed to deliver again"
-    );
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(!p.reason.contains("oscillation"), "{}", p.reason);
 }
 
 #[test]
-fn fresh_post_ack_alternation_refires_the_guard() {
+fn fresh_post_ack_alternation_surfaces_again() {
     let mut goal = goal_with_history(vec![
         accepted(1, 1),
         rejected(2, 2),
@@ -202,16 +203,15 @@ fn fresh_post_ack_alternation_refires_the_guard() {
     // One fresh pair post-ACK: not enough.
     goal.history.push(accepted(5, 11));
     goal.history.push(rejected(6, 12));
-    assert_eq!(
-        decide(&goal, SystemTime::now()).interaction_contract.mode,
-        TurnMode::BoundedDelivery
-    );
-    // Two full fresh pairs: the loop survived the replan — fire again.
+    assert!(!decide(&goal, SystemTime::now())
+        .reason
+        .contains("oscillation"));
+    // Two full fresh pairs: the loop survived the replan — signal again.
     goal.history.push(accepted(7, 13));
     goal.history.push(rejected(8, 14));
     let p = decide(&goal, SystemTime::now());
-    assert_eq!(p.interaction_contract.mode, TurnMode::Replan);
-    assert!(p.reason.contains("oscillation detected"));
+    assert_eq!(p.interaction_contract.mode, TurnMode::BoundedDelivery);
+    assert!(p.reason.contains("oscillation"), "{}", p.reason);
 }
 
 // ── The guard only blocks delivery, never other modes ─────────────────────

--- a/orchestration/loop/tests/outcome_floor_contract.rs
+++ b/orchestration/loop/tests/outcome_floor_contract.rs
@@ -28,9 +28,9 @@ fn run_record(turn: u32, todo_id: &str, state: &str, tools: usize, evidence: &st
     }
 }
 
-// ── Contract: outcome floor rejects surface-only progress loops ────────────
+// ── Contract: outcome floor surfaces as a signal, not a forced replan ─────
 #[test]
-fn outcome_floor_stops_surface_only_loops() {
+fn outcome_floor_surfaces_as_a_signal() {
     let mut goal = Goal::new("g", "objective", "/tmp");
     goal.execution_profile = ExecutionProfile {
         outcome_floor_streak_threshold: 3,
@@ -46,16 +46,18 @@ fn outcome_floor_stops_surface_only_loops() {
     goal.todo_mut("t1").unwrap().status = future_loop::state::TodoStatus::Open;
     assert_eq!(goal.outcome_streak, 2);
 
-    // Third surface-only turn crosses the floor → replan, not delivery.
+    // Third surface-only turn crosses the floor → a SIGNAL in the delivery
+    // reason, not a forced replan (ARCHITECTURE-SIMPLIFICATION: the agent
+    // reads the signal and decides, the kernel keeps delivering).
     writeback(&mut goal, &surface, None, Some((false, vec!["t2".into()])));
     goal.todo_mut("t1").unwrap().status = future_loop::state::TodoStatus::Open;
     let p = decide(&goal, SystemTime::now());
     assert_eq!(
         p.interaction_contract.mode,
-        TurnMode::Replan,
-        "outcome floor must reject the surface-only progress loop"
+        TurnMode::BoundedDelivery,
+        "outcome floor surfaces as an advisory; delivery continues"
     );
-    assert!(p.reason.contains("outcome floor"));
+    assert!(p.reason.contains("outcome floor"), "{}", p.reason);
 }
 
 #[test]

--- a/orchestration/loop/tests/store_contract.rs
+++ b/orchestration/loop/tests/store_contract.rs
@@ -215,16 +215,19 @@ fn full_goal_lifecycle_through_events() {
         future_loop::contract::TurnMode::MonitorPoll
     );
 
-    // No-change stall → replan (pure decision test on an in-memory goal).
+    // No-change stall → quiet wait + signal (ARCHITECTURE-SIMPLIFICATION: a
+    // stalled monitor is an advisory, not a forced replan).
     let mut g = store.replay("g3").unwrap().unwrap();
     let rec = crate_helper::run_record(1, "m1", "completed");
     for _ in 0..MONITOR_NO_CHANGE_REPLAN_THRESHOLD {
         future_loop::executor::writeback(&mut g, &rec, Some(false), None);
     }
+    let p = decide(&g, SystemTime::now());
     assert_eq!(
-        decide(&g, SystemTime::now()).interaction_contract.mode,
-        future_loop::contract::TurnMode::Replan
+        p.interaction_contract.mode,
+        future_loop::contract::TurnMode::WaitMonitor
     );
+    assert!(p.reason.contains("stalled"), "{}", p.reason);
 }
 
 /// Helper module (integration tests cannot use `#[path]` into the bin).


### PR DESCRIPTION
## 原则

**决策者是大模型（agent），不是 loop 内核。** loop 内核应该是「kanban 工具」——提供 todo 状态、verify 门、acceptance 契约、evidence、lease 这些确定性工具，而不是「规则引擎」——替 agent 判断「你卡住了，停下来重新规划」。对 agent 的决策提示放在 future-loop SKILL.md 里，由 agent 自己读取、自己决策。

## A. 弱化规则型强制 replan

内核不再「替 agent 判断卡住 → 强制 replan」。这些规则变成交付 reason 里的**信号**，agent 读信号后自己决策：

| 规则 | 旧（强制 replan） | 新（信号 + 继续交付） |
|---|---|---|
| outcome floor | replan | `[signal: ...]` 附加提示 |
| oscillation (A→V→A→V) | replan | `[signal: ...]` 附加提示 |
| repair budget | 过滤失败 todo + replan | 失败 todo 仍 runnable + `[signal: N failed]` |
| LLM zombie | replan | `[signal: N turns no write]` 附加提示 |
| monitor stall | replan | quiet wait + `[signal: stalled]` |

**保留的正确性底线**（kanban 确定性语义，不弱化）：verify 门、acceptance 契约、terminal 判定、succession、user gate、lease。

## B. Session retention（同一原则的延伸）

resume-vs-fresh 也是「决策权在调用方」：

- 内核只记录**为什么中断**（`SessionRetention`：failure_kind + resumable advisory + session id），不替调用方决定
- 调用方通过 `run --session-policy auto|fresh|resume` / `--resume-session ID` 显式决策
- `auto` 只 resume 内核判定「可恢复」的会话（InfraRecoverable，如 HTTP 429 — LLM 状态完好）；HardError/verify 失败（推理状态已坏）→ 删除
- 429 backoff（45s）加入 run loop，让重启落在冷却后的引擎上

## C. 提示移到 SKILL.md

「信号 → 该怎么做」决策表（failed → supersede；oscillation → 换验证器；429 → 退避；zombie → 新会话）写入 future-loop SKILL.md，agent 自己读。

## 测试

- 823 测试全过，0 失败，0 clippy warning
- 更新 decision/oscillation/outcome_floor/store/agent_run_drive/decision_split_regression + legacy + snapshot 到新的信号语义
- mock_agent 现在跟踪 live sessions，让 session_alive 有真实的 false 路径

## 背景

来自 ASC S4 Round 4 24 小时无人值守比赛的复盘：149 turn 中 89% 失败，根因之一是内核替 agent 做了太多「你卡住了」的决策（oscillation 死锁、repair budget 强制 replan、429 误判为 science failure），而这些本应是 agent 读完信号后的自主判断。