### PR TITLE
fix(tui): /new really starts a fresh session (session id was inherited)

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1179,6 +1179,10 @@ impl<T: TerminalIo> App<T> {
                         if let Some(s) = state {
                             self.apply_refresh_state(s);
                         }
+                        // The new session has no history — drop the previous
+                        // transcript, or the old conversation stays on screen
+                        // and /new looks like it did nothing.
+                        self.chat.clear_messages();
                         self.restore_session_input();
                         self.add_system_message("New session started.".into());
                     }
@@ -7909,6 +7913,30 @@ mod tests {
         let (mut app, mut rx) = make_app_at(&addr, &CliOptions::default());
         app.handle_submit("/new");
         pump(&mut app, &mut rx).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn slash_new_clears_the_previous_transcript() {
+        let (addr, _seen) = spawn_app_mock().await;
+        let (mut app, mut rx) = make_app_at(&addr, &CliOptions::default());
+        app.chat.add_message(ChatMessage::new(
+            "old".into(),
+            ChatRole::User,
+            "previous session question",
+        ));
+        app.handle_submit("/new");
+        pump_until_msg(&mut app, &mut rx, "New session started").await;
+        // Only the confirmation remains — the old conversation is gone.
+        let texts: Vec<String> = app
+            .chat
+            .plain_messages()
+            .iter()
+            .map(|(_, content)| content.clone())
+            .collect();
+        assert!(
+            !texts.iter().any(|t| t.contains("previous session")),
+            "old transcript survived /new: {texts:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/tui/src/rpc/grpc_client.rs
+++ b/tui/src/rpc/grpc_client.rs
@@ -258,7 +258,15 @@ impl GrpcClient {
             cmd.r#type = r#type.to_string();
             // TS: `sessionId: this.currentSessionId || undefined` spread
             // BEFORE `...cmd` — an explicit sessionId in cmd wins.
-            if cmd.session_id.is_empty() && !st.current_session_id.is_empty() {
+            // `new_session` must stay session-less: the agent treats a
+            // non-empty session_id as "create THIS id" and restores its
+            // persisted entries, so inheriting the current id would hand
+            // back the same session with its full history (TS expressed
+            // this as `sessionId: undefined` overriding the spread).
+            if cmd.session_id.is_empty()
+                && !st.current_session_id.is_empty()
+                && r#type != "new_session"
+            {
                 cmd.session_id = st.current_session_id.clone();
             }
         }
@@ -1241,6 +1249,8 @@ mod tests {
         data_by_type: Arc<std::sync::Mutex<StdHashMap<String, String>>>,
         status_errors: StdHashMap<String, tonic::Status>,
         seen: Arc<std::sync::Mutex<Vec<String>>>,
+        /// (type, session_id) of every command, for routing assertions.
+        seen_sessions: Arc<std::sync::Mutex<Vec<(String, String)>>>,
         /// Answer success=false with this error string for these types.
         fail_with: StdHashMap<String, String>,
         /// stream_events returns a tonic error immediately.
@@ -1261,6 +1271,10 @@ mod tests {
         ) -> Result<tonic::Response<RpcResponse>, tonic::Status> {
             let cmd = request.into_inner();
             self.seen.lock().unwrap().push(cmd.r#type.clone());
+            self.seen_sessions
+                .lock()
+                .unwrap()
+                .push((cmd.r#type.clone(), cmd.session_id.clone()));
             if let Some(status) = self.status_errors.get(&cmd.r#type) {
                 return Err(status.clone());
             }
@@ -1399,6 +1413,44 @@ mod tests {
         let sessions = client.list_sessions().await.unwrap();
         assert_eq!(sessions.len(), 1); // the malformed entry is dropped
         assert_eq!(sessions[0].id, "s1");
+        client.disconnect();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn new_session_does_not_inherit_current_session_id() {
+        // Regression: `call` used to backfill the current session id onto
+        // every command with an empty one — including `new_session`, which
+        // the agent then read as "create/restore THAT id", handing back the
+        // same session with its full history (so /new looked like a no-op).
+        let seen_sessions = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let addr = spawn_api_mock(ApiMock {
+            data_by_type: Arc::new(std::sync::Mutex::new(StdHashMap::from([
+                ("new_session".into(), "{\"sessionId\":\"s-new\"}".into()),
+                ("get_state".into(), "{\"sessionId\":\"s-new\"}".into()),
+            ]))),
+            seen_sessions: seen_sessions.clone(),
+            ..Default::default()
+        })
+        .await;
+        let (client, _events, _conn) = GrpcClient::new(&addr);
+        client.set_current_session_id("s-old");
+
+        client.new_session(None, None, None).await.unwrap();
+        assert_eq!(client.get_current_session_id(), "s-new");
+        // Other commands still inherit the current session id (routing).
+        client.get_state().await.unwrap();
+
+        let seen = seen_sessions.lock().unwrap().clone();
+        assert!(
+            seen.iter()
+                .any(|(t, sid)| t == "new_session" && sid.is_empty()),
+            "new_session must be sent session-less, saw {seen:?}"
+        );
+        assert!(
+            seen.iter()
+                .any(|(t, sid)| t == "get_state" && sid == "s-new"),
+            "other commands keep routing by session id, saw {seen:?}"
+        );
         client.disconnect();
     }
 


### PR DESCRIPTION
# Problem

In the TUI, `/new` did not start a new session: the session id stayed the same and the whole conversation history was still there (reported by the user as "`/new` 貌似没法启动新会话?会话历史还在").

# Root cause

`GrpcClient::call` backfills the current session id onto every command whose `session_id` is empty (that is how commands get routed to the right session) — **including `new_session`**:

```rust
if cmd.session_id.is_empty() && !st.current_session_id.is_empty() {
    cmd.session_id = st.current_session_id.clone();   // also hit new_session
}
```

Agent-side, `cmd_new_session` reads a non-empty `session_id` as "create *this* id" and then **restores that id's persisted entries from disk** (the semantics fork / clone / desktop import rely on). So `/new` rebuilt the very same session, re-hydrated its history, and replaced the live session in the sessions map — same id, same transcript, i.e. a no-op with extra steps.

The same path also affected startup: plain `future tui` does `get_state` (which adopts the agent's current session id) and then `new_session()`, so a fresh TUI silently continued the previous session's history instead of starting clean.

The TypeScript client avoided this by passing `sessionId: undefined` *after* the spread, explicitly clearing the field. The Rust port (#114) cannot distinguish "unset" from "empty string" in the proto message, so the guard was lost.

# Fix

- `tui/src/rpc/grpc_client.rs`: skip the session-id backfill for `new_session`; every other command keeps routing by the current session id.
- `tui/src/app.rs`: clear the chat transcript in `NewSessionDone`. The new session has no history, so leaving the old conversation on screen made `/new` look like it did nothing (the TS version had this wart too).

# Tests

- `new_session_does_not_inherit_current_session_id` (grpc_client) — asserts `new_session` goes out session-less while `get_state` still carries the id. Verified to fail before the fix: `new_session must be sent session-less, saw [("new_session", "s-old"), ("get_state", "s-new")]`.
- `slash_new_clears_the_previous_transcript` (app) — the previous conversation is gone after `/new`.
- The `ApiMock` now records `(type, session_id)` per command so session routing is assertable.

# Verification (local, Windows)

- `cargo fmt --check --all` and `cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: only 3 pre-existing **Windows-only** `future-cli` errors (`cfg(unix)`-gated test helpers: unused `dir`, dead `OverrideReset` / `set_driver_override`) — byte-identical on unmodified `main`, and CI lints on Linux. `--exclude future-cli` is clean; desktop backend clippy clean.
- Rust tests, each compared against an unmodified-`main` baseline on the same machine: `future-tui` 755 pass / 15 fail (baseline 753 / **same 15**), `future-cli` 623 / 42 (baseline identical), `future-agent` 1347 / 23 (baseline identical), `future-loop` 301 / 10 (baseline identical), `future-rpc` green. All failures are pre-existing Windows-environment ones (POSIX terminal, symlinks, `which`, macOS/Linux init links).
- Not run locally: `future-channel` tests (hang on this Windows box without network) and the desktop / mobile JS suites (`npm install` needs network). This diff is `tui/`-only, so neither can be affected; CI's Linux jobs cover both.
