### PR TITLE
fix(desktop): stabilize session updates and streaming

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -66,6 +66,11 @@ pub struct Loop {
     /// Cached model registry — avoids re-deserialising the 906-model catalog
     /// on auto-compaction checks and image-support queries inside the hot loop.
     pub model_registry: Option<Arc<parking_lot::RwLock<crate::models::Registry>>>,
+    /// Force one threshold-gated context-fit check immediately before the
+    /// run's first LLM request. Session runs enable this even when automatic
+    /// mid-run compaction is disabled, so selecting a smaller model never
+    /// mutates history at click time and cannot send an oversized next request.
+    pub preflight_context_check: bool,
     /// Mid-turn steering notes: orchestrators/injected operator messages that
     /// must reach a RUNNING turn. The run loop drains this cell at every step
     /// and appends pending notes to the system prompt of the next LLM call.
@@ -96,6 +101,7 @@ impl Loop {
             last_prompt_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             stream_incomplete: Arc::new(AtomicBool::new(false)),
             model_registry: None,
+            preflight_context_check: false,
             steering_notes: Arc::new(Mutex::new(vec![])),
         }
     }
@@ -134,6 +140,7 @@ impl Loop {
         copy.verbose = self.verbose;
         copy.parallel_tools = self.parallel_tools;
         copy.model_registry = self.model_registry.clone();
+        copy.preflight_context_check = self.preflight_context_check;
         copy.context_manager = self.context_manager.clone();
         copy.active_checkpoint = self.active_checkpoint.clone();
         // Share the steering cell with the snapshot so notes pushed while the

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -112,11 +112,23 @@ impl Loop {
             } else {
                 crate::compaction::CompactionPhase::MidTurn
             };
+            // Model selection is a control-plane change only: it must never
+            // compact history when the user clicks the selector. A real session
+            // enables this preflight guard on its run snapshot, so the first LLM
+            // request checks the selected model's actual context window here.
+            // `ModelContextDownshift` is threshold-gated but bypasses the user's
+            // automatic mid-run compaction preference; no checkpoint is written
+            // unless the request truly needs one to fit.
+            let automatic_trigger = if turn == 0 && self.preflight_context_check {
+                crate::compaction::CompactionTrigger::ModelContextDownshift
+            } else {
+                crate::compaction::CompactionTrigger::Automatic
+            };
             let automatic_operation_id = format!("cmp_{}", crate::utils::generate_entry_id());
             let emit_automatic_started = || {
                 on_event(RunEvent::CompactionStarted {
                     operation_id: automatic_operation_id.clone(),
-                    trigger: crate::compaction::CompactionTrigger::Automatic,
+                    trigger: automatic_trigger,
                     phase: automatic_phase,
                 });
             };
@@ -130,7 +142,7 @@ impl Loop {
                     manager
                         .prepare_semantic_with_lifecycle(
                             projected,
-                            crate::compaction::CompactionTrigger::Automatic,
+                            automatic_trigger,
                             automatic_phase,
                             None,
                             self.provider.as_ref(),
@@ -150,7 +162,7 @@ impl Loop {
                         if let Err(error) = commit(&checkpoint) {
                             on_event(RunEvent::CompactionFailed {
                                 operation_id: automatic_operation_id.clone(),
-                                trigger: crate::compaction::CompactionTrigger::Automatic,
+                                trigger: automatic_trigger,
                                 phase: automatic_phase,
                                 error: error.to_string(),
                             });
@@ -168,7 +180,7 @@ impl Loop {
                 Err(error) => {
                     on_event(RunEvent::CompactionFailed {
                         operation_id: automatic_operation_id.clone(),
-                        trigger: crate::compaction::CompactionTrigger::Automatic,
+                        trigger: automatic_trigger,
                         phase: automatic_phase,
                         error: error.to_string(),
                     });
@@ -2004,6 +2016,64 @@ mod tests {
         assert_eq!(prompts.len(), 1);
         assert!(prompts[0].contains("base"));
         assert!(prompts[0].contains("be brief"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn llm_preflight_compacts_only_when_the_selected_model_requires_it() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![ev_text("ok"), ev_stop()])]);
+        let mut loop_ = Loop::new(provider, "small");
+        loop_.context_manager = Some(crate::compaction::ContextManager {
+            // The model-fit guard is mandatory and independent from optional
+            // automatic compaction between tool turns.
+            enabled: false,
+            reserve_tokens: 1,
+            keep_recent_tokens: 1,
+            context_window: 1,
+            model: "small".into(),
+        });
+        loop_.preflight_context_check = true;
+        let mut messages = user_messages("old");
+        messages.push(AgentMessage {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::text("older reply")],
+            ..Default::default()
+        });
+        messages.push(AgentMessage::new_user("user", serde_json::json!("latest")));
+        let triggers = Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        let (text, _) = loop_
+            .run_streaming_with_messages(
+                messages,
+                &StreamContext {
+                    on_checkpoint: Some(Arc::new(|_| Ok(()))),
+                    ..Default::default()
+                },
+                noop_on_text,
+                {
+                    let triggers = triggers.clone();
+                    move |event| match event {
+                        RunEvent::CompactionStarted { trigger, .. } => {
+                            triggers.lock().push(trigger)
+                        }
+                        RunEvent::CompactionCommitted { checkpoint, .. } => {
+                            triggers.lock().push(checkpoint.trigger)
+                        }
+                        _ => {}
+                    }
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(text, "ok");
+        assert_eq!(
+            triggers.lock().as_slice(),
+            [
+                crate::compaction::CompactionTrigger::ModelContextDownshift,
+                crate::compaction::CompactionTrigger::ModelContextDownshift,
+            ]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -406,17 +406,11 @@ impl ServerSession {
             .map(|m| format!("{}/{}", m.provider, m.id))
             .unwrap_or_else(|| model.to_string());
 
-        let current_context_window = self
-            .model_registry
-            .read()
-            .resolve(&self.model)
-            .map(|m| m.context_window)
-            .unwrap_or(1_000_000);
-
         // Construct the selected provider before changing any session state.
-        // Besides making the switch atomic from the loop's perspective, this
-        // provider is the only allowed fallback when the old model cannot
-        // summarize a context that must fit the newly selected smaller window.
+        // This keeps the switch atomic from the next run's perspective. Context
+        // fit is deliberately NOT checked here: a selector click must not write
+        // a checkpoint. The run loop checks immediately before its first LLM
+        // request, using this newly selected provider and model window.
         let new_provider = if let Some(model_config) = resolved.as_ref() {
             let max_tokens = Some(crate::models::effective_max_tokens(model_config));
             let auth = crate::AuthStore::load();
@@ -446,22 +440,6 @@ impl ServerSession {
             None
         };
 
-        if canonical_model != self.model {
-            if let Some(model_config) = resolved.as_ref() {
-                if model_config.context_window < current_context_window {
-                    self.compact_with_policy(
-                        "",
-                        crate::compaction::CompactionTrigger::ModelContextDownshift,
-                        crate::compaction::CompactionPhase::PreTurn,
-                        model_config.context_window,
-                        new_provider
-                            .clone()
-                            .map(|provider| (provider, model_config.id.clone())),
-                    )?;
-                }
-            }
-        }
-
         // Update the agent loop in one shot — both model name and provider endpoint.
         // Fail explicitly when the loop is busy so the caller knows to retry
         // rather than silently continuing with the old model. Active runs use
@@ -484,8 +462,9 @@ impl ServerSession {
                 self.strip_image_content_from_messages();
             }
 
-            // The fresh provider was built and validated before downshift
-            // compaction, so the loop switch cannot expose a half-built client.
+            // The fresh provider was built and validated before publishing the
+            // selection, so the next-run control plane cannot expose a
+            // half-built client.
             if let Some(provider) = new_provider {
                 loop_.provider = provider;
             }
@@ -2911,8 +2890,8 @@ mod tests {
         assert_eq!(started_data["operation_id"], committed_data["operation_id"]);
     }
 
-    #[test]
-    fn model_context_downshift_compacts_before_switching_models() {
+    #[tokio::test]
+    async fn model_context_downshift_defers_compaction_until_llm_preflight() {
         let mut session = make_test_session("model-downshift");
         let model = |id: &str, context_window: i32| crate::models::Model {
             id: id.to_string(),
@@ -2976,6 +2955,30 @@ mod tests {
         session.set_model("test/small").unwrap();
 
         let loaded = session.session_manager.load(&session.session_id).unwrap();
+        assert!(
+            crate::session::latest_context_checkpoint(&loaded.entries).is_none(),
+            "selecting a model must not compact history before an LLM request"
+        );
+        assert_eq!(session.model, "test/small");
+        assert_eq!(session.agent_loop.try_read().unwrap().model, "small");
+
+        // The first actual request under the selected model performs the
+        // threshold check and commits the checkpoint before calling the model.
+        std::fs::create_dir_all(&session.cwd).unwrap();
+        session.agent_loop.try_write().unwrap().provider = Arc::new(SummaryProvider);
+        let lease = session
+            .prompt("next interaction", &[], &[], Some("run-after-switch"), None)
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while session.runtime.snapshot().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(lease.run_id, "run-after-switch");
+
+        let loaded = session.session_manager.load(&session.session_id).unwrap();
         let checkpoint = crate::session::latest_context_checkpoint(&loaded.entries).unwrap();
         assert_eq!(
             checkpoint.trigger,
@@ -2986,8 +2989,6 @@ mod tests {
             Some(crate::compaction::CompactionPhase::PreTurn)
         );
         assert_eq!(checkpoint.context_window, 32_000);
-        assert_eq!(session.model, "test/small");
-        assert_eq!(session.agent_loop.try_read().unwrap().model, "small");
     }
 
     #[test]

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -1138,6 +1138,11 @@ impl ServerSession {
             context_window,
             model: summarizer_model,
         });
+        // Always validate the selected model's window at the actual execution
+        // boundary. This guard is separate from optional automatic mid-run
+        // compaction and, because it lives on the per-run snapshot, cannot
+        // affect an already streaming response.
+        r#loop.preflight_context_check = true;
         let checkpoint = self
             .session_manager
             .load(&self.session_id)

--- a/desktop/src-tauri/src/agent_bridge/persist.rs
+++ b/desktop/src-tauri/src/agent_bridge/persist.rs
@@ -7,6 +7,23 @@ use std::path::Path;
 
 use crate::{git_review, store};
 
+/// Whether an Agent event contributes to a GUI-owned projection. The Agent
+/// journal remains the canonical, complete event log; events outside this set
+/// need no duplicate SQLite/tool projection work in the desktop process.
+pub(super) fn requires_gui_projection(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "tool_start"
+            | "toolcall_start"
+            | "tool_end"
+            | "tool_result"
+            | "approval_request"
+            | "approval_decision"
+            | "artifact_created"
+            | "artifact.created"
+    )
+}
+
 pub(super) fn persist_run_event(
     run_id: Option<&str>,
     event_type: &str,
@@ -38,9 +55,22 @@ pub(super) fn persist_run_event(
         store::advance_tool_projection(run_id, std::slice::from_ref(&record));
     }
 
-    // Raw events are durable in the Agent event journal.  Do not create a
+    // Raw events are durable in the Agent event journal. Do not create a
     // second GUI JSONL copy: SQLite receives only independently useful
     // projections needed by sidebar approvals and tool/detail panels.
+    // Tool starts have already advanced the shared in-memory tool projection
+    // above and need no payload parse a second time.
+    if !matches!(
+        event_type,
+        "approval_request"
+            | "approval_decision"
+            | "tool_end"
+            | "tool_result"
+            | "artifact_created"
+            | "artifact.created"
+    ) {
+        return;
+    }
     persist_agent_tool_projection(run_id, event_type, payload, sequence);
 }
 
@@ -567,7 +597,7 @@ mod tests {
     // ── store-backed persistence paths ────────────────────────────────
 
     use super::super::test_support::{seed_run, seed_thread, seed_workspace, TestHome};
-    use super::{event_value, persist_run_event, value_string};
+    use super::{event_value, persist_run_event, requires_gui_projection, value_string};
     use serde_json::json;
 
     struct Fixture {
@@ -587,6 +617,38 @@ mod tests {
             workspace,
             thread,
             run,
+        }
+    }
+
+    #[test]
+    fn only_gui_projection_events_require_blocking_work() {
+        for event_type in [
+            "tool_start",
+            "toolcall_start",
+            "tool_end",
+            "tool_result",
+            "approval_request",
+            "approval_decision",
+            "artifact_created",
+            "artifact.created",
+        ] {
+            assert!(
+                requires_gui_projection(event_type),
+                "{event_type} must retain its GUI projection"
+            );
+        }
+
+        for event_type in [
+            "text_chunk",
+            "thinking_chunk",
+            "usage",
+            "agent_end",
+            "error",
+        ] {
+            assert!(
+                !requires_gui_projection(event_type),
+                "{event_type} should use the journal-only fast path"
+            );
         }
     }
 

--- a/desktop/src-tauri/src/agent_bridge/stream.rs
+++ b/desktop/src-tauri/src/agent_bridge/stream.rs
@@ -6,7 +6,10 @@
 use tokio::time::{sleep, timeout, Duration};
 use tonic::Code;
 
-use super::{connect_agent, persist::persist_run_event};
+use super::{
+    connect_agent,
+    persist::{persist_run_event, requires_gui_projection},
+};
 use crate::agent_proto::StreamRequest;
 
 const AGENT_EVENT_STREAM_TIMEOUT_SECS: u64 = 600;
@@ -85,10 +88,10 @@ fn retryable_stream_code(code: Code) -> bool {
     )
 }
 
-/// Persist a run event on a blocking thread, so the synchronous SQLite write
-/// (and the occasional `git` fork on write/artifact events) doesn't stall the
-/// async event loop. Awaited to preserve event order; errors are logged inside
-/// `persist_run_event`.
+/// Project GUI-owned run state on a blocking thread. Raw events are already
+/// durable in the Agent journal, so token-heavy events bypass this work and
+/// only invalidate the live frontend projection. Projection-bearing events are
+/// awaited to preserve their SQLite/tool lifecycle order.
 pub(super) async fn persist_run_event_off_thread(
     thread_id: &str,
     run_id: Option<&str>,
@@ -96,20 +99,32 @@ pub(super) async fn persist_run_event_off_thread(
     data: String,
     sequence: i64,
 ) {
-    let thread_id = thread_id.to_string();
-    let run_id = run_id.map(str::to_string);
-    let emitted_run_id = run_id.clone();
+    let Some(run_id) = run_id else {
+        return;
+    };
     let status = if event_type == "agent_end" {
         "finalizing"
     } else {
         "running"
     }
     .to_string();
+
+    if !requires_gui_projection(&event_type) {
+        crate::emit_thread_runtime_updated(
+            thread_id.to_string(),
+            run_id.to_string(),
+            status,
+            false,
+        );
+        return;
+    }
+
+    let thread_id = thread_id.to_string();
+    let run_id = run_id.to_string();
+    let emitted_run_id = run_id.clone();
     let _ = tokio::task::spawn_blocking(move || {
-        persist_run_event(run_id.as_deref(), &event_type, &data, sequence);
-        if let Some(run_id) = emitted_run_id {
-            crate::emit_thread_runtime_updated(thread_id, run_id, status, false);
-        }
+        persist_run_event(Some(&run_id), &event_type, &data, sequence);
+        crate::emit_thread_runtime_updated(thread_id, emitted_run_id, status, false);
     })
     .await;
 }
@@ -245,6 +260,19 @@ pub(super) async fn collect_agent_response(
                 break "Future Agent event stream closed before the run terminal.".to_string();
             };
             reconnect_attempt = 0;
+
+            // `StreamEvents` attaches to one session broadcaster. Even an
+            // atomic run attachment therefore continues to receive settings
+            // changes, which are deliberately session-scoped (`run_id == ""`
+            // with their own monotonic `session_idx`). The long-lived observer
+            // owns forwarding those events to the UI/remote clients; this
+            // collector must leave the active run untouched and keep waiting
+            // for its next run-scoped event. In particular, changing model or
+            // thinking level applies to the session's next LLM request without
+            // interrupting the response already streaming.
+            if event.run_id.is_empty() && event.session_idx >= 0 {
+                continue;
+            }
 
             if event.run_id != canonical_run_id {
                 return Err(format!(
@@ -526,6 +554,21 @@ mod tests {
         }
     }
 
+    fn session_event(
+        event_type: &str,
+        session_idx: i64,
+        data: &str,
+    ) -> crate::agent_proto::StreamEvent {
+        crate::agent_proto::StreamEvent {
+            r#type: event_type.to_string(),
+            data: data.to_string(),
+            run_id: String::new(),
+            idx: -1,
+            session_idx,
+            ..Default::default()
+        }
+    }
+
     /// A clean one-shot run: text then a complete agent_end.
     #[tokio::test]
     async fn collect_clean_run_assembles_content() {
@@ -548,6 +591,28 @@ mod tests {
         assert_eq!(attaches.len(), 1);
         assert!(attaches[0].atomic_attach);
         assert_eq!(attaches[0].after_idx, -1);
+    }
+
+    #[tokio::test]
+    async fn collect_ignores_session_settings_changes_during_active_run() {
+        let mock = mock_agent();
+        mock.push_stream(StreamScript::Events(
+            vec![
+                stream_event("run-1", 0, "text_chunk", r#"{"text":"before"}"#),
+                session_event("model_changed", 4, r#"{"model":"provider/next"}"#),
+                session_event("thinking_level_changed", 5, r#"{"level":"high"}"#),
+                stream_event("run-1", 1, "text_chunk", r#"{"text":" after"}"#),
+                stream_event("run-1", 2, "agent_end", r#"{"reason":"complete"}"#),
+            ],
+            None,
+        ));
+
+        let response = collect_agent_response(None, "run-1", "sess-1", "thread-1")
+            .await
+            .expect("session settings must not interrupt the active run");
+
+        assert_eq!(response.content, "before after");
+        assert!(response.complete);
     }
 
     /// The lease-coupled collector path (replica.rs collect) end to end.
@@ -982,7 +1047,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_persists_events_off_thread_for_local_runs() {
+    async fn collect_keeps_fast_path_text_complete_and_projects_tools() {
         let home = TestHome::new("stream-persist");
         let mock = mock_agent();
         let workspace = seed_workspace(home.path(), "ws");
@@ -991,14 +1056,15 @@ mod tests {
 
         mock.push_stream(StreamScript::Events(
             vec![
+                stream_event(&run.id, 0, "text_chunk", r#"{"text":"complete answer"}"#),
                 stream_event(
                     &run.id,
-                    0,
+                    1,
                     "tool_start",
                     r#"{"tool_id":"tc1","tool_name":"shell","tool_args":"{}"}"#,
                 ),
-                stream_event(&run.id, 1, "tool_end", r#"{"tool_id":"tc1","text":"ok"}"#),
-                stream_event(&run.id, 2, "agent_end", r#"{"reason":"complete"}"#),
+                stream_event(&run.id, 2, "tool_end", r#"{"tool_id":"tc1","text":"ok"}"#),
+                stream_event(&run.id, 3, "agent_end", r#"{"reason":"complete"}"#),
             ],
             None,
         ));
@@ -1006,6 +1072,7 @@ mod tests {
             .await
             .expect("collect");
         assert!(response.complete);
+        assert_eq!(response.content, "complete answer");
         // The off-thread persistence is awaited per event, so the tool
         // projection is warm by the time collect returns.
         let input = crate::store::get_tool_call_input(&run.id, "tc1").expect("projection");

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -28,6 +28,11 @@ pub fn get_recent_thread() -> Result<Option<store::ThreadRecord>, crate::AppErro
 }
 
 #[tauri::command]
+pub fn mark_thread_opened(thread_id: String) -> Result<(), crate::AppError> {
+    store::mark_thread_opened(&thread_id)
+}
+
+#[tauri::command]
 pub fn create_thread(
     input: store::CreateThreadInput,
 ) -> Result<store::ThreadRecord, crate::AppError> {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -307,6 +307,12 @@ pub(crate) struct ThreadRuntimeUpdate {
     pub reset_projection: bool,
 }
 
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ThreadRuntimeUpdateBatch {
+    updates: Vec<ThreadRuntimeUpdate>,
+}
+
 static NEXT_RUNTIME_REVISION: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
 static RUNTIME_EMIT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -364,9 +370,9 @@ fn is_terminal_run_status(status: &str) -> bool {
     matches!(status, "completed" | "failed" | "cancelled")
 }
 
-/// Coalesce token-heavy run updates into a single UI notification per run
-/// roughly every 40ms. Persistence remains event-by-event and authoritative;
-/// this channel is only a low-latency projection invalidation signal.
+/// Coalesce token-heavy run updates into one UI batch roughly once per display
+/// frame. Persistence remains authoritative and complete; this channel carries
+/// only low-latency projection invalidations.
 ///
 /// `revision` is assigned here from one process-global monotonic sequence.
 /// Callers must not mix event cursors and wall-clock values into the UI ordering
@@ -448,16 +454,18 @@ fn emit_approvals_updated_on<R: tauri::Runtime>(
     );
 }
 
-/// Emit the coalesced "thread-runtime-updated" updates on a caller-supplied
-/// handle (see [`emit_review_updated_on`]).
+/// Emit one coalesced "thread-runtime-updated" batch on a caller-supplied
+/// handle (see [`emit_review_updated_on`]). One Tauri event crosses the WebView
+/// boundary regardless of how many runs changed during the frame.
 fn emit_runtime_updates_on<R: tauri::Runtime>(
     handle: &tauri::AppHandle<R>,
     updates: Vec<ThreadRuntimeUpdate>,
 ) {
     use tauri::Emitter;
-    for update in updates {
-        let _ = handle.emit("thread-runtime-updated", update);
-    }
+    let _ = handle.emit(
+        "thread-runtime-updated",
+        ThreadRuntimeUpdateBatch { updates },
+    );
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -493,13 +501,13 @@ async fn thread_streaming_monitor_loop() {
     }
 }
 
-/// Drain the runtime-update channel: coalesce bursts within a 40ms window,
+/// Drain the runtime-update channel: coalesce bursts within a 16ms frame window,
 /// then emit the coalesced update. Extracted so the drain/coalesce/emit body
 /// is testable; the `APP_HANDLE` Some arm needs the real Wry handle.
 fn runtime_update_drain_loop(rx: std::sync::mpsc::Receiver<ThreadRuntimeUpdate>) {
     use std::time::{Duration, Instant};
     while let Ok(first) = rx.recv() {
-        let deadline = Instant::now() + Duration::from_millis(40);
+        let deadline = Instant::now() + Duration::from_millis(16);
         let mut rest = Vec::new();
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -787,6 +795,7 @@ pub fn run() {
             get_or_create_chat_workspace,
             get_thread,
             get_recent_thread,
+            mark_thread_opened,
             create_thread,
             rename_thread,
             update_thread_model,
@@ -931,7 +940,7 @@ mod runtime_update_tests {
         emit_review_updated_on, emit_review_updated_via, emit_runtime_updates_on,
         main_window_geometry, runtime_update_drain_loop, sample_thread_streaming,
         sample_thread_streaming_with, size_main_window_to_screen, thread_streaming_monitor_loop,
-        ThreadRuntimeUpdate,
+        ThreadRuntimeUpdate, ThreadRuntimeUpdateBatch,
     };
 
     fn update(run_id: &str, revision: i64, status: &str, reset: bool) -> ThreadRuntimeUpdate {
@@ -987,6 +996,18 @@ mod runtime_update_tests {
         );
 
         assert_eq!(updates, vec![update("run-1", 2, "finalizing", false)]);
+    }
+
+    #[test]
+    fn runtime_update_batch_serializes_the_frontend_contract() {
+        let value = serde_json::to_value(ThreadRuntimeUpdateBatch {
+            updates: vec![update("run-1", 7, "running", true)],
+        })
+        .expect("serialize runtime batch");
+
+        assert_eq!(value["updates"].as_array().map(Vec::len), Some(1));
+        assert_eq!(value["updates"][0]["runId"], "run-1");
+        assert_eq!(value["updates"][0]["resetProjection"], true);
     }
 
     #[test]

--- a/desktop/src-tauri/src/store.rs
+++ b/desktop/src-tauri/src/store.rs
@@ -62,7 +62,7 @@ pub use runs::{
 pub(crate) use runs::{append_run_event, flush_run_event_log_for_test};
 pub use threads::{
     archive_thread, batch_delete_threads, create_thread, delete_thread, delete_thread_with_files,
-    find_thread_by_agent_session, get_recent_thread, get_thread, list_threads,
+    find_thread_by_agent_session, get_recent_thread, get_thread, list_threads, mark_thread_opened,
     move_thread_to_workspace, pin_thread, purge_soft_deleted_threads, rename_thread,
     restore_thread, sync_thread_title, update_thread_model, update_thread_session_id,
     update_thread_thinking_level, ThreadRecord,

--- a/desktop/src-tauri/src/store/runs.rs
+++ b/desktop/src-tauri/src/store/runs.rs
@@ -113,21 +113,28 @@ pub fn create_run(input: CreateRunInput) -> Result<RunRecord, crate::AppError> {
         .filter(|id| !id.trim().is_empty())
         .unwrap_or_else(|| create_id("run"));
     let now = now_millis();
-    let conn = connect()?;
-    conn.execute(
+    let mut conn = connect()?;
+    let tx = conn.transaction()?;
+    tx.execute(
         "INSERT INTO runs (
              id, thread_id, trigger_message_id, status, model_provider, model_id,
              started_at, created_at, updated_at
-         ) VALUES (?1, ?2, ?3, 'running', ?4, ?5, ?6, ?6, ?6)",
+        ) VALUES (?1, ?2, ?3, 'running', ?4, ?5, ?6, ?6, ?6)",
         params![
             id,
-            input.thread_id,
+            &input.thread_id,
             input.trigger_message_id,
             input.model_provider,
             input.model_id,
             now
         ],
     )?;
+    // A run is created immediately before a prompt is delivered to the Agent,
+    // including prompts originating from a paired device. Stamp the activity
+    // in the same transaction so the sidebar reliably moves the conversation
+    // to its most-recent-message position after a refresh.
+    super::threads::mark_thread_message_activity_in(&tx, &input.thread_id, now)?;
+    tx.commit()?;
     let run = loaded(get_run(&id)?, "Created run")?;
     mark_catalog_dirty();
     Ok(run)
@@ -1118,6 +1125,7 @@ mod tests {
     use rusqlite::{params, Connection};
 
     use super::*;
+    use crate::store::db::test_support::guarded_conn;
     use crate::store::schema::SCHEMA;
 
     fn test_conn() -> Connection {
@@ -1137,6 +1145,38 @@ mod tests {
             params![id, status],
         )
         .expect("insert run");
+    }
+
+    #[test]
+    fn create_run_records_thread_message_activity() {
+        let (_home, conn) = guarded_conn("run_thread_activity");
+        conn.execute_batch(
+            "INSERT INTO workspaces (id, name, kind, path, created_at, updated_at)
+                 VALUES ('workspace', 'Workspace', 'user', '/tmp/workspace', 1, 1);
+             INSERT INTO threads (id, workspace_id, mode, title, status, created_at, updated_at)
+                 VALUES ('thread', 'workspace', 'chat', 'Thread', 'active', 1, 1);",
+        )
+        .expect("seed thread");
+        drop(conn);
+
+        create_run(CreateRunInput {
+            id: Some("run_activity".to_string()),
+            thread_id: "thread".to_string(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .expect("create run");
+
+        let conn = connect().expect("connect");
+        let activity: Option<i64> = conn
+            .query_row(
+                "SELECT last_message_at FROM threads WHERE id = 'thread'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read thread activity");
+        assert!(activity.is_some());
     }
 
     #[test]
@@ -1671,8 +1711,6 @@ mod tests {
     }
 
     // ── connect()-backed read wrappers ─────────────────────────────────────
-
-    use crate::store::db::test_support::guarded_conn;
 
     #[test]
     fn run_read_wrappers_query_per_thread() {

--- a/desktop/src-tauri/src/store/threads.rs
+++ b/desktop/src-tauri/src/store/threads.rs
@@ -42,7 +42,7 @@ pub fn list_threads() -> Result<Vec<ThreadRecord>, crate::AppError> {
         "SELECT {THREAD_COLUMNS}
              FROM threads
              WHERE status != 'deleted'
-             ORDER BY pinned DESC, COALESCE(last_message_at, last_opened_at, updated_at) DESC"
+             ORDER BY pinned DESC, COALESCE(last_message_at, updated_at, created_at) DESC"
     ))?;
     let rows = stmt.query_map([], thread_from_row)?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -225,6 +225,31 @@ pub fn update_thread_session_id(thread_id: &str, session_id: &str) -> Result<(),
     let conn = connect()?;
     conn.execute(SQL, params![session_id, now, thread_id])?;
     mark_catalog_dirty();
+    Ok(())
+}
+
+/// Record that a thread was opened without treating the visit as message
+/// activity. `last_opened_at` chooses the startup thread, but deliberately
+/// does not affect the sidebar's conversation order.
+pub fn mark_thread_opened(thread_id: &str) -> Result<(), crate::AppError> {
+    let now = now_millis();
+    const SQL: &str = "UPDATE threads SET last_opened_at = ?1
+         WHERE id = ?2 AND status != 'deleted'";
+    let conn = connect()?;
+    conn.execute(SQL, params![now, thread_id])?;
+    Ok(())
+}
+
+/// Record conversation activity. This is kept separate from `updated_at`:
+/// metadata changes such as a rename must not reorder the rail.
+pub(super) fn mark_thread_message_activity_in(
+    conn: &Connection,
+    thread_id: &str,
+    now: i64,
+) -> Result<(), crate::AppError> {
+    const SQL: &str = "UPDATE threads SET last_message_at = ?1
+         WHERE id = ?2 AND status != 'deleted'";
+    conn.execute(SQL, params![now, thread_id])?;
     Ok(())
 }
 
@@ -703,6 +728,31 @@ mod tests {
         assert!(find_thread_by_agent_session("sess3")
             .expect("find")
             .is_none());
+    }
+
+    #[test]
+    fn sidebar_sort_ignores_open_time_but_opening_is_still_recorded() {
+        let (_home, conn) = guarded_conn("threads_activity_times");
+        seed_two_threads(&conn);
+        conn.execute("UPDATE threads SET pinned = 0 WHERE id = 't1'", [])
+            .expect("unpin t1");
+        drop(conn);
+
+        // t2 was opened more recently (300), but t1's message is newer (200).
+        let ids: Vec<String> = list_threads()
+            .expect("list")
+            .into_iter()
+            .map(|thread| thread.id)
+            .collect();
+        assert_eq!(ids, vec!["t1", "t2"]);
+
+        mark_thread_opened("t1").expect("record open");
+        let thread = get_thread("t1").expect("get").expect("thread");
+        assert!(thread.last_opened_at.is_some());
+        assert_eq!(
+            thread.updated_at, 1,
+            "opening does not become sidebar activity"
+        );
     }
 
     fn chat_input() -> CreateThreadInput {

--- a/desktop/src/components/layout/ActivityRail.tsx
+++ b/desktop/src/components/layout/ActivityRail.tsx
@@ -7,6 +7,7 @@ import {
   Blocks,
   ChevronDown,
   ChevronRight,
+  Download,
   Folder,
   MessageSquare,
   PanelLeft,
@@ -787,7 +788,7 @@ export function ActivityRail({
 
 /**
  * Signed-in account chip (avatar initial + email prefix) that opens a flat
- * popover with Settings / Balance (+Recharge). An Upgrade button sits to the
+ * popover with Settings / Balance (+Recharge). A blue update-download icon sits to the
  * right of the avatar when a new app version is available (opening the Settings
  * update tab). Replaces the plain Settings button at the bottom of the rail.
  *
@@ -839,16 +840,18 @@ function AccountMenuButton({
         {hasUpdate
           ? (
               <button
-                className="ml-auto shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium leading-none text-white transition-colors hover:bg-accent-hover"
+                aria-label={t("userMenu.upgrade")}
+                className="ml-auto inline-flex size-7 shrink-0 items-center justify-center rounded text-accent transition-colors hover:bg-accent-soft"
                 onClick={(event) => {
                   event.stopPropagation();
                   onOpenUpdate?.();
                   close();
                 }}
                 onKeyDown={event => event.stopPropagation()}
+                title={t("userMenu.upgrade")}
                 type="button"
               >
-                {t("userMenu.upgrade")}
+                <Download className="size-4" />
               </button>
             )
           : null}
@@ -895,7 +898,7 @@ function MenuRow({ action, icon: Icon, label, onClick }: { action?: ReactNode; i
   );
 }
 
-/** Solid accent pill used as the right-hand action label (Recharge / Upgrade). */
+/** Solid accent pill used as the right-hand action label (Recharge). */
 function ActionBadge({ children }: { children: ReactNode }) {
   return (
     <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium leading-none text-white">
@@ -915,7 +918,7 @@ function sortThreads(items: StoredThread[]) {
 }
 
 function threadSortTime(thread: StoredThread) {
-  return thread.lastMessageAt ?? thread.lastOpenedAt ?? thread.updatedAt ?? thread.createdAt;
+  return thread.lastMessageAt ?? thread.updatedAt ?? thread.createdAt;
 }
 
 /** Tri-state checkbox for select-all / deselect-all in the selection action bar. */

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { refreshSkills } from "../../integrations/skills/skillsClient";
 import { openExternalUrl } from "../../integrations/storage/files";
 import {
   createWorkspace,
+  markThreadOpened,
   pinThread,
   restoreThread,
 } from "../../integrations/storage/threadStore";
@@ -142,6 +143,14 @@ export function AppShell() {
     return () => window.removeEventListener("future:cwd-changed", handler);
   }, [refreshStore]);
 
+  // Keep the startup/default thread and every user-selected thread eligible
+  // for next-launch restoration. This timestamp is intentionally excluded
+  // from the sidebar's recency sort.
+  useEffect(() => {
+    if (activeThreadId)
+      void markThreadOpened(activeThreadId);
+  }, [activeThreadId]);
+
   const { activeApproval, decideApproval } = useApprovals(activeThread?.id ?? null);
   const {
     agentConnection,
@@ -199,9 +208,14 @@ export function AppShell() {
       // possibly by less than the TTL, which would short-circuit a plain
       // prefetch — so force-revalidate the viewed thread. Other threads
       // revalidate on their next activation.
-      revalidateAgentState(activeThreadId);
+      // A new thread has no authoritative Agent state until its first prompt
+      // creates a session. Preserve its explicit draft model/thinking cache;
+      // forcing get_state now would return nulls and replace the user's pick
+      // with the selected model's default.
+      if (activeThread?.agentSessionId)
+        revalidateAgentState(activeThread.id);
     }
-  }, [activeThreadId, agentConnection.status]);
+  }, [activeThread?.id, activeThread?.agentSessionId, agentConnection.status]);
 
   // BYOK (bring your own key): the user chose to skip FutureOS sign-in and add
   // their own provider. Open Settings → Providers so they can configure it.

--- a/desktop/src/components/layout/hooks/useThreadStore.hook.test.ts
+++ b/desktop/src/components/layout/hooks/useThreadStore.hook.test.ts
@@ -37,8 +37,8 @@ vi.mock("@tauri-apps/api/event", () => ({
   },
 }));
 
-function thread(id: string, workspaceId = "w1", status = "active") {
-  return { id, workspaceId, status } as unknown as StoredThread;
+function thread(id: string, workspaceId = "w1", status = "active", agentSessionId: string | null = `s-${id}`) {
+  return { id, workspaceId, status, agentSessionId } as unknown as StoredThread;
 }
 
 const workspace: StoredWorkspace = { id: "w1", kind: "user" } as unknown as StoredWorkspace;
@@ -76,6 +76,18 @@ describe("useThreadStore", () => {
     expect(h.current.activeThreads.map(t => t.id)).toEqual(["t1", "t2"]);
     // Active thread prefetches agent state.
     expect(prefetchAgentState).toHaveBeenCalledWith("t1");
+    h.unmount();
+  });
+
+  it("does not overwrite a fresh thread's draft selection with null agent state", async () => {
+    const fresh = thread("fresh", "w1", "active", null);
+    listThreads.mockResolvedValue([fresh]);
+    getRecentOrCreateDefaultThread.mockResolvedValue(fresh);
+
+    const h = await mountStore();
+
+    expect(h.current.activeThread?.id).toBe("fresh");
+    expect(prefetchAgentState).not.toHaveBeenCalled();
     h.unmount();
   });
 
@@ -142,14 +154,18 @@ describe("useThreadStore", () => {
     h.unmount();
   });
 
-  it("reduces thread-runtime-updated pushes into run statuses", async () => {
+  it("reduces a thread-runtime-updated batch into run statuses", async () => {
     const h = await mountStore();
     act(() => {
       listeners.get("thread-runtime-updated")?.({
-        payload: { threadId: "t1", runId: "r1", revision: 5, status: "running", resetProjection: false },
+        payload: { updates: [
+          { threadId: "t1", runId: "r1", revision: 5, status: "running", resetProjection: false },
+          { threadId: "t2", runId: "r2", revision: 6, status: "completed", resetProjection: false },
+        ] },
       });
     });
     expect(h.current.threadRunStatuses.t1).toMatchObject({ runId: "r1", status: "running" });
+    expect(h.current.threadRunStatuses.t2).toMatchObject({ runId: "r2", status: "completed" });
     h.unmount();
   });
 
@@ -251,7 +267,7 @@ describe("useThreadStore", () => {
     // A push arrives while the fetch is in flight.
     act(() => {
       listeners.get("thread-runtime-updated")?.({
-        payload: { threadId: "t1", runId: "r9", revision: 9, status: "running", resetProjection: false },
+        payload: { updates: [{ threadId: "t1", runId: "r9", revision: 9, status: "running", resetProjection: false }] },
       });
     });
     expect(h.current.threadRunStatuses.t1).toMatchObject({ runId: "r9" });
@@ -269,7 +285,7 @@ describe("useThreadStore", () => {
     const h = await mountStore();
     act(() => {
       listeners.get("thread-runtime-updated")?.({
-        payload: { threadId: "t1", runId: "r1", revision: 5, status: "running", resetProjection: false },
+        payload: { updates: [{ threadId: "t1", runId: "r1", revision: 5, status: "running", resetProjection: false }] },
       });
     });
     expect(h.current.threadRunStatuses.t1).toBeDefined();

--- a/desktop/src/components/layout/hooks/useThreadStore.ts
+++ b/desktop/src/components/layout/hooks/useThreadStore.ts
@@ -1,4 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
+import type { ThreadRuntimeUpdate, ThreadRuntimeUpdateBatch } from "../../../integrations/agent/runtimeEvents";
 import type { StoredRun, StoredThread, StoredWorkspace } from "../../../integrations/storage/threadStore";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -25,14 +26,6 @@ export interface ThreadRunInfo {
 
 type ThreadRunStatuses = Record<string, ThreadRunInfo | undefined>;
 type ThreadStreamingStatuses = Record<string, boolean>;
-
-interface ThreadRuntimeUpdate {
-  threadId: string;
-  runId: string;
-  revision: number;
-  status: string;
-  resetProjection: boolean;
-}
 
 interface ThreadStreamingUpdate {
   revision: number;
@@ -294,12 +287,15 @@ export function useThreadStore(): ThreadStore {
     deps: [activeThreads, refreshThreadRunStatuses],
   });
   useEffect(() => {
-    const unlisten = listen<ThreadRuntimeUpdate>("thread-runtime-updated", (event) => {
+    const unlisten = listen<ThreadRuntimeUpdateBatch>("thread-runtime-updated", (event) => {
       // A push is newer than any reconciliation query already in flight.
       // Invalidate that query before reducing the event so its stale snapshot
       // cannot revert this status when it eventually resolves.
       runStatusGenRef.current += 1;
-      setThreadRunStatuses(previous => reduceThreadRunStatus(previous, event.payload));
+      setThreadRunStatuses(previous => event.payload.updates.reduce(
+        (statuses, update) => reduceThreadRunStatus(statuses, update),
+        previous,
+      ));
     });
     return () => {
       void unlisten.then(stop => stop());
@@ -344,10 +340,14 @@ export function useThreadStore(): ThreadStore {
   // timer needed. Synchronous reads are stale-while-revalidate, so a late
   // revalidation can never flash the composer back to the draft model.
   useEffect(() => {
-    if (!activeThreadId)
+    // A fresh thread has no Agent session until its first prompt. Its cached
+    // model/thinking values are the user's explicit draft selections; fetching
+    // the honest "no session" payload here would replace them with nulls and
+    // make the composer fall back to the model default before sending.
+    if (!activeThread?.agentSessionId)
       return;
-    prefetchAgentState(activeThreadId);
-  }, [activeThreadId]);
+    prefetchAgentState(activeThread.id);
+  }, [activeThread?.id, activeThread?.agentSessionId]);
 
   return {
     activeThread,

--- a/desktop/src/features/agent/sendPipeline.test.ts
+++ b/desktop/src/features/agent/sendPipeline.test.ts
@@ -299,13 +299,15 @@ describe("runSendPipeline stream/failure edges", () => {
       expect(handler).not.toBeNull();
     });
     // Matching run: resetProjection variant + plain variant.
-    handler!({ payload: { runId: "run-1", resetProjection: true } });
-    handler!({ payload: { runId: "run-1", resetProjection: false } });
+    handler!({ payload: { updates: [{ runId: "run-1", resetProjection: true }] } });
+    handler!({ payload: { updates: [{ runId: "run-1", resetProjection: false }] } });
     // A different run's event is ignored.
-    handler!({ payload: { runId: "run-other", resetProjection: true } });
+    handler!({ payload: { updates: [{ runId: "run-other", resetProjection: true }] } });
     const { listRunEventsSince } = await import("../../integrations/storage/threadStore");
     await vi.waitFor(() => {
-      expect(listRunEventsSince).toHaveBeenCalled();
+      // One leading read plus one trailing read: burst notifications never run
+      // journal IPCs concurrently, but the newest tail is still consumed.
+      expect(listRunEventsSince).toHaveBeenCalledTimes(2);
     });
     resolveReply({
       content: "answer",

--- a/desktop/src/features/agent/sendPipeline.ts
+++ b/desktop/src/features/agent/sendPipeline.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@future-os/thread-projection";
 import type { Dispatch, SetStateAction } from "react";
+import type { ThreadRuntimeUpdateBatch } from "../../integrations/agent/runtimeEvents";
 import type { StoredRun, StoredThread } from "../../integrations/storage/threadStore";
 import type { ComposerSendPayload } from "./Composer";
 import { listen } from "@tauri-apps/api/event";
@@ -60,9 +61,12 @@ export async function runSendPipeline(
   const importedAttachments = preparedAttachments.attachments;
 
   let stopStreamUpdates: (() => void) | null = null;
+  let streamUpdateRunning = false;
+  let streamUpdateQueued = false;
   const clearStreamUpdates = () => {
     stopStreamUpdates?.();
     stopStreamUpdates = null;
+    streamUpdateQueued = false;
   };
   const optimisticUserId = clientId("pending_user");
   const pendingId = clientId("pending");
@@ -96,7 +100,6 @@ export async function runSendPipeline(
   if (isCurrentSend()) {
     setMessages(current => [...current, optimisticUserMessage, assistantMessage]);
   }
-  onThreadActivity();
 
   let run: StoredRun | null = null;
 
@@ -114,6 +117,9 @@ export async function runSendPipeline(
       triggerMessageId: null,
       modelId,
     });
+    // `create_run` atomically stamps the thread's last-message time. Refresh
+    // only afterwards so the sidebar receives the new sort key immediately.
+    onThreadActivity();
 
     if (isCurrentSend()) {
       setRecentRun(run);
@@ -122,17 +128,33 @@ export async function runSendPipeline(
 
     clearStreamUpdates();
     if (isCurrentSend()) {
-      stopStreamUpdates = await listen<{
-        threadId: string;
-        runId: string;
-        revision: number;
-        status: string;
-        resetProjection: boolean;
-      }>("thread-runtime-updated", (event) => {
-        if (run && event.payload.runId === run.id && isCurrentSend()) {
-          if (event.payload.resetProjection)
-            resetRunProjection(run.id);
-          void updatePendingMessageFromRunEvents(run.id, pendingId, setMessages, isCurrentSend);
+      const streamingRun = run;
+      const queueStreamUpdate = () => {
+        streamUpdateQueued = true;
+        if (streamUpdateRunning)
+          return;
+        streamUpdateRunning = true;
+        void (async () => {
+          while (streamUpdateQueued && isCurrentSend()) {
+            streamUpdateQueued = false;
+            await updatePendingMessageFromRunEvents(streamingRun.id, pendingId, setMessages, isCurrentSend);
+          }
+        })().finally(() => {
+          streamUpdateRunning = false;
+          // An event can land after the loop condition but before `finally`.
+          if (streamUpdateQueued && isCurrentSend())
+            queueStreamUpdate();
+        });
+      };
+      stopStreamUpdates = await listen<ThreadRuntimeUpdateBatch>("thread-runtime-updated", (event) => {
+        const update = event.payload.updates.find(candidate => candidate.runId === streamingRun.id);
+        if (update && isCurrentSend()) {
+          if (update.resetProjection)
+            resetRunProjection(streamingRun.id);
+          // Keep at most one Agent-journal read in flight. Bursts collapse into
+          // one trailing read, so 60 FPS notifications cannot build an IPC
+          // backlog while the visible stream still receives the newest tail.
+          queueStreamUpdate();
         }
       });
     }

--- a/desktop/src/features/agent/useRunReattach.ts
+++ b/desktop/src/features/agent/useRunReattach.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@future-os/thread-projection";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { ThreadRuntimeUpdateBatch } from "../../integrations/agent/runtimeEvents";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
 import { resetRunProjection, upsertStreamingPreview } from "./threadRunProjection";
@@ -69,30 +70,39 @@ export function useRunReattach({
     const startedAt = activeRunStartedAt;
     let cancelled = false;
     const isLive = () => !cancelled;
+    let tickRunning = false;
+    let tickQueued = false;
     const tick = () => {
       if (!isLive())
         return;
-      void upsertStreamingPreview(runId, startedAt, setMessages, isLive).then(() => {
-        // Bump the generation counter after every streaming upsert so an
-        // in-flight quiet reload sees that state changed under it and
-        // discards its write instead of clobbering the live bubble.
-        if (isLive())
-          messagesGenRef.current += 1;
+      tickQueued = true;
+      if (tickRunning)
+        return;
+      tickRunning = true;
+      void (async () => {
+        while (tickQueued && isLive()) {
+          tickQueued = false;
+          await upsertStreamingPreview(runId, startedAt, setMessages, isLive);
+          // Bump the generation counter after every streaming upsert so an
+          // in-flight quiet reload sees that state changed under it and
+          // discards its write instead of clobbering the live bubble.
+          if (isLive())
+            messagesGenRef.current += 1;
+        }
+      })().finally(() => {
+        tickRunning = false;
+        if (tickQueued && isLive())
+          tick();
       });
     };
     tick();
-    const unlisten = listen<{
-      threadId: string;
-      runId: string;
-      revision: number;
-      status: string;
-      resetProjection: boolean;
-    }>("thread-runtime-updated", (event) => {
-      if (!isLive() || event.payload.threadId !== threadId || event.payload.runId !== runId)
+    const unlisten = listen<ThreadRuntimeUpdateBatch>("thread-runtime-updated", (event) => {
+      const update = event.payload.updates.find(candidate => candidate.threadId === threadId && candidate.runId === runId);
+      if (!isLive() || !update)
         return;
-      if (event.payload.resetProjection)
+      if (update.resetProjection)
         resetRunProjection(runId);
-      if (["completed", "failed", "cancelled"].includes(event.payload.status)) {
+      if (["completed", "failed", "cancelled"].includes(update.status)) {
         void refreshRecentRun(threadId, workspaceId);
         void reloadMessagesQuiet(threadId, true);
         return;
@@ -118,6 +128,7 @@ export function useRunReattach({
 
     return () => {
       cancelled = true;
+      tickQueued = false;
       clearInterval(selfHeal);
       void unlisten.then(stop => stop());
     };

--- a/desktop/src/features/markdown/futureReferenceStore.test.ts
+++ b/desktop/src/features/markdown/futureReferenceStore.test.ts
@@ -16,7 +16,7 @@ vi.mock("../../integrations/storage/markdownReferences", () => ({
   resolveMarkdownReferences: (workspaceId: string, refs: unknown[]) => resolveMock(workspaceId, refs),
 }));
 
-type Listener = (event: { payload: { runId?: string; status?: string } }) => void;
+type Listener = (event: { payload: { updates: Array<{ runId: string; status: string }> } }) => void;
 let terminalListener: Listener | null = null;
 const listenMock = vi.fn((_name: string, handler: Listener) => {
   terminalListener = handler;
@@ -184,15 +184,15 @@ describe("futureReferenceStore", () => {
 
     // Non-terminal payloads are ignored.
     const callsBefore = resolveMock.mock.calls.length;
-    terminalListener!({ payload: { runId: "run-term", status: "running" } });
-    terminalListener!({ payload: { status: "completed" } });
+    terminalListener!({ payload: { updates: [{ runId: "run-term", status: "running" }] } });
+    terminalListener!({ payload: { updates: [] } });
     await flush();
     expect(resolveMock.mock.calls.length).toBe(callsBefore);
 
     // Terminal status re-resolves exactly that run's records.
     resolveMock.mockResolvedValue([resolvedRecord("run-term")]);
     await act(async () => {
-      terminalListener!({ payload: { runId: "run-term", status: "completed" } });
+      terminalListener!({ payload: { updates: [{ runId: "run-term", status: "completed" }] } });
       await Promise.resolve();
     });
     await flush();

--- a/desktop/src/features/markdown/futureReferenceStore.ts
+++ b/desktop/src/features/markdown/futureReferenceStore.ts
@@ -1,3 +1,4 @@
+import type { ThreadRuntimeUpdateBatch } from "../../integrations/agent/runtimeEvents";
 import type { ResolvedMarkdownReference } from "../../integrations/storage/markdownReferences";
 import type { FutureReference } from "./futureMarkdownTypes";
 import { listen } from "@tauri-apps/api/event";
@@ -260,11 +261,12 @@ function installTerminalRunListener() {
   if (terminalListenerInstalled)
     return;
   terminalListenerInstalled = true;
-  void listen<{ runId?: string; status?: string }>("thread-runtime-updated", (event) => {
-    const { runId, status } = event.payload ?? {};
-    if (!runId || !status || !["completed", "failed", "cancelled"].includes(status))
-      return;
-    void reresolveRunRecords(runId);
+  void listen<ThreadRuntimeUpdateBatch>("thread-runtime-updated", (event) => {
+    for (const { runId, status } of event.payload.updates) {
+      if (!["completed", "failed", "cancelled"].includes(status))
+        continue;
+      void reresolveRunRecords(runId);
+    }
   });
 }
 

--- a/desktop/src/i18n/locales/zh/settings.json
+++ b/desktop/src/i18n/locales/zh/settings.json
@@ -10,8 +10,8 @@
     "off": "完全放开",
     "description": {
       "manual": "读写文件前询问；只读命令直接放行，其余命令需批准。",
-      "sandbox": "命令在 macOS 沙箱中运行（越界时申请提权），文件操作仍需批准。",
-      "sandboxWindows": "命令启用 Windows 写保护；访问范围外的写入需要批准。",
+      "sandbox": "命令在 macOS 沙箱中运行，越界时申请提权。",
+      "sandboxWindows": "命令启用 Windows 写保护；越界写入需要批准。",
       "off": "全部放开，不再询问，也不启用沙箱。"
     }
   },

--- a/desktop/src/integrations/agent/runtimeEvents.ts
+++ b/desktop/src/integrations/agent/runtimeEvents.ts
@@ -1,0 +1,12 @@
+export interface ThreadRuntimeUpdate {
+  threadId: string;
+  runId: string;
+  revision: number;
+  status: string;
+  resetProjection: boolean;
+}
+
+/** One frame's coalesced run invalidations from the desktop backend. */
+export interface ThreadRuntimeUpdateBatch {
+  updates: ThreadRuntimeUpdate[];
+}

--- a/desktop/src/integrations/storage/storage.test.ts
+++ b/desktop/src/integrations/storage/storage.test.ts
@@ -66,6 +66,7 @@ import {
   getThreadCleanupSummary,
   listThreads,
   listWorkspaces,
+  markThreadOpened,
   pinThread,
   renameThread,
   renameWorkspace,
@@ -249,6 +250,8 @@ describe("storage invoke wrappers", () => {
     expect(invokeMock).toHaveBeenLastCalledWith("delete_workspace", { workspaceId: "w" });
     await getRecentThread();
     expect(invokeMock).toHaveBeenLastCalledWith("get_recent_thread", undefined);
+    await markThreadOpened("t");
+    expect(invokeMock).toHaveBeenLastCalledWith("mark_thread_opened", { threadId: "t" });
     await listThreads();
     expect(invokeMock).toHaveBeenLastCalledWith("list_threads", undefined);
     await createDefaultChatThread("New Chat");

--- a/desktop/src/integrations/storage/threads.ts
+++ b/desktop/src/integrations/storage/threads.ts
@@ -34,6 +34,11 @@ export async function getRecentThread() {
   return invokeCommand<StoredThread | null>("get_recent_thread");
 }
 
+/** Record a visit for startup restoration. It intentionally does not reorder the sidebar. */
+export async function markThreadOpened(threadId: string) {
+  return invokeCommand<void>("mark_thread_opened", { threadId });
+}
+
 export async function listThreads() {
   return invokeCommand<StoredThread[]>("list_threads");
 }

--- a/mobile/src/components/ErrorBanner.tsx
+++ b/mobile/src/components/ErrorBanner.tsx
@@ -21,29 +21,21 @@ import { friendlyError } from "./errorMessage";
  * states (desktop asleep, reconnecting) never reach the banner; the badge and
  * offline empty state are their dedicated UI.
  */
-export function ErrorBanner({
-  message,
-  onDismiss,
-}: {
-  message: string;
-  onDismiss?: () => void;
-}) {
+export function ErrorBanner({ message, onDismiss }: { message: string; onDismiss?: () => void }) {
   const { t } = useTranslation();
   return (
     <View style={styles.banner}>
       <Text style={styles.text}>{friendlyError(message, t)}</Text>
-      {onDismiss
-        ? (
-            <Pressable
-              accessibilityLabel={t("common.close")}
-              accessibilityRole="button"
-              onPress={onDismiss}
-              style={styles.dismiss}
-            >
-              <X color={colors.danger} size={16} />
-            </Pressable>
-          )
-        : null}
+      {onDismiss ? (
+        <Pressable
+          accessibilityLabel={t("common.close")}
+          accessibilityRole="button"
+          onPress={onDismiss}
+          style={styles.dismiss}
+        >
+          <X color={colors.danger} size={16} />
+        </Pressable>
+      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -356,20 +356,28 @@ function CompactionDivider({
   const manual = trigger === "manual";
   const label =
     status === "running"
-      ? manual ? t("chat.manuallyCompacting") : t("chat.compacting")
+      ? manual
+        ? t("chat.manuallyCompacting")
+        : t("chat.compacting")
       : status === "failed"
-        ? manual ? t("chat.manualCompactionFailed") : t("chat.compactionFailed")
+        ? manual
+          ? t("chat.manualCompactionFailed")
+          : t("chat.compactionFailed")
         : manual
           ? t("chat.manuallyCompacted")
-        : tokensBefore && tokensBefore > 0
-      ? t("chat.compactedTokens", {
-          formattedCount: new Intl.NumberFormat(i18n.language).format(tokensBefore),
-        })
-      : t("chat.compacted");
+          : tokensBefore && tokensBefore > 0
+            ? t("chat.compactedTokens", {
+                formattedCount: new Intl.NumberFormat(i18n.language).format(tokensBefore),
+              })
+            : t("chat.compacted");
   const color = status === "failed" ? colors.danger : colors.inkMuted;
   const lineColor = status === "failed" ? colors.dangerLine : colors.line;
   return (
-    <View accessibilityLabel={label} accessibilityRole={status === "failed" ? "alert" : "text"} style={styles.compactionDivider}>
+    <View
+      accessibilityLabel={label}
+      accessibilityRole={status === "failed" ? "alert" : "text"}
+      style={styles.compactionDivider}
+    >
       <View style={[styles.compactionLine, { backgroundColor: lineColor }]} />
       <Text style={[styles.compactionLabel, { color }]}>{label}</Text>
       <View style={[styles.compactionLine, { backgroundColor: lineColor }]} />
@@ -497,7 +505,13 @@ function SegmentBlock({
     return <ToolRow tool={segment.tool} />;
   }
   // compaction
-  return <CompactionDivider status={segment.status} tokensBefore={segment.tokensBefore} trigger={segment.trigger} />;
+  return (
+    <CompactionDivider
+      status={segment.status}
+      tokensBefore={segment.tokensBefore}
+      trigger={segment.trigger}
+    />
+  );
 }
 
 /**

--- a/mobile/src/features/chat/ChatScreen.tsx
+++ b/mobile/src/features/chat/ChatScreen.tsx
@@ -299,12 +299,7 @@ export function ChatScreen() {
           t={t}
         />
 
-        <ModelSelectorSheet
-          selector={selector}
-          setSelector={setSelector}
-          remote={remote}
-          t={t}
-        />
+        <ModelSelectorSheet selector={selector} setSelector={setSelector} remote={remote} t={t} />
 
         <RenameModal
           renameOpen={rename.renameOpen}

--- a/mobile/src/features/chat/components/ComposerDock.tsx
+++ b/mobile/src/features/chat/components/ComposerDock.tsx
@@ -96,19 +96,14 @@ export function ComposerDock({
         </Pressable>
       )}
       {showOffline && <Text style={styles.offlineComposer}>{t("connection.offlineHint")}</Text>}
-      {!remote.draft &&
-        remote.desktopOnline &&
-        remote.models.length === 0 &&
-        !remote.modelId && (
-          <Text style={styles.offlineComposer}>{t("connection.noModelsHint")}</Text>
-        )}
+      {!remote.draft && remote.desktopOnline && remote.models.length === 0 && !remote.modelId && (
+        <Text style={styles.offlineComposer}>{t("connection.noModelsHint")}</Text>
+      )}
       {pendingApprovals.map(item => (
         <View key={item.id} style={styles.dockedApproval}>
           <PendingApprovalCard
             error={approvalSubmitting === item.payload.approval_request_id ? null : approvalError}
-            onDecision={decision =>
-              void decideApproval(item.payload.approval_request_id, decision)
-            }
+            onDecision={decision => void decideApproval(item.payload.approval_request_id, decision)}
             payload={item.payload}
             submitting={approvalSubmitting === item.payload.approval_request_id}
           />
@@ -124,10 +119,7 @@ export function ComposerDock({
               showsHorizontalScrollIndicator={false}
             >
               {attachments.map((attachment, index) => (
-                <View
-                  key={`${attachment.localUri}:${index}`}
-                  style={styles.pendingAttachment}
-                >
+                <View key={`${attachment.localUri}:${index}`} style={styles.pendingAttachment}>
                   {attachment.kind === "image" && !supportsImages ? (
                     <CircleAlert color={colors.warning} size={13} />
                   ) : attachment.kind === "image" ? (
@@ -177,9 +169,7 @@ export function ComposerDock({
             <Pressable
               accessibilityLabel={t("attachment.add")}
               accessibilityRole="button"
-              disabled={
-                remote.timeline.streaming || remote.busy || !remote.fileTransferSupported
-              }
+              disabled={remote.timeline.streaming || remote.busy || !remote.fileTransferSupported}
               onPress={openAttachmentMenu}
               style={({ pressed }) => [
                 styles.attachmentButton,

--- a/mobile/src/features/chat/components/ModelSelectorSheet.tsx
+++ b/mobile/src/features/chat/components/ModelSelectorSheet.tsx
@@ -88,9 +88,7 @@ export function ModelSelectorSheet({
                             pressed && styles.selectorOptionPressed,
                           ]}
                         >
-                          <Text style={styles.selectorOptionLabel}>
-                            {t(`thinking.${level}`)}
-                          </Text>
+                          <Text style={styles.selectorOptionLabel}>{t(`thinking.${level}`)}</Text>
                           {selected ? <Check color={colors.accent} size={18} /> : null}
                         </Pressable>
                       );

--- a/mobile/src/features/chat/components/PreviewModal.tsx
+++ b/mobile/src/features/chat/components/PreviewModal.tsx
@@ -69,11 +69,7 @@ export function PreviewModal({
           </Pressable>
         </View>
         {preview?.info.previewKind === "image" ? (
-          <Image
-            resizeMode="contain"
-            source={{ uri: preview.uri }}
-            style={styles.previewImage}
-          />
+          <Image resizeMode="contain" source={{ uri: preview.uri }} style={styles.previewImage} />
         ) : preview?.info.previewKind === "markdown" ? (
           <ScrollView contentContainerStyle={styles.previewMarkdown}>
             {!!preview?.truncated && (

--- a/mobile/src/features/chat/components/RenameModal.tsx
+++ b/mobile/src/features/chat/components/RenameModal.tsx
@@ -40,12 +40,7 @@ export function RenameModal({
           />
           <View style={styles.dialogActions}>
             <View style={styles.dialogAction}>
-              <Button
-                compact
-                label={t("chat.cancel")}
-                onPress={onClose}
-                variant="secondary"
-              />
+              <Button compact label={t("chat.cancel")} onPress={onClose} variant="secondary" />
             </View>
             <View style={styles.dialogAction}>
               <Button

--- a/mobile/src/features/chat/useChatScroll.ts
+++ b/mobile/src/features/chat/useChatScroll.ts
@@ -22,7 +22,10 @@ export interface ChatScrollApi {
   onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
-export function useChatScroll(selectedSessionId: string, transcriptItemCount: number): ChatScrollApi {
+export function useChatScroll(
+  selectedSessionId: string,
+  transcriptItemCount: number,
+): ChatScrollApi {
   const listRef = useRef<FlatList<TimelineItem>>(null);
   const [atLatest, setAtLatest] = useState(true);
   const [composerHeight, setComposerHeight] = useState(0);
@@ -125,8 +128,7 @@ export function useChatScroll(selectedSessionId: string, transcriptItemCount: nu
     if (initialScrollPendingRef.current) return;
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
     setAtLatest(
-      contentOffset.y + layoutMeasurement.height >=
-        contentSize.height - AT_LATEST_THRESHOLD,
+      contentOffset.y + layoutMeasurement.height >= contentSize.height - AT_LATEST_THRESHOLD,
     );
   };
 

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -326,10 +326,7 @@ describe("RemoteClient terminal iterator recovery", () => {
 
   test.each([
     ["failed", new Error("remote_service_misconfigured")],
-    [
-      "revoked",
-      new RemoteApiError("revoked", "credentials_revoked", 401),
-    ],
+    ["revoked", new RemoteApiError("revoked", "credentials_revoked", 401)],
   ] as const)("late iterator completion cannot revive %s", async (terminal, failure) => {
     jest.useFakeTimers();
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -582,10 +579,7 @@ describe("RemoteClient terminal iterator recovery", () => {
       for (let generation = 0; generation < 4; generation += 1) {
         testClient.generation = generation;
         testClient.failedGeneration = null;
-        testClient.failGeneration(
-          new Error("remote_event_subscription_ended"),
-          generation,
-        );
+        testClient.failGeneration(new Error("remote_event_subscription_ended"), generation);
       }
       expect(testClient.state).toBe("failed");
       expect(jest.getTimerCount()).toBe(0);

--- a/mobile/src/remote/__tests__/syncEngine.test.ts
+++ b/mobile/src/remote/__tests__/syncEngine.test.ts
@@ -224,6 +224,24 @@ describe("SyncEngine", () => {
     expect(h.textOf("s1")).toBe("abc");
   });
 
+  test("coalesces established live deltas into one frame commit", async () => {
+    const run = nextRunId();
+    const h = new Harness(run);
+    h.engine.event("s1", agentStart(run, 0));
+    await h.settle();
+
+    const commits = jest.fn();
+    h.engine.subscribe(commits);
+    h.engine.event("s1", textChunk(run, 1, "a"));
+    // Model separate NATS deliveries while keeping both inside one frame.
+    await Promise.resolve();
+    h.engine.event("s1", textChunk(run, 2, "b"));
+    await h.settle();
+
+    expect(commits).toHaveBeenCalledTimes(1);
+    expect(h.textOf("s1")).toBe("ab");
+  });
+
   test("a failed gap replay preserves queued events and retries automatically", async () => {
     const run = nextRunId();
     const h = new Harness(run);

--- a/mobile/src/remote/__tests__/timeline.test.ts
+++ b/mobile/src/remote/__tests__/timeline.test.ts
@@ -128,26 +128,36 @@ describe("entry reducer", () => {
   });
 
   test("projects a durable checkpoint from reloaded history", () => {
-    const state = timelineFromEntries([{
-      id: "checkpoint-entry",
-      entry_type: "compaction",
-      role: "system",
-      content: "",
-      checkpoint: {
-        schema_version: 2,
-        checkpoint_id: "cp-history",
-        tokens_before: 190_000,
-        tokens_after: 20_000,
-        trigger: "manual",
+    const state = timelineFromEntries([
+      {
+        id: "checkpoint-entry",
+        entry_type: "compaction",
+        role: "system",
+        content: "",
+        checkpoint: {
+          schema_version: 2,
+          checkpoint_id: "cp-history",
+          tokens_before: 190_000,
+          tokens_after: 20_000,
+          trigger: "manual",
+        },
       },
-    }]);
-    const divider = state.items.find(item =>
-      item.kind === "message" && item.segments?.some(segment => segment.kind === "compaction")
+    ]);
+    const divider = state.items.find(
+      item =>
+        item.kind === "message" && item.segments?.some(segment => segment.kind === "compaction"),
     );
     expect(divider).toMatchObject({
       kind: "message",
       id: "m_cp-history",
-      segments: [{ id: "seg_cp-history_compaction", kind: "compaction", tokensBefore: 190_000, trigger: "manual" }],
+      segments: [
+        {
+          id: "seg_cp-history_compaction",
+          kind: "compaction",
+          tokensBefore: 190_000,
+          trigger: "manual",
+        },
+      ],
     });
   });
 

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -117,7 +117,10 @@ export class RemoteClient {
     lastError: string;
     nextRetryAt: number | null;
   } | null = null;
-  private readonly failureLogQuota = new Map<string, { windowStartedAt: number; emitted: number }>();
+  private readonly failureLogQuota = new Map<
+    string,
+    { windowStartedAt: number; emitted: number }
+  >();
   private downloadWaiters = new Map<
     string,
     {
@@ -189,8 +192,8 @@ export class RemoteClient {
     // a 24-hour outage bounded to 16 lines per category.
     if (
       episode.reports < 15 &&
-      (episode.attempts & (episode.attempts - 1)) === 0
-      && this.permitFailureLog(category)
+      (episode.attempts & (episode.attempts - 1)) === 0 &&
+      this.permitFailureLog(category)
     ) {
       episode.reports += 1;
       console.warn("[remote] failure episode retry", {

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -122,9 +122,10 @@ export function messageToItems(message: AgentMessage): TimelineItem[] {
 /** History entries (mobile wire shape) → the shared session-entry shape. */
 function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
   return entries.map((entry, index) => {
-    const role = entry.role === "assistant" || entry.role === "tool" || entry.role === "system"
-      ? entry.role
-      : "user";
+    const role =
+      entry.role === "assistant" || entry.role === "tool" || entry.role === "system"
+        ? entry.role
+        : "user";
     const toolCalls = (entry.tool_calls ?? [])
       .filter(call => !!call && typeof call?.function?.name === "string")
       .map(call => ({

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -109,12 +109,15 @@ interface SessionLane {
 
 const MAX_REPLAY_QUEUE = 6;
 const RECONCILE_RETRY_MAX_MS = 30_000;
+const LIVE_EVENT_FRAME_MS = 16;
 
 export class SyncEngine {
   private lanes = new Map<string, SessionLane>();
   private subscribers = new Set<(commit: Commit) => void>();
   private generation = 0;
   private deps: SyncDeps;
+  private liveFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private liveFlushLanes = new Set<SessionLane>();
 
   constructor(deps: SyncDeps) {
     this.deps = deps;
@@ -131,11 +134,16 @@ export class SyncEngine {
     // First contact for a real session: establish the timeline from durable
     // history + a full replay so a mid-run join gets its prefix (H3), not just
     // the live tail.
-    if (!lane.established && lane.sessionId !== "") {
+    const establishing = !lane.established && lane.sessionId !== "";
+    if (establishing) {
       this.enqueueReplay(lane, { reason: "open" });
     }
     lane.ops.push({ kind: "event", event });
-    this.loop(lane);
+    // First contact already queued an immediate reconcile step, which will
+    // drain this op. Established lanes collect live deltas for one display
+    // frame so React Native receives one timeline commit instead of one per
+    // token, while retaining every event and its cursor in order.
+    if (!establishing) this.scheduleLiveFlush(lane);
   }
 
   /** Enqueue a reconcile. Repeats of the same reason+run are folded. */
@@ -177,6 +185,9 @@ export class SyncEngine {
   /** Drop all lanes (unpair / credentials cleared). */
   clear(): void {
     this.generation += 1;
+    if (this.liveFlushTimer) clearTimeout(this.liveFlushTimer);
+    this.liveFlushTimer = null;
+    this.liveFlushLanes.clear();
     for (const lane of this.lanes.values()) {
       if (lane.retryTimer) clearTimeout(lane.retryTimer);
     }
@@ -202,6 +213,19 @@ export class SyncEngine {
       this.lanes.set(sessionId, lane);
     }
     return lane;
+  }
+
+  private scheduleLiveFlush(lane: SessionLane): void {
+    this.liveFlushLanes.add(lane);
+    if (this.liveFlushTimer) return;
+    this.liveFlushTimer = setTimeout(() => {
+      this.liveFlushTimer = null;
+      const lanes = [...this.liveFlushLanes];
+      this.liveFlushLanes.clear();
+      for (const pending of lanes) {
+        if (this.isCurrent(pending)) this.loop(pending);
+      }
+    }, LIVE_EVENT_FRAME_MS);
   }
 
   private enqueueReplay(lane: SessionLane, request: ReconcileRequest): void {


### PR DESCRIPTION
## Summary
- keep new-conversation model and thinking selections until the Agent session exists
- defer model-driven compaction to the next LLM preflight and preserve in-flight output
- batch desktop and mobile stream projection updates while retaining durable event order
- refresh conversation ordering and settings copy, and normalize mobile formatting

## Validation
- make lint-rust
- desktop typecheck, lint, Vitest (607 passed), and Tauri tests (1019 passed)
- mobile typecheck, lint, Prettier, and Jest (371 passed)
- full make test was rerun outside the restricted sandbox; its remaining concurrent shared-state flakes passed when rerun individually