### PR TITLE
feat(loop): human-readable agent session titles from goal objective

### DIFF
--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -446,6 +446,14 @@ pub(crate) fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> S
         new_sess.thinking_level = cmd.level.clone();
     }
 
+    // Automation-minted sessions (loop control plane, channels) may pass an
+    // initial human-readable title in `name` (same proto field as
+    // set_session_name). Empty name keeps the default — the name stays empty
+    // until the user renames or a client derives one from the first message.
+    if !cmd.name.is_empty() {
+        new_sess.set_session_name(&cmd.name);
+    }
+
     // Restore entries from a pre-existing session (forked or persisted).
     if let Some((entries, disk_model)) = existing_entries {
         // Gate image re-hydration on the model that will actually run

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -412,6 +412,24 @@ fn new_session_honors_explicit_id_cwd_model_level_and_provenance() {
 }
 
 #[test]
+fn new_session_accepts_initial_human_readable_title() {
+    let state = make_app_state();
+    let mut cmd = make_cmd_for("new_session", "ns-titled");
+    cmd.name = "把 readme 更新成中文".to_string();
+    let resp = parse_response(&handle_command_internal(&state, cmd));
+    assert_eq!(resp["success"], true);
+    let session = state.get_session("ns-titled").unwrap();
+    assert_eq!(session.read().session_name(), "把 readme 更新成中文");
+
+    // No name → default empty (clients derive a display name later).
+    let cmd2 = make_cmd_for("new_session", "ns-untitled");
+    let resp2 = parse_response(&handle_command_internal(&state, cmd2));
+    assert_eq!(resp2["success"], true);
+    let sess2 = state.get_session("ns-untitled").unwrap();
+    assert_eq!(sess2.read().session_name(), "");
+}
+
+#[test]
 fn new_session_legacy_provenance_via_custom_instructions() {
     let state = make_app_state();
     let mut cmd = make_cmd_for("new_session", "ns-legacy");

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -162,14 +162,17 @@ impl AgentClient {
     }
 
     /// Create a fresh, isolated session for this goal. One goal = one session
-    /// (LoopX: durable identity is the goal, not a chat thread).
-    pub async fn new_session(&mut self, cwd: &str) -> Result<String> {
+    /// (LoopX: durable identity is the goal, not a chat thread). `title` is a
+    /// human-readable session name (the goal objective, truncated) surfaced in
+    /// agent session lists instead of an empty/default name.
+    pub async fn new_session(&mut self, cwd: &str, title: &str) -> Result<String> {
         let resp = self
             .call(
                 "new_session",
                 "",
                 RpcCommand {
                     cwd: cwd.to_string(),
+                    name: title.to_string(),
                     ..Default::default()
                 },
             )

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3550,6 +3550,9 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
                 .map(|r| r.session_id.clone()),
         }
     };
+    // Human-readable session title for agent session lists: the goal
+    // objective, bounded so long objectives don't produce unwieldy names.
+    let session_title = crate::decision::truncate(&goal0.objective, 60);
     let session_id = match want_session {
         Some(id) if client.session_alive(&id).await => {
             println!("   ⤺ resuming session {id} (policy {session_policy})");
@@ -3557,9 +3560,9 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         }
         Some(id) => {
             println!("   ⚠ retained session {id} is no longer alive — starting fresh");
-            client.new_session(&goal0.cwd).await?
+            client.new_session(&goal0.cwd, &session_title).await?
         }
-        None => client.new_session(&goal0.cwd).await?,
+        None => client.new_session(&goal0.cwd, &session_title).await?,
     };
     if let Some(m) = model {
         client.set_model(&session_id, &m).await?;
@@ -6072,7 +6075,7 @@ async fn cmd_doctor(store: &Store, args: &[String]) -> Result<()> {
     if let Some(addr) = &agent_addr {
         let probe = async {
             let mut client = crate::agent_client::AgentClient::connect(addr).await?;
-            let session = client.new_session("/tmp").await?;
+            let session = client.new_session("/tmp", "loop doctor probe").await?;
             let totals = client.session_totals(&session).await?;
             anyhow::Ok(format!(
                 "session {session} live (tokens_in={} tokens_out={})",

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -68,7 +68,10 @@ fn session_and_command_happy_paths() {
         let (addr, shared) = spawn_mock(MockState::default()).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
 
-        let session = client.new_session("/tmp").await.unwrap();
+        let session = client
+            .new_session("/tmp", "把 readme 更新成中文")
+            .await
+            .unwrap();
         assert_eq!(session, "mock-session-1");
 
         client
@@ -101,6 +104,11 @@ fn session_and_command_happy_paths() {
         client.delete_session(&session).await.unwrap();
 
         let recorded = shared.lock().unwrap().recorded.clone();
+        assert_eq!(
+            shared.lock().unwrap().new_session_names,
+            vec!["把 readme 更新成中文".to_string()],
+            "new_session must carry the human-readable title on the wire"
+        );
         for expected in [
             "new_session",
             "append_system_prompt",
@@ -126,7 +134,7 @@ fn command_error_paths() {
         // success=false with an error message.
         let (addr, _) = spawn_mock(MockState::fail("new_session")).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let err = client.new_session("/tmp").await.unwrap_err();
+        let err = client.new_session("/tmp", "t").await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("mock_error"), "{msg}");
         assert!(msg.contains("mock failure for new_session"), "{msg}");
@@ -160,7 +168,7 @@ fn command_error_paths() {
         };
         let (addr, _) = spawn_mock(st).await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
-        let err = client.new_session("/tmp").await.unwrap_err();
+        let err = client.new_session("/tmp", "t").await.unwrap_err();
         assert!(format!("{err:#}").contains("missing sessionId"));
 
         // prompt payload without run_id.

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -64,6 +64,8 @@ pub struct MockState {
     pub models_payload: Option<String>,
     /// Command types seen, in order (for assertions).
     pub recorded: Vec<String>,
+    /// `name` field of every new_session command seen (wire-level title).
+    pub new_session_names: Vec<String>,
 }
 
 impl MockState {
@@ -132,6 +134,7 @@ impl FutureAgent for MockAgent {
         let data = match cmd.r#type.as_str() {
             "new_session" => {
                 st.sessions_created += 1;
+                st.new_session_names.push(cmd.name.clone());
                 let id = format!("mock-session-{}", st.sessions_created);
                 st.live_sessions.insert(id.clone());
                 format!("{{\"sessionId\":\"{}\"}}", id)

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -119,7 +119,8 @@ message RpcCommand {
   optional int64 offset = 96;
   optional int64 limit = 97;
 
-  // Session name (set by /name command).  Used with set_session_name.
+  // Session name (set by /name command).  Used with set_session_name, and
+  // accepted by new_session as the initial human-readable session title.
   string name = 93;
 
   // ── new_session cwd ────────────────────────────────────────────────────

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -57,7 +57,8 @@ pub struct RpcCommand {
     pub offset: ::core::option::Option<i64>,
     #[prost(int64, optional, tag = "97")]
     pub limit: ::core::option::Option<i64>,
-    /// Session name (set by /name command).  Used with set_session_name.
+    /// Session name (set by /name command).  Used with set_session_name, and
+    /// accepted by new_session as the initial human-readable session title.
     #[prost(string, tag = "93")]
     pub name: ::prost::alloc::string::String,
     /// Working directory for the new session.  The agent resolves "~" and


### PR DESCRIPTION
## 问题

loop 控制平面通过 gRPC `new_session` 创建的 agent session 不带任何名称，在 session 列表（TUI/GUI）里显示为空，无法一眼看出对应哪个 goal。

## 改动

- **loop**：`AgentClient::new_session` 增加 `title` 参数，`cmd_run` 用 goal 的 objective（`truncate(…, 60)`，UTF-8 安全）作为标题；doctor 探测用固定标签。
- **agent**：`cmd_new_session` 接受非空 `cmd.name` 作为初始 session 名（空则保持默认行为，不影响 TUI/GUI/channels 等其他客户端）。
- **proto**：`name` 字段注释说明 `new_session` 也接受它作为初始标题（仅注释变更，重新生成 `proto.rs` 保持 CI freshness 检查通过）。
- **测试**：agent 侧新增初始标题行为测试（含空名默认）；loop mock agent 记录 `new_session` 的 `name` 字段并断言标题真正上了 wire。

## 验证

- `cargo test`：agent 1388 / loop 全部 / future-rpc / tui 810 / cli 697 / channels / desktop backend 1014 全绿（HOME 隔离跑法）
- clippy `--workspace --all-targets -- -D warnings`：agent / loop / rpc / desktop backend 干净
- rustfmt workspace + desktop backend 干净
- proto codegen freshness：`REGENERATE_PROTO=1` 再生成后 diff 已纳入提交