### PR TITLE
fix(windows): harden unelevated sandbox behavior

### DIFF
--- a/agent/src/rpc/commands/settings.rs
+++ b/agent/src/rpc/commands/settings.rs
@@ -335,9 +335,22 @@ pub(crate) fn handle_set_sandbox_policy(
     let Some(policy) = cmd.sandbox_policy.clone() else {
         return RpcResponse::build_fail(id, "set_sandbox_policy", "missing sandbox_policy payload");
     };
+    let sandbox_available = match crate::sandbox::platform_sandbox_availability() {
+        Ok(available) => available,
+        Err(error) if policy.tier.as_str() == "sandbox" => {
+            return RpcResponse::build_fail(
+                id,
+                "set_sandbox_policy",
+                &format!("Windows sandbox availability could not be determined: {error}"),
+            );
+        }
+        // Manual/off do not depend on the OS sandbox and must remain selectable
+        // while a transient Windows probe error is being retried.
+        Err(_) => false,
+    };
     let summary = serde_json::json!({
         "tier": policy.tier.as_str(),
-        "sandboxAvailable": crate::sandbox::platform_sandbox_available(),
+        "sandboxAvailable": sandbox_available,
     });
     let tier = policy.tier.as_str().to_string();
     session.write().set_sandbox_policy(policy);

--- a/agent/src/sandbox/mod.rs
+++ b/agent/src/sandbox/mod.rs
@@ -795,39 +795,56 @@ pub fn shell_display_name() -> &'static str {
 
 /// Whether the OS-level sandbox is usable on this platform.
 pub fn platform_sandbox_available() -> bool {
+    platform_sandbox_availability().unwrap_or(false)
+}
+
+/// Resolve product sandbox support without collapsing a transient Windows
+/// probe failure into an authoritative unsupported result.
+pub(crate) fn platform_sandbox_availability() -> std::io::Result<bool> {
     #[cfg(target_os = "macos")]
     {
-        Path::new("/usr/bin/sandbox-exec").exists()
+        Ok(Path::new("/usr/bin/sandbox-exec").exists())
     }
     #[cfg(target_os = "windows")]
     {
-        cached_windows_sandbox_probe().available
+        cached_windows_sandbox_probe().map(|probe| probe.available)
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        false
+        Ok(false)
     }
 }
 
 #[cfg(target_os = "windows")]
-fn cached_windows_sandbox_probe() -> &'static WindowsSandboxProbe {
-    WINDOWS_SANDBOX_PROBE.get_or_init(|| match probe_windows_sandbox_host() {
-        Ok(result) => {
-            tracing::info!(
-                available = result.available,
-                code = result.code,
-                "Windows sandbox host probe completed"
-            );
-            result
-        }
-        Err(error) => {
-            tracing::warn!(
-                error_kind = ?error.kind(),
-                "Windows sandbox host probe failed"
-            );
-            WindowsSandboxProbe::unavailable("probe_failed", error)
-        }
-    })
+fn cached_windows_sandbox_probe() -> std::io::Result<&'static WindowsSandboxProbe> {
+    if let Some(result) = WINDOWS_SANDBOX_PROBE.get() {
+        return Ok(result);
+    }
+
+    let result = probe_windows_sandbox_host()?;
+    if let Some(diagnostic) = result.diagnostic() {
+        // Initialization and cleanup failures can be transient (for example,
+        // while another process is releasing a capability lock). Do not turn
+        // them into a process-lifetime unsupported verdict.
+        tracing::warn!(
+            code = result.code,
+            error = diagnostic,
+            "Windows sandbox host probe failed"
+        );
+        return Err(std::io::Error::other(format!(
+            "Windows sandbox probe failed [{}]",
+            result.code
+        )));
+    }
+    tracing::info!(
+        available = result.available,
+        code = result.code,
+        "Windows sandbox host probe completed"
+    );
+    let _ = WINDOWS_SANDBOX_PROBE.set(result);
+    WINDOWS_SANDBOX_PROBE
+        .get()
+        .ok_or_else(|| std::io::Error::other("Windows sandbox probe cache was not initialized"))
 }
 
 #[cfg(target_os = "windows")]
@@ -893,7 +910,7 @@ pub(crate) fn probe_windows_sandbox_host() -> std::io::Result<WindowsSandboxProb
 pub(crate) fn probe_windows_sandbox_product() -> std::io::Result<WindowsSandboxProbe> {
     #[cfg(target_os = "windows")]
     {
-        Ok(cached_windows_sandbox_probe().clone())
+        Ok(cached_windows_sandbox_probe()?.clone())
     }
     #[cfg(not(target_os = "windows"))]
     probe_windows_sandbox_host()

--- a/agent/src/sandbox/windows/integration_tests.rs
+++ b/agent/src/sandbox/windows/integration_tests.rs
@@ -173,6 +173,31 @@ fn release_probe_validates_complete_write_boundary() {
 }
 
 #[tokio::test]
+async fn release_probe_is_independent_of_an_active_sandbox_job() {
+    let fixture = Fixture::new();
+    let plan = fixture.plan();
+    let child = runner::spawn_with_plan_for_test(
+        &plan,
+        "Start-Sleep -Seconds 30",
+        &fixture.workspace,
+        &[],
+        None,
+        &fixture.state_path,
+    )
+    .expect("spawn active sandbox job");
+
+    let result = runner::probe_host().expect("concurrent host probe completes");
+    assert!(
+        result.available,
+        "concurrent host probe unavailable: {}",
+        result.code
+    );
+
+    child.terminate();
+    assert_ne!(child.wait().await.unwrap(), 0);
+}
+
+#[tokio::test]
 async fn stale_capability_gc_waits_for_active_process_tree() {
     let fixture = Fixture::new();
     let old_plan = fixture.plan();

--- a/agent/src/sandbox/windows/runner.rs
+++ b/agent/src/sandbox/windows/runner.rs
@@ -31,6 +31,11 @@ static ACTIVE_CAPABILITIES: OnceLock<Mutex<ActiveCapabilities>> = OnceLock::new(
 
 #[derive(Default)]
 struct ActiveCapabilities {
+    states: HashMap<PathBuf, ActiveCapabilityState>,
+}
+
+#[derive(Default)]
+struct ActiveCapabilityState {
     names: HashMap<String, usize>,
     process_lock: Option<CapabilityFileLock>,
 }
@@ -101,6 +106,7 @@ impl Drop for CapabilityFileLock {
 /// Keeps capability generations alive while their restricted process tree can
 /// still use inherited ACEs. GC only revokes a SID when no lease references it.
 pub(crate) struct CapabilityLease {
+    state_path: PathBuf,
     names: Vec<String>,
 }
 
@@ -121,14 +127,18 @@ impl CapabilityLease {
         let mut active = active_capabilities()
             .lock()
             .map_err(|_| io::Error::other("active capability lock is poisoned"))?;
-        if active.names.is_empty() {
-            debug_assert!(active.process_lock.is_none());
-            active.process_lock = Some(CapabilityFileLock::acquire(state_path)?);
+        let state = active.states.entry(state_path.to_path_buf()).or_default();
+        if state.names.is_empty() {
+            debug_assert!(state.process_lock.is_none());
+            state.process_lock = Some(CapabilityFileLock::acquire(state_path)?);
         }
         for name in &names {
-            *active.names.entry(name.clone()).or_default() += 1;
+            *state.names.entry(name.clone()).or_default() += 1;
         }
-        Ok(Self { names })
+        Ok(Self {
+            state_path: state_path.to_path_buf(),
+            names,
+        })
     }
 }
 
@@ -137,8 +147,11 @@ impl Drop for CapabilityLease {
         let Ok(mut active) = active_capabilities().lock() else {
             return;
         };
+        let Some(state) = active.states.get_mut(&self.state_path) else {
+            return;
+        };
         for name in &self.names {
-            let remove = match active.names.get_mut(name) {
+            let remove = match state.names.get_mut(name) {
                 Some(count) if *count > 1 => {
                     *count -= 1;
                     false
@@ -147,11 +160,12 @@ impl Drop for CapabilityLease {
                 None => false,
             };
             if remove {
-                active.names.remove(name);
+                state.names.remove(name);
             }
         }
-        if active.names.is_empty() {
-            active.process_lock.take();
+        if state.names.is_empty() {
+            state.process_lock.take();
+            active.states.remove(&self.state_path);
         }
     }
 }
@@ -322,10 +336,10 @@ fn reconcile_stale_records(
     let active = active_capabilities()
         .lock()
         .map_err(|_| io::Error::other("active capability lock is poisoned"))?
-        .names
-        .keys()
-        .cloned()
-        .collect::<HashSet<_>>();
+        .states
+        .get(state_path)
+        .map(|state| state.names.keys().cloned().collect::<HashSet<_>>())
+        .unwrap_or_default();
     // A failed revoke leaves both the ACE and metadata intact so a later run
     // can retry. Removing metadata first would turn recoverable cleanup into an
     // undiscoverable persistent ACE.
@@ -443,12 +457,13 @@ fn reset_capabilities_at(state_path: &Path) -> io::Result<usize> {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .map_err(|_| io::Error::other("Windows capability preparation lock is poisoned"))?;
-    if !active_capabilities()
+    let state_is_active = active_capabilities()
         .lock()
         .map_err(|_| io::Error::other("active capability lock is poisoned"))?
-        .names
-        .is_empty()
-    {
+        .states
+        .get(state_path)
+        .is_some_and(|state| !state.names.is_empty());
+    if state_is_active {
         return Err(io::Error::new(
             io::ErrorKind::WouldBlock,
             "Windows sandbox permissions are in use by an active command",
@@ -546,6 +561,26 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
         drop(first);
         CapabilityFileLock::acquire(&state_path).unwrap();
+    }
+
+    #[test]
+    fn active_capabilities_block_only_their_own_state_file() {
+        let fixture = tempfile::tempdir().unwrap();
+        let active_state_path = fixture.path().join("active/capabilities.json");
+        let probe_state_path = fixture.path().join("probe/capabilities.json");
+        let plan = WindowsSandboxPlan {
+            writable_roots: vec![fixture.path().join("workspace")],
+            ..WindowsSandboxPlan::default()
+        };
+        let records = policy_records(&plan);
+        let lease = CapabilityLease::acquire(&records, &active_state_path).unwrap();
+
+        let active_error = reset_capabilities_at(&active_state_path).unwrap_err();
+        assert_eq!(active_error.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(reset_capabilities_at(&probe_state_path).unwrap(), 0);
+
+        drop(lease);
+        assert_eq!(reset_capabilities_at(&active_state_path).unwrap(), 0);
     }
 
     #[test]

--- a/desktop/DEV_MD/APPROVAL_PLAN.md
+++ b/desktop/DEV_MD/APPROVAL_PLAN.md
@@ -223,6 +223,8 @@ Windows `sandbox` 档的 shell 调用新增显式能力请求；示意结构：
 
 路径能力只是在 RestrictedToken 的第二次写检查中增加许可，**不会提升当前用户本来没有的 NTFS 权限**。若正常用户 SID 对目标也无写权，批准后仍应返回原生权限错误，不得尝试改 owner、绕过 DACL 或请求 UAC。
 
+本期 Windows 后端明确是 Unelevated：shell 仍以当前真实用户为主体，路径能力卡表示“允许这次内容写入范围”，不表示已经获得 Elevated 独立用户等级的防删除保证。`scope=file` 不授 capability `DELETE`，但当前用户对父目录已有的 `FILE_DELETE_CHILD` 仍可能允许删除目标；既有 Everyone/Logon/`Users`/`Authenticated Users` 宽 ACL 也属于知情边界。普通卡片不堆叠这些实现细节，但开发文档、测试与 review 不得把“修改文件”解读成“OS 已绝对禁止删除”。完整边界与单专用用户后续路线见 SANDBOX_PLAN §11.6、§11.10。
+
 ## 7. 启用范围与三档审批
 
 审批以**单一枚举 `tier`** 表达，session 建立时经 `set_sandbox_policy { tier }` 下发（proto `string tier`）。三档：
@@ -272,5 +274,6 @@ v1 的 `read-only / workspace-write / danger-full-access` 三种模式与 `untru
 | V11（2026-08-21） | Windows `sandbox` 定义为 unelevated **写保护**，不声称具备 macOS Seatbelt 的 shell deny-read；UI 必须明确能力差异 |
 | V12（2026-08-21） | Windows shell 额外写权限必须声明具体路径；批准只扩展对应 capability 并保持 RestrictedToken，不以笼统 error 5 触发整命令脱沙盒重跑 |
 | V13（2026-08-21） | 所有平台复用 `ApprovalPrompt`；普通卡片由可信后端用标题表达“行为 + 目标”，单目标不重复字段，技术 enforcement 数据不展示，原始命令折叠；多目标最多 8 项且整组决策，payload 无法可信解析时 fail closed |
+| V14（2026-08-25） | Windows 本期范围冻结为 Unelevated；真实用户主体、`FILE_DELETE_CHILD` 与既有宽 ACL 是知情能力边界，不以 Elevated 保证验收本期。后续若升级独立安全主体，优先单独评估一个专用本地用户，不混入当前 PR |
 
 沿用 v1 未变的决策：macOS escalation 按命令放行（原 Q2）、`.git` 不排除（Q4）、`sandbox-exec` deprecated 风险接受（Q5）、失败特征启发式保守（Q6）、temp 目录读写全开。Windows 改用路径能力放行；Linux 后续再做。

--- a/desktop/DEV_MD/SANDBOX_PLAN.md
+++ b/desktop/DEV_MD/SANDBOX_PLAN.md
@@ -186,6 +186,8 @@ v2 决策（V1–V9）见 APPROVAL_PLAN §9。v1 期间沿用有效的：escalat
 
 状态：**W1–W6 底层与本机可执行生命周期已在 Windows 11 Home 真机 PASS；W7 已在当前本地测试分支直接开启。** AppContainer SID、private desktop、PowerShell/CLM、Unicode/大输出、用户级单例、活动 capability lease、跨进程占用锁、旧代际 ACE/metadata GC、完整 host probe、reset、Desktop graceful shutdown 及 RPC/CLI 调用均已有自动化证据；RM-01、RM-02、RM-04～RM-07 已在本机 PASS。RM-03 及额外主机矩阵仍待完成。Windows 启动时直接运行完整 host probe；通过才显示该档，任何失败都隐藏入口并回退 `manual`。
 
+> **本期范围冻结（2026-08-25）**：本期交付目标明确为 **Unelevated**，即命令仍以当前真实 Windows 用户为主体，在其 token 上叠加 `WRITE_RESTRICTED`、capability SID 与 NTFS ACL。它与 Codex 的 legacy/unelevated 路线具有相同的基础机制和能力上限。本期不创建本地沙盒用户、不要求 UAC、不引入 elevated command runner，也不以 Elevated 的独立安全主体保证作为本期 review 或完成门槛。下文 §11.6 的限制是知情接受的产品边界，不应在后续 review 中被误判为“遗漏了 Elevated 实现”；后续候选路线见 §11.10。
+
 Windows 与 macOS 共用 `SandboxTier::Sandbox` 协议值，但 UI 和保证不同：
 
 | | macOS 沙箱保护 | Windows 写保护 |
@@ -207,10 +209,12 @@ Windows 与 macOS 共用 `SandboxTier::Sandbox` 协议值，但 UI 和保证不�
 |---|---|---|---|---|---|
 | elevated（独立用户）| ❌ 要管理员/企业易崩 | ❌ 需补读 | ✅ 天然 | 低（还自带多余的网络隔离）| 暂缓 |
 | **unelevated（`WRITE_RESTRICTED` + ACL）** | ✅ | ✅ 沿用当前用户正常读能力 | ❌ 不可靠参与 read AccessCheck | **高（接受只做写保护）** | **选它** |
-| Low-IL（完整性级别）| ✅ | ✅ 天然 | ❌ 拦不住 | 中 | 备选 |
+| Low-IL（完整性级别）| ✅ | ✅ 天然 | ❌ 拦不住 | 中 | 不采用：会把真实 workspace 持久标为低完整性，扩大其他 Low-IL 进程的写入面 |
 | WSL2 复用 bwrap | ✅ | — | ✅ | — | 兜底腿，排在 Linux bwrap 之后 |
 
-关键差异 vs Codex：FutureOS 网络全开，不做防火墙、offline-user、本地账号 provisioning。与 macOS 的关键差异则是 `WRITE_RESTRICTED` 只适合构建兼容性良好的写边界，不能可靠复刻 Seatbelt deny-read。第一版接受这一差异并在 UI 明示，不用提示词或 stderr 猜测冒充 OS 读保护。
+与 Codex Unelevated 的关系：两者都保留真实用户作为 token 主体，都使用 `WRITE_RESTRICTED + capability SID + NTFS ACL`，都给可写根的后代授予 `DELETE` 而不向父目录 capability 授予 `FILE_DELETE_CHILD`，也都不获得 Elevated 独立用户的身份边界。FutureOS 的主要扩展是 request-scoped `file/subtree` 路径审批和自身的 capability 生命周期；这不会提升 Windows 原语本身的能力上限。Codex 的 Unelevated 原型、方案取舍及当前 Elevated 架构可参考 [OpenAI《为 Windows 上的 Codex 构建安全高效的沙箱环境》（简体中文）](https://openai.com/zh-Hans-CN/index/building-codex-windows-sandbox/)。
+
+关键产品差异：FutureOS 网络全开，不做防火墙、offline-user、本地账号 provisioning。与 macOS 的关键差异则是 `WRITE_RESTRICTED` 只适合构建兼容性良好的写边界，不能可靠复刻 Seatbelt deny-read。第一版接受这一差异并在 UI 明示，不用提示词或 stderr 猜测冒充 OS 读保护。
 
 ### 11.2 强制模型
 
@@ -317,11 +321,11 @@ RestrictedToken/NTFS 不向父进程可靠报告“刚才拒绝了哪个对象�
 - **`FILE_DELETE_CHILD` 不受 `WRITE_RESTRICTED` 限制**：`WRITE_RESTRICTED` 只对写数据/追加/新建子项/`DELETE` 做第二道 restricting-SID 检查，删除文件实际走的父目录 `FILE_DELETE_CHILD` 不在其列。因此 `scope=file` 只授 `FILE_GENERIC_WRITE`（不授 `DELETE`），只能阻止改文件内容，**不能阻止删除该文件**——只要当前用户对父目录有普通删除权，受限 token 就仍能 `Remove-Item`。真机 AccessCheck 已验证 `FILE_DELETE_CHILD` 在 external 目录上返回 true、`DELETE`/`FILE_WRITE_DATA` 返回 false。这是 write-protect 模型的知情限制，不是可修复的 ACL 缺陷；文档与测试均不得声称 file scope 阻止删除。
 - **有状态**：写授权修改真实 NTFS ACL。基础策略代际 SID 和幂等 ACE 避免普通命令反复增删；workspace/temp 外的具体目标批准使用 request-scoped SID。并发创建代际/SID/确保 ACE 必须按规范化根串行或事务化；GC 必须知道活动 token/Job 引用，不能提前删除旧代际 deny。卸载/重置提供独立清理流程，安全性不依赖普通命令结束时同步回滚成功。
 - **单例与退出回收**：长驻 Agent 持有 `~/.future/agent/agent-instance.lock` 的用户级文件锁，不能通过改 gRPC 端口启动第二份共享同一状态的 Agent；probe/reset 等无服务维护命令不占该锁。桌面正常退出、强制退出确认后的任务收敛、清数据重启、环境切换和更新重启，都会在 bundled Agent 仍存活时先请求 reset，再终止子进程；独立 Agent 的 Ctrl+C 正常退出也会幂等 reset。桌面不清理或终止外部管理的 Agent。该步骤有超时且是 best-effort：崩溃、强杀、活动 lease 或临时失败时保留元数据，由下次启动 GC、设置重置和卸载流程继续回收。
-- **既有宽写 ACL**：若目标目录本身对 Everyone/相关 restricting SID 可写，可能削弱默认写边界；启动诊断与 smoke 必须覆盖，不能仅靠假设。
+- **既有宽写 ACL**：若目标或父目录本身对 Everyone、Logon SID、`Users`、`Authenticated Users` 或其他当前 token 可命中的宽泛主体授予写入/删除子项权限，可能削弱默认写边界。产品接受“主机 ACL 已把对象判为普通用户可广泛修改”时的这一边界，但测试、review 和发布说明必须准确保留，不能声称所有 workspace 外对象都只由 capability 决定。
 - **网络与读取开放**：任何 shell 可读取当前用户能读的文件并经网络外传；这是 Windows 写保护的明确非目标，在模式选择、首次启用说明和设置页持续说明，不塞进每次路径审批卡片。
 - **shell**：Windows 使用现有 pwsh 7 / Windows PowerShell 5.1 选择逻辑；不再假设 Git Bash/WSL。
 - **CLM 下的输出编码**：受限 token 使 Windows PowerShell 5.1 进入 Constrained Language Mode，而 CLM 禁止 `[Console]::OutputEncoding` 的 setter（也禁止 `GetBytes`/`OpenStandardOutput().Write` 等 .NET 方法），因此 5.1 的 stdout/stderr 只能用其控制台输出代码页输出，wrapper 里设置 UTF-8 均无效。stdout 被重定向到管道（无控制台）时，`[Console]::OutputEncoding` 回退到 **OEM 代码页 `GetOEMCP`**（而非 ANSI 代码页 `GetACP`），故捕获端用 `MultiByteToWideChar(CP_OEMCP)` 解码（`decode_restricted_shell_output`：5.1→OEM、pwsh 7→UTF-8，pwsh 7 硬编码 UTF-8 不受影响）。CJK 区域 ACP 与 OEMCP 相同（如简体中文均为 936/GBK），但西欧/俄文/希腊文不同（1252 vs 437/850、1251 vs 866、1253 vs 737），必须用 OEMCP 才能跨区域正确解码。native 子进程的管道输出同样经过 PowerShell 的 OEM 解码-重编码，`chcp 65001` 在 stdout 为 pipe（无控制台）时本就不生效，因此不引入额外不一致。
-- **elevated（独立用户强隔离）暂缓**：留给将来"要独立安全主体"的企业诉求。
+- **Elevated 暂缓，不属于本期缺陷**：本期明确只实现 Unelevated。后续若需要独立安全主体，优先评估 §11.10 的单专用用户方案；在该阶段到来前，不用 Elevated 的保证倒推本期实现必须创建用户、提权或增加 broker。
 
 ### 11.7 实施阶段
 
@@ -374,6 +378,20 @@ W1～W7 已在当前开发分支形成一个完整纵向闭环：规则计划、
 - Windows 真实环境兼容性、ACL 恢复/重置、升级降级和失败回退均有自动化或可重复的 smoke 证据。
 
 **明确不做（第一版）**：shell deny-read、glob ACE、elevated 独立用户、防火墙/网络隔离、WSL 捆绑、笼统 error 5 整命令脱沙盒放行。
+
+### 11.10 后续路线：单专用用户（候选，未承诺）
+
+若后续产品目标从“当前用户下的写保护”升级为“独立安全主体”，优先考虑 Codex Elevated 的精简变体，而不是继续给真实用户的 Restricted Token 叠加更多 ACE：
+
+1. 由一次性 elevated setup helper 创建一个普通本地用户（暂称 `FutureSandbox`）和 FutureOS 专用本地组；凭证随机生成、用 DPAPI 保存，并确保沙盒用户本身不可读取。
+2. Future Agent 仍以真实用户运行，通过 `CreateProcessWithLogonW` 以 `FutureSandbox` 启动精简 command runner；runner 在专用用户一侧创建最终 `WRITE_RESTRICTED` token，并启动完整子进程树。
+3. workspace/session temp 同时授予专用沙盒组的普通访问 ACE 与路径 capability SID 的 restricting-pass ACE；继续沿用“后代继承 `DELETE`、父目录不授 capability `FILE_DELETE_CHILD`”的设计。
+4. 为保持开发工具兼容性，需要向专用组补充必要的 read/execute ACL，并明确敏感目录排除、ACL 刷新、账户隐藏、升级、reset 和卸载清理策略。
+5. FutureOS 当前网络策略为开放，因此候选第一版只需要一个专用用户，不照搬 Codex 的 Online/Offline 双用户与防火墙；若以后增加网络隔离，再单独评估第二用户和 WFP。
+
+该路线能让真实用户在父目录上的 owner/current-user `FILE_DELETE_CHILD` 不再匹配沙盒命令，但仍不承诺保护本身已向 Everyone、`Users`、`Authenticated Users` 等宽泛主体开放删除权限的对象。它需要 UAC、本地账户 provisioning、跨用户 runner/IPC、read ACL 与完整卸载恢复，必须作为独立里程碑设计和安全 review，不能混入本期 Unelevated PR。
+
+已评估但不采用为下一步的替代路线：解析 PowerShell/shell 命令只能覆盖部分删除入口，不能形成任意子程序的 OS 边界；Low-IL 会改变真实 workspace 的完整性标签和信任模型；minifilter 虽能精确拦截删除/rename，但需要管理员安装、驱动签名和长期内核兼容维护。除非单专用用户方案不可接受，不优先投入这些方向。
 
 ---
 

--- a/desktop/DEV_MD/WINDOWS_SANDBOX_REAL_MACHINE_VALIDATION.md
+++ b/desktop/DEV_MD/WINDOWS_SANDBOX_REAL_MACHINE_VALIDATION.md
@@ -10,6 +10,8 @@
 
 本文只记录必须在 Windows 真机完成的工作。平台无关的生命周期、审批语义、失败路径、格式和 Clippy 测试应在提交前由开发端完成，不在这里重复。
 
+> **本期验收范围冻结（2026-08-25）**：本手册只验收 Unelevated。命令主体仍是当前真实 Windows 用户；不创建本地沙盒用户、不触发 UAC、不运行跨用户 elevated command runner。Reviewer 应按 `SANDBOX_PLAN.md` §11.6 的知情边界判断本期结果，不得把 Elevated 的独立用户、防火墙或完整 deny-read 能力当作本期缺失项。单专用用户仅是 §11.10 的后续候选路线。
+
 ## 1. 验证目标
 
 本轮必须确认以下结论：
@@ -22,6 +24,7 @@
 6. Unicode 路径、PowerShell 5.1/pwsh 7、重定向、管道和大输出不乱码、不死锁。
 7. probe/reset 经发布使用的统一 `future agent` CLI 路由工作，并且所有不支持/失败情况 fail closed。
 8. Desktop 后端的退出顺序始终是“清理权限，再终止 bundled Agent”；超时或 reset 失败仍能继续退出。
+9. 验收报告明确区分内容写入边界与删除边界：不得把 `scope=file`、既有宽 ACL 或父目录 `FILE_DELETE_CHILD` 场景报告成已具备 Elevated 等级的防删除保证。
 
 这些验证通过也**不表示 Windows 与 macOS Seatbelt 等价**。Windows 第一版仍只承诺写保护；shell 读取和网络开放，glob、未来文件名、`FILE_DELETE_CHILD`、Everyone/Logon 宽 ACL 等边界以 `SANDBOX_PLAN.md` §11.6 为准。
 
@@ -450,6 +453,8 @@ Windows 11 Pro、PowerShell 7、中文用户名等 P2 多主机矩阵因当前�
 | W7-06 外部 Agent | 手工启动外部 Agent，再启动 Desktop | 以外部 Agent 的 probe 为准；Desktop 不启动第二个 Agent，选项可用性与外部 Agent 一致 |
 | W7-07 重启与回退 | 保存 sandbox 档后正常重启；另外检查已有的 probe 失败/不可用单测 | probe 仍通过时保留 sandbox；不可用时选项隐藏并将已保存值改为 `manual` |
 | W7-08 退出回收 | 执行过 sandbox 命令后正常退出 FutureOS，运行生命周期脚本 `ExpectStopped` | Desktop/Agent 进程为 0，capability record 为 0；用户文件保留，没有非 FutureOS DACL 被覆盖 |
+
+W7-03～W7-05 的“写入”验收指文件内容创建/修改，不包含“允许修改单个文件但绝对禁止删除”的保证。Unelevated 下，当前真实用户对父目录已有的 `FILE_DELETE_CHILD` 可能允许删除目标或 sibling；Everyone/Logon/`Users`/`Authenticated Users` 等既有宽 ACL 也可能削弱边界。出现这类结果时应按 `SANDBOX_PLAN.md` §11.6 记录为已知能力限制，而不是修改测试去宣称已阻止删除，也不是据此要求本期临时加入 Elevated。
 
 为 W7-03～W7-05 准备可重复判断的 workspace 外目标（在启用 sandbox 前执行）：
 

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -20,20 +20,20 @@ static COMMAND_EPISODE: LazyLock<super::FailureEpisode> = LazyLock::new(Default:
 
 type ReplySlot = Arc<tokio::sync::Mutex<Option<Vec<u8>>>>;
 
-async fn product_sandbox_available() -> bool {
+async fn product_sandbox_available() -> Result<bool, crate::AppError> {
     #[cfg(target_os = "macos")]
     {
-        true
+        Ok(true)
     }
     #[cfg(target_os = "windows")]
     {
         crate::agent_bridge::probe_windows_sandbox()
             .await
-            .is_ok_and(|result| result.available)
+            .map(|result| result.available)
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        false
+        Ok(false)
     }
 }
 
@@ -783,7 +783,13 @@ async fn handle_command(
         "get_settings" => {
             match crate::store::get_app_settings() {
                 Ok(settings) => {
-                    let sandbox_available = product_sandbox_available().await;
+                    let sandbox_available = match product_sandbox_available().await {
+                        Ok(available) => available,
+                        Err(error) => {
+                            reply(client, &msg, false, Value::Null, Some(&error.to_string())).await;
+                            return;
+                        }
+                    };
                     reply(
                         client,
                         &msg,
@@ -807,8 +813,15 @@ async fn handle_command(
             // here is the same as flipping it in the desktop Settings. It takes
             // effect on the next session establishment, where the bridge pushes
             // it to the agent via `set_agent_sandbox_policy`.
-            let tier = if cmd.tier == "sandbox" && !product_sandbox_available().await {
-                "manual".to_string()
+            let tier = if cmd.tier == "sandbox" {
+                match product_sandbox_available().await {
+                    Ok(true) => cmd.tier.clone(),
+                    Ok(false) => "manual".to_string(),
+                    Err(error) => {
+                        reply(client, &msg, false, Value::Null, Some(&error.to_string())).await;
+                        return;
+                    }
+                }
             } else {
                 cmd.tier.clone()
             };

--- a/desktop/src/components/layout/hooks/useAppSettings.ts
+++ b/desktop/src/components/layout/hooks/useAppSettings.ts
@@ -1,7 +1,10 @@
 import type { AppSettings } from "../../../integrations/storage/appSettings";
 import { useEffect, useRef, useState } from "react";
 import i18n from "../../../i18n";
-import { useSandboxAvailability } from "../../../integrations/agent/useSandboxAvailability";
+import {
+  shouldPersistSandboxFallback,
+  useSandboxAvailability,
+} from "../../../integrations/agent/useSandboxAvailability";
 import { DEFAULT_APP_SETTINGS, getAppSettings, updateAppSettings } from "../../../integrations/storage/appSettings";
 import { errorMessage } from "../../../lib/errors";
 import { emitFutureEvent } from "../../../lib/futureEvents";
@@ -78,18 +81,26 @@ export function useAppSettings(): UseAppSettingsResult {
     await write;
   }
 
+  const sandboxFallbackRequired = shouldPersistSandboxFallback(
+    sandboxAvailability,
+    appSettings.approvalTier,
+  );
+
   useEffect(() => {
-    if (!sandboxAvailability.resolved || sandboxAvailability.available) {
+    if (!sandboxFallbackRequired) {
       sandboxFallbackRef.current = false;
       return;
     }
-    if (appSettings.approvalTier !== "sandbox" || sandboxFallbackRef.current)
+    if (sandboxFallbackRef.current)
       return;
     sandboxFallbackRef.current = true;
     void changeSettings({ approvalTier: "manual" }).finally(() => {
       sandboxFallbackRef.current = false;
     });
-  }, [appSettings.approvalTier, sandboxAvailability.available, sandboxAvailability.resolved]);
+  }, [
+    appSettings.approvalTier,
+    sandboxFallbackRequired,
+  ]);
 
   return { appSettings, changeSettings };
 }

--- a/desktop/src/features/settings/GeneralPage.tsx
+++ b/desktop/src/features/settings/GeneralPage.tsx
@@ -60,8 +60,12 @@ export function GeneralPage({
             onChange={e => onChangeApprovalTier(e.target.value as ApprovalTier)}
           >
             <option value="manual">{t("approvalTier.manual")}</option>
-            {sandboxAvailability.available
-              ? <option value="sandbox">{t("approvalTier.sandbox")}</option>
+            {sandboxAvailability.available || (approvalTier === "sandbox" && !sandboxAvailability.definitive)
+              ? (
+                  <option disabled={!sandboxAvailability.available} value="sandbox">
+                    {t("approvalTier.sandbox")}
+                  </option>
+                )
               : null}
             <option value="off">{t("approvalTier.off")}</option>
           </Select>

--- a/desktop/src/integrations/agent/useSandboxAvailability.test.ts
+++ b/desktop/src/integrations/agent/useSandboxAvailability.test.ts
@@ -1,10 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { probeWindowsSandboxWithRetry, windowsSandboxAvailable } from "./useSandboxAvailability";
+import {
+  probeWindowsSandboxWithRetry,
+  shouldPersistSandboxFallback,
+  windowsSandboxAvailable,
+} from "./useSandboxAvailability";
 
 describe("windowsSandboxAvailable", () => {
   it("reflects the native host probe without a separate product switch", () => {
-    expect(windowsSandboxAvailable({ available: true, code: "available" })).toBe(true);
-    expect(windowsSandboxAvailable({ available: false, code: "write_boundary_failed" })).toBe(false);
+    expect(
+      windowsSandboxAvailable({ available: true, code: "available" }),
+    ).toBe(true);
+    expect(
+      windowsSandboxAvailable({
+        available: false,
+        code: "write_boundary_failed",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldPersistSandboxFallback", () => {
+  it("falls back only for an authoritative unavailable result", () => {
+    expect(
+      shouldPersistSandboxFallback(
+        { available: false, definitive: true, resolved: true },
+        "sandbox",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves the saved tier after a transient probe error", () => {
+    expect(
+      shouldPersistSandboxFallback(
+        { available: false, definitive: false, resolved: true },
+        "sandbox",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -48,14 +79,16 @@ describe("probeWindowsSandboxWithRetry", () => {
   it("rejects after exhausting transient failures", async () => {
     let attempts = 0;
 
-    await expect(probeWindowsSandboxWithRetry(
-      async () => {
-        attempts += 1;
-        throw new Error("connection refused");
-      },
-      [0, 100, 250],
-      async () => {},
-    )).rejects.toThrow("connection refused");
+    await expect(
+      probeWindowsSandboxWithRetry(
+        async () => {
+          attempts += 1;
+          throw new Error("connection refused");
+        },
+        [0, 100, 250],
+        async () => {},
+      ),
+    ).rejects.toThrow("connection refused");
 
     expect(attempts).toBe(3);
   });

--- a/desktop/src/integrations/agent/useSandboxAvailability.ts
+++ b/desktop/src/integrations/agent/useSandboxAvailability.ts
@@ -9,6 +9,7 @@ interface WindowsSandboxProbeResult {
 
 export interface SandboxAvailability {
   available: boolean;
+  definitive: boolean;
   resolved: boolean;
 }
 
@@ -16,14 +17,29 @@ let windowsProbe: Promise<boolean> | null = null;
 
 const WINDOWS_PROBE_RETRY_DELAYS_MS = [0, 100, 250, 500, 1_000, 2_000] as const;
 
-export function windowsSandboxAvailable(result: WindowsSandboxProbeResult): boolean {
+export function windowsSandboxAvailable(
+  result: WindowsSandboxProbeResult,
+): boolean {
   return result.available;
+}
+
+export function shouldPersistSandboxFallback(
+  availability: SandboxAvailability,
+  approvalTier: string,
+): boolean {
+  return (
+    availability.resolved
+    && availability.definitive
+    && !availability.available
+    && approvalTier === "sandbox"
+  );
 }
 
 type WindowsSandboxProbe = () => Promise<WindowsSandboxProbeResult>;
 type Delay = (milliseconds: number) => Promise<void>;
 
-const delay: Delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+const delay: Delay = milliseconds =>
+  new Promise(resolve => setTimeout(resolve, milliseconds));
 
 export async function probeWindowsSandboxWithRetry(
   probe: WindowsSandboxProbe,
@@ -50,8 +66,8 @@ export async function probeWindowsSandboxWithRetry(
 }
 
 function sharedWindowsProbe(): Promise<boolean> {
-  windowsProbe ??= probeWindowsSandboxWithRetry(
-    () => invokeCommand<WindowsSandboxProbeResult>("probe_windows_sandbox"),
+  windowsProbe ??= probeWindowsSandboxWithRetry(() =>
+    invokeCommand<WindowsSandboxProbeResult>("probe_windows_sandbox"),
   ).catch((error) => {
     // Do not permanently cache a transient Agent connection failure. A later
     // mount (for example, opening Settings after startup) gets a fresh attempt.
@@ -63,10 +79,10 @@ function sharedWindowsProbe(): Promise<boolean> {
 
 function initialAvailability(): SandboxAvailability {
   if (isMacOS)
-    return { available: true, resolved: true };
+    return { available: true, definitive: true, resolved: true };
   if (!isWindows)
-    return { available: false, resolved: true };
-  return { available: false, resolved: false };
+    return { available: false, definitive: true, resolved: true };
+  return { available: false, definitive: false, resolved: false };
 }
 
 /**
@@ -84,13 +100,19 @@ export function useSandboxAvailability(): SandboxAvailability {
     void sharedWindowsProbe()
       .then((available) => {
         if (current)
-          setAvailability({ available, resolved: true });
+          setAvailability({ available, definitive: true, resolved: true });
       })
       .catch(() => {
-        // Exhausted connection retries fail closed for this mount. Because the
-        // shared promise was cleared, a later mount can recover automatically.
-        if (current)
-          setAvailability({ available: false, resolved: true });
+        // Exhausted connection/probe retries fail closed for this mount, but
+        // are not an authoritative unsupported verdict. Keep the saved tier so
+        // a later mount can recover automatically.
+        if (current) {
+          setAvailability({
+            available: false,
+            definitive: false,
+            resolved: true,
+          });
+        }
       });
     return () => {
       current = false;

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -35,6 +35,7 @@ import { basename } from "../remote/localPath";
 import { canRecoverMessage } from "../remote/recovery";
 import { colors, radius, spacing } from "../theme/tokens";
 import { Button } from "./Button";
+import { approvalDecisionDisabled } from "./approvalState";
 
 interface TimelineCardProps {
   item: TimelineItem;
@@ -148,6 +149,7 @@ export function PendingApprovalCard({
     action?.category === "windows_write_capability" ? action.targets : undefined;
   const capabilityTarget = capabilityTargets?.length === 1 ? capabilityTargets[0] : undefined;
   const malformedCapability = payload.kind === "windows_write_capability" && !capabilityTargets;
+  const decisionDisabled = approvalDecisionDisabled(submitting, malformedCapability);
   const kindI18n = APPROVAL_KIND_I18N[payload.kind ?? ""];
   const titleText = capabilityTargets
     ? capabilityTarget
@@ -265,7 +267,7 @@ export function PendingApprovalCard({
         <View style={styles.approvalActionLeft}>
           <Button
             compact
-            disabled={submitting || malformedCapability}
+            disabled={decisionDisabled.rejected}
             icon={<X color={colors.ink} size={15} />}
             label={submitting ? t("approval.denying") : t("approval.deny")}
             loading={submitting}
@@ -276,7 +278,7 @@ export function PendingApprovalCard({
         <View style={styles.approvalActionRight}>
           <Button
             compact
-            disabled={submitting}
+            disabled={decisionDisabled.approved}
             icon={<Check color={colors.surface} size={15} />}
             label={submitting ? t("approval.allowing") : t("approval.allowOnce")}
             loading={submitting}

--- a/mobile/src/components/__tests__/approvalState.test.ts
+++ b/mobile/src/components/__tests__/approvalState.test.ts
@@ -1,0 +1,24 @@
+import { approvalDecisionDisabled } from "../approvalState";
+
+describe("approvalDecisionDisabled", () => {
+  test("keeps malformed capabilities rejectable but blocks approval", () => {
+    expect(approvalDecisionDisabled(false, true)).toEqual({
+      approved: true,
+      rejected: false,
+    });
+  });
+
+  test("blocks both decisions while a response is being submitted", () => {
+    expect(approvalDecisionDisabled(true, false)).toEqual({
+      approved: true,
+      rejected: true,
+    });
+  });
+
+  test("allows both decisions for a valid idle request", () => {
+    expect(approvalDecisionDisabled(false, false)).toEqual({
+      approved: false,
+      rejected: false,
+    });
+  });
+});

--- a/mobile/src/components/approvalState.ts
+++ b/mobile/src/components/approvalState.ts
@@ -1,0 +1,18 @@
+export interface ApprovalDecisionDisabled {
+  approved: boolean;
+  rejected: boolean;
+}
+
+/**
+ * A malformed capability must remain rejectable, but no approval path may be
+ * available when the trusted target list cannot be rendered.
+ */
+export function approvalDecisionDisabled(
+  submitting: boolean,
+  malformedCapability: boolean,
+): ApprovalDecisionDisabled {
+  return {
+    approved: submitting || malformedCapability,
+    rejected: submitting,
+  };
+}


### PR DESCRIPTION
## 摘要
- 将 Windows sandbox 的短暂 host probe 错误与确定性不可用区分，避免把已保存的 sandbox 档永久回退为 manual。
- 以状态文件隔离 probe 与活跃 capability lease，避免 probe 与正在运行的 sandbox 作业相互阻塞。
- 修复移动端不完整 capability 请求：保留拒绝入口，仅禁用批准；补充针对性测试。
- 记录本期明确仅交付 Unelevated，以及 FILE_DELETE_CHILD、既有宽 ACL 等删除边界；单专用用户为后续候选路线。

## 验证
- cargo fmt --check（agent、desktop/src-tauri）
- cargo test --manifest-path agent/Cargo.toml
- cargo clippy --all-targets --manifest-path agent/Cargo.toml -- -D warnings
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- npm --prefix desktop test（57 files / 606 tests）
- npm --prefix desktop run lint
- npm --prefix mobile run typecheck
- npm --prefix mobile run lint
- npm --prefix mobile test -- approvalState.test.ts --no-watchman

## 未在本机运行
- Windows 专属 host probe、RestrictedToken 和 ACL 集成测试：当前验证主机为 macOS；真机矩阵与边界已记录在 WINDOWS_SANDBOX_REAL_MACHINE_VALIDATION.md。