### PR TITLE
chore(skills): bump future-skills to 332259d (future-loop v3.1.0)

### DIFF
--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -800,7 +800,9 @@ impl Loop {
             // not a finished answer. End the turn as `incomplete` (keeping the
             // partial text so it isn't lost) rather than presenting a cut-off
             // reply as `complete`. Tool calls, if
-            // any, are left unexecuted — their arguments may be partial.
+            // any, are left unexecuted — their arguments may be partial — but
+            // every tool_call_id must still get a placeholder result or the
+            // next LLM request is rejected with HTTP 400.
             if stream_truncated {
                 self.stream_incomplete
                     .store(true, std::sync::atomic::Ordering::SeqCst);
@@ -811,6 +813,12 @@ impl Loop {
                         assistant_text.len()
                     );
                 }
+                append_skipped_tool_placeholders(
+                    &mut messages,
+                    &agent_tool_calls,
+                    "the stream was truncated",
+                    ctx.save_callback.as_ref(),
+                );
                 return Ok((assistant_text, messages));
             }
 
@@ -822,6 +830,15 @@ impl Loop {
                 stop_fn(llm_msgs, &assistant_text)
             });
             if stop_hit {
+                // The stop condition fired while the model had emitted tool
+                // calls; they are never executed, so append placeholder
+                // results to keep the conversation API-valid for the next run.
+                append_skipped_tool_placeholders(
+                    &mut messages,
+                    &agent_tool_calls,
+                    "the stop condition fired",
+                    ctx.save_callback.as_ref(),
+                );
                 return Ok((assistant_text, messages));
             }
 
@@ -1127,6 +1144,35 @@ fn has_unclosed_string(value: &str) -> bool {
         }
     }
     in_string
+}
+
+/// Append placeholder tool-result messages for tool calls that were never
+/// executed (truncated stream or stop condition). Without a matching tool
+/// message per tool_call_id, the LLM API rejects the conversation on the
+/// next request with HTTP 400: "An assistant message with 'tool_calls'
+/// must be followed by tool messages responding to each 'tool_call_id'".
+fn append_skipped_tool_placeholders(
+    messages: &mut Vec<AgentMessage>,
+    tool_calls: &[AgentToolCall],
+    reason: &str,
+    save: Option<&crate::agent::PersistCallback>,
+) {
+    for tc in tool_calls {
+        let note = format!(
+            "[Tool execution skipped — {} was not executed because {reason}]",
+            tc.name
+        );
+        let mut placeholder = AgentMessage {
+            role: "tool".to_string(),
+            content: vec![ContentBlock::tool_result(tc.id.clone(), &note, false)],
+            name: tc.name.clone(),
+            ..Default::default()
+        };
+        if let Some(save) = save {
+            save(&mut placeholder);
+        }
+        messages.push(placeholder);
+    }
 }
 
 /// Returns true when the LLM error was caused by request body exceeding
@@ -1744,6 +1790,76 @@ mod tests {
         assert!(loop_
             .stream_incomplete
             .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn truncated_stream_with_tool_calls_appends_placeholder_results() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![
+            ev_toolcall_start(0, "call_1", "echo", "{}"),
+            ev_toolcall_end(),
+            ModelStreamEvent::Finish {
+                reason: FinishReason::Incomplete,
+                usage: None,
+            },
+        ])]);
+        let saved = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let ctx = StreamContext {
+            save_callback: Some({
+                let saved = saved.clone();
+                Arc::new(move |m: &mut AgentMessage| saved.lock().push(m.role.clone()))
+            }),
+            ..Default::default()
+        };
+        let loop_ = Loop::new(provider, "mock");
+        let (_, messages) = loop_
+            .run_streaming_with_messages(user_messages("hi"), &ctx, noop_on_text, |_| {}, None)
+            .await
+            .unwrap();
+        // user, assistant(tool_calls), placeholder tool result — the next
+        // run must be able to send this history without an HTTP 400.
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1].tool_calls().len(), 1);
+        assert_eq!(messages[2].role, "tool");
+        assert_eq!(messages[2].tool_call_id(), "call_1");
+        assert!(messages[2].text().contains("stream was truncated"));
+        // The placeholder is persisted so a reload cannot resurrect the
+        // dangling assistant tool_calls.
+        assert!(saved.lock().contains(&"tool".to_string()));
+        assert!(loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stop_condition_with_tool_calls_appends_placeholder_results() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![
+            ev_toolcall_start(0, "call_1", "echo", "{}"),
+            ev_toolcall_end(),
+            ModelStreamEvent::Finish {
+                reason: FinishReason::ToolCalls,
+                usage: None,
+            },
+        ])]);
+        let config = crate::types::AgentConfig {
+            stop_condition: Some(Arc::new(|_, _| true)),
+            ..Default::default()
+        };
+        let loop_ = Loop::new(provider, "mock").with_config(config);
+        let (_, messages) = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1].tool_calls().len(), 1);
+        assert_eq!(messages[2].role, "tool");
+        assert_eq!(messages[2].tool_call_id(), "call_1");
+        assert!(messages[2].text().contains("stop condition"));
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -7,8 +7,27 @@ use tokio_stream::StreamExt;
 
 use super::{Loop, RunEvent, C_GREEN, C_MAGENTA, C_RESET, DEFAULT_MAX_TURNS};
 
-const STREAM_EVENT_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
-const COMPLETE_TOOL_CALL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+/// Per-event idle windows (stream, complete-tool-call) by thinking budget.
+/// High-reasoning models legitimately pause tens of seconds between token
+/// bursts (e.g. while generating tool-call argument JSON after thinking), so
+/// the truncation guard must only fire on genuinely dead streams. A too-tight
+/// window truncates a healthy xhigh run mid-tool-call (measured: DeepSeek
+/// xhigh went 45s+ silent right after emitting a tool-call header, killing
+/// the run at the old 45s limit). Truncation stays safe either way — skipped
+/// tool calls now get persisted placeholder results — but false truncations
+/// still burn turns and force retries.
+fn idle_timeouts_for(thinking_budget: i32) -> (Duration, Duration) {
+    if thinking_budget >= 16_000 {
+        // high / xhigh
+        (Duration::from_secs(180), Duration::from_secs(60))
+    } else if thinking_budget >= 8_000 {
+        // medium
+        (Duration::from_secs(120), Duration::from_secs(45))
+    } else {
+        // minimal / low / unset
+        (Duration::from_secs(90), Duration::from_secs(30))
+    }
+}
 
 impl Loop {
     pub async fn run_streaming_with_messages(
@@ -396,13 +415,15 @@ impl Loop {
             let mut saw_terminal_event = false;
 
             loop {
+                let (stream_idle, complete_tool_call_idle) =
+                    idle_timeouts_for(self.config.thinking_budget);
                 let event_idle_timeout = if current_tool_calls
                     .iter()
                     .any(|tc| tc.as_ref().map(tool_call_args_complete).unwrap_or(false))
                 {
-                    COMPLETE_TOOL_CALL_IDLE_TIMEOUT
+                    complete_tool_call_idle
                 } else {
-                    STREAM_EVENT_IDLE_TIMEOUT
+                    stream_idle
                 };
 
                 let mut event_timed_out = false;
@@ -2739,6 +2760,75 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(text, "stuck");
+        assert!(loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn idle_timeouts_scale_with_thinking_budget() {
+        use super::idle_timeouts_for;
+        assert_eq!(
+            idle_timeouts_for(0),
+            (Duration::from_secs(90), Duration::from_secs(30))
+        );
+        assert_eq!(
+            idle_timeouts_for(4_000),
+            (Duration::from_secs(90), Duration::from_secs(30))
+        );
+        assert_eq!(
+            idle_timeouts_for(8_000),
+            (Duration::from_secs(120), Duration::from_secs(45))
+        );
+        assert_eq!(
+            idle_timeouts_for(16_000),
+            (Duration::from_secs(180), Duration::from_secs(60))
+        );
+        assert_eq!(
+            idle_timeouts_for(24_000),
+            (Duration::from_secs(180), Duration::from_secs(60))
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn xhigh_budget_tolerates_silence_beyond_the_old_45s_limit() {
+        // Regression for the 2026-08-24 incident: DeepSeek xhigh emitted a
+        // tool-call header, then went silent while generating argument JSON;
+        // the old flat 45s window truncated the run mid-tool-call. With an
+        // xhigh budget the stream window is 180s, so a 60s silence must NOT
+        // truncate; only the full window expiry ends the turn.
+        let provider = ScriptedProvider::new(vec![Script::PartialThenStall(vec![ev_text("tick")])]);
+        let config = crate::types::AgentConfig {
+            thinking_budget: 24_000,
+            ..Default::default()
+        };
+        let loop_ = std::sync::Arc::new(Loop::new(provider, "mock").with_config(config));
+        let handle = {
+            let loop_ = loop_.clone();
+            tokio::spawn(async move {
+                loop_
+                    .run_streaming_with_messages(
+                        user_messages("hi"),
+                        &StreamContext::default(),
+                        noop_on_text,
+                        |_| {},
+                        None,
+                    )
+                    .await
+            })
+        };
+        // 60s of silence: comfortably past the old 45s limit, still inside
+        // the xhigh 180s window — the run must still be waiting, not
+        // truncated.
+        tokio::time::advance(Duration::from_secs(60)).await;
+        assert!(
+            !handle.is_finished(),
+            "60s silence must not truncate an xhigh run (old 45s limit did)"
+        );
+        // Cross the full 180s window — now the stall guard fires.
+        tokio::time::advance(Duration::from_secs(130)).await;
+        let (text, _) = handle.await.unwrap().unwrap();
+        assert_eq!(text, "tick");
         assert!(loop_
             .stream_incomplete
             .load(std::sync::atomic::Ordering::SeqCst));

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3452,6 +3452,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut thinking = None;
     let mut max_turns = 6u32;
     let mut max_turn_secs = 0u64;
+    let mut max_incomplete_retries = crate::executor::DEFAULT_MAX_INCOMPLETE_RETRIES;
     let mut agent_id = None;
     let mut anonymous = false;
     let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
@@ -3473,6 +3474,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             "--force-workspace",
             "--goal",
             "--lease-secs",
+            "--max-incomplete-retries",
             "--max-turn-secs",
             "--max-turns",
             "--model",
@@ -3492,6 +3494,10 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             max_turns = v.parse().unwrap_or(6);
         } else if k == "--max-turn-secs" {
             max_turn_secs = v.parse().unwrap_or(0);
+        } else if k == "--max-incomplete-retries" {
+            max_incomplete_retries = v
+                .parse()
+                .unwrap_or(crate::executor::DEFAULT_MAX_INCOMPLETE_RETRIES);
         } else if k == "--agent-id" {
             agent_id = Some(v);
         } else if k == "--lease-secs" {
@@ -3577,6 +3583,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         lease_secs,
         agent_id.as_deref(),
         max_turn_secs,
+        max_incomplete_retries,
         force_workspace,
         &mut last_failure_kind,
     )
@@ -3796,6 +3803,10 @@ fn claim_selected_with_lease(
 /// owns the session lifecycle (create before, delete after); this function
 /// only executes turns and writes back their ledger effects.
 ///
+/// `max_incomplete_retries`: consecutive `incomplete` turns (model stream
+/// truncated mid-reply) tolerated on the same todo before the run stops; each
+/// retried turn gets an explicit continue note injected into its envelope.
+///
 /// `last_failure_kind`: out-parameter set to the failure classification of the
 /// LAST executed turn (`None` when no turn ran this invocation) — the caller
 /// uses it to decide session retention (resume vs delete), never the kernel.
@@ -3809,10 +3820,14 @@ async fn run_turns(
     lease_secs: u64,
     agent_id: Option<&str>,
     max_turn_secs: u64,
+    max_incomplete_retries: u32,
     force_workspace: bool,
     last_failure_kind: &mut Option<crate::state::FailureKind>,
 ) -> Result<()> {
     let mut turn = 0u32;
+    // Continue note for the NEXT turn: set when the previous turn ended
+    // incomplete; consumed exactly once by the next execute_turn call.
+    let mut next_continue_note: Option<String> = None;
     // P1-2③: read-model self-healing — a drifted run index means run-history
     // consumers (status, stale-latest-run, run history projection) read stale
     // state; rebuild it from the run files before the first decision and
@@ -3927,6 +3942,7 @@ async fn run_turns(
         // O3: progress signals for this turn (tool starts observed on the
         // stream; read at turn end, including the budget-truncation path).
         let progress = std::sync::Arc::new(TurnProgressTracker::new(now_epoch()));
+        let continue_note = next_continue_note.take();
         let turn_future = execute_turn(
             client,
             session_id,
@@ -3940,6 +3956,7 @@ async fn run_turns(
             Some(&packet),
             Some(runs_dir),
             Some(&progress),
+            continue_note.as_deref(),
         );
         let record = if max_turn_secs > 0 {
             // Wall-clock budget per turn: a long turn that never sees new
@@ -4122,6 +4139,34 @@ async fn run_turns(
                 .unwrap_or(false);
             if stop {
                 break;
+            }
+        }
+        // Incomplete retry: a truncated model stream is an infra event, not a
+        // science failure — the todo stays runnable (no repair budget spent)
+        // and the next turn gets an explicit continue note so the agent picks
+        // up where it left off instead of restarting. Bounded: N consecutive
+        // incomplete turns on the same todo stop the run (the stream keeps
+        // dying mid-turn — relaunch with a fresh session or a lower thinking
+        // level).
+        if record.terminal_state == "incomplete" {
+            let streak = crate::executor::incomplete_streak(&g.history, &todo_id);
+            match crate::executor::incomplete_continue_note(
+                streak,
+                max_incomplete_retries,
+                &todo_id,
+            ) {
+                Some(note) => {
+                    println!(
+                        "   ↻ turn incomplete (stream truncated, attempt {streak}/{max_incomplete_retries}) — next turn continues where it left off"
+                    );
+                    next_continue_note = Some(note);
+                }
+                None => {
+                    println!(
+                        "   ✘ incomplete retry budget exhausted ({streak}/{max_incomplete_retries}) — the model stream keeps truncating mid-turn; stopping (relaunch later or reduce --thinking-level)"
+                    );
+                    break;
+                }
             }
         }
         // P0-2②: outcome_followthrough — auto-derive a follow-up todo for any

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -21,6 +21,13 @@ use crate::state::{
 /// error turns in a single night, every one of them a 429.)
 pub const RATE_LIMIT_BACKOFF_SECS: u64 = 45;
 
+/// Default bound for consecutive `incomplete` turns (model stream truncated
+/// mid-reply) on the same todo before `future loop run` stops. The retry
+/// itself is free — an incomplete turn is an infra event that never consumes
+/// the repair budget — but an endless truncation loop would spin without
+/// progress, so it is bounded.
+pub const DEFAULT_MAX_INCOMPLETE_RETRIES: u32 = 3;
+
 /// Whether a turn's error is a recoverable rate-limit (HTTP 429 / overloaded).
 /// These are NOT science failures — they are throttle events — so the loop
 /// must back off, not count them toward a repair budget or replan.
@@ -161,10 +168,40 @@ fn run_validator(goal: &Goal, todo: &Todo) -> Option<TaskValidation> {
     }
 }
 
+/// Consecutive trailing `incomplete` records for `todo_id` (the just-written
+/// record included). Replayed from the ledger, so an orchestrator restart
+/// does not reset the bound.
+pub fn incomplete_streak(history: &[RunRecord], todo_id: &str) -> u32 {
+    history
+        .iter()
+        .rev()
+        .take_while(|r| r.todo_id == todo_id && r.terminal_state == "incomplete")
+        .count() as u32
+}
+
+/// The continue note injected into the next turn's envelope when the previous
+/// turn ended `incomplete`, or `None` when the retry bound is exhausted and
+/// the run must stop. A truncated stream is an infra event, not a science
+/// failure — the agent gets an explicit "continue where you left off" instead
+/// of a bare re-offer of the same todo (which invites restarting from scratch).
+pub fn incomplete_continue_note(streak: u32, max_retries: u32, todo_id: &str) -> Option<String> {
+    if max_retries == 0 || streak >= max_retries {
+        return None;
+    }
+    Some(format!(
+        "CONTINUE: your previous turn for todo {todo_id} ended INCOMPLETE \
+         (the model stream was truncated mid-reply). Pick up exactly where \
+         you left off — do not restart work that already completed. \
+         (incomplete attempt {streak}/{max_retries})"
+    ))
+}
+
 /// Execute one bounded turn for `todo` and return the ledger entry (spend).
 /// `decision_summary` (G-9): the `ShouldRunPacket` from the decision kernel,
 /// embedded in the turn envelope so the agent sees the decision context
 /// (mode / reason / arbitration) alongside the instruction.
+/// `continue_note`: injected at the top of the turn message when the previous
+/// turn ended incomplete (bounded retry).
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_turn(
     client: &mut AgentClient,
@@ -177,6 +214,7 @@ pub async fn execute_turn(
     decision_summary: Option<&crate::contract::ShouldRunPacket>,
     runs_dir: Option<std::path::PathBuf>,
     progress: Option<&TurnProgressTracker>,
+    continue_note: Option<&str>,
 ) -> Result<RunRecord> {
     if !boundary_injected {
         client
@@ -190,7 +228,10 @@ pub async fn execute_turn(
     // Surface the backing agent session id so in-turn tooling (e.g. trace
     // converters) can locate the real session deterministically instead of
     // guessing by file mtime.
-    let message = format!("session: {session_id}\n{message}");
+    let message = match continue_note {
+        Some(note) => format!("{note}\n\nsession: {session_id}\n{message}"),
+        None => format!("session: {session_id}\n{message}"),
+    };
     // Idempotency key owned by the orchestrator — retry must not double-execute.
     let client_request_id = format!("turn-{}-{}", turn, todo.id);
 
@@ -300,7 +341,6 @@ pub fn writeback(
 #[cfg(test)]
 mod validator_tests {
     use super::validator_tautology;
-
     #[test]
     fn empty_n_literal_is_always_false() {
         assert!(validator_tautology("test -d out && test -n \"\"").is_some());
@@ -335,5 +375,65 @@ mod validator_tests {
         assert!(!is_rate_limit_error(Some("validator exited 1")));
         assert!(!is_rate_limit_error(Some("timeout")));
         assert!(!is_rate_limit_error(None));
+    }
+
+    #[test]
+    fn incomplete_streak_counts_only_trailing_same_todo_records() {
+        use super::{incomplete_streak, RunRecord};
+        fn rec(turn: u32, todo: &str, state: &str) -> RunRecord {
+            RunRecord {
+                turn,
+                todo_id: todo.to_string(),
+                run_id: format!("run-{turn}"),
+                terminal_state: state.to_string(),
+                error: None,
+                tokens_in_delta: 0,
+                tokens_out_delta: 0,
+                cost_delta: 0.0,
+                tools: vec![],
+                evidence: String::new(),
+                recorded_at: 0,
+                spend_source: Some("run".into()),
+                failure_kind: None,
+                validation: None,
+            }
+        }
+        // completed, incomplete, incomplete → streak 2
+        let history = vec![
+            rec(1, "T1", "completed"),
+            rec(2, "T1", "incomplete"),
+            rec(3, "T1", "incomplete"),
+        ];
+        assert_eq!(incomplete_streak(&history, "T1"), 2);
+        // a trailing record for ANOTHER todo breaks the streak
+        let history = vec![
+            rec(1, "T1", "incomplete"),
+            rec(2, "T1", "incomplete"),
+            rec(3, "T2", "completed"),
+        ];
+        assert_eq!(incomplete_streak(&history, "T1"), 0);
+        // a completed record for the same todo breaks the streak
+        let history = vec![
+            rec(1, "T1", "incomplete"),
+            rec(2, "T1", "completed"),
+            rec(3, "T1", "incomplete"),
+        ];
+        assert_eq!(incomplete_streak(&history, "T1"), 1);
+        assert_eq!(incomplete_streak(&[], "T1"), 0);
+    }
+
+    #[test]
+    fn incomplete_continue_note_respects_the_bound() {
+        use super::incomplete_continue_note;
+        let note = incomplete_continue_note(1, 3, "T1").expect("retry allowed");
+        assert!(note.contains("CONTINUE"), "note: {note}");
+        assert!(note.contains("todo T1"), "note: {note}");
+        assert!(note.contains("1/3"), "note: {note}");
+        assert!(incomplete_continue_note(2, 3, "T1").is_some());
+        // streak reaches the bound → stop
+        assert!(incomplete_continue_note(3, 3, "T1").is_none());
+        assert!(incomplete_continue_note(4, 3, "T1").is_none());
+        // a zero bound disables retries entirely
+        assert!(incomplete_continue_note(1, 0, "T1").is_none());
     }
 }

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -485,6 +485,7 @@ fn execute_turn_completed_no_validator() {
             None,
             Some(runs_dir.clone()),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -525,6 +526,7 @@ fn execute_turn_with_decision_summary_and_prev() {
             Some(&packet),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -560,6 +562,7 @@ fn execute_turn_error_turn_skips_validator() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -591,6 +594,7 @@ fn execute_turn_validator_pass_and_fail() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -614,6 +618,7 @@ fn execute_turn_validator_pass_and_fail() {
             1,
             None,
             true,
+            None,
             None,
             None,
             None,

--- a/orchestration/loop/tests/executor_env_drive.rs
+++ b/orchestration/loop/tests/executor_env_drive.rs
@@ -40,6 +40,7 @@ fn validator_spawn_failure_is_inconclusive() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Pointer bump for future-skills#16: documents `future loop run --max-incomplete-retries` + incomplete-turn auto-retry semantics (v3.1.0).