### PR TITLE
fix(agent): clippy nonminimal_bool in windows capability validation

### DIFF
--- a/agent/src/sandbox/windows/capability.rs
+++ b/agent/src/sandbox/windows/capability.rs
@@ -359,8 +359,8 @@ impl CapabilityState {
                 || !record.writable_root.is_absolute()
                 || !names.insert(&record.name)
                 || matches!(record.kind, CapabilityKind::Request) != record.request_id.is_some()
-                || (matches!(record.kind, CapabilityKind::Request)
-                    != !record.approved_targets.is_empty())
+                || matches!(record.kind, CapabilityKind::Request)
+                    == record.approved_targets.is_empty()
                 || record
                     .write_carveouts
                     .iter()


### PR DESCRIPTION
## Why

The Rust lint gate (clippy 1.97.0, `-D warnings`) is red on main since #342: `agent/src/sandbox/windows/capability.rs` uses

```rust
matches!(record.kind, CapabilityKind::Request) != !record.approved_targets.is_empty()
```

which clippy flags as `nonminimal_bool`. Every PR's lint job fails on it until fixed.

## What

Same semantics, clippy-clean form:

```rust
matches!(record.kind, CapabilityKind::Request) == record.approved_targets.is_empty()
```

No behavior change. Unblocks CI for all in-flight PRs (including the loop webui dashboard PR).