### PR TITLE
feat(loop): future loop ui — local read-only web dashboard for the control plane

### DIFF
--- a/agent/src/sandbox/windows/capability.rs
+++ b/agent/src/sandbox/windows/capability.rs
@@ -359,8 +359,8 @@ impl CapabilityState {
                 || !record.writable_root.is_absolute()
                 || !names.insert(&record.name)
                 || matches!(record.kind, CapabilityKind::Request) != record.request_id.is_some()
-                || (matches!(record.kind, CapabilityKind::Request)
-                    != !record.approved_targets.is_empty())
+                || matches!(record.kind, CapabilityKind::Request)
+                    == record.approved_targets.is_empty()
                 || record
                     .write_carveouts
                     .iter()

--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -48,7 +48,7 @@ agent executes one bounded turn (gRPC) → writes evidence → kernel decides th
 | Gate | `gate resolve` | Any open user gate freezes all work until resolved; user-actions (non-blocking human to-dos) surface to the user without freezing the agent |
 | Delivery closure | `delivery status/record` | Completion lands in a pending `delivered` state; an operator resolves it as `verified/failed/rework`; unverified deliveries auto-derive a follow-up after 3 turns |
 | Terminal | `frontier show` | Validated closure: todos done/superseded + closure intent + no acceptance gaps + no pending deferred work; `frontier` gives the terminal judgement with gap detail |
-| Dashboard | `ui` | Local web dashboard on 127.0.0.1: goal cards, attention queue, kernel decision, todo DAG, agents/leases, delivery closure, run/event ledgers — live over SSE; gate resolve & goal cancel included |
+| Dashboard | `ui` | Local read-only web dashboard on 127.0.0.1: goal cards, attention queue, kernel decision, todo DAG, workers/cost, run/event ledgers — live over SSE; mutations stay in the CLI |
 | Quota | `quota should-run/usage/spend/decisions` | The deterministic should-run kernel: scheduling, refusal reasons, and spend are all auditable |
 | Scheduler | `scheduler tick/show/liveness` | Monitor cadence, host-failure records, liveness heartbeats |
 | Multi-agent | `agent contract/recipe/succession/collective` | One goal, several workers: contract (backups / handoff rules), named recipes for one-command onboarding, auto back-up promotion on offline timeout, wake roster, collective turn ledger |
@@ -106,23 +106,29 @@ future loop delivery record --goal G ...  # verified / failed / rework
 ## Web dashboard (`future loop ui`)
 
 `future loop ui [--port N] [--root DIR] [--no-open]` serves a local,
-read-mostly dashboard on `127.0.0.1` (default port 7717). It replays the
-same event ledger as the CLI on every request and pushes changes over SSE,
-so the page is always a faithful, live projection — no separate state.
+**strictly read-only** dashboard on `127.0.0.1` (default port 7717). It
+replays the same event ledger as the CLI on every request and pushes
+changes over SSE, so the page is always a faithful, live projection of
+`.future/loop/` — and nothing else: the server only reads the loop state
+root, and only GET endpoints exist (any other method is a 405). Mutations
+(gate resolve, goal cancel, …) stay in the CLI — the page shows the exact
+`future loop` command to run instead.
 
 - **Overview**: fleet totals (active/terminal/cancelled goals, open gates,
   24h/7d runs/cost/quota slots), the attention queue (severity, waiting-on,
   recommended action), and per-goal cards sorted by triage order.
-- **Goal detail**: the kernel's should-run decision (reason + code + waiting
-  on), next action, spend/throughput (14-day sparkline, token/cost/slot
-  buckets, 7-day outcome split), the todo dependency DAG (layered,
-  click-through inspector with verify/acceptance/lease/evidence detail),
-  todos table, agents & leases & liveness alerts, delivery closure, replan
-  obligations, acceptance gaps, semantic history, and the run + event
-  ledgers.
-- **Actions**: resolve user gates and cancel a goal from the page (both
-  append the same ledger events as the CLI); everything else is read-only
-  by design — drive work with `future loop run`.
+- **Goal detail** (tabbed): Board — the kernel's should-run decision
+  (reason + code + waiting on), next action, spend/throughput (14-day
+  sparkline, token/cost/slot buckets, 7-day outcome split), open gates,
+  and the todo dependency DAG (layered, click-through inspector with
+  verify/acceptance/lease/evidence detail); Todos — full table with
+  per-todo runs/token/cost rollup and activity window; Workers — agent
+  leases, heartbeats, liveness alerts, per-worker cost/token rollup,
+  delivery closure, replan obligations, acceptance gaps; Runs — the run
+  ledger (validation receipts, failure kinds, tokens, cost, evidence) +
+  semantic history; Events — the raw event ledger.
+- All state is projected from `.future/loop/` on every request; the
+  dashboard holds no separate state and writes nothing.
 
 ## Hard checks first (conventions fail, gates hold)
 

--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -48,6 +48,7 @@ agent executes one bounded turn (gRPC) → writes evidence → kernel decides th
 | Gate | `gate resolve` | Any open user gate freezes all work until resolved; user-actions (non-blocking human to-dos) surface to the user without freezing the agent |
 | Delivery closure | `delivery status/record` | Completion lands in a pending `delivered` state; an operator resolves it as `verified/failed/rework`; unverified deliveries auto-derive a follow-up after 3 turns |
 | Terminal | `frontier show` | Validated closure: todos done/superseded + closure intent + no acceptance gaps + no pending deferred work; `frontier` gives the terminal judgement with gap detail |
+| Dashboard | `ui` | Local web dashboard on 127.0.0.1: goal cards, attention queue, kernel decision, todo DAG, agents/leases, delivery closure, run/event ledgers — live over SSE; gate resolve & goal cancel included |
 | Quota | `quota should-run/usage/spend/decisions` | The deterministic should-run kernel: scheduling, refusal reasons, and spend are all auditable |
 | Scheduler | `scheduler tick/show/liveness` | Monitor cadence, host-failure records, liveness heartbeats |
 | Multi-agent | `agent contract/recipe/succession/collective` | One goal, several workers: contract (backups / handoff rules), named recipes for one-command onboarding, auto back-up promotion on offline timeout, wake roster, collective turn ledger |
@@ -96,10 +97,32 @@ future loop run --goal G --agent-id mac-worker --model M --thinking-level L --ma
 future loop gate resolve --goal G --todo-id GATE --decision "approve"
 
 # 5. Observe and close
+future loop ui                       # live web dashboard (http://127.0.0.1:7717)
 future loop status --goal G
 future loop frontier show --goal G        # terminal judgement + gap detail
 future loop delivery record --goal G ...  # verified / failed / rework
 ```
+
+## Web dashboard (`future loop ui`)
+
+`future loop ui [--port N] [--root DIR] [--no-open]` serves a local,
+read-mostly dashboard on `127.0.0.1` (default port 7717). It replays the
+same event ledger as the CLI on every request and pushes changes over SSE,
+so the page is always a faithful, live projection — no separate state.
+
+- **Overview**: fleet totals (active/terminal/cancelled goals, open gates,
+  24h/7d runs/cost/quota slots), the attention queue (severity, waiting-on,
+  recommended action), and per-goal cards sorted by triage order.
+- **Goal detail**: the kernel's should-run decision (reason + code + waiting
+  on), next action, spend/throughput (14-day sparkline, token/cost/slot
+  buckets, 7-day outcome split), the todo dependency DAG (layered,
+  click-through inspector with verify/acceptance/lease/evidence detail),
+  todos table, agents & leases & liveness alerts, delivery closure, replan
+  obligations, acceptance gaps, semantic history, and the run + event
+  ledgers.
+- **Actions**: resolve user gates and cancel a goal from the page (both
+  append the same ledger events as the CLI); everything else is read-only
+  by design — drive work with `future loop run`.
 
 ## Hard checks first (conventions fail, gates hold)
 

--- a/orchestration/loop/src/compat.rs
+++ b/orchestration/loop/src/compat.rs
@@ -174,7 +174,7 @@ pub fn release_active_state_lock(lock_path: &Path) {
 /// conservatively report alive so a lock is never stolen from a possibly
 /// live holder (empty-lock aging still applies).
 #[cfg(unix)]
-pub(crate) fn pid_alive(pid: u32) -> bool {
+pub fn pid_alive(pid: u32) -> bool {
     // SAFETY: signal 0 performs existence checking only; no signal is sent.
     let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
     if rc == 0 {
@@ -185,7 +185,7 @@ pub(crate) fn pid_alive(pid: u32) -> bool {
 }
 
 #[cfg(not(unix))]
-pub(crate) fn pid_alive(_pid: u32) -> bool {
+pub fn pid_alive(_pid: u32) -> bool {
     true
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -238,7 +238,7 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         goal,
         "ui",
-        "local web dashboard (read-mostly: gate resolve / goal cancel) on 127.0.0.1",
+        "local read-only web dashboard on 127.0.0.1",
         "ui [--port N] [--root DIR] [--no-open]",
     );
     r.command(
@@ -2524,20 +2524,11 @@ fn print_ledger_read_note(store: &Store, goal_id: &str) {
     }
 }
 
-/// Web-UI parity projection refresh: the dashboard appends events through
-/// the store directly, so it calls this instead of duplicating the
-/// next-action + active-state sync convention every CLI mutation follows.
-pub fn refresh_projections_after_append(store: &Store, goal_id: &str) -> Result<()> {
-    refresh_next_action(store, goal_id)?;
-    sync_compat(store, goal_id)
-}
-
 // ── ui ─────────────────────────────────────────────────────────────────────
 
 /// `loop ui [--port N] [--root DIR] [--no-open]` — serve the local web
-/// dashboard. Read-mostly (gate resolve / goal cancel are the only
-/// mutations); all state is replayed from the same event ledger the CLI
-/// reads, on `127.0.0.1` only.
+/// dashboard. Strictly read-only (GET only) over the loop state root
+/// (`.future/loop/`); run mutations stay in the CLI. Binds 127.0.0.1.
 async fn cmd_webui(args: &[String]) -> Result<()> {
     let mut port: u16 = 7717;
     let mut root: Option<String> = None;

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -131,6 +131,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "frontier" => cmd_frontier(&store, &args[1..]),
         "profile" => cmd_profile(&mut store, &args[1..]),
         "status" => cmd_status(&store, &args[1..]),
+        "ui" => cmd_webui(&args[1..]).await,
         "quota" => cmd_quota(&store, &args[1..]),
         "scheduler" => cmd_scheduler(&mut store, &args[1..]),
         "store" => cmd_store(&mut store, &args[1..]),
@@ -173,6 +174,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     // Start here — first goal, first status, install checks
     ("goal", Journey::Starter),
     ("status", Journey::Starter),
+    ("ui", Journey::Starter),
     ("doctor", Journey::Starter),
     ("agent", Journey::Starter),
     // Daily operator — the day-to-day control surface
@@ -232,6 +234,12 @@ fn build_cli_registry() -> CommandRegistry {
         "status",
         "project the active state",
         "status [--goal G] [--format json]",
+    );
+    r.command(
+        goal,
+        "ui",
+        "local web dashboard (read-mostly: gate resolve / goal cancel) on 127.0.0.1",
+        "ui [--port N] [--root DIR] [--no-open]",
     );
     r.command(
         goal,
@@ -2514,6 +2522,55 @@ fn print_ledger_read_note(store: &Store, goal_id: &str) {
     }) {
         println!("note      : {note}");
     }
+}
+
+/// Web-UI parity projection refresh: the dashboard appends events through
+/// the store directly, so it calls this instead of duplicating the
+/// next-action + active-state sync convention every CLI mutation follows.
+pub fn refresh_projections_after_append(store: &Store, goal_id: &str) -> Result<()> {
+    refresh_next_action(store, goal_id)?;
+    sync_compat(store, goal_id)
+}
+
+// ── ui ─────────────────────────────────────────────────────────────────────
+
+/// `loop ui [--port N] [--root DIR] [--no-open]` — serve the local web
+/// dashboard. Read-mostly (gate resolve / goal cancel are the only
+/// mutations); all state is replayed from the same event ledger the CLI
+/// reads, on `127.0.0.1` only.
+async fn cmd_webui(args: &[String]) -> Result<()> {
+    let mut port: u16 = 7717;
+    let mut root: Option<String> = None;
+    let mut open_browser = true;
+    reject_unknown_flags(args, &["--port", "--root", "--no-open"])?;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--no-open" => {
+                open_browser = false;
+                i += 1;
+            }
+            "--port" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("--port requires a value"))?;
+                port = v
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("--port must be 0-65535 (0 picks a free port)"))?;
+                i += 2;
+            }
+            "--root" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("--root requires a value"))?;
+                root = Some(v.clone());
+                i += 2;
+            }
+            other => bail!("unknown argument `{other}`"),
+        }
+    }
+    let root = root.unwrap_or_else(root_dir);
+    crate::webui::run_server(root, port, open_browser).await
 }
 
 /// `loop status --format json` — machine-readable projection (goal, todos

--- a/orchestration/loop/src/lib.rs
+++ b/orchestration/loop/src/lib.rs
@@ -30,5 +30,6 @@ pub mod scheduler;
 pub mod state;
 pub mod store;
 pub mod turn_envelope;
+pub mod webui;
 pub mod work_items;
 pub mod worker_bridge;

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -1,0 +1,638 @@
+//! Dashboard projections — every payload is derived fresh from a replay of
+//! the event ledger, so the UI is always a faithful read model of CLI state.
+
+use std::time::SystemTime;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::decision;
+use crate::state::{
+    now_epoch, DeliveryState, FailureKind, Goal, RunRecord, TaskClass, Todo, TodoStatus,
+};
+use crate::store::{Event, Store};
+use crate::work_items::{attention, replan_obligation, task_graph};
+
+/// Serialize a SystemTime as epoch seconds (JSON has no SystemTime).
+fn epoch_secs(t: Option<SystemTime>) -> Option<u64> {
+    t.and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TodoView {
+    pub id: String,
+    pub index: u32,
+    pub title: String,
+    pub text: String,
+    pub class: String,
+    pub status: String,
+    pub priority: String,
+    pub role: String,
+    pub gate_question: Option<String>,
+    pub decision: Option<String>,
+    pub note: Option<String>,
+    pub blocked_by: Vec<String>,
+    pub blocked: bool,
+    pub claimed_by: Option<String>,
+    pub lease_expires_at: Option<u64>,
+    pub holder_pid: Option<u32>,
+    pub holder_alive: Option<bool>,
+    pub evidence: Option<String>,
+    pub validator: Option<String>,
+    pub acceptance: Option<String>,
+    pub failed_attempts: u32,
+    pub max_validation_attempts: u32,
+    pub monitor_target: Option<String>,
+    pub monitor_cadence: Option<String>,
+    pub monitor_due_at: Option<u64>,
+    pub consecutive_no_change: u32,
+    pub resume_when_text: Option<String>,
+    pub successor_ids: Vec<String>,
+    pub no_follow_up: bool,
+    pub archive_state: String,
+    pub updated_at: u64,
+    pub completed_at: Option<u64>,
+    pub passed_validation: bool,
+}
+
+fn class_label(t: &Todo) -> &'static str {
+    match t.class {
+        TaskClass::Advancement => "advancement",
+        TaskClass::UserGate => "user_gate",
+        TaskClass::UserAction => "user_action",
+        TaskClass::Monitor => "monitor",
+        TaskClass::Blocker => "blocker",
+    }
+}
+
+fn status_label(t: &Todo) -> &'static str {
+    match t.status {
+        TodoStatus::Open => "open",
+        TodoStatus::Done => "done",
+        TodoStatus::Superseded => "superseded",
+        TodoStatus::Deferred => "deferred",
+        TodoStatus::Blocked => "blocked",
+    }
+}
+
+fn todo_view(goal: &Goal, t: &Todo) -> TodoView {
+    TodoView {
+        id: t.id.clone(),
+        index: t.index,
+        title: t.title.clone(),
+        text: t.text.clone(),
+        class: class_label(t).to_string(),
+        status: status_label(t).to_string(),
+        priority: t.priority.to_string(),
+        role: match t.role {
+            crate::state::TodoRole::Agent => "agent",
+            crate::state::TodoRole::User => "user",
+        }
+        .to_string(),
+        gate_question: t.gate_question.clone(),
+        decision: t.decision.clone(),
+        note: t.note.clone(),
+        blocked_by: task_graph::predecessors_of(t),
+        blocked: goal.is_blocked(t),
+        claimed_by: t.claimed_by.clone(),
+        lease_expires_at: t.lease_expires_at,
+        holder_pid: t.holder_pid,
+        holder_alive: t.holder_pid.map(crate::compat::pid_alive),
+        evidence: t.evidence.clone(),
+        validator: t.validator.clone(),
+        acceptance: t.acceptance.clone(),
+        failed_attempts: t.failed_attempts,
+        max_validation_attempts: t.max_validation_attempts,
+        monitor_target: t.monitor_target.clone(),
+        monitor_cadence: t.monitor_cadence.clone(),
+        monitor_due_at: epoch_secs(t.resume_when),
+        consecutive_no_change: t.consecutive_no_change,
+        resume_when_text: t.resume_when_text.clone(),
+        successor_ids: t.successor_ids.clone(),
+        no_follow_up: t.no_follow_up,
+        archive_state: t.archive_state.clone(),
+        updated_at: t.updated_at,
+        completed_at: t.completed_at,
+        passed_validation: goal.has_passed_validation(&t.id),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentView {
+    pub id: String,
+    pub capabilities: Vec<String>,
+    pub workspaces: Vec<String>,
+    pub last_heartbeat: Option<u64>,
+    pub heartbeat_age_secs: Option<u64>,
+    pub active_leases: Vec<String>,
+}
+
+fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
+    let mut ids: Vec<String> = goal.registered_agents.clone();
+    for a in goal.scheduler_heartbeats.keys() {
+        if !ids.iter().any(|x| x == a) {
+            ids.push(a.clone());
+        }
+    }
+    ids.sort();
+    ids.into_iter()
+        .map(|id| {
+            let profile = goal.agent_profiles.iter().find(|p| p.id == id);
+            let hb = goal.scheduler_heartbeats.get(&id).copied();
+            let mut leases: Vec<&Todo> = goal
+                .todos
+                .iter()
+                .filter(|t| {
+                    t.claimed_by.as_deref() == Some(id.as_str())
+                        && t.lease_expires_at.is_some_and(|e| e > now)
+                })
+                .collect();
+            leases.sort_by_key(|t| t.index);
+            AgentView {
+                id: id.clone(),
+                capabilities: profile.map(|p| p.capabilities.clone()).unwrap_or_default(),
+                workspaces: profile.map(|p| p.workspaces.clone()).unwrap_or_default(),
+                last_heartbeat: hb,
+                heartbeat_age_secs: hb.map(|h| now.saturating_sub(h)),
+                active_leases: leases.into_iter().map(|t| t.id.clone()).collect(),
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpendBucket {
+    pub runs: u32,
+    pub slots: u64,
+    pub cost: f64,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+}
+
+impl SpendBucket {
+    fn fold(&mut self, r: &RunRecord) {
+        self.runs += 1;
+        self.slots += crate::quota::slot_accounting::slot_spend(r);
+        self.cost = nnz(self.cost + r.cost_delta);
+        self.tokens_in += r.tokens_in_delta;
+        self.tokens_out += r.tokens_out_delta;
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OutcomeSplit {
+    pub succeeded: u32,
+    pub verify_failed: u32,
+    pub infra_failed: u32,
+    pub errored: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpendView {
+    pub runs_24h: SpendBucket,
+    pub runs_7d: SpendBucket,
+    pub total: SpendBucket,
+    pub outcomes_7d: OutcomeSplit,
+}
+
+fn failure_kind_of(_goal: &Goal, r: &RunRecord) -> FailureKind {
+    r.failure_kind
+        .unwrap_or_else(|| crate::executor::classify_failure(r))
+}
+
+fn spend_view(goal: &Goal, now: u64) -> SpendView {
+    let cutoff_24h = now.saturating_sub(24 * 3600);
+    let cutoff_7d = now.saturating_sub(7 * 24 * 3600);
+    let mut v = SpendView {
+        runs_24h: SpendBucket {
+            runs: 0,
+            slots: 0,
+            cost: 0.0,
+            tokens_in: 0,
+            tokens_out: 0,
+        },
+        runs_7d: SpendBucket {
+            runs: 0,
+            slots: 0,
+            cost: 0.0,
+            tokens_in: 0,
+            tokens_out: 0,
+        },
+        total: SpendBucket {
+            runs: 0,
+            slots: 0,
+            cost: 0.0,
+            tokens_in: 0,
+            tokens_out: 0,
+        },
+        outcomes_7d: OutcomeSplit {
+            succeeded: 0,
+            verify_failed: 0,
+            infra_failed: 0,
+            errored: 0,
+        },
+    };
+    for r in &goal.history {
+        v.total.fold(r);
+        if r.recorded_at >= cutoff_24h {
+            v.runs_24h.fold(r);
+        }
+        if r.recorded_at >= cutoff_7d {
+            v.runs_7d.fold(r);
+            match failure_kind_of(goal, r) {
+                FailureKind::None => v.outcomes_7d.succeeded += 1,
+                FailureKind::ScienceVerifyFailed => v.outcomes_7d.verify_failed += 1,
+                FailureKind::InfraRecoverable => v.outcomes_7d.infra_failed += 1,
+                FailureKind::HardError => v.outcomes_7d.errored += 1,
+            }
+        }
+    }
+    v
+}
+
+/// JSON payloads must not carry `-0.0` (an empty run history sums to
+/// negative zero via f64 and renders as "$-0.00" in the UI).
+fn nnz(x: f64) -> f64 {
+    if x == 0.0 {
+        0.0
+    } else {
+        x
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GoalCard {
+    pub goal_id: String,
+    pub objective: String,
+    pub cwd: String,
+    pub status: String,
+    pub created_at: u64,
+    pub todos_open: usize,
+    pub todos_done: usize,
+    pub todos_total: usize,
+    pub open_gates: usize,
+    pub runs_total: usize,
+    pub cost_total: f64,
+    pub decision: String,
+    pub decision_reason: String,
+    pub waiting_on: String,
+    pub severity: Option<String>,
+    pub terminal: bool,
+    pub cancelled: bool,
+    pub last_run_at: Option<u64>,
+}
+
+fn goal_card(goal: &Goal, now: u64) -> GoalCard {
+    let packet = decision::decide_for(goal, SystemTime::now(), None);
+    let item = attention::goal_attention_item(goal);
+    GoalCard {
+        goal_id: goal.goal_id.clone(),
+        objective: goal.objective.clone(),
+        cwd: goal.cwd.clone(),
+        status: goal.status.clone(),
+        created_at: goal.created_at,
+        todos_open: goal
+            .todos
+            .iter()
+            .filter(|t| t.status == TodoStatus::Open)
+            .count(),
+        todos_done: goal
+            .todos
+            .iter()
+            .filter(|t| t.status == TodoStatus::Done)
+            .count(),
+        todos_total: goal.todos.len(),
+        open_gates: goal.open_gates().count(),
+        runs_total: goal.history.len(),
+        cost_total: nnz(goal.history.iter().map(|r| r.cost_delta).sum()),
+        decision: packet.decision.clone(),
+        decision_reason: packet.reason.clone(),
+        waiting_on: item
+            .as_ref()
+            .map(|i| i.waiting_on.clone())
+            .unwrap_or_else(|| packet.waiting_on.clone()),
+        severity: item.as_ref().map(|i| i.severity.clone()),
+        terminal: goal.is_terminal(),
+        cancelled: goal.status == "cancelled",
+        last_run_at: goal
+            .history
+            .iter()
+            .map(|r| r.recorded_at)
+            .max()
+            .filter(|_| now > 0),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OverviewTotals {
+    pub goals: usize,
+    pub active: usize,
+    pub terminal: usize,
+    pub cancelled: usize,
+    pub open_gates: usize,
+    pub open_todos: usize,
+    pub runs_24h: u32,
+    pub cost_24h: f64,
+    pub runs_7d: u32,
+    pub cost_7d: f64,
+    pub slots_7d: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Overview {
+    pub generated_at: u64,
+    pub root: String,
+    pub totals: OverviewTotals,
+    pub attention: attention::AttentionQueue,
+    pub goals: Vec<GoalCard>,
+}
+
+/// Replay every registered goal (a goal whose ledger fails to replay is
+/// skipped — one corrupt goal must not blank the whole dashboard).
+fn replay_all(store: &Store) -> Vec<Goal> {
+    store
+        .registry()
+        .iter()
+        .filter_map(|e| store.replay(&e.goal_id).ok().flatten())
+        .collect()
+}
+
+pub fn overview(store: &Store) -> Result<Overview> {
+    let now = now_epoch();
+    let goals = replay_all(store);
+    let mut cards: Vec<GoalCard> = goals.iter().map(|g| goal_card(g, now)).collect();
+    // Triage order: goals needing a human first, then actionable, then the rest.
+    cards.sort_by(|a, b| {
+        fn rank(c: &GoalCard) -> u8 {
+            if c.cancelled || c.terminal {
+                3
+            } else if c.open_gates > 0 {
+                0
+            } else if c.severity.as_deref() == Some("high") {
+                1
+            } else {
+                2
+            }
+        }
+        rank(a).cmp(&rank(b)).then(b.created_at.cmp(&a.created_at))
+    });
+    let items: Vec<attention::AttentionItem> = goals
+        .iter()
+        .filter_map(attention::goal_attention_item)
+        .collect();
+    let queue = attention::build_attention_queue(items);
+    let cutoff_24h = now.saturating_sub(24 * 3600);
+    let cutoff_7d = now.saturating_sub(7 * 24 * 3600);
+    let mut totals = OverviewTotals {
+        goals: goals.len(),
+        active: 0,
+        terminal: 0,
+        cancelled: 0,
+        open_gates: 0,
+        open_todos: 0,
+        runs_24h: 0,
+        cost_24h: 0.0,
+        runs_7d: 0,
+        cost_7d: 0.0,
+        slots_7d: 0,
+    };
+    for g in &goals {
+        if g.status == "cancelled" {
+            totals.cancelled += 1;
+        } else if g.is_terminal() {
+            totals.terminal += 1;
+        } else {
+            totals.active += 1;
+        }
+        totals.open_gates += g.open_gates().count();
+        totals.open_todos += g
+            .todos
+            .iter()
+            .filter(|t| t.status == TodoStatus::Open)
+            .count();
+        for r in &g.history {
+            if r.recorded_at >= cutoff_24h {
+                totals.runs_24h += 1;
+                totals.cost_24h = nnz(totals.cost_24h + r.cost_delta);
+            }
+            if r.recorded_at >= cutoff_7d {
+                totals.runs_7d += 1;
+                totals.cost_7d = nnz(totals.cost_7d + r.cost_delta);
+                totals.slots_7d += crate::quota::slot_accounting::slot_spend(r);
+            }
+        }
+    }
+    Ok(Overview {
+        generated_at: now,
+        root: store.root_path(),
+        totals,
+        attention: queue,
+        goals: cards,
+    })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GoalDetail {
+    pub goal_id: String,
+    pub objective: String,
+    pub cwd: String,
+    pub status: String,
+    pub created_at: u64,
+    pub next_action: Option<String>,
+    pub terminal: bool,
+    pub decision: serde_json::Value,
+    pub attention: Option<attention::AttentionItem>,
+    pub replan_obligations: Vec<replan_obligation::ReplanObligation>,
+    pub todos: Vec<TodoView>,
+    pub agents: Vec<AgentView>,
+    pub acceptance: Vec<crate::state::AcceptanceGap>,
+    pub deliveries: Vec<DeliveryState>,
+    pub unvalidated_deliveries: Vec<String>,
+    pub spend: SpendView,
+    pub runs: Vec<RunRecord>,
+    pub semantic_history: Vec<crate::decision::goal_frontier::semantic_history::SemanticEvent>,
+    pub frontier: crate::decision::goal_frontier::FrontierShow,
+    pub task_graph: Option<task_graph::TaskGraph>,
+    pub liveness_alerts: Vec<crate::state::LivenessAlert>,
+    pub authority: crate::state::Authority,
+    pub execution_profile: crate::state::ExecutionProfile,
+    pub event_count: usize,
+}
+
+pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(None);
+    };
+    let now = now_epoch();
+    let packet = decision::decide_for(&goal, SystemTime::now(), None);
+    let mut todos: Vec<TodoView> = goal.todos.iter().map(|t| todo_view(&goal, t)).collect();
+    todos.sort_by_key(|t| t.index);
+    let mut runs = goal.history.clone();
+    runs.sort_by_key(|r| std::cmp::Reverse(r.recorded_at));
+    runs.truncate(200);
+    let graph = task_graph::build_task_graph(&goal).ok();
+    let event_count = store.events(goal_id).map(|e| e.len()).unwrap_or(0);
+    Ok(Some(GoalDetail {
+        goal_id: goal.goal_id.clone(),
+        objective: goal.objective.clone(),
+        cwd: goal.cwd.clone(),
+        status: goal.status.clone(),
+        created_at: goal.created_at,
+        next_action: goal.next_action.clone(),
+        terminal: goal.is_terminal(),
+        decision: serde_json::to_value(&packet)?,
+        attention: attention::goal_attention_item(&goal),
+        replan_obligations: replan_obligation::detect_obligations(&goal),
+        todos,
+        agents: agent_views(&goal, now),
+        acceptance: goal.acceptance.clone(),
+        deliveries: goal.delivery_states.clone(),
+        unvalidated_deliveries: goal
+            .unvalidated_deliveries()
+            .iter()
+            .map(|t| t.id.clone())
+            .collect(),
+        spend: spend_view(&goal, now),
+        runs,
+        semantic_history: goal.semantic_history.clone(),
+        frontier: crate::decision::goal_frontier::frontier_show(&goal),
+        task_graph: graph,
+        liveness_alerts: goal.liveness_alerts.clone(),
+        authority: goal.authority.clone(),
+        execution_profile: goal.execution_profile.clone(),
+        event_count,
+    }))
+}
+
+pub fn runs_page(store: &Store, goal_id: &str, limit: usize) -> Result<Option<Vec<RunRecord>>> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(None);
+    };
+    let mut runs = goal.history.clone();
+    runs.sort_by_key(|r| std::cmp::Reverse(r.recorded_at));
+    runs.truncate(limit.min(500));
+    Ok(Some(runs))
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EventView {
+    pub event_id: String,
+    pub kind: String,
+    pub ts: u64,
+    pub event: serde_json::Value,
+}
+
+pub fn events_page(store: &Store, goal_id: &str, limit: usize) -> Result<Option<Vec<EventView>>> {
+    if !store.registered(goal_id) {
+        return Ok(None);
+    }
+    // Raw ledger lines: the stored envelope is flattened (kind/goal_id/ts
+    // plus the payload live at the top level, next to the provenance
+    // fields), so we project directly instead of re-deriving from `Event`.
+    let mut lines = store.raw_ledger_lines(goal_id)?;
+    lines.reverse();
+    let views = lines
+        .into_iter()
+        .take(limit.min(500))
+        .map(|line| {
+            let value: serde_json::Value =
+                serde_json::from_str(&line).unwrap_or_else(|_| serde_json::json!({"raw": line}));
+            EventView {
+                event_id: value
+                    .get("event_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                kind: value
+                    .get("kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string(),
+                ts: value.get("ts").and_then(|v| v.as_u64()).unwrap_or(0),
+                event: value,
+            }
+        })
+        .collect();
+    Ok(Some(views))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GateResolveBody {
+    pub todo_id: String,
+    pub decision: String,
+    pub note: Option<String>,
+}
+
+pub fn resolve_gate(store: &mut Store, goal_id: &str, body: &GateResolveBody) -> Result<String> {
+    if body.decision.trim().is_empty() {
+        anyhow::bail!("decision must not be empty");
+    }
+    let goal = store
+        .replay(goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let gate = goal
+        .todo(&body.todo_id)
+        .ok_or_else(|| anyhow::anyhow!("todo {} not found", body.todo_id))?;
+    if gate.class != TaskClass::UserGate {
+        anyhow::bail!("todo {} is not a user gate", body.todo_id);
+    }
+    if gate.status != TodoStatus::Open {
+        anyhow::bail!("gate {} is already resolved", body.todo_id);
+    }
+    store.append(Event::GateResolved {
+        goal_id: goal_id.to_string(),
+        todo_id: body.todo_id.clone(),
+        decision: body.decision.trim().to_string(),
+        note: body.note.clone().filter(|n| !n.trim().is_empty()),
+        ts: now_epoch(),
+    })?;
+    crate::console::refresh_projections_after_append(store, goal_id)?;
+    Ok(format!("gate {} resolved", body.todo_id))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct LifecycleBody {
+    pub action: String,
+    pub reason: Option<String>,
+}
+
+pub fn set_lifecycle(store: &mut Store, goal_id: &str, body: &LifecycleBody) -> Result<String> {
+    let goal = store
+        .replay(goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    match body.action.as_str() {
+        "cancel" => {
+            if goal.status == "cancelled" {
+                anyhow::bail!("goal {goal_id} is already cancelled");
+            }
+            let reason = body
+                .reason
+                .clone()
+                .filter(|r| !r.trim().is_empty())
+                .unwrap_or_else(|| "cancelled from web ui".to_string());
+            store.append(Event::GoalCancelled {
+                goal_id: goal_id.to_string(),
+                reason,
+                ts: now_epoch(),
+            })?;
+            crate::console::refresh_projections_after_append(store, goal_id)?;
+            Ok(format!("goal {goal_id} cancelled"))
+        }
+        "resume" => anyhow::bail!(
+            "resume is not supported by the loop kernel (no GoalResumed event) — \
+             create a follow-up goal or steer via `todo update`"
+        ),
+        other => anyhow::bail!("unknown lifecycle action `{other}` (cancel)"),
+    }
+}
+
+/// Compact per-goal push payload for the SSE stream (avoids resending full
+/// details every tick; the detail view refetches on `goals` events anyway).
+pub fn goals_push(store: &Store) -> Result<Vec<GoalCard>> {
+    let now = now_epoch();
+    Ok(replay_all(store)
+        .iter()
+        .map(|g| goal_card(g, now))
+        .collect())
+}

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -54,6 +54,14 @@ pub struct TodoView {
     pub updated_at: u64,
     pub completed_at: Option<u64>,
     pub passed_validation: bool,
+    // ── run rollup for the cost column ───────────────────────────────
+    pub runs: u32,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost: f64,
+    pub first_run_at: Option<u64>,
+    pub last_run_at: Option<u64>,
+    pub last_holder: Option<String>,
 }
 
 fn class_label(t: &Todo) -> &'static str {
@@ -77,6 +85,20 @@ fn status_label(t: &Todo) -> &'static str {
 }
 
 fn todo_view(goal: &Goal, t: &Todo) -> TodoView {
+    let mut runs = 0u32;
+    let mut tokens_in = 0u64;
+    let mut tokens_out = 0u64;
+    let mut cost = 0.0f64;
+    let mut first_run_at: Option<u64> = None;
+    let mut last_run_at: Option<u64> = None;
+    for r in goal.history.iter().filter(|r| r.todo_id == t.id) {
+        runs += 1;
+        tokens_in += r.tokens_in_delta;
+        tokens_out += r.tokens_out_delta;
+        cost += r.cost_delta;
+        first_run_at = Some(first_run_at.map_or(r.recorded_at, |f: u64| f.min(r.recorded_at)));
+        last_run_at = Some(last_run_at.map_or(r.recorded_at, |l: u64| l.max(r.recorded_at)));
+    }
     TodoView {
         id: t.id.clone(),
         index: t.index,
@@ -115,6 +137,13 @@ fn todo_view(goal: &Goal, t: &Todo) -> TodoView {
         updated_at: t.updated_at,
         completed_at: t.completed_at,
         passed_validation: goal.has_passed_validation(&t.id),
+        runs,
+        tokens_in,
+        tokens_out,
+        cost: nnz(cost),
+        first_run_at,
+        last_run_at,
+        last_holder: t.claimed_by.clone(),
     }
 }
 
@@ -126,13 +155,31 @@ pub struct AgentView {
     pub last_heartbeat: Option<u64>,
     pub heartbeat_age_secs: Option<u64>,
     pub active_leases: Vec<String>,
+    // ── run rollup for the cost column ───────────────────────────────
+    pub runs: u32,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost: f64,
+    pub first_run_at: Option<u64>,
+    pub last_run_at: Option<u64>,
+    /// Model used for NEW runs of this agent (loop-wide default — the
+    /// kernel does not persist per-run model; see `model_config`).
+    pub model: String,
 }
 
-fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
+fn agent_views(goal: &Goal, now: u64, default_model: &str) -> Vec<AgentView> {
     let mut ids: Vec<String> = goal.registered_agents.clone();
     for a in goal.scheduler_heartbeats.keys() {
         if !ids.iter().any(|x| x == a) {
             ids.push(a.clone());
+        }
+    }
+    // Agents inferred from lease claims (never registered explicitly).
+    for t in &goal.todos {
+        if let Some(c) = &t.claimed_by {
+            if !ids.iter().any(|x| x == c) {
+                ids.push(c.clone());
+            }
         }
     }
     ids.sort();
@@ -149,6 +196,25 @@ fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
                 })
                 .collect();
             leases.sort_by_key(|t| t.index);
+            let mut runs = 0u32;
+            let mut tokens_in = 0u64;
+            let mut tokens_out = 0u64;
+            let mut cost = 0.0f64;
+            let mut first_run_at: Option<u64> = None;
+            let mut last_run_at: Option<u64> = None;
+            for r in goal
+                .history
+                .iter()
+                .filter(|r| r.run_id.starts_with(&format!("{id}-")))
+            {
+                runs += 1;
+                tokens_in += r.tokens_in_delta;
+                tokens_out += r.tokens_out_delta;
+                cost += r.cost_delta;
+                first_run_at =
+                    Some(first_run_at.map_or(r.recorded_at, |f: u64| f.min(r.recorded_at)));
+                last_run_at = Some(last_run_at.map_or(r.recorded_at, |l: u64| l.max(r.recorded_at)));
+            }
             AgentView {
                 id: id.clone(),
                 capabilities: profile.map(|p| p.capabilities.clone()).unwrap_or_default(),
@@ -156,6 +222,13 @@ fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
                 last_heartbeat: hb,
                 heartbeat_age_secs: hb.map(|h| now.saturating_sub(h)),
                 active_leases: leases.into_iter().map(|t| t.id.clone()).collect(),
+                runs,
+                tokens_in,
+                tokens_out,
+                cost: nnz(cost),
+                first_run_at,
+                last_run_at,
+                model: default_model.to_string(),
             }
         })
         .collect()
@@ -249,6 +322,52 @@ fn spend_view(goal: &Goal, now: u64) -> SpendView {
         }
     }
     v
+}
+
+/// Loop-run model configuration. The loop kernel does not persist which
+/// model a turn used (only token/cost deltas land in the run ledger), so
+/// the dashboard shows the model that NEW runs will use. Resolution order
+/// mirrors `run`: explicit `--model` flag (not visible here) → agent
+/// settings `default_model` → first credentialed catalog entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelConfig {
+    /// Effective model used when `run` is invoked without `--model`.
+    pub default_model: Option<String>,
+    /// Where the value came from: `settings.json` | null (agent fallback).
+    pub source: Option<String>,
+    /// ~/.future/agent/settings.json (shown so the user knows where to edit).
+    pub settings_path: String,
+    pub note: String,
+}
+
+pub fn model_config() -> ModelConfig {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default();
+    let settings_path = format!("{home}/.future/agent/settings.json");
+    let mut model = None;
+    let mut source = None;
+    if let Ok(text) = std::fs::read_to_string(&settings_path) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+            let m = v
+                .get("default_model")
+                .and_then(|m| m.as_str())
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+                .map(str::to_string);
+            if m.is_some() {
+                model = m;
+                source = Some("settings.json");
+            }
+        }
+    }
+    ModelConfig {
+        default_model: model,
+        source: source.map(str::to_string),
+        settings_path,
+        note: "applies to new `run` turns; past runs record only token/cost deltas, not the model"
+            .to_string(),
+    }
 }
 
 /// JSON payloads must not carry `-0.0` (an empty run history sums to
@@ -346,6 +465,7 @@ pub struct Overview {
     pub totals: OverviewTotals,
     pub attention: attention::AttentionQueue,
     pub goals: Vec<GoalCard>,
+    pub model: ModelConfig,
 }
 
 /// Replay every registered goal (a goal whose ledger fails to replay is
@@ -429,6 +549,7 @@ pub fn overview(store: &Store) -> Result<Overview> {
         totals,
         attention: queue,
         goals: cards,
+        model: model_config(),
     })
 }
 
@@ -458,6 +579,8 @@ pub struct GoalDetail {
     pub authority: crate::state::Authority,
     pub execution_profile: crate::state::ExecutionProfile,
     pub event_count: usize,
+    /// Model applied to new runs (loop-wide; see `model_config`).
+    pub model: ModelConfig,
 }
 
 pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
@@ -473,6 +596,8 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
     runs.truncate(200);
     let graph = task_graph::build_task_graph(&goal).ok();
     let event_count = store.events(goal_id).map(|e| e.len()).unwrap_or(0);
+    let model = model_config();
+    let default_model = model.default_model.clone().unwrap_or_default();
     Ok(Some(GoalDetail {
         goal_id: goal.goal_id.clone(),
         objective: goal.objective.clone(),
@@ -485,7 +610,7 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
         attention: attention::goal_attention_item(&goal),
         replan_obligations: replan_obligation::detect_obligations(&goal),
         todos,
-        agents: agent_views(&goal, now),
+        agents: agent_views(&goal, now, &default_model),
         acceptance: goal.acceptance.clone(),
         deliveries: goal.delivery_states.clone(),
         unvalidated_deliveries: goal
@@ -502,6 +627,7 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
         authority: goal.authority.clone(),
         execution_profile: goal.execution_profile.clone(),
         event_count,
+        model,
     }))
 }
 

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -353,7 +353,7 @@ pub struct GoalCard {
     pub last_run_at: Option<u64>,
 }
 
-fn goal_card(goal: &Goal, now: u64) -> GoalCard {
+fn goal_card(goal: &Goal, created_at: u64, now: u64) -> GoalCard {
     let packet = decision::decide_for(goal, SystemTime::now(), None);
     let item = attention::goal_attention_item(goal);
     GoalCard {
@@ -361,7 +361,7 @@ fn goal_card(goal: &Goal, now: u64) -> GoalCard {
         objective: goal.objective.clone(),
         cwd: goal.cwd.clone(),
         status: goal.status.clone(),
-        created_at: goal.created_at,
+        created_at,
         todos_open: goal
             .todos
             .iter()
@@ -431,7 +431,18 @@ fn replay_all(store: &Store) -> Vec<Goal> {
 pub fn overview(store: &Store) -> Result<Overview> {
     let now = now_epoch();
     let goals = replay_all(store);
-    let mut cards: Vec<GoalCard> = goals.iter().map(|g| goal_card(g, now)).collect();
+    // Registry timestamps are stable across replays; the replayed goal's
+    // `created_at` is not (the ledger ignores GoalStarted, so replay stamps
+    // it with "now" — which would make every fingerprint change per tick).
+    let created_by: std::collections::HashMap<String, u64> = store
+        .registry()
+        .iter()
+        .map(|e| (e.goal_id.clone(), e.created_at))
+        .collect();
+    let mut cards: Vec<GoalCard> = goals
+        .iter()
+        .map(|g| goal_card(g, created_by.get(&g.goal_id).copied().unwrap_or(g.created_at), now))
+        .collect();
     // Triage order: goals needing a human first, then actionable, then the rest.
     cards.sort_by(|a, b| {
         fn rank(c: &GoalCard) -> u8 {
@@ -543,12 +554,20 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
     runs.truncate(200);
     let graph = task_graph::build_task_graph(&goal).ok();
     let event_count = store.events(goal_id).map(|e| e.len()).unwrap_or(0);
+    // Stable creation timestamp (see overview(): the replayed goal's
+    // created_at is re-stamped with "now" on every replay).
+    let created_at = store
+        .registry()
+        .iter()
+        .find(|e| e.goal_id == goal_id)
+        .map(|e| e.created_at)
+        .unwrap_or(goal.created_at);
     Ok(Some(GoalDetail {
         goal_id: goal.goal_id.clone(),
         objective: goal.objective.clone(),
         cwd: goal.cwd.clone(),
         status: goal.status.clone(),
-        created_at: goal.created_at,
+        created_at,
         next_action: goal.next_action.clone(),
         terminal: goal.is_terminal(),
         decision: serde_json::to_value(&packet)?,
@@ -635,8 +654,13 @@ pub fn events_page(store: &Store, goal_id: &str, limit: usize) -> Result<Option<
 /// details every tick; the detail view refetches on `goals` events anyway).
 pub fn goals_push(store: &Store) -> Result<Vec<GoalCard>> {
     let now = now_epoch();
+    let created_by: std::collections::HashMap<String, u64> = store
+        .registry()
+        .iter()
+        .map(|e| (e.goal_id.clone(), e.created_at))
+        .collect();
     Ok(replay_all(store)
         .iter()
-        .map(|g| goal_card(g, now))
+        .map(|g| goal_card(g, created_by.get(&g.goal_id).copied().unwrap_or(g.created_at), now))
         .collect())
 }

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -10,7 +10,7 @@ use crate::decision;
 use crate::state::{
     now_epoch, DeliveryState, FailureKind, Goal, RunRecord, TaskClass, Todo, TodoStatus,
 };
-use crate::store::{Event, Store};
+use crate::store::Store;
 use crate::work_items::{attention, replan_obligation, task_graph};
 
 /// Serialize a SystemTime as epoch seconds (JSON has no SystemTime).
@@ -162,12 +162,9 @@ pub struct AgentView {
     pub cost: f64,
     pub first_run_at: Option<u64>,
     pub last_run_at: Option<u64>,
-    /// Model used for NEW runs of this agent (loop-wide default — the
-    /// kernel does not persist per-run model; see `model_config`).
-    pub model: String,
 }
 
-fn agent_views(goal: &Goal, now: u64, default_model: &str) -> Vec<AgentView> {
+fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
     let mut ids: Vec<String> = goal.registered_agents.clone();
     for a in goal.scheduler_heartbeats.keys() {
         if !ids.iter().any(|x| x == a) {
@@ -228,7 +225,6 @@ fn agent_views(goal: &Goal, now: u64, default_model: &str) -> Vec<AgentView> {
                 cost: nnz(cost),
                 first_run_at,
                 last_run_at,
-                model: default_model.to_string(),
             }
         })
         .collect()
@@ -322,52 +318,6 @@ fn spend_view(goal: &Goal, now: u64) -> SpendView {
         }
     }
     v
-}
-
-/// Loop-run model configuration. The loop kernel does not persist which
-/// model a turn used (only token/cost deltas land in the run ledger), so
-/// the dashboard shows the model that NEW runs will use. Resolution order
-/// mirrors `run`: explicit `--model` flag (not visible here) → agent
-/// settings `default_model` → first credentialed catalog entry.
-#[derive(Debug, Clone, Serialize)]
-pub struct ModelConfig {
-    /// Effective model used when `run` is invoked without `--model`.
-    pub default_model: Option<String>,
-    /// Where the value came from: `settings.json` | null (agent fallback).
-    pub source: Option<String>,
-    /// ~/.future/agent/settings.json (shown so the user knows where to edit).
-    pub settings_path: String,
-    pub note: String,
-}
-
-pub fn model_config() -> ModelConfig {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_default();
-    let settings_path = format!("{home}/.future/agent/settings.json");
-    let mut model = None;
-    let mut source = None;
-    if let Ok(text) = std::fs::read_to_string(&settings_path) {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-            let m = v
-                .get("default_model")
-                .and_then(|m| m.as_str())
-                .map(str::trim)
-                .filter(|m| !m.is_empty())
-                .map(str::to_string);
-            if m.is_some() {
-                model = m;
-                source = Some("settings.json");
-            }
-        }
-    }
-    ModelConfig {
-        default_model: model,
-        source: source.map(str::to_string),
-        settings_path,
-        note: "applies to new `run` turns; past runs record only token/cost deltas, not the model"
-            .to_string(),
-    }
 }
 
 /// JSON payloads must not carry `-0.0` (an empty run history sums to
@@ -465,7 +415,6 @@ pub struct Overview {
     pub totals: OverviewTotals,
     pub attention: attention::AttentionQueue,
     pub goals: Vec<GoalCard>,
-    pub model: ModelConfig,
 }
 
 /// Replay every registered goal (a goal whose ledger fails to replay is
@@ -549,7 +498,6 @@ pub fn overview(store: &Store) -> Result<Overview> {
         totals,
         attention: queue,
         goals: cards,
-        model: model_config(),
     })
 }
 
@@ -579,8 +527,6 @@ pub struct GoalDetail {
     pub authority: crate::state::Authority,
     pub execution_profile: crate::state::ExecutionProfile,
     pub event_count: usize,
-    /// Model applied to new runs (loop-wide; see `model_config`).
-    pub model: ModelConfig,
 }
 
 pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
@@ -596,8 +542,6 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
     runs.truncate(200);
     let graph = task_graph::build_task_graph(&goal).ok();
     let event_count = store.events(goal_id).map(|e| e.len()).unwrap_or(0);
-    let model = model_config();
-    let default_model = model.default_model.clone().unwrap_or_default();
     Ok(Some(GoalDetail {
         goal_id: goal.goal_id.clone(),
         objective: goal.objective.clone(),
@@ -610,7 +554,7 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
         attention: attention::goal_attention_item(&goal),
         replan_obligations: replan_obligation::detect_obligations(&goal),
         todos,
-        agents: agent_views(&goal, now, &default_model),
+        agents: agent_views(&goal, now),
         acceptance: goal.acceptance.clone(),
         deliveries: goal.delivery_states.clone(),
         unvalidated_deliveries: goal
@@ -627,7 +571,6 @@ pub fn goal_detail(store: &Store, goal_id: &str) -> Result<Option<GoalDetail>> {
         authority: goal.authority.clone(),
         execution_profile: goal.execution_profile.clone(),
         event_count,
-        model,
     }))
 }
 
@@ -683,75 +626,9 @@ pub fn events_page(store: &Store, goal_id: &str, limit: usize) -> Result<Option<
     Ok(Some(views))
 }
 
-#[derive(Debug, serde::Deserialize)]
-pub struct GateResolveBody {
-    pub todo_id: String,
-    pub decision: String,
-    pub note: Option<String>,
-}
-
-pub fn resolve_gate(store: &mut Store, goal_id: &str, body: &GateResolveBody) -> Result<String> {
-    if body.decision.trim().is_empty() {
-        anyhow::bail!("decision must not be empty");
-    }
-    let goal = store
-        .replay(goal_id)?
-        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    let gate = goal
-        .todo(&body.todo_id)
-        .ok_or_else(|| anyhow::anyhow!("todo {} not found", body.todo_id))?;
-    if gate.class != TaskClass::UserGate {
-        anyhow::bail!("todo {} is not a user gate", body.todo_id);
-    }
-    if gate.status != TodoStatus::Open {
-        anyhow::bail!("gate {} is already resolved", body.todo_id);
-    }
-    store.append(Event::GateResolved {
-        goal_id: goal_id.to_string(),
-        todo_id: body.todo_id.clone(),
-        decision: body.decision.trim().to_string(),
-        note: body.note.clone().filter(|n| !n.trim().is_empty()),
-        ts: now_epoch(),
-    })?;
-    crate::console::refresh_projections_after_append(store, goal_id)?;
-    Ok(format!("gate {} resolved", body.todo_id))
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct LifecycleBody {
-    pub action: String,
-    pub reason: Option<String>,
-}
-
-pub fn set_lifecycle(store: &mut Store, goal_id: &str, body: &LifecycleBody) -> Result<String> {
-    let goal = store
-        .replay(goal_id)?
-        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    match body.action.as_str() {
-        "cancel" => {
-            if goal.status == "cancelled" {
-                anyhow::bail!("goal {goal_id} is already cancelled");
-            }
-            let reason = body
-                .reason
-                .clone()
-                .filter(|r| !r.trim().is_empty())
-                .unwrap_or_else(|| "cancelled from web ui".to_string());
-            store.append(Event::GoalCancelled {
-                goal_id: goal_id.to_string(),
-                reason,
-                ts: now_epoch(),
-            })?;
-            crate::console::refresh_projections_after_append(store, goal_id)?;
-            Ok(format!("goal {goal_id} cancelled"))
-        }
-        "resume" => anyhow::bail!(
-            "resume is not supported by the loop kernel (no GoalResumed event) — \
-             create a follow-up goal or steer via `todo update`"
-        ),
-        other => anyhow::bail!("unknown lifecycle action `{other}` (cancel)"),
-    }
-}
+// The dashboard is strictly read-only: it projects the event ledger and
+// never appends to it. Mutations (gate resolve, goal cancel, …) stay in
+// the CLI (`future loop gate resolve`, `future loop goal cancel`).
 
 /// Compact per-goal push payload for the SSE stream (avoids resending full
 /// details every tick; the detail view refetches on `goals` events anyway).

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -441,7 +441,13 @@ pub fn overview(store: &Store) -> Result<Overview> {
         .collect();
     let mut cards: Vec<GoalCard> = goals
         .iter()
-        .map(|g| goal_card(g, created_by.get(&g.goal_id).copied().unwrap_or(g.created_at), now))
+        .map(|g| {
+            goal_card(
+                g,
+                created_by.get(&g.goal_id).copied().unwrap_or(g.created_at),
+                now,
+            )
+        })
         .collect();
     // Triage order: goals needing a human first, then actionable, then the rest.
     cards.sort_by(|a, b| {
@@ -661,6 +667,12 @@ pub fn goals_push(store: &Store) -> Result<Vec<GoalCard>> {
         .collect();
     Ok(replay_all(store)
         .iter()
-        .map(|g| goal_card(g, created_by.get(&g.goal_id).copied().unwrap_or(g.created_at), now))
+        .map(|g| {
+            goal_card(
+                g,
+                created_by.get(&g.goal_id).copied().unwrap_or(g.created_at),
+                now,
+            )
+        })
         .collect())
 }

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -210,7 +210,8 @@ fn agent_views(goal: &Goal, now: u64) -> Vec<AgentView> {
                 cost += r.cost_delta;
                 first_run_at =
                     Some(first_run_at.map_or(r.recorded_at, |f: u64| f.min(r.recorded_at)));
-                last_run_at = Some(last_run_at.map_or(r.recorded_at, |l: u64| l.max(r.recorded_at)));
+                last_run_at =
+                    Some(last_run_at.map_or(r.recorded_at, |l: u64| l.max(r.recorded_at)));
             }
             AgentView {
                 id: id.clone(),

--- a/orchestration/loop/src/webui/mod.rs
+++ b/orchestration/loop/src/webui/mod.rs
@@ -1,8 +1,13 @@
-//! `future loop ui` — local read-mostly web dashboard for the loop control
+//! `future loop ui` — local read-only web dashboard for the loop control
 //! plane. Zero-dependency HTTP server (raw tokio TCP, loopback only) with an
 //! embedded single-page UI; state is projected live from the event ledger
 //! via [`crate::store::Store::replay`] on every request, so the dashboard
 //! never drifts from CLI state.
+//!
+//! Strictly read-only: only GET endpoints are served (any other method is a
+//! 405), and every projection reads exclusively from the loop state root
+//! (`.future/loop/` — the event ledger and its replayed state). Mutations
+//! (gate resolve, goal cancel, …) stay in the `future loop` CLI.
 //!
 //! Surface:
 //!   GET  /                              embedded dashboard (static)
@@ -11,8 +16,6 @@
 //!   GET  /api/goals/{id}/runs?limit=N   run ledger (newest first)
 //!   GET  /api/goals/{id}/events?limit=N raw event ledger (newest first)
 //!   GET  /api/stream                    SSE: `overview` + `goals` pushed on change / interval
-//!   POST /api/goals/{id}/gate           {"todo_id","decision","note"?} — resolve a user gate
-//!   POST /api/goals/{id}/lifecycle      {"action":"cancel"|"resume","reason"?}
 
 mod api;
 mod page;

--- a/orchestration/loop/src/webui/mod.rs
+++ b/orchestration/loop/src/webui/mod.rs
@@ -1,0 +1,21 @@
+//! `future loop ui` — local read-mostly web dashboard for the loop control
+//! plane. Zero-dependency HTTP server (raw tokio TCP, loopback only) with an
+//! embedded single-page UI; state is projected live from the event ledger
+//! via [`crate::store::Store::replay`] on every request, so the dashboard
+//! never drifts from CLI state.
+//!
+//! Surface:
+//!   GET  /                              embedded dashboard (static)
+//!   GET  /api/overview                  registry + per-goal cards + attention + 24h/7d totals
+//!   GET  /api/goals/{id}                full goal detail projection
+//!   GET  /api/goals/{id}/runs?limit=N   run ledger (newest first)
+//!   GET  /api/goals/{id}/events?limit=N raw event ledger (newest first)
+//!   GET  /api/stream                    SSE: `overview` + `goals` pushed on change / interval
+//!   POST /api/goals/{id}/gate           {"todo_id","decision","note"?} — resolve a user gate
+//!   POST /api/goals/{id}/lifecycle      {"action":"cancel"|"resume","reason"?}
+
+mod api;
+mod page;
+mod server;
+
+pub use server::run_server;

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -1,0 +1,592 @@
+//! The embedded single-page dashboard. Hand-rolled vanilla JS (no build
+//! step, no CDN — the page must work fully offline on a loopback server).
+
+pub const PAGE: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>FutureOS · Loop Control Plane</title>
+<style>
+:root {
+  --bg: #0b0f14; --bg-1: #10161d; --bg-2: #161e27; --bg-3: #1d2732;
+  --line: #24303d; --line-2: #2e3d4d;
+  --tx: #dbe4ec; --tx-2: #8fa1b3; --tx-3: #5d6f80;
+  --acc: #4da3ff; --acc-dim: #1f3a56;
+  --ok: #3fb96c; --ok-bg: #12301e;
+  --warn: #e0a53c; --warn-bg: #38290d;
+  --bad: #e05c5c; --bad-bg: #3a1616;
+  --vio: #a58bff; --vio-bg: #241d3d;
+  --mono: "SF Mono", ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+  --sans: -apple-system, "Segoe UI", "Inter", Roboto, "Helvetica Neue", sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body { background: var(--bg); color: var(--tx); font: 13px/1.5 var(--sans); overflow: hidden; }
+a { color: var(--acc); text-decoration: none; }
+button { font: inherit; cursor: pointer; }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 5px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-track { background: transparent; }
+
+#app { display: flex; flex-direction: column; height: 100vh; }
+
+/* ── header ─────────────────────────────────────────── */
+header { display: flex; align-items: center; gap: 14px; padding: 0 18px; height: 50px;
+  background: var(--bg-1); border-bottom: 1px solid var(--line); flex: 0 0 auto; }
+.logo { display: flex; align-items: baseline; gap: 8px; font-weight: 650; font-size: 14px; letter-spacing: .2px; }
+.logo .mark { color: var(--acc); }
+.logo .sub { color: var(--tx-3); font-weight: 400; font-size: 11.5px; }
+.tabs { display: flex; gap: 2px; margin-left: 14px; }
+.tab { padding: 5px 13px; border-radius: 6px; color: var(--tx-2); background: transparent; border: 1px solid transparent; font-size: 12.5px; }
+.tab:hover { color: var(--tx); background: var(--bg-2); }
+.tab.active { color: var(--tx); background: var(--bg-3); border-color: var(--line-2); }
+.hdr-right { margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--tx-3); font-size: 11.5px; }
+.live { display: flex; align-items: center; gap: 6px; }
+.live .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--tx-3); transition: background .3s; }
+.live.on .dot { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.live.off .dot { background: var(--bad); }
+
+main { flex: 1; overflow: hidden; display: flex; }
+.view { flex: 1; overflow-y: auto; padding: 20px 22px 60px; }
+.hidden { display: none !important; }
+
+/* ── stat cards ─────────────────────────────────────── */
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; margin-bottom: 18px; }
+.stat { background: var(--bg-1); border: 1px solid var(--line); border-radius: 9px; padding: 11px 14px 9px; }
+.stat .v { font: 600 21px/1.15 var(--mono); letter-spacing: -.5px; }
+.stat .k { color: var(--tx-3); font-size: 10.5px; text-transform: uppercase; letter-spacing: .8px; margin-top: 3px; }
+.stat.accent .v { color: var(--acc); }
+.stat.warn .v { color: var(--warn); }
+.stat.ok .v { color: var(--ok); }
+
+/* ── sections ───────────────────────────────────────── */
+.sect { margin-bottom: 22px; }
+.sect > h2 { font-size: 12px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px;
+  color: var(--tx-2); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+.sect > h2 .count { color: var(--tx-3); font-weight: 400; }
+.card { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; }
+
+/* ── badges & chips ─────────────────────────────────── */
+.badge { display: inline-flex; align-items: center; gap: 5px; padding: 1.5px 8px; border-radius: 20px;
+  font: 550 10.5px/1.6 var(--sans); letter-spacing: .3px; white-space: nowrap; }
+.badge::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+.b-ok   { color: #6fd598; background: var(--ok-bg); }
+.b-warn { color: #f0c06a; background: var(--warn-bg); }
+.b-bad  { color: #f08a8a; background: var(--bad-bg); }
+.b-info { color: #7cb9f5; background: var(--acc-dim); }
+.b-vio  { color: #c2aeff; background: var(--vio-bg); }
+.b-mut  { color: var(--tx-2); background: var(--bg-3); }
+.b-mut::before { background: var(--tx-3); }
+.chip { display: inline-block; padding: 0 6px; border-radius: 4px; background: var(--bg-3);
+  color: var(--tx-2); font: 500 10.5px/1.7 var(--mono); }
+.prio { font: 650 10.5px/1.7 var(--mono); padding: 0 6px; border-radius: 4px; }
+.prio-P0 { color: #f08a8a; background: var(--bad-bg); }
+.prio-P1 { color: #f0c06a; background: var(--warn-bg); }
+.prio-P2 { color: var(--tx-2); background: var(--bg-3); }
+
+/* ── attention banner ───────────────────────────────── */
+.attn { border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.attn-row { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-top: 1px solid var(--line); cursor: pointer; }
+.attn-row:first-child { border-top: 0; }
+.attn-row:hover { background: var(--bg-2); }
+.attn-row .goal { font: 550 11.5px var(--mono); color: var(--tx-2); }
+.attn-row .what { flex: 1; color: var(--tx); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.attn-row .rec { color: var(--tx-2); font-size: 12px; max-width: 46%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── goal cards ─────────────────────────────────────── */
+.goals { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 12px; }
+.gcard { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px;
+  cursor: pointer; transition: border-color .15s, transform .1s; }
+.gcard:hover { border-color: var(--line-2); transform: translateY(-1px); }
+.gcard.terminal { opacity: .62; }
+.gcard.cancelled { opacity: .45; }
+.gcard .top { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+.gcard .gid { font: 550 11px var(--mono); color: var(--tx-3); }
+.gcard .obj { font-size: 13.5px; font-weight: 550; line-height: 1.4; margin-bottom: 9px;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.gcard .meta { display: flex; gap: 14px; color: var(--tx-3); font-size: 11px; margin-bottom: 10px; }
+.gcard .meta b { color: var(--tx-2); font-weight: 550; }
+.gcard .dec { display: flex; align-items: center; gap: 8px; background: var(--bg-2); border-radius: 7px;
+  padding: 7px 10px; font-size: 11.5px; color: var(--tx-2); }
+.gcard .dec .why { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.bar { height: 4px; background: var(--bg-3); border-radius: 2px; margin-top: 10px; overflow: hidden; }
+.bar > i { display: block; height: 100%; background: var(--acc); border-radius: 2px; }
+
+/* ── detail layout ──────────────────────────────────── */
+.backrow { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; flex-wrap: wrap; }
+.btn { background: var(--bg-2); color: var(--tx); border: 1px solid var(--line-2); border-radius: 7px; padding: 5px 13px; font-size: 12px; }
+.btn:hover { background: var(--bg-3); }
+.btn.primary { background: var(--acc); border-color: var(--acc); color: #06121f; font-weight: 600; }
+.btn.danger { color: #f08a8a; border-color: #5c2b2b; }
+.btn:disabled { opacity: .45; cursor: default; }
+.dhead { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 16px; flex-wrap: wrap; }
+.dhead .obj { font-size: 17px; font-weight: 650; line-height: 1.35; flex: 1; min-width: 260px; }
+.dhead .path { color: var(--tx-3); font: 11.5px var(--mono); margin-top: 4px; }
+.grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+@media (max-width: 1100px) { .grid2, .grid3 { grid-template-columns: 1fr; } }
+.panel { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; }
+.panel h3 { font-size: 11px; font-weight: 650; text-transform: uppercase; letter-spacing: .9px; color: var(--tx-2); margin-bottom: 10px; }
+.kv { display: grid; grid-template-columns: 96px 1fr; gap: 4px 14px; font-size: 12px; }
+.kv dt { color: var(--tx-3); white-space: nowrap; }
+.kv dd { color: var(--tx); font-family: var(--mono); font-size: 11.5px; word-break: break-word; min-width: 0; }
+
+/* ── tables ─────────────────────────────────────────── */
+table { width: 100%; border-collapse: collapse; font-size: 12px; }
+th { text-align: left; color: var(--tx-3); font-weight: 550; font-size: 10.5px; text-transform: uppercase;
+  letter-spacing: .7px; padding: 8px 12px; border-bottom: 1px solid var(--line); }
+td { padding: 8px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+tr:last-child td { border-bottom: 0; }
+tbody tr:hover { background: var(--bg-2); }
+td .sub { color: var(--tx-3); font-size: 11px; margin-top: 2px; }
+.twrap { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.mono { font-family: var(--mono); font-size: 11.5px; }
+.ttitle { max-width: 420px; }
+.ttitle .t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.clickable { cursor: pointer; }
+
+/* ── graph ──────────────────────────────────────────── */
+.gwrap { display: flex; gap: 0; }
+.gwrap svg { flex: 0 0 auto; }
+.gnode { cursor: pointer; }
+.gnode rect { fill: var(--bg-2); stroke: var(--line-2); rx: 6; }
+.gnode.selected rect { stroke: var(--acc); stroke-width: 2; }
+.gnode text { fill: var(--tx); font: 11px var(--sans); }
+.gnode .gsub { fill: var(--tx-3); font: 9.5px var(--mono); }
+.gedge { stroke: var(--line-2); stroke-width: 1.4; fill: none; marker-end: url(#arrow); }
+
+/* ── inspector / drawer ─────────────────────────────── */
+.drawer { position: fixed; top: 50px; right: 0; bottom: 0; width: min(560px, 92vw); background: var(--bg-1);
+  border-left: 1px solid var(--line-2); box-shadow: -12px 0 40px rgba(0,0,0,.5); z-index: 50;
+  display: flex; flex-direction: column; transform: translateX(100%); transition: transform .18s ease; }
+.drawer.open { transform: translateX(0); }
+.drawer .dhead2 { display: flex; align-items: center; gap: 10px; padding: 14px 18px; border-bottom: 1px solid var(--line); }
+.drawer .dbody { flex: 1; overflow-y: auto; padding: 16px 18px 40px; }
+.drawer .x { margin-left: auto; background: none; border: 0; color: var(--tx-3); font-size: 17px; }
+.fgroup { margin-bottom: 14px; }
+.fgroup .fk { color: var(--tx-3); font-size: 10.5px; text-transform: uppercase; letter-spacing: .7px; margin-bottom: 3px; }
+.fgroup .fv { font-size: 12.5px; word-break: break-word; white-space: pre-wrap; }
+.fgroup .fv.mono { font-size: 11.5px; }
+textarea, input[type=text] { width: 100%; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 7px;
+  color: var(--tx); padding: 8px 10px; font: 12.5px var(--sans); resize: vertical; }
+textarea:focus, input[type=text]:focus { outline: 1px solid var(--acc); }
+
+/* ── misc ───────────────────────────────────────────── */
+.toast { position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%); background: var(--bg-3);
+  border: 1px solid var(--line-2); border-radius: 8px; padding: 9px 18px; font-size: 12.5px; z-index: 99;
+  box-shadow: 0 8px 30px rgba(0,0,0,.5); animation: fade .25s; }
+.toast.err { border-color: #5c2b2b; color: #f08a8a; }
+@keyframes fade { from { opacity: 0; transform: translate(-50%, 6px); } }
+.empty { color: var(--tx-3); text-align: center; padding: 46px 0; font-size: 12.5px; }
+.spark { display: flex; align-items: flex-end; gap: 2px; height: 34px; }
+.spark i { flex: 1; background: var(--acc-dim); border-radius: 1.5px 1.5px 0 0; min-height: 2px; }
+.spark i.hot { background: var(--acc); }
+.legend { display: flex; gap: 14px; color: var(--tx-3); font-size: 11px; margin-top: 6px; flex-wrap: wrap; }
+.legend b { font-weight: 550; }
+pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font: 10.5px/1.5 var(--mono);
+  overflow-x: auto; max-height: 320px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+.sev-high { color: #f08a8a; } .sev-action { color: #f0c06a; } .sev-info { color: #7cb9f5; }
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <div class="logo"><span class="mark">◉</span> FutureOS <span style="color:var(--tx-3)">·</span> <span style="color:var(--acc)">Loop</span><span class="sub">control plane</span></div>
+    <nav class="tabs">
+      <button class="tab active" data-view="overview" onclick="showView('overview')">Overview</button>
+      <button class="tab" data-view="detail" id="tab-detail" style="display:none" onclick="showView('detail')">Goal</button>
+    </nav>
+    <div class="hdr-right">
+      <span id="root-path" class="mono" title="loop state root"></span>
+      <span class="live" id="live"><span class="dot"></span><span id="live-txt">connecting</span></span>
+      <span id="clock" class="mono"></span>
+    </div>
+  </header>
+  <main>
+    <div class="view" id="view-overview"></div>
+    <div class="view hidden" id="view-detail"></div>
+  </main>
+</div>
+<div class="drawer" id="drawer"><div class="dhead2" id="drawer-head"></div><div class="dbody" id="drawer-body"></div></div>
+<div id="toast-root"></div>
+
+<script>
+"use strict";
+/* ── helpers ─────────────────────────────────────────── */
+const $ = s => document.querySelector(s);
+const esc = s => String(s ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const now = () => Math.floor(Date.now()/1000);
+function ago(ts){ if(!ts) return "—"; const d = now()-ts; if(d<0) return "in "+fmtDur(-d); return fmtDur(d)+" ago"; }
+function fmtDur(s){ s=Math.floor(s); if(s<60) return s+"s"; if(s<3600) return Math.floor(s/60)+"m "+(s%60)+"s";
+  if(s<86400) return Math.floor(s/3600)+"h "+Math.floor((s%3600)/60)+"m"; return Math.floor(s/86400)+"d "+Math.floor((s%86400)/3600)+"h"; }
+function tsLocal(ts){ if(!ts) return "—"; return new Date(ts*1000).toLocaleString(); }
+function money(c){ if(!c || Math.abs(c) < 1e-9) return "$0.00"; return c<0.01 ? "$"+c.toFixed(4) : "$"+c.toFixed(2); }
+function tok(n){ if(!n) return "0"; if(n>=1e6) return (n/1e6).toFixed(2)+"M"; if(n>=1e3) return (n/1e3).toFixed(1)+"k"; return String(n); }
+function shorten(p){ if(!p) return "—"; return p.replace(/^\/Users\/[^/]+/, "~"); }
+function badge(txt, cls){ return `<span class="badge ${cls}">${esc(txt)}</span>`; }
+function decBadge(d){ const m = {run:"b-ok", wait:"b-mut", replan:"b-warn", ask:"b-vio", terminal_no_followup:"b-info", skip:"b-mut", error:"b-bad"};
+  return badge(d||"?", m[d]||"b-mut"); }
+function statusBadge(s){ const m = {open:"b-info", done:"b-ok", superseded:"b-mut", deferred:"b-warn", blocked:"b-bad",
+  active:"b-ok", cancelled:"b-mut", delivered:"b-warn", verified:"b-ok", failed:"b-bad", rework:"b-vio"}; return badge(s||"?", m[s]||"b-mut"); }
+function classBadge(c){ const m = {advancement:"b-info", user_gate:"b-vio", user_action:"b-vio", monitor:"b-warn", blocker:"b-bad"};
+  return badge((c||"").replace(/_/g," "), m[c]||"b-mut"); }
+function sevBadge(s){ const m = {high:"b-bad", action:"b-warn", info:"b-info"}; return badge(s||"—", m[s]||"b-mut"); }
+function toast(msg, isErr){ const t = document.createElement("div"); t.className = "toast"+(isErr?" err":""); t.textContent = msg;
+  $("#toast-root").appendChild(t); setTimeout(()=>t.remove(), 3600); }
+async function api(path, opts){ const r = await fetch(path, opts); const j = await r.json().catch(()=>({ok:false,error:"bad response"}));
+  if(!j.ok) throw new Error(j.error||r.statusText); return j.data ?? j; }
+
+/* ── state ───────────────────────────────────────────── */
+let OVERVIEW = null, DETAIL = null, DETAIL_ID = null, EVENTS = null;
+let graphSel = null;
+
+/* ── live updates (SSE with polling fallback) ────────── */
+function setLive(on, txt){ const l = $("#live"); l.className = "live "+(on?"on":"off"); $("#live-txt").textContent = txt||(on?"live":"reconnecting"); }
+function connect(){
+  let es;
+  try { es = new EventSource("/api/stream"); } catch(e){ return pollLoop(); }
+  es.addEventListener("overview", ev => { OVERVIEW = JSON.parse(ev.data); setLive(true); renderOverview(); syncDetailTab(); });
+  es.addEventListener("goals", ev => { if(OVERVIEW) OVERVIEW.goals = JSON.parse(ev.data);
+    if(DETAIL_ID) loadDetail(DETAIL_ID, true); });
+  es.onerror = () => { setLive(false); es.close(); setTimeout(connect, 3000); };
+}
+let polling = false;
+function pollLoop(){ if(polling) return; polling = true;
+  const tick = async () => { try { OVERVIEW = await api("/api/overview"); setLive(true,"polling"); renderOverview(); }
+    catch(e){ setLive(false); } setTimeout(tick, 4000); }; tick(); }
+
+/* ── views ───────────────────────────────────────────── */
+function showView(v){ for(const t of document.querySelectorAll(".tab")) t.classList.toggle("active", t.dataset.view===v);
+  $("#view-overview").classList.toggle("hidden", v!=="overview");
+  $("#view-detail").classList.toggle("hidden", v!=="detail");
+  if(v==="overview"){ renderOverview(); } }
+function syncDetailTab(){ const t = $("#tab-detail"); if(DETAIL_ID){ t.style.display=""; t.textContent = "Goal · "+DETAIL_ID.slice(0,14); } }
+
+function openGoal(id){ location.hash = "#/goal/"+id; }
+async function route(){ const m = location.hash.match(/^#\/goal\/(.+)$/);
+  if(m){ DETAIL_ID = decodeURIComponent(m[1]); syncDetailTab(); showView("detail"); await loadDetail(DETAIL_ID); }
+  else { DETAIL_ID = null; syncDetailTab(); $("#tab-detail").style.display="none"; showView("overview"); } }
+window.addEventListener("hashchange", route);
+
+/* ── overview render ─────────────────────────────────── */
+function renderOverview(){
+  const o = OVERVIEW; if(!o) return;
+  $("#root-path").textContent = shorten(o.root);
+  const t = o.totals;
+  const goalRows = o.goals.map(g => {
+    const pct = g.todos_total ? Math.round(100*g.todos_done/g.todos_total) : 0;
+    return `<div class="gcard ${g.terminal?"terminal":""} ${g.cancelled?"cancelled":""}" onclick="openGoal('${encodeURIComponent(g.goal_id)}')">
+      <div class="top">${statusBadge(g.cancelled?"cancelled":(g.terminal?"done":"active"))}
+        ${g.open_gates? badge(g.open_gates+" gate"+(g.open_gates>1?"s":""),"b-vio"):""}
+        <span class="gid">${esc(g.goal_id)}</span></div>
+      <div class="obj">${esc(g.objective)}</div>
+      <div class="meta"><span>todos <b>${g.todos_done}/${g.todos_total}</b></span><span>runs <b>${g.runs_total}</b></span>
+        <span>cost <b>${money(g.cost_total)}</b></span><span>last run <b>${ago(g.last_run_at)}</b></span></div>
+      <div class="dec">${decBadge(g.decision)}<span class="why" title="${esc(g.decision_reason)}">${esc(g.decision_reason)}</span></div>
+      <div class="bar"><i style="width:${pct}%"></i></div>
+    </div>`; }).join("");
+  const attn = o.attention.items.length ? `<div class="sect"><h2>Attention queue <span class="count">${o.attention.item_count}</span></h2>
+    <div class="attn card">${o.attention.items.map(i => `<div class="attn-row" onclick="openGoal('${encodeURIComponent(i.goal_id)}')">
+      ${sevBadge(i.severity)}<span class="goal">${esc(i.goal_id)}</span>
+      <span class="what">${esc(i.status.replace(/_/g," "))} · waits on <b>${esc(i.waiting_on)}</b></span>
+      <span class="rec">${esc(i.recommended_action)}</span></div>`).join("")}</div></div>` : "";
+  $("#view-overview").innerHTML = `
+    <div class="stats">
+      <div class="stat accent"><div class="v">${t.active}</div><div class="k">active goals</div></div>
+      <div class="stat ok"><div class="v">${t.terminal}</div><div class="k">terminal</div></div>
+      <div class="stat"><div class="v">${t.cancelled}</div><div class="k">cancelled</div></div>
+      <div class="stat ${t.open_gates?"warn":""}"><div class="v">${t.open_gates}</div><div class="k">open gates</div></div>
+      <div class="stat"><div class="v">${t.open_todos}</div><div class="k">open todos</div></div>
+      <div class="stat"><div class="v">${t.runs_24h}</div><div class="k">runs · 24h</div></div>
+      <div class="stat"><div class="v">${t.runs_7d}</div><div class="k">runs · 7d</div></div>
+      <div class="stat"><div class="v">${money(t.cost_24h)}</div><div class="k">cost · 24h</div></div>
+      <div class="stat"><div class="v">${money(t.cost_7d)}</div><div class="k">cost · 7d</div></div>
+      <div class="stat"><div class="v">${t.slots_7d}</div><div class="k">quota slots · 7d</div></div>
+    </div>
+    ${attn}
+    <div class="sect"><h2>Goals <span class="count">${t.goals}</span></h2>
+      ${o.goals.length? `<div class="goals">${goalRows}</div>` : `<div class="empty card">No goals yet — <code>future loop goal init --objective "…"</code></div>`}
+    </div>`;
+}
+
+/* ── goal detail ─────────────────────────────────────── */
+async function loadDetail(id, soft){
+  try { DETAIL = await api("/api/goals/"+encodeURIComponent(id)); } catch(e){ if(!soft) toast(e.message, true); return; }
+  renderDetail();
+  try { EVENTS = await api("/api/goals/"+encodeURIComponent(id)+"/events?limit=150"); } catch(e){ EVENTS = null; }
+  renderEvents();
+}
+async function gateResolve(todoId, question){
+  openDrawer(`Resolve gate`, `
+    <div class="fgroup"><div class="fk">gate question</div><div class="fv">${esc(question||todoId)}</div></div>
+    <div class="fgroup"><div class="fk">decision *</div><textarea id="gate-dec" rows="3" placeholder="approve / reject / a concrete decision…"></textarea></div>
+    <div class="fgroup"><div class="fk">note (optional)</div><input type="text" id="gate-note" placeholder="context for the record"></div>
+    <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:6px">
+      <button class="btn" onclick="closeDrawer()">Cancel</button>
+      <button class="btn primary" onclick="doGateResolve('${esc(todoId)}')">Resolve gate</button></div>`);
+}
+async function doGateResolve(todoId){
+  const decision = $("#gate-dec").value.trim(); if(!decision) return toast("decision is required", true);
+  const note = $("#gate-note").value.trim();
+  try { const r = await api("/api/goals/"+encodeURIComponent(DETAIL_ID)+"/gate",
+    {method:"POST", headers:{"content-type":"application/json"}, body: JSON.stringify({todo_id: todoId, decision, note: note||undefined})});
+    toast(r.message||"gate resolved"); closeDrawer(); loadDetail(DETAIL_ID, true);
+  } catch(e){ toast(e.message, true); }
+}
+async function goalCancel(){
+  if(!confirm("Cancel this goal? Automation stops; state is retained.")) return;
+  try { const r = await api("/api/goals/"+encodeURIComponent(DETAIL_ID)+"/lifecycle",
+    {method:"POST", headers:{"content-type":"application/json"}, body: JSON.stringify({action:"cancel", reason:"cancelled from web ui"})});
+    toast(r.message); loadDetail(DETAIL_ID, true);
+  } catch(e){ toast(e.message, true); }
+}
+function openDrawer(title, html){ $("#drawer-head").innerHTML = `<b style="font-size:13px">${title}</b><button class="x" onclick="closeDrawer()">✕</button>`;
+  $("#drawer-body").innerHTML = html; $("#drawer").classList.add("open"); }
+function closeDrawer(){ $("#drawer").classList.remove("open"); }
+
+function sparkline(runs){
+  const days = []; for(let i=13;i>=0;i--){ const d0 = now()-i*86400; const dayStart = d0-(d0%86400); days.push({start:dayStart, n:0}); }
+  for(const r of runs){ const idx = Math.floor((now()-r.recorded_at)/86400); if(idx>=0 && idx<14) days[13-idx].n++; }
+  const mx = Math.max(1, ...days.map(d=>d.n));
+  return `<div class="spark">${days.map(d=>`<i class="${d.n?"hot":""}" style="height:${Math.max(6,Math.round(100*d.n/mx))}%" title="${d.n} runs"></i>`).join("")}</div>
+    <div class="legend"><span>runs/day · last 14d</span><span>peak <b>${mx}</b></span></div>`;
+}
+
+function renderDetail(){
+  const g = DETAIL; if(!g) return;
+  const d = g.decision;
+  const openTodos = g.todos.filter(t=>t.status==="open");
+  const gates = openTodos.filter(t=>t.class==="user_gate");
+  const spend = g.spend;
+  const unvalidated = new Set(g.unvalidated_deliveries||[]);
+  const deliveriesByTodo = {}; for(const dv of g.deliveries) deliveriesByTodo[dv.todo_id] = dv;
+
+  const todoRows = g.todos.map(t => {
+    const dv = deliveriesByTodo[t.id];
+    const lease = t.claimed_by ? `<div class="sub">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
+    const val = t.validator ? `<div class="sub mono" title="verify command">✓ ${esc(t.validator)}${t.passed_validation?" · passed":(t.status==="done"?" · <span class='sev-high'>UNVALIDATED</span>":"")}</div>` : "";
+    const gateQ = t.gate_question ? `<div class="sub">❓ ${esc(t.gate_question)}</div>` : "";
+    const dec = t.decision ? `<div class="sub">→ ${esc(t.decision)}</div>` : "";
+    const blockedBy = t.blocked ? `<div class="sub">blocked by ${t.blocked_by.map(esc).join(", ")}</div>` : "";
+    return `<tr class="clickable" onclick='inspectTodo(${JSON.stringify(t.id)})'>
+      <td class="mono" style="white-space:nowrap">${esc(t.id)}</td>
+      <td><span class="prio prio-${esc(t.priority)}">${esc(t.priority)}</span></td>
+      <td class="ttitle"><div class="t" title="${esc(t.text)}">${esc(t.title||t.text)}</div>${gateQ}${dec}${lease}${val}${blockedBy}</td>
+      <td>${classBadge(t.class)}</td><td>${statusBadge(t.status)}</td>
+      <td>${dv? statusBadge(dv.outcome):""}${unvalidated.has(t.id)? badge("unvalidated","b-bad"):""}</td>
+      <td style="white-space:nowrap">${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick="event.stopPropagation();gateResolve('${esc(t.id)}', ${JSON.stringify(t.gate_question||t.text)})">Resolve</button>`:""}
+        ${t.failed_attempts? `<span class="chip" title="failed validation attempts">${t.failed_attempts}/${t.max_validation_attempts}</span>`:""}</td></tr>`;
+  }).join("");
+
+  const runRows = g.runs.slice(0,40).map(r => {
+    const v = r.validation ? `<span class="chip" title="${esc(r.validation.summary||"")}">${esc(r.validation.status)}${r.validation.exit_code!=null?" · exit "+r.validation.exit_code:""}</span>` : "";
+    const fk = r.failure_kind && r.failure_kind!=="none" ? badge(r.failure_kind.replace(/_/g," "),"b-bad") : "";
+    return `<tr><td class="mono">#${r.turn}</td><td class="mono">${esc(r.todo_id)}</td>
+      <td class="mono" title="${esc(r.run_id)}">${esc((r.run_id||"").slice(0,14))}</td>
+      <td>${badge(r.terminal_state||"?", (r.terminal_state||"").includes("succe")||(r.terminal_state||"").includes("complet")?"b-ok":((r.terminal_state||"").includes("error")||(r.terminal_state||"").includes("fail")?"b-bad":"b-mut"))} ${v} ${fk}</td>
+      <td class="mono">${tok(r.tokens_in_delta)}/${tok(r.tokens_out_delta)}</td>
+      <td class="mono">${money(r.cost_delta)}</td>
+      <td class="ttitle"><div class="t" title="${esc(r.evidence)}">${esc(r.evidence||"—")}</div></td>
+      <td class="mono" title="${tsLocal(r.recorded_at)}">${ago(r.recorded_at)}</td></tr>`;
+  }).join("");
+
+  const agentRows = g.agents.map(a => `<tr><td class="mono">${esc(a.id)}</td>
+    <td>${a.capabilities.length? a.capabilities.map(c=>`<span class="chip">${esc(c)}</span> `).join(""):"—"}</td>
+    <td class="mono">${a.active_leases.length? a.active_leases.map(esc).join(", "):"—"}</td>
+    <td class="mono">${a.last_heartbeat? ago(a.last_heartbeat):"—"}</td></tr>`).join("");
+
+  const delivRows = g.deliveries.map(dv => `<tr><td class="mono">${esc(dv.todo_id)}</td><td>${statusBadge(dv.outcome)}</td>
+    <td class="mono">turn ${dv.delivered_turn}</td><td>${esc(dv.note||"—")}</td>
+    <td class="mono">${dv.followthrough_todo_id? "→ "+esc(dv.followthrough_todo_id):"—"}</td><td class="mono">${ago(dv.updated_at)}</td></tr>`).join("");
+
+  const oblRows = g.replan_obligations.map(o => `<tr><td>${badge(o.kind.replace(/_/g," "), o.cleared?"b-mut":"b-warn")}</td>
+    <td class="mono">${esc(o.todo_id||"—")}</td><td class="ttitle"><div class="t" title="${esc(o.evidence)}">${esc(o.evidence)}</div></td>
+    <td>${o.cleared? badge("cleared","b-ok") : badge("open","b-warn")}</td><td class="mono">${ago(o.raised_at)}</td></tr>`).join("");
+
+  const accRows = g.acceptance.map(a => `<tr><td class="mono">${esc(a.id)}</td><td>${esc(a.description)}</td>
+    <td>${a.satisfied? badge("satisfied","b-ok"):badge("open","b-warn")}</td></tr>`).join("");
+
+  const semRows = (g.semantic_history||[]).slice(-12).reverse().map(s => `<tr>
+    <td class="mono">${ago(s.ts)}</td><td>${badge(s.kind||"evt","b-mut")}</td><td class="ttitle"><div class="t">${esc(s.summary||s.text||JSON.stringify(s))}</div></td></tr>`).join("");
+
+  const termJ = g.frontier && g.frontier.terminal_judgement;
+  const alerts = (g.liveness_alerts||[]).map(a => `<tr><td class="mono">${esc(a.agent_id)}</td>
+    <td class="mono">${fmtDur(a.elapsed_secs)} / ${fmtDur(a.threshold_secs)}</td><td class="mono">#${a.consecutive}</td><td class="mono">${ago(a.ts)}</td></tr>`).join("");
+
+  $("#view-detail").innerHTML = `
+    <div class="backrow">
+      <button class="btn" onclick="location.hash=''">← Overview</button>
+      ${statusBadge(g.status)} ${g.terminal? badge("terminal closure","b-info"):""}
+      <span class="chip">${esc(g.goal_id)}</span>
+      <span style="flex:1"></span>
+      ${g.status!=="cancelled" && !g.terminal ? `<button class="btn danger" onclick="goalCancel()">Cancel goal</button>`:""}
+    </div>
+    <div class="dhead"><div class="obj">${esc(g.objective)}<div class="path">${esc(shorten(g.cwd))} · created ${tsLocal(g.created_at)} · ${g.event_count} ledger events</div></div></div>
+
+    <div class="grid3" style="margin-bottom:14px">
+      <div class="panel"><h3>Kernel decision</h3>
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${decBadge(d.decision)} ${badge(d.mode,"b-mut")} ${d.should_run? badge("should_run","b-ok"):badge("no run","b-mut")}</div>
+        <div style="font-size:12.5px;margin-bottom:8px">${esc(d.reason)}</div>
+        <dl class="kv">
+          <dt>reason code</dt><dd>${esc(d.reason_code)}</dd>
+          <dt>state</dt><dd>${esc(d.state)}</dd>
+          <dt>waiting on</dt><dd>${esc(d.waiting_on)}</dd>
+          <dt>recommended</dt><dd>${esc(d.recommended_action)}</dd>
+          <dt>lifecycle</dt><dd>${esc(d.lifecycle_phase)}${d.lifecycle_flags&&d.lifecycle_flags.length?" · "+esc(d.lifecycle_flags.join(", ")):""}</dd>
+          <dt>open todos</dt><dd>${d.open_count}</dd>
+        </dl></div>
+      <div class="panel"><h3>Next action & attention</h3>
+        <div style="font-size:12.5px;margin-bottom:10px">${esc(g.next_action||"—")}</div>
+        ${g.attention? `<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${sevBadge(g.attention.severity)}${badge(g.attention.waiting_on,"b-mut")}</div>
+          <div style="font-size:12px;color:var(--tx-2)">${esc(g.attention.recommended_action)}</div>` : `<div style="color:var(--tx-3);font-size:12px">No attention item — nothing waiting on the operator.</div>`}
+        ${termJ? `<div style="margin-top:10px"><h3 style="margin-bottom:6px">Terminal judgement</h3><dl class="kv">
+          <dt>terminal</dt><dd>${termJ.is_terminal??termJ.terminal??"—"}</dd></dl></div>`:""}
+      </div>
+      <div class="panel"><h3>Spend & throughput</h3>
+        ${sparkline(g.runs)}
+        <dl class="kv" style="margin-top:10px">
+          <dt>24h</dt><dd>${spend.runs_24h.runs} runs · ${money(spend.runs_24h.cost)} · ${tok(spend.runs_24h.tokens_in)}↓ ${tok(spend.runs_24h.tokens_out)}↑</dd>
+          <dt>7d</dt><dd>${spend.runs_7d.runs} runs · ${money(spend.runs_7d.cost)} · ${spend.runs_7d.slots} slots</dd>
+          <dt>all time</dt><dd>${spend.total.runs} runs · ${money(spend.total.cost)}</dd>
+          <dt>7d outcomes</dt><dd>${spend.outcomes_7d.succeeded} ok · ${spend.outcomes_7d.verify_failed} verify-fail · ${spend.outcomes_7d.infra_failed} infra · ${spend.outcomes_7d.errored} err</dd>
+        </dl></div>
+    </div>
+
+    ${gates.length? `<div class="sect"><h2>Open gates <span class="count">${gates.length} — all work frozen</span></h2>
+      <div class="twrap"><table><thead><tr><th>id</th><th>question</th><th></th></tr></thead><tbody>
+      ${gates.map(t=>`<tr><td class="mono">${esc(t.id)}</td><td>${esc(t.gate_question||t.text)}</td>
+        <td><button class="btn primary" onclick='gateResolve(${JSON.stringify(t.id)}, ${JSON.stringify(t.gate_question||t.text)})'>Resolve</button></td></tr>`).join("")}
+      </tbody></table></div></div>`:""}
+
+    <div class="sect"><h2>Dependency graph <span class="count">${g.todos.length} nodes</span></h2>
+      <div class="panel" style="padding:6px"><div id="graph"></div></div></div>
+
+    <div class="sect"><h2>Todos <span class="count">${g.todos.length} · ${openTodos.length} open</span></h2>
+      <div class="twrap"><table><thead><tr><th>id</th><th>pri</th><th>todo</th><th>class</th><th>status</th><th>delivery</th><th></th></tr></thead>
+      <tbody>${todoRows}</tbody></table></div></div>
+
+    <div class="grid2">
+      <div class="sect"><h2>Agents <span class="count">${g.agents.length}</span></h2>
+        ${g.agents.length? `<div class="twrap"><table><thead><tr><th>agent</th><th>capabilities</th><th>active leases</th><th>heartbeat</th></tr></thead><tbody>${agentRows}</tbody></table></div>`:`<div class="empty card">No agents registered</div>`}
+        ${alerts? `<h2 style="margin-top:14px">Liveness alerts</h2><div class="twrap"><table><thead><tr><th>agent</th><th>silent / threshold</th><th>seq</th><th>when</th></tr></thead><tbody>${alerts}</tbody></table></div>`:""}
+      </div>
+      <div class="sect"><h2>Delivery closure <span class="count">${g.deliveries.length}</span></h2>
+        ${g.deliveries.length? `<div class="twrap"><table><thead><tr><th>todo</th><th>outcome</th><th>delivered</th><th>note</th><th>follow-through</th><th>updated</th></tr></thead><tbody>${delivRows}</tbody></table></div>`:`<div class="empty card">No deliveries recorded</div>`}
+      </div>
+    </div>
+
+    <div class="grid2">
+      <div class="sect"><h2>Replan obligations <span class="count">${g.replan_obligations.filter(o=>!o.cleared).length} open</span></h2>
+        ${oblRows? `<div class="twrap"><table><thead><tr><th>kind</th><th>todo</th><th>evidence</th><th>state</th><th>raised</th></tr></thead><tbody>${oblRows}</tbody></table></div>`:`<div class="empty card">None</div>`}
+        ${accRows? `<h2 style="margin-top:14px">Acceptance gaps</h2><div class="twrap"><table><thead><tr><th>id</th><th>condition</th><th>state</th></tr></thead><tbody>${accRows}</tbody></table></div>`:""}
+      </div>
+      <div class="sect"><h2>Semantic history <span class="count">latest</span></h2>
+        ${semRows? `<div class="twrap"><table><tbody>${semRows}</tbody></table></div>`:`<div class="empty card">No semantic events</div>`}
+      </div>
+    </div>
+
+    <div class="sect"><h2>Run ledger <span class="count">latest ${Math.min(40,g.runs.length)} of ${g.runs.length}</span></h2>
+      ${g.runs.length? `<div class="twrap"><table><thead><tr><th>turn</th><th>todo</th><th>run</th><th>outcome</th><th>tok in/out</th><th>cost</th><th>evidence</th><th>when</th></tr></thead><tbody>${runRows}</tbody></table></div>`:`<div class="empty card">No runs recorded yet</div>`}
+    </div>
+
+    <div class="sect"><h2>Event ledger <span class="count">newest first · ${g.event_count} total</span></h2>
+      <div id="events"><div class="empty card">loading…</div></div></div>`;
+
+  renderGraph(g);
+}
+
+function renderEvents(){
+  const el = $("#events"); if(!el) return;
+  if(!EVENTS || !EVENTS.length){ el.innerHTML = `<div class="empty card">No events</div>`; return; }
+  el.innerHTML = `<div class="twrap"><table><thead><tr><th>when</th><th>kind</th><th>event id</th><th>payload</th></tr></thead><tbody>
+    ${EVENTS.map(e => `<tr><td class="mono" title="${tsLocal(e.ts)}">${ago(e.ts)}</td><td>${badge(e.kind,"b-mut")}</td>
+      <td class="mono">${esc((e.event_id||"").slice(0,16))}</td>
+      <td><details><summary class="mono" style="cursor:pointer;color:var(--tx-2)">${esc(summarizeEvent(e))}</summary>
+        <pre class="raw">${esc(JSON.stringify(e.event,null,1))}</pre></details></td></tr>`).join("")}
+  </tbody></table></div>`;
+}
+function summarizeEvent(e){
+  const v = e.event||{}; const f = k => v[k] ? String(v[k]) : null;
+  return [f("todo_id"), f("agent_id"), f("decision"), f("terminal_state"), f("outcome"), f("reason")]
+    .filter(Boolean).join(" · ") || e.kind;
+}
+
+/* ── todo inspector ──────────────────────────────────── */
+function inspectTodo(id){
+  const t = (DETAIL.todos||[]).find(x=>x.id===id); if(!t) return;
+  const row = (k,v) => v!=null && v!=="" && v!==false ? `<div class="fgroup"><div class="fk">${k}</div><div class="fv">${v}</div></div>` : "";
+  const monos = (k,v) => v!=null && v!=="" ? `<div class="fgroup"><div class="fk">${k}</div><div class="fv mono">${esc(v)}</div></div>` : "";
+  openDrawer(`Todo · ${esc(t.id)}`, `
+    <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px">${statusBadge(t.status)}${classBadge(t.class)}
+      <span class="prio prio-${esc(t.priority)}">${esc(t.priority)}</span>${badge(t.role,"b-mut")}
+      ${t.blocked?badge("blocked","b-bad"):""}${t.archive_state==="archived"?badge("archived","b-mut"):""}</div>
+    <div class="fgroup"><div class="fk">text</div><div class="fv">${esc(t.text)}</div></div>
+    ${row("gate question", esc(t.gate_question))}${row("decision", esc(t.decision))}${row("note", esc(t.note))}
+    ${row("blocked by", t.blocked_by.map(esc).join(", "))}
+    ${row("successors", t.successor_ids.map(esc).join(", "))}${row("closure intent", t.no_follow_up?"no follow-up":"")}
+    ${monos("verify command", t.validator)}${row("validation", t.validator? (t.passed_validation?"passed":"not passed") : null)}
+    ${row("acceptance tokens", esc(t.acceptance))}
+    ${row("failed attempts", t.failed_attempts? t.failed_attempts+" / "+t.max_validation_attempts : null)}
+    ${monos("monitor target", t.monitor_target)}${row("monitor cadence", t.monitor_cadence)}
+    ${row("monitor due", t.monitor_due_at? tsLocal(t.monitor_due_at)+" ("+ago(t.monitor_due_at)+")" : null)}
+    ${row("no-change polls", t.consecutive_no_change || null)}
+    ${row("resume when", esc(t.resume_when_text))}
+    ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false?" · HOLDER DEAD":"") : null)}
+    ${row("evidence", esc(t.evidence))}
+    <div class="fgroup"><div class="fk">timestamps</div><div class="fv mono">updated ${tsLocal(t.updated_at)}${t.completed_at?" · completed "+tsLocal(t.completed_at):""}</div></div>
+    ${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick='gateResolve(${JSON.stringify(t.id)}, ${JSON.stringify(t.gate_question||t.text)})'>Resolve gate</button>`:""}
+  `);
+}
+
+/* ── dependency graph (layered DAG, no libs) ─────────── */
+function renderGraph(g){
+  const el = $("#graph"); if(!el) return;
+  const todos = g.todos.filter(t=>t.archive_state!=="archived");
+  if(!todos.length){ el.innerHTML = `<div class="empty">No todos</div>`; return; }
+  const edges = [];
+  for(const t of todos){ for(const pred of (t.blocked_by||[])){ if(todos.find(x=>x.id===pred)) edges.push([pred, t.id]); }
+    for(const s of (t.successor_ids||[])){ if(todos.find(x=>x.id===s)) edges.push([t.id, s]); } }
+  // longest-path layering over the DAG (fallback: index order on cycles)
+  const layer = {}; const byId = Object.fromEntries(todos.map(t=>[t.id,t]));
+  const indeg = {}; todos.forEach(t=>indeg[t.id]=0); edges.forEach(([a,b])=>indeg[b]=(indeg[b]||0)+1);
+  const memo = {};
+  function depth(id, seen){ if(memo[id]!=null) return memo[id]; if(seen.has(id)) return 0;
+    seen.add(id); const preds = edges.filter(e=>e[1]===id).map(e=>e[0]);
+    const d = preds.length? Math.max(...preds.map(p=>depth(p,seen)))+1 : 0; seen.delete(id); memo[id]=d; return d; }
+  todos.forEach(t=>{ layer[t.id] = edges.length? depth(t.id, new Set()) : 0; });
+  const layers = []; todos.forEach(t=>{ (layers[layer[t.id]] = layers[layer[t.id]]||[]).push(t); });
+  layers.forEach(l=>l.sort((a,b)=>a.index-b.index));
+  const W = 218, H = 54, GX = 64, GY = 22;
+  const MAX_COLS = 5; // serpentine wrap so a long chain never runs off-screen
+  const pos = {}; layers.forEach((l,li)=>l.forEach((t,ri)=>{
+    const row = Math.floor(li/MAX_COLS), colRaw = li%MAX_COLS;
+    const col = row%2 ? MAX_COLS-1-colRaw : colRaw; // snake: even rows L→R, odd R→L
+    pos[t.id] = {x: col*(W+GX)+10, y: (row*4+ri)*(H+GY)+10};
+  }));
+  const totalRows = Math.ceil(layers.length/MAX_COLS);
+  const width = Math.min(layers.length,MAX_COLS)*(W+GX)-GX+20, height = totalRows*4*(H+GY)-GY+20;
+  const stColor = s => ({open:"#4da3ff", done:"#3fb96c", superseded:"#5d6f80", deferred:"#e0a53c", blocked:"#e05c5c"}[s]||"#5d6f80");
+  const clsGlyph = c => ({user_gate:"◆", user_action:"◇", monitor:"◔", blocker:"✕", advancement:"▸"}[c]||"▸");
+  const nodes = todos.map(t => { const p = pos[t.id]; const label = (t.title||t.text||t.id);
+    const short = label.length>34? label.slice(0,33)+"…" : label;
+    return `<g class="gnode" data-id="${esc(t.id)}" transform="translate(${p.x},${p.y})" onclick="inspectTodo('${esc(t.id)}')">
+      <rect width="${W}" height="${H}" style="stroke:${stColor(t.status)};stroke-width:${t.status==="open"?1.8:1}"></rect>
+      <text x="10" y="21">${clsGlyph(t.class)} ${esc(short)}</text>
+      <text class="gsub" x="10" y="39">${esc(t.id)} · ${esc(t.priority)} · ${esc(t.status)}${t.claimed_by?" · "+esc(t.claimed_by):""}</text></g>`; }).join("");
+  const paths = edges.map(([a,b]) => { const p1 = pos[a], p2 = pos[b]; if(!p1||!p2) return "";
+    const x1 = p1.x+W, y1 = p1.y+H/2, x2 = p2.x, y2 = p2.y+H/2; const mx = (x1+x2)/2;
+    return `<path class="gedge" d="M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}"/>`; }).join("");
+  el.innerHTML = `<div style="overflow-x:auto"><svg width="${Math.max(width,300)}" height="${Math.max(height,60)}">
+    <defs><marker id="arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+    <path d="M0,0 L8,4 L0,8 z" fill="#2e3d4d"/></marker></defs>${paths}${nodes}</svg></div>`;
+}
+
+/* ── boot ────────────────────────────────────────────── */
+setInterval(()=>{ $("#clock").textContent = new Date().toLocaleTimeString(); }, 1000);
+connect();
+route();
+</script>
+</body>
+</html>
+"##;

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -42,6 +42,8 @@ header { display: flex; align-items: center; gap: 14px; padding: 0 18px; height:
 .tab:hover { color: var(--tx); background: var(--bg-2); }
 .tab.active { color: var(--tx); background: var(--bg-3); border-color: var(--line-2); }
 .hdr-right { margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--tx-3); font-size: 11.5px; }
+.hdr-model { display: flex; align-items: baseline; gap: 6px; }
+.hdr-model .mv { color: var(--acc); font-family: var(--mono); font-size: 11.5px; }
 .live { display: flex; align-items: center; gap: 6px; }
 .live .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--tx-3); transition: background .3s; }
 .live.on .dot { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
@@ -64,7 +66,7 @@ main { flex: 1; overflow: hidden; display: flex; }
 .sect { margin-bottom: 22px; }
 .sect > h2 { font-size: 12px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px;
   color: var(--tx-2); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
-.sect > h2 .count { color: var(--tx-3); font-weight: 400; }
+.sect > h2 .count { color: var(--tx-3); font-weight: 400; text-transform: none; letter-spacing: 0; }
 .card { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; }
 
 /* ── badges & chips ─────────────────────────────────── */
@@ -105,7 +107,7 @@ main { flex: 1; overflow: hidden; display: flex; }
 .gcard .gid { font: 550 11px var(--mono); color: var(--tx-3); }
 .gcard .obj { font-size: 13.5px; font-weight: 550; line-height: 1.4; margin-bottom: 9px;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-.gcard .meta { display: flex; gap: 14px; color: var(--tx-3); font-size: 11px; margin-bottom: 10px; }
+.gcard .meta { display: flex; gap: 14px; color: var(--tx-3); font-size: 11px; margin-bottom: 10px; flex-wrap: wrap; }
 .gcard .meta b { color: var(--tx-2); font-weight: 550; }
 .gcard .dec { display: flex; align-items: center; gap: 8px; background: var(--bg-2); border-radius: 7px;
   padding: 7px 10px; font-size: 11.5px; color: var(--tx-2); }
@@ -128,27 +130,34 @@ main { flex: 1; overflow: hidden; display: flex; }
 @media (max-width: 1100px) { .grid2, .grid3 { grid-template-columns: 1fr; } }
 .panel { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; }
 .panel h3 { font-size: 11px; font-weight: 650; text-transform: uppercase; letter-spacing: .9px; color: var(--tx-2); margin-bottom: 10px; }
-.kv { display: grid; grid-template-columns: 96px 1fr; gap: 4px 14px; font-size: 12px; }
+.kv { display: grid; grid-template-columns: 104px 1fr; gap: 4px 14px; font-size: 12px; }
 .kv dt { color: var(--tx-3); white-space: nowrap; }
 .kv dd { color: var(--tx); font-family: var(--mono); font-size: 11.5px; word-break: break-word; min-width: 0; }
+
+/* ── detail tabs ────────────────────────────────────── */
+.dtabs { display: flex; gap: 2px; border-bottom: 1px solid var(--line); margin: 4px 0 16px; flex-wrap: wrap; }
+.dtab { padding: 7px 14px; background: none; border: 0; border-bottom: 2px solid transparent; color: var(--tx-2); font-size: 12.5px; }
+.dtab:hover { color: var(--tx); }
+.dtab.active { color: var(--acc); border-bottom-color: var(--acc); font-weight: 600; }
+.dtab .pill { margin-left: 6px; padding: 0 6px; border-radius: 10px; background: var(--bg-3); color: var(--tx-2); font: 600 10px/1.7 var(--mono); }
+.dtab .pill.hot { background: var(--bad-bg); color: #f08a8a; }
 
 /* ── tables ─────────────────────────────────────────── */
 table { width: 100%; border-collapse: collapse; font-size: 12px; }
 th { text-align: left; color: var(--tx-3); font-weight: 550; font-size: 10.5px; text-transform: uppercase;
-  letter-spacing: .7px; padding: 8px 12px; border-bottom: 1px solid var(--line); }
+  letter-spacing: .7px; padding: 8px 12px; border-bottom: 1px solid var(--line); white-space: nowrap; }
 td { padding: 8px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
 tr:last-child td { border-bottom: 0; }
 tbody tr:hover { background: var(--bg-2); }
 td .sub { color: var(--tx-3); font-size: 11px; margin-top: 2px; }
-.twrap { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.twrap { background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; overflow-x: auto; }
 .mono { font-family: var(--mono); font-size: 11.5px; }
 .ttitle { max-width: 420px; }
 .ttitle .t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .clickable { cursor: pointer; }
+th.tip { text-decoration: underline dotted var(--tx-3); text-underline-offset: 3px; cursor: help; }
 
 /* ── graph ──────────────────────────────────────────── */
-.gwrap { display: flex; gap: 0; }
-.gwrap svg { flex: 0 0 auto; }
 .gnode { cursor: pointer; }
 .gnode rect { fill: var(--bg-2); stroke: var(--line-2); rx: 6; }
 .gnode.selected rect { stroke: var(--acc); stroke-width: 2; }
@@ -172,6 +181,13 @@ textarea, input[type=text] { width: 100%; background: var(--bg-2); border: 1px s
   color: var(--tx); padding: 8px 10px; font: 12.5px var(--sans); resize: vertical; }
 textarea:focus, input[type=text]:focus { outline: 1px solid var(--acc); }
 
+/* ── tooltip ────────────────────────────────────────── */
+#tip { position: fixed; z-index: 200; max-width: 320px; background: #0d141b; border: 1px solid var(--line-2);
+  border-radius: 8px; padding: 8px 11px; font-size: 11.5px; line-height: 1.45; color: var(--tx);
+  box-shadow: 0 10px 34px rgba(0,0,0,.6); pointer-events: none; opacity: 0; transition: opacity .12s; }
+#tip.show { opacity: 1; }
+#tip .tt { font-weight: 650; color: var(--acc); margin-bottom: 2px; }
+
 /* ── misc ───────────────────────────────────────────── */
 .toast { position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%); background: var(--bg-3);
   border: 1px solid var(--line-2); border-radius: 8px; padding: 9px 18px; font-size: 12.5px; z-index: 99;
@@ -187,6 +203,7 @@ textarea:focus, input[type=text]:focus { outline: 1px solid var(--acc); }
 pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font: 10.5px/1.5 var(--mono);
   overflow-x: auto; max-height: 320px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
 .sev-high { color: #f08a8a; } .sev-action { color: #f0c06a; } .sev-info { color: #7cb9f5; }
+.num { font-family: var(--mono); font-size: 11.5px; text-align: right; white-space: nowrap; }
 </style>
 </head>
 <body>
@@ -198,8 +215,9 @@ pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font:
       <button class="tab" data-view="detail" id="tab-detail" style="display:none" onclick="showView('detail')">Goal</button>
     </nav>
     <div class="hdr-right">
-      <span id="root-path" class="mono" title="loop state root"></span>
-      <span class="live" id="live"><span class="dot"></span><span id="live-txt">connecting</span></span>
+      <span class="hdr-model" data-tip="Model used for NEW `future loop run` turns (from agent settings.json default_model or --model flag). Past runs record only token/cost deltas, not the model.">model <span class="mv" id="hdr-model">—</span></span>
+      <span id="root-path" class="mono" data-tip="Loop state root: the project-local .future/loop directory this dashboard reads (override with FUTURE_LOOP_ROOT or --root)."></span>
+      <span class="live" id="live" data-tip="Live connection to the dashboard server (SSE push; falls back to polling). Green = receiving updates."><span class="dot"></span><span id="live-txt">connecting</span></span>
       <span id="clock" class="mono"></span>
     </div>
   </header>
@@ -210,6 +228,7 @@ pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font:
 </div>
 <div class="drawer" id="drawer"><div class="dhead2" id="drawer-head"></div><div class="dbody" id="drawer-body"></div></div>
 <div id="toast-root"></div>
+<div id="tip"></div>
 
 <script>
 "use strict";
@@ -224,29 +243,66 @@ function tsLocal(ts){ if(!ts) return "—"; return new Date(ts*1000).toLocaleStr
 function money(c){ if(!c || Math.abs(c) < 1e-9) return "$0.00"; return c<0.01 ? "$"+c.toFixed(4) : "$"+c.toFixed(2); }
 function tok(n){ if(!n) return "0"; if(n>=1e6) return (n/1e6).toFixed(2)+"M"; if(n>=1e3) return (n/1e3).toFixed(1)+"k"; return String(n); }
 function shorten(p){ if(!p) return "—"; return p.replace(/^\/Users\/[^/]+/, "~"); }
-function badge(txt, cls){ return `<span class="badge ${cls}">${esc(txt)}</span>`; }
+function badge(txt, cls, tip){ return `<span class="badge ${cls}"${tip?` data-tip="${esc(tip)}"`:""}>${esc(txt)}</span>`; }
 function decBadge(d){ const m = {run:"b-ok", wait:"b-mut", replan:"b-warn", ask:"b-vio", terminal_no_followup:"b-info", skip:"b-mut", error:"b-bad"};
-  return badge(d||"?", m[d]||"b-mut"); }
+  const tip = {run:"kernel: a runnable todo is selected — a worker should run one bounded turn",
+    wait:"kernel: nothing to do right now (e.g. waiting for a monitor cadence)",
+    replan:"kernel: state drifted — a replan obligation must be acked before more spend",
+    ask:"kernel: a user gate needs a human decision; work is frozen until resolved",
+    terminal_no_followup:"kernel: validated terminal closure — goal complete",
+    skip:"kernel: deliberately not running (e.g. goal cancelled)"}[d];
+  return badge(d||"?", m[d]||"b-mut", tip); }
 function statusBadge(s){ const m = {open:"b-info", done:"b-ok", superseded:"b-mut", deferred:"b-warn", blocked:"b-bad",
-  active:"b-ok", cancelled:"b-mut", delivered:"b-warn", verified:"b-ok", failed:"b-bad", rework:"b-vio"}; return badge(s||"?", m[s]||"b-mut"); }
+  active:"b-ok", cancelled:"b-mut", delivered:"b-warn", verified:"b-ok", failed:"b-bad", rework:"b-vio"};
+  const tip = {open:"not started / runnable", done:"completed with evidence", superseded:"replaced by a better route — no longer blocks closure",
+    deferred:"held until its resume condition", blocked:"held by a gate/blocker/predecessor",
+    delivered:"delivered, awaiting operator verification", verified:"operator-confirmed delivery",
+    failed:"delivery rejected", rework:"sent back for rework"}[s];
+  return badge(s||"?", m[s]||"b-mut", tip); }
 function classBadge(c){ const m = {advancement:"b-info", user_gate:"b-vio", user_action:"b-vio", monitor:"b-warn", blocker:"b-bad"};
-  return badge((c||"").replace(/_/g," "), m[c]||"b-mut"); }
-function sevBadge(s){ const m = {high:"b-bad", action:"b-warn", info:"b-info"}; return badge(s||"—", m[s]||"b-mut"); }
+  const tip = {advancement:"runnable agent work", user_gate:"a human decision that FREEZES dependent work until resolved",
+    user_action:"a human to-do that does NOT freeze the agent", monitor:"periodic read-only observation of an external target",
+    blocker:"an external blocker gating dependent todos"}[c];
+  return badge((c||"").replace(/_/g," "), m[c]||"b-mut", tip); }
+function sevBadge(s){ const m = {high:"b-bad", action:"b-warn", info:"b-info"};
+  const tip = {high:"needs a human now", action:"needs the agent/controller", info:"informational"}[s];
+  return badge(s||"—", m[s]||"b-mut", tip); }
 function toast(msg, isErr){ const t = document.createElement("div"); t.className = "toast"+(isErr?" err":""); t.textContent = msg;
   $("#toast-root").appendChild(t); setTimeout(()=>t.remove(), 3600); }
 async function api(path, opts){ const r = await fetch(path, opts); const j = await r.json().catch(()=>({ok:false,error:"bad response"}));
   if(!j.ok) throw new Error(j.error||r.statusText); return j.data ?? j; }
 
+/* ── tooltip (delegated; works for dynamically-added nodes) ── */
+(function(){
+  const tip = $("#tip");
+  let cur = null;
+  document.addEventListener("mouseover", e => {
+    const el = e.target && e.target.closest ? e.target.closest("[data-tip]") : null;
+    if(el === cur) return; cur = el;
+    if(!el){ tip.classList.remove("show"); return; }
+    tip.textContent = el.dataset.tip;
+    tip.classList.add("show");
+    const r = el.getBoundingClientRect();
+    const tw = tip.offsetWidth, thh = tip.offsetHeight;
+    let x = Math.min(r.left, window.innerWidth - tw - 12);
+    let y = r.bottom + 8; if(y + thh > window.innerHeight - 8) y = r.top - thh - 8;
+    tip.style.left = Math.max(8, x) + "px"; tip.style.top = Math.max(8, y) + "px";
+  });
+  document.addEventListener("mouseout", e => { const rt = e.relatedTarget; if(!rt || !rt.closest || !rt.closest("[data-tip]")) { cur = null; tip.classList.remove("show"); } });
+})();
+
 /* ── state ───────────────────────────────────────────── */
 let OVERVIEW = null, DETAIL = null, DETAIL_ID = null, EVENTS = null;
-let graphSel = null;
+let dTab = "board";
 
 /* ── live updates (SSE with polling fallback) ────────── */
 function setLive(on, txt){ const l = $("#live"); l.className = "live "+(on?"on":"off"); $("#live-txt").textContent = txt||(on?"live":"reconnecting"); }
 function connect(){
   let es;
   try { es = new EventSource("/api/stream"); } catch(e){ return pollLoop(); }
-  es.addEventListener("overview", ev => { OVERVIEW = JSON.parse(ev.data); setLive(true); renderOverview(); syncDetailTab(); });
+  es.addEventListener("overview", ev => { OVERVIEW = JSON.parse(ev.data); setLive(true);
+    if(OVERVIEW.model && OVERVIEW.model.default_model) $("#hdr-model").textContent = OVERVIEW.model.default_model;
+    renderOverview(); syncDetailTab(); });
   es.addEventListener("goals", ev => { if(OVERVIEW) OVERVIEW.goals = JSON.parse(ev.data);
     if(DETAIL_ID) loadDetail(DETAIL_ID, true); });
   es.onerror = () => { setLive(false); es.close(); setTimeout(connect, 3000); };
@@ -270,39 +326,56 @@ async function route(){ const m = location.hash.match(/^#\/goal\/(.+)$/);
 window.addEventListener("hashchange", route);
 
 /* ── overview render ─────────────────────────────────── */
+const TIP = {
+  activeGoals: "Goals whose automation is still running (not terminal, not cancelled)",
+  terminal: "Goals that reached validated closure: all todos done/superseded + closure intent + no acceptance gaps",
+  cancelled: "Goals stopped by the operator (state retained for audit, automation off)",
+  openGates: "Unresolved user gates — every open gate FREEZES its goal's work until a human decides",
+  openTodos: "Todos not yet done across all goals",
+  runs24: "Bounded turns executed in the last 24 hours",
+  runs7: "Bounded turns executed in the last 7 days",
+  cost24: "LLM cost burned in the last 24 hours (sum over run ledger)",
+  cost7: "LLM cost over the last 7 days",
+  slots7: "Quota slots spent in 7 days — the kernel's spend unit (run / agent / heartbeat classified)",
+  attnQueue: "One item per goal that needs something: a human decision (gate), the agent (advancement/replan), or a monitor poll",
+  severity: "high = blocked on a human · action = agent work · info = monitor signal",
+  waitingOn: "Who the goal is waiting on: user_or_controller / codex (agent) / monitor_signal / external_evidence",
+  recAction: "The single most useful next step the control plane recommends",
+};
 function renderOverview(){
   const o = OVERVIEW; if(!o) return;
   $("#root-path").textContent = shorten(o.root);
+  if(o.model && o.model.default_model) $("#hdr-model").textContent = o.model.default_model;
   const t = o.totals;
   const goalRows = o.goals.map(g => {
     const pct = g.todos_total ? Math.round(100*g.todos_done/g.todos_total) : 0;
     return `<div class="gcard ${g.terminal?"terminal":""} ${g.cancelled?"cancelled":""}" onclick="openGoal('${encodeURIComponent(g.goal_id)}')">
       <div class="top">${statusBadge(g.cancelled?"cancelled":(g.terminal?"done":"active"))}
-        ${g.open_gates? badge(g.open_gates+" gate"+(g.open_gates>1?"s":""),"b-vio"):""}
+        ${g.open_gates? badge(g.open_gates+" gate"+(g.open_gates>1?"s":""),"b-vio", TIP.openGates):""}
         <span class="gid">${esc(g.goal_id)}</span></div>
       <div class="obj">${esc(g.objective)}</div>
-      <div class="meta"><span>todos <b>${g.todos_done}/${g.todos_total}</b></span><span>runs <b>${g.runs_total}</b></span>
-        <span>cost <b>${money(g.cost_total)}</b></span><span>last run <b>${ago(g.last_run_at)}</b></span></div>
-      <div class="dec">${decBadge(g.decision)}<span class="why" title="${esc(g.decision_reason)}">${esc(g.decision_reason)}</span></div>
-      <div class="bar"><i style="width:${pct}%"></i></div>
+      <div class="meta"><span data-tip="done / total todos">todos <b>${g.todos_done}/${g.todos_total}</b></span><span data-tip="bounded turns recorded">runs <b>${g.runs_total}</b></span>
+        <span data-tip="total LLM cost">cost <b>${money(g.cost_total)}</b></span><span data-tip="time of the most recent run">last run <b>${ago(g.last_run_at)}</b></span></div>
+      <div class="dec">${decBadge(g.decision)}<span class="why" data-tip="${esc(g.decision_reason)}">${esc(g.decision_reason)}</span></div>
+      <div class="bar" data-tip="${pct}% of todos done"><i style="width:${pct}%"></i></div>
     </div>`; }).join("");
-  const attn = o.attention.items.length ? `<div class="sect"><h2>Attention queue <span class="count">${o.attention.item_count}</span></h2>
+  const attn = o.attention.items.length ? `<div class="sect"><h2 data-tip="${esc(TIP.attnQueue)}">Attention queue <span class="count">${o.attention.item_count}</span></h2>
     <div class="attn card">${o.attention.items.map(i => `<div class="attn-row" onclick="openGoal('${encodeURIComponent(i.goal_id)}')">
-      ${sevBadge(i.severity)}<span class="goal">${esc(i.goal_id)}</span>
-      <span class="what">${esc(i.status.replace(/_/g," "))} · waits on <b>${esc(i.waiting_on)}</b></span>
-      <span class="rec">${esc(i.recommended_action)}</span></div>`).join("")}</div></div>` : "";
+      <span data-tip="${esc(TIP.severity)}">${sevBadge(i.severity)}</span><span class="goal">${esc(i.goal_id)}</span>
+      <span class="what" data-tip="${esc(TIP.waitingOn)}">${esc(i.status.replace(/_/g," "))} · waits on <b>${esc(i.waiting_on)}</b></span>
+      <span class="rec" data-tip="${esc(TIP.recAction)}">${esc(i.recommended_action)}</span></div>`).join("")}</div></div>` : "";
   $("#view-overview").innerHTML = `
     <div class="stats">
-      <div class="stat accent"><div class="v">${t.active}</div><div class="k">active goals</div></div>
-      <div class="stat ok"><div class="v">${t.terminal}</div><div class="k">terminal</div></div>
-      <div class="stat"><div class="v">${t.cancelled}</div><div class="k">cancelled</div></div>
-      <div class="stat ${t.open_gates?"warn":""}"><div class="v">${t.open_gates}</div><div class="k">open gates</div></div>
-      <div class="stat"><div class="v">${t.open_todos}</div><div class="k">open todos</div></div>
-      <div class="stat"><div class="v">${t.runs_24h}</div><div class="k">runs · 24h</div></div>
-      <div class="stat"><div class="v">${t.runs_7d}</div><div class="k">runs · 7d</div></div>
-      <div class="stat"><div class="v">${money(t.cost_24h)}</div><div class="k">cost · 24h</div></div>
-      <div class="stat"><div class="v">${money(t.cost_7d)}</div><div class="k">cost · 7d</div></div>
-      <div class="stat"><div class="v">${t.slots_7d}</div><div class="k">quota slots · 7d</div></div>
+      <div class="stat accent" data-tip="${esc(TIP.activeGoals)}"><div class="v">${t.active}</div><div class="k">active goals</div></div>
+      <div class="stat ok" data-tip="${esc(TIP.terminal)}"><div class="v">${t.terminal}</div><div class="k">terminal</div></div>
+      <div class="stat" data-tip="${esc(TIP.cancelled)}"><div class="v">${t.cancelled}</div><div class="k">cancelled</div></div>
+      <div class="stat ${t.open_gates?"warn":""}" data-tip="${esc(TIP.openGates)}"><div class="v">${t.open_gates}</div><div class="k">open gates</div></div>
+      <div class="stat" data-tip="${esc(TIP.openTodos)}"><div class="v">${t.open_todos}</div><div class="k">open todos</div></div>
+      <div class="stat" data-tip="${esc(TIP.runs24)}"><div class="v">${t.runs_24h}</div><div class="k">runs · 24h</div></div>
+      <div class="stat" data-tip="${esc(TIP.runs7)}"><div class="v">${t.runs_7d}</div><div class="k">runs · 7d</div></div>
+      <div class="stat" data-tip="${esc(TIP.cost24)}"><div class="v">${money(t.cost_24h)}</div><div class="k">cost · 24h</div></div>
+      <div class="stat" data-tip="${esc(TIP.cost7)}"><div class="v">${money(t.cost_7d)}</div><div class="k">cost · 7d</div></div>
+      <div class="stat" data-tip="${esc(TIP.slots7)}"><div class="v">${t.slots_7d}</div><div class="k">quota slots · 7d</div></div>
     </div>
     ${attn}
     <div class="sect"><h2>Goals <span class="count">${t.goals}</span></h2>
@@ -344,163 +417,206 @@ async function goalCancel(){
 function openDrawer(title, html){ $("#drawer-head").innerHTML = `<b style="font-size:13px">${title}</b><button class="x" onclick="closeDrawer()">✕</button>`;
   $("#drawer-body").innerHTML = html; $("#drawer").classList.add("open"); }
 function closeDrawer(){ $("#drawer").classList.remove("open"); }
+function setDTab(t){ dTab = t; renderDetail(); }
 
 function sparkline(runs){
   const days = []; for(let i=13;i>=0;i--){ const d0 = now()-i*86400; const dayStart = d0-(d0%86400); days.push({start:dayStart, n:0}); }
   for(const r of runs){ const idx = Math.floor((now()-r.recorded_at)/86400); if(idx>=0 && idx<14) days[13-idx].n++; }
   const mx = Math.max(1, ...days.map(d=>d.n));
-  return `<div class="spark">${days.map(d=>`<i class="${d.n?"hot":""}" style="height:${Math.max(6,Math.round(100*d.n/mx))}%" title="${d.n} runs"></i>`).join("")}</div>
+  return `<div class="spark" data-tip="bounded turns per day over the last 14 days">${days.map(d=>`<i class="${d.n?"hot":""}" style="height:${Math.max(6,Math.round(100*d.n/mx))}%" data-tip="${d.n} runs that day"></i>`).join("")}</div>
     <div class="legend"><span>runs/day · last 14d</span><span>peak <b>${mx}</b></span></div>`;
 }
+
+/* Column header with tooltip */
+const TH = (label, tip) => `<th class="tip" data-tip="${esc(tip)}">${label}</th>`;
 
 function renderDetail(){
   const g = DETAIL; if(!g) return;
   const d = g.decision;
   const openTodos = g.todos.filter(t=>t.status==="open");
   const gates = openTodos.filter(t=>t.class==="user_gate");
-  const spend = g.spend;
   const unvalidated = new Set(g.unvalidated_deliveries||[]);
   const deliveriesByTodo = {}; for(const dv of g.deliveries) deliveriesByTodo[dv.todo_id] = dv;
+  const openObl = g.replan_obligations.filter(o=>!o.cleared).length;
 
-  const todoRows = g.todos.map(t => {
-    const dv = deliveriesByTodo[t.id];
-    const lease = t.claimed_by ? `<div class="sub">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
-    const val = t.validator ? `<div class="sub mono" title="verify command">✓ ${esc(t.validator)}${t.passed_validation?" · passed":(t.status==="done"?" · <span class='sev-high'>UNVALIDATED</span>":"")}</div>` : "";
-    const gateQ = t.gate_question ? `<div class="sub">❓ ${esc(t.gate_question)}</div>` : "";
-    const dec = t.decision ? `<div class="sub">→ ${esc(t.decision)}</div>` : "";
-    const blockedBy = t.blocked ? `<div class="sub">blocked by ${t.blocked_by.map(esc).join(", ")}</div>` : "";
-    return `<tr class="clickable" onclick='inspectTodo(${JSON.stringify(t.id)})'>
-      <td class="mono" style="white-space:nowrap">${esc(t.id)}</td>
-      <td><span class="prio prio-${esc(t.priority)}">${esc(t.priority)}</span></td>
-      <td class="ttitle"><div class="t" title="${esc(t.text)}">${esc(t.title||t.text)}</div>${gateQ}${dec}${lease}${val}${blockedBy}</td>
-      <td>${classBadge(t.class)}</td><td>${statusBadge(t.status)}</td>
-      <td>${dv? statusBadge(dv.outcome):""}${unvalidated.has(t.id)? badge("unvalidated","b-bad"):""}</td>
-      <td style="white-space:nowrap">${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick="event.stopPropagation();gateResolve('${esc(t.id)}', ${JSON.stringify(t.gate_question||t.text)})">Resolve</button>`:""}
-        ${t.failed_attempts? `<span class="chip" title="failed validation attempts">${t.failed_attempts}/${t.max_validation_attempts}</span>`:""}</td></tr>`;
-  }).join("");
-
-  const runRows = g.runs.slice(0,40).map(r => {
-    const v = r.validation ? `<span class="chip" title="${esc(r.validation.summary||"")}">${esc(r.validation.status)}${r.validation.exit_code!=null?" · exit "+r.validation.exit_code:""}</span>` : "";
-    const fk = r.failure_kind && r.failure_kind!=="none" ? badge(r.failure_kind.replace(/_/g," "),"b-bad") : "";
-    return `<tr><td class="mono">#${r.turn}</td><td class="mono">${esc(r.todo_id)}</td>
-      <td class="mono" title="${esc(r.run_id)}">${esc((r.run_id||"").slice(0,14))}</td>
-      <td>${badge(r.terminal_state||"?", (r.terminal_state||"").includes("succe")||(r.terminal_state||"").includes("complet")?"b-ok":((r.terminal_state||"").includes("error")||(r.terminal_state||"").includes("fail")?"b-bad":"b-mut"))} ${v} ${fk}</td>
-      <td class="mono">${tok(r.tokens_in_delta)}/${tok(r.tokens_out_delta)}</td>
-      <td class="mono">${money(r.cost_delta)}</td>
-      <td class="ttitle"><div class="t" title="${esc(r.evidence)}">${esc(r.evidence||"—")}</div></td>
-      <td class="mono" title="${tsLocal(r.recorded_at)}">${ago(r.recorded_at)}</td></tr>`;
-  }).join("");
-
-  const agentRows = g.agents.map(a => `<tr><td class="mono">${esc(a.id)}</td>
-    <td>${a.capabilities.length? a.capabilities.map(c=>`<span class="chip">${esc(c)}</span> `).join(""):"—"}</td>
-    <td class="mono">${a.active_leases.length? a.active_leases.map(esc).join(", "):"—"}</td>
-    <td class="mono">${a.last_heartbeat? ago(a.last_heartbeat):"—"}</td></tr>`).join("");
-
-  const delivRows = g.deliveries.map(dv => `<tr><td class="mono">${esc(dv.todo_id)}</td><td>${statusBadge(dv.outcome)}</td>
-    <td class="mono">turn ${dv.delivered_turn}</td><td>${esc(dv.note||"—")}</td>
-    <td class="mono">${dv.followthrough_todo_id? "→ "+esc(dv.followthrough_todo_id):"—"}</td><td class="mono">${ago(dv.updated_at)}</td></tr>`).join("");
-
-  const oblRows = g.replan_obligations.map(o => `<tr><td>${badge(o.kind.replace(/_/g," "), o.cleared?"b-mut":"b-warn")}</td>
-    <td class="mono">${esc(o.todo_id||"—")}</td><td class="ttitle"><div class="t" title="${esc(o.evidence)}">${esc(o.evidence)}</div></td>
-    <td>${o.cleared? badge("cleared","b-ok") : badge("open","b-warn")}</td><td class="mono">${ago(o.raised_at)}</td></tr>`).join("");
-
-  const accRows = g.acceptance.map(a => `<tr><td class="mono">${esc(a.id)}</td><td>${esc(a.description)}</td>
-    <td>${a.satisfied? badge("satisfied","b-ok"):badge("open","b-warn")}</td></tr>`).join("");
-
-  const semRows = (g.semantic_history||[]).slice(-12).reverse().map(s => `<tr>
-    <td class="mono">${ago(s.ts)}</td><td>${badge(s.kind||"evt","b-mut")}</td><td class="ttitle"><div class="t">${esc(s.summary||s.text||JSON.stringify(s))}</div></td></tr>`).join("");
-
-  const termJ = g.frontier && g.frontier.terminal_judgement;
-  const alerts = (g.liveness_alerts||[]).map(a => `<tr><td class="mono">${esc(a.agent_id)}</td>
-    <td class="mono">${fmtDur(a.elapsed_secs)} / ${fmtDur(a.threshold_secs)}</td><td class="mono">#${a.consecutive}</td><td class="mono">${ago(a.ts)}</td></tr>`).join("");
+  // tab bar with live counters
+  const tabs = [
+    ["board","Board", null],
+    ["todos","Todos", g.todos.length, gates.length],
+    ["agents","Workers", g.agents.length, null],
+    ["runs","Runs", g.runs.length, null],
+    ["events","Events", g.event_count, null],
+  ].map(([id,label,n,hot]) => `<button class="dtab ${dTab===id?"active":""}" onclick="setDTab('${id}')">${label}${n!=null?`<span class="pill ${hot?"hot":""}">${hot||n}</span>`:""}</button>`).join("");
 
   $("#view-detail").innerHTML = `
     <div class="backrow">
       <button class="btn" onclick="location.hash=''">← Overview</button>
-      ${statusBadge(g.status)} ${g.terminal? badge("terminal closure","b-info"):""}
-      <span class="chip">${esc(g.goal_id)}</span>
+      ${statusBadge(g.status)} ${g.terminal? badge("terminal closure","b-info","validated closure: every todo done/superseded, closure intent declared, no acceptance gaps"):""}
+      <span class="chip" data-tip="goal id">${esc(g.goal_id)}</span>
       <span style="flex:1"></span>
-      ${g.status!=="cancelled" && !g.terminal ? `<button class="btn danger" onclick="goalCancel()">Cancel goal</button>`:""}
+      ${g.status!=="cancelled" && !g.terminal ? `<button class="btn danger" data-tip="stop automation for this goal (state retained for audit)" onclick="goalCancel()">Cancel goal</button>`:""}
     </div>
-    <div class="dhead"><div class="obj">${esc(g.objective)}<div class="path">${esc(shorten(g.cwd))} · created ${tsLocal(g.created_at)} · ${g.event_count} ledger events</div></div></div>
+    <div class="dhead"><div class="obj">${esc(g.objective)}<div class="path" data-tip="goal working directory · created at · ledger length">${esc(shorten(g.cwd))} · created ${tsLocal(g.created_at)} · ${g.event_count} ledger events</div></div></div>
+    <div class="dtabs">${tabs}</div>
+    <div id="dbody"></div>`;
+  renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl);
+  lucideScrollFix();
+}
+function lucideScrollFix(){ /* keep the active tab in view on data refresh */ }
 
+function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
+  const el = $("#dbody"); if(!el) return;
+
+  if(dTab === "board"){
+    const spend = g.spend;
+    el.innerHTML = `
     <div class="grid3" style="margin-bottom:14px">
-      <div class="panel"><h3>Kernel decision</h3>
-        <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${decBadge(d.decision)} ${badge(d.mode,"b-mut")} ${d.should_run? badge("should_run","b-ok"):badge("no run","b-mut")}</div>
+      <div class="panel"><h3 data-tip="The deterministic should-run kernel's current verdict for this goal">Kernel decision</h3>
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${decBadge(d.decision)} ${badge(d.mode,"b-mut","turn mode: normal / monitor_poll / terminal")} ${d.should_run? badge("should_run","b-ok","a worker should run one bounded turn now"):badge("no run","b-mut","nothing for a worker to do right now")}</div>
         <div style="font-size:12.5px;margin-bottom:8px">${esc(d.reason)}</div>
         <dl class="kv">
-          <dt>reason code</dt><dd>${esc(d.reason_code)}</dd>
-          <dt>state</dt><dd>${esc(d.state)}</dd>
-          <dt>waiting on</dt><dd>${esc(d.waiting_on)}</dd>
-          <dt>recommended</dt><dd>${esc(d.recommended_action)}</dd>
-          <dt>lifecycle</dt><dd>${esc(d.lifecycle_phase)}${d.lifecycle_flags&&d.lifecycle_flags.length?" · "+esc(d.lifecycle_flags.join(", ")):""}</dd>
-          <dt>open todos</dt><dd>${d.open_count}</dd>
+          <dt data-tip="stable machine-readable reason code">reason code</dt><dd>${esc(d.reason_code)}</dd>
+          <dt data-tip="kernel state bucket">state</dt><dd>${esc(d.state)}</dd>
+          <dt data-tip="who the goal waits on">waiting on</dt><dd>${esc(d.waiting_on)}</dd>
+          <dt data-tip="the single most useful next step">recommended</dt><dd>${esc(d.recommended_action)}</dd>
+          <dt data-tip="lifecycle phase + flags">lifecycle</dt><dd>${esc(d.lifecycle_phase)}${d.lifecycle_flags&&d.lifecycle_flags.length?" · "+esc(d.lifecycle_flags.join(", ")):""}</dd>
+          <dt data-tip="todos still open">open todos</dt><dd>${d.open_count}</dd>
         </dl></div>
       <div class="panel"><h3>Next action & attention</h3>
         <div style="font-size:12.5px;margin-bottom:10px">${esc(g.next_action||"—")}</div>
-        ${g.attention? `<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${sevBadge(g.attention.severity)}${badge(g.attention.waiting_on,"b-mut")}</div>
+        ${g.attention? `<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">${sevBadge(g.attention.severity)}${badge(g.attention.waiting_on,"b-mut",TIP.waitingOn)}</div>
           <div style="font-size:12px;color:var(--tx-2)">${esc(g.attention.recommended_action)}</div>` : `<div style="color:var(--tx-3);font-size:12px">No attention item — nothing waiting on the operator.</div>`}
-        ${termJ? `<div style="margin-top:10px"><h3 style="margin-bottom:6px">Terminal judgement</h3><dl class="kv">
-          <dt>terminal</dt><dd>${termJ.is_terminal??termJ.terminal??"—"}</dd></dl></div>`:""}
       </div>
-      <div class="panel"><h3>Spend & throughput</h3>
+      <div class="panel"><h3 data-tip="LLM cost / token / quota-slot spend over 24h, 7d and all time">Spend & throughput</h3>
         ${sparkline(g.runs)}
         <dl class="kv" style="margin-top:10px">
-          <dt>24h</dt><dd>${spend.runs_24h.runs} runs · ${money(spend.runs_24h.cost)} · ${tok(spend.runs_24h.tokens_in)}↓ ${tok(spend.runs_24h.tokens_out)}↑</dd>
-          <dt>7d</dt><dd>${spend.runs_7d.runs} runs · ${money(spend.runs_7d.cost)} · ${spend.runs_7d.slots} slots</dd>
-          <dt>all time</dt><dd>${spend.total.runs} runs · ${money(spend.total.cost)}</dd>
-          <dt>7d outcomes</dt><dd>${spend.outcomes_7d.succeeded} ok · ${spend.outcomes_7d.verify_failed} verify-fail · ${spend.outcomes_7d.infra_failed} infra · ${spend.outcomes_7d.errored} err</dd>
+          <dt data-tip="last 24 hours">24h</dt><dd>${spend.runs_24h.runs} runs · ${money(spend.runs_24h.cost)} · ${tok(spend.runs_24h.tokens_in)}↓ ${tok(spend.runs_24h.tokens_out)}↑</dd>
+          <dt data-tip="last 7 days">7d</dt><dd>${spend.runs_7d.runs} runs · ${money(spend.runs_7d.cost)} · ${spend.runs_7d.slots} slots</dd>
+          <dt data-tip="all time">all time</dt><dd>${spend.total.runs} runs · ${money(spend.total.cost)}</dd>
+          <dt data-tip="turn outcomes over 7d: ok / verify-gate failure / recoverable infra (e.g. 429) / hard error">7d outcomes</dt><dd>${spend.outcomes_7d.succeeded} ok · ${spend.outcomes_7d.verify_failed} verify-fail · ${spend.outcomes_7d.infra_failed} infra · ${spend.outcomes_7d.errored} err</dd>
         </dl></div>
     </div>
-
-    ${gates.length? `<div class="sect"><h2>Open gates <span class="count">${gates.length} — all work frozen</span></h2>
-      <div class="twrap"><table><thead><tr><th>id</th><th>question</th><th></th></tr></thead><tbody>
+    ${gates.length? `<div class="sect"><h2 data-tip="${esc(TIP.openGates)}">Open gates <span class="count">${gates.length} — all work frozen</span></h2>
+      <div class="twrap"><table><thead><tr>${TH("id","gate todo id")}${TH("question","the concrete decision a human must make")}<th></th></tr></thead><tbody>
       ${gates.map(t=>`<tr><td class="mono">${esc(t.id)}</td><td>${esc(t.gate_question||t.text)}</td>
         <td><button class="btn primary" onclick='gateResolve(${JSON.stringify(t.id)}, ${JSON.stringify(t.gate_question||t.text)})'>Resolve</button></td></tr>`).join("")}
       </tbody></table></div></div>`:""}
+    <div class="sect"><h2 data-tip="Todo dependency DAG — an arrow A→B means A blocks B (B cannot run until A is done/superseded). Click a node for full detail.">Dependency graph <span class="count">${g.todos.length} nodes</span></h2>
+      <div class="panel" style="padding:6px"><div id="graph"></div></div></div>`;
+    renderGraph(g);
+    return;
+  }
 
-    <div class="sect"><h2>Dependency graph <span class="count">${g.todos.length} nodes</span></h2>
-      <div class="panel" style="padding:6px"><div id="graph"></div></div></div>
+  if(dTab === "todos"){
+    const rows = g.todos.map(t => {
+      const dv = deliveriesByTodo[t.id];
+      const lease = t.claimed_by ? `<div class="sub" data-tip="current lease holder + expiry${t.holder_alive===false?" · the holding process is DEAD (auto-reclaimed on next claim)":""}">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
+      const val = t.validator ? `<div class="sub mono" data-tip="independent verify command run after each turn; exit 0 = validated${t.passed_validation?" · passed":""}">✓ ${esc(t.validator)}${t.passed_validation?" · passed":(t.status==="done"?" · <span class='sev-high'>UNVALIDATED</span>":"")}</div>` : "";
+      const gateQ = t.gate_question ? `<div class="sub">❓ ${esc(t.gate_question)}</div>` : "";
+      const dec = t.decision ? `<div class="sub">→ ${esc(t.decision)}</div>` : "";
+      const blockedBy = t.blocked ? `<div class="sub" data-tip="predecessor todos that must finish first">blocked by ${t.blocked_by.map(esc).join(", ")}</div>` : "";
+      const span = t.first_run_at ? `<span data-tip="first run: ${tsLocal(t.first_run_at)} · latest run: ${tsLocal(t.last_run_at)}">${ago(t.first_run_at)} → ${ago(t.last_run_at)}</span>` : "—";
+      return `<tr class="clickable" onclick='inspectTodo(${JSON.stringify(t.id)})'>
+        <td class="mono" style="white-space:nowrap">${esc(t.id)}</td>
+        <td><span class="prio prio-${esc(t.priority)}" data-tip="priority: P0 highest — the kernel sorts the frontier by priority first">${esc(t.priority)}</span></td>
+        <td class="ttitle"><div class="t" data-tip="${esc(t.text)}">${esc(t.title||t.text)}</div>${gateQ}${dec}${lease}${val}${blockedBy}</td>
+        <td>${classBadge(t.class)}</td><td>${statusBadge(t.status)}</td>
+        <td class="num" data-tip="turns on this todo">${t.runs||"—"}</td>
+        <td class="num" data-tip="input tokens (LLM in)">${t.runs? tok(t.tokens_in):"—"}</td>
+        <td class="num" data-tip="output tokens (LLM out)">${t.runs? tok(t.tokens_out):"—"}</td>
+        <td class="num" data-tip="LLM cost spent on this todo">${t.runs? money(t.cost):"—"}</td>
+        <td class="mono" style="white-space:nowrap">${span}</td>
+        <td>${dv? statusBadge(dv.outcome):""}${unvalidated.has(t.id)? badge("unvalidated","b-bad","completed past its --verify gate (never exited 0) — does NOT count toward terminal closure"):""}</td>
+        <td style="white-space:nowrap">${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick="event.stopPropagation();gateResolve('${esc(t.id)}', ${JSON.stringify(t.gate_question||t.text)})">Resolve</button>`:""}
+          ${t.failed_attempts? `<span class="chip" data-tip="failed validation attempts / budget before replan">${t.failed_attempts}/${t.max_validation_attempts}</span>`:""}</td></tr>`;
+    }).join("");
+    el.innerHTML = `<div class="sect"><h2>Todos <span class="count">${g.todos.length} · ${g.todos.filter(t=>t.status==="open").length} open</span></h2>
+      <div class="twrap"><table><thead><tr>
+        ${TH("id","todo id (goal-scoped)")}${TH("pri","priority P0/P1/P2 — the decision kernel sorts by it first")}${TH("todo","title / gate question / lease / verify / blockers")}${TH("class","advancement · user_gate · user_action · monitor · blocker")}${TH("status","open · done · superseded · deferred · blocked")}
+        ${TH("runs","bounded turns spent on this todo")}${TH("tok in","input tokens (LLM)")}${TH("tok out","output tokens (LLM)")}${TH("cost","LLM cost on this todo")}${TH("first → latest run","when work on this todo started / last happened")}${TH("delivery","post-delivery outcome: delivered → verified/failed/rework")}<th></th></tr></thead>
+      <tbody>${rows}</tbody></table></div></div>`;
+    return;
+  }
 
-    <div class="sect"><h2>Todos <span class="count">${g.todos.length} · ${openTodos.length} open</span></h2>
-      <div class="twrap"><table><thead><tr><th>id</th><th>pri</th><th>todo</th><th>class</th><th>status</th><th>delivery</th><th></th></tr></thead>
-      <tbody>${todoRows}</tbody></table></div></div>
-
-    <div class="grid2">
-      <div class="sect"><h2>Agents <span class="count">${g.agents.length}</span></h2>
-        ${g.agents.length? `<div class="twrap"><table><thead><tr><th>agent</th><th>capabilities</th><th>active leases</th><th>heartbeat</th></tr></thead><tbody>${agentRows}</tbody></table></div>`:`<div class="empty card">No agents registered</div>`}
-        ${alerts? `<h2 style="margin-top:14px">Liveness alerts</h2><div class="twrap"><table><thead><tr><th>agent</th><th>silent / threshold</th><th>seq</th><th>when</th></tr></thead><tbody>${alerts}</tbody></table></div>`:""}
+  if(dTab === "agents"){
+    const agentRows = g.agents.map(a => `<tr><td class="mono">${esc(a.id)}</td>
+      <td><span class="chip" data-tip="model for NEW runs by this worker (loop-wide default: agent settings.json default_model or --model flag; not recorded per past run)">${esc(a.model||"—")}</span></td>
+      <td>${a.capabilities.length? a.capabilities.map(c=>`<span class="chip" data-tip="declared capability">${esc(c)}</span> `).join(""):"—"}</td>
+      <td class="mono">${a.active_leases.length? a.active_leases.map(x=>`<span class="chip" data-tip="todo currently leased to this worker">${esc(x)}</span>`).join(" "):"—"}</td>
+      <td class="num" data-tip="turns executed">${a.runs||"—"}</td>
+      <td class="num" data-tip="input tokens">${a.runs? tok(a.tokens_in):"—"}</td>
+      <td class="num" data-tip="output tokens">${a.runs? tok(a.tokens_out):"—"}</td>
+      <td class="num" data-tip="LLM cost">${a.runs? money(a.cost):"—"}</td>
+      <td class="mono" style="white-space:nowrap">${a.first_run_at? `<span data-tip="first run ${tsLocal(a.first_run_at)} · latest ${tsLocal(a.last_run_at)}">${ago(a.first_run_at)} → ${ago(a.last_run_at)}</span>`:"—"}</td>
+      <td class="mono" data-tip="last scheduler heartbeat">${a.last_heartbeat? ago(a.last_heartbeat):"—"}</td></tr>`).join("");
+    const alerts = (g.liveness_alerts||[]).map(a => `<tr><td class="mono">${esc(a.agent_id)}</td>
+      <td class="mono" data-tip="silent for / threshold">${fmtDur(a.elapsed_secs)} / ${fmtDur(a.threshold_secs)}</td><td class="mono" data-tip="consecutive breach ordinal">#${a.consecutive}</td><td class="mono">${ago(a.ts)}</td></tr>`).join("");
+    const delivRows = g.deliveries.map(dv => `<tr><td class="mono">${esc(dv.todo_id)}</td><td>${statusBadge(dv.outcome)}</td>
+      <td class="mono" data-tip="run-turn counter at delivery time">turn ${dv.delivered_turn}</td><td>${esc(dv.note||"—")}</td>
+      <td class="mono" data-tip="auto-created follow-up after an unverified delivery">${dv.followthrough_todo_id? "→ "+esc(dv.followthrough_todo_id):"—"}</td><td class="mono">${ago(dv.updated_at)}</td></tr>`).join("");
+    const oblRows = g.replan_obligations.map(o => `<tr><td>${badge(o.kind.replace(/_/g," "), o.cleared?"b-mut":"b-warn","why a replan is required")}</td>
+      <td class="mono">${esc(o.todo_id||"—")}</td><td class="ttitle"><div class="t" data-tip="${esc(o.evidence)}">${esc(o.evidence)}</div></td>
+      <td>${o.cleared? badge("cleared","b-ok","acked with a frontier delta") : badge("open","b-warn","blocks further spend until acked")}</td><td class="mono">${ago(o.raised_at)}</td></tr>`).join("");
+    const accRows = g.acceptance.map(a => `<tr><td class="mono">${esc(a.id)}</td><td>${esc(a.description)}</td>
+      <td>${a.satisfied? badge("satisfied","b-ok"):badge("open","b-warn","terminal closure requires every gap satisfied")}</td></tr>`).join("");
+    el.innerHTML = `
+      <div class="sect"><h2 data-tip="Registered worker identities for this goal (one lane per --agent-id). Model/cost/tokens aggregated from the run ledger.">Workers <span class="count">${g.agents.length}</span></h2>
+        ${g.agents.length? `<div class="twrap"><table><thead><tr>
+          ${TH("worker","agent id (registered peer)")}${TH("model","model for new runs — loop-wide default, not recorded per past run")}${TH("capabilities","declared capabilities (metadata)")}${TH("active leases","todos this worker currently holds")}${TH("runs","turns executed")}${TH("tok in","input tokens")}${TH("tok out","output tokens")}${TH("cost","LLM cost")}${TH("first → latest run","activity window")}${TH("heartbeat","last scheduler heartbeat — silence past threshold raises a liveness alert")}
+          </tr></thead><tbody>${agentRows}</tbody></table></div>`:`<div class="empty card">No agents registered</div>`}
       </div>
-      <div class="sect"><h2>Delivery closure <span class="count">${g.deliveries.length}</span></h2>
-        ${g.deliveries.length? `<div class="twrap"><table><thead><tr><th>todo</th><th>outcome</th><th>delivered</th><th>note</th><th>follow-through</th><th>updated</th></tr></thead><tbody>${delivRows}</tbody></table></div>`:`<div class="empty card">No deliveries recorded</div>`}
-      </div>
-    </div>
+      ${alerts? `<div class="sect"><h2 data-tip="scheduler heartbeat went silent past the threshold — the host automation may be dead">Liveness alerts</h2><div class="twrap"><table><thead><tr>${TH("agent","worker id")}${TH("silent / threshold","elapsed silence vs alert threshold")}${TH("seq","consecutive breach count")}${TH("when","alert time")}</tr></thead><tbody>${alerts}</tbody></table></div></div>`:""}
+      <div class="grid2">
+        <div class="sect"><h2 data-tip="post-delivery outcome closure: delivered → verified / failed / rework">Delivery closure <span class="count">${g.deliveries.length}</span></h2>
+          ${g.deliveries.length? `<div class="twrap"><table><thead><tr>${TH("todo","work item")}${TH("outcome","delivered → verified/failed/rework")}${TH("delivered","turn at delivery")}${TH("note","operator note")}${TH("follow-through","auto follow-up todo for unverified deliveries")}${TH("updated","last outcome change")}</tr></thead><tbody>${delivRows}</tbody></table></div>`:`<div class="empty card">No deliveries recorded</div>`}
+        </div>
+        <div class="sect"><h2 data-tip="state drift the kernel wants replanned before more spend (e.g. a completion without closure intent)">Replan obligations <span class="count">${openObl} open</span></h2>
+          ${oblRows? `<div class="twrap"><table><thead><tr>${TH("kind","obligation kind")}${TH("todo","related todo")}${TH("evidence","why it was raised")}${TH("state","open / cleared")}${TH("raised","when")}</tr></thead><tbody>${oblRows}</tbody></table></div>`:`<div class="empty card">None</div>`}
+          ${accRows? `<div class="sect"><h2 data-tip="acceptance conditions that must ALL be satisfied for terminal closure">Acceptance gaps</h2><div class="twrap"><table><thead><tr>${TH("id","gap id")}${TH("condition","what must be true")}${TH("state","satisfied / open")}</tr></thead><tbody>${accRows}</tbody></table></div></div>`:""}
+        </div>
+      </div>`;
+    return;
+  }
 
-    <div class="grid2">
-      <div class="sect"><h2>Replan obligations <span class="count">${g.replan_obligations.filter(o=>!o.cleared).length} open</span></h2>
-        ${oblRows? `<div class="twrap"><table><thead><tr><th>kind</th><th>todo</th><th>evidence</th><th>state</th><th>raised</th></tr></thead><tbody>${oblRows}</tbody></table></div>`:`<div class="empty card">None</div>`}
-        ${accRows? `<h2 style="margin-top:14px">Acceptance gaps</h2><div class="twrap"><table><thead><tr><th>id</th><th>condition</th><th>state</th></tr></thead><tbody>${accRows}</tbody></table></div>`:""}
+  if(dTab === "runs"){
+    const runRows = g.runs.map(r => {
+      const v = r.validation ? `<span class="chip" data-tip="independent verify receipt: ${esc(r.validation.summary||"")}${r.validation.exit_code!=null?" (exit "+r.validation.exit_code+")":""}">${esc(r.validation.status)}</span>` : "";
+      const fk = r.failure_kind && r.failure_kind!=="none" ? badge(r.failure_kind.replace(/_/g," "),"b-bad","why the turn did not deliver a verified outcome") : "";
+      return `<tr><td class="mono" data-tip="turn ordinal">#${r.turn}</td><td class="mono">${esc(r.todo_id)}</td>
+        <td class="mono" data-tip="${esc(r.run_id)}">${esc((r.run_id||"").slice(0,14))}</td>
+        <td>${badge(r.terminal_state||"?", (r.terminal_state||"").includes("succe")||(r.terminal_state||"").includes("complet")?"b-ok":((r.terminal_state||"").includes("error")||(r.terminal_state||"").includes("fail")?"b-bad":"b-mut"),"turn terminal state")} ${v} ${fk}</td>
+        <td class="num" data-tip="input / output tokens this turn">${tok(r.tokens_in_delta)} / ${tok(r.tokens_out_delta)}</td>
+        <td class="num" data-tip="cost this turn">${money(r.cost_delta)}</td>
+        <td class="ttitle"><div class="t" data-tip="${esc(r.evidence)}">${esc(r.evidence||"—")}</div></td>
+        <td class="mono" data-tip="${tsLocal(r.recorded_at)}" style="white-space:nowrap">${ago(r.recorded_at)}</td></tr>`;
+    }).join("");
+    const semRows = (g.semantic_history||[]).slice(-30).reverse().map(s => `<tr>
+      <td class="mono" style="white-space:nowrap">${ago(s.ts)}</td><td>${badge(s.kind||"evt","b-mut","semantic event kind")}</td><td class="ttitle"><div class="t" data-tip="${esc(s.summary||s.text||"")}">${esc(s.summary||s.text||JSON.stringify(s))}</div></td></tr>`).join("");
+    el.innerHTML = `
+      <div class="sect"><h2 data-tip="every bounded turn: validation receipt, failure classification, tokens, cost, evidence">Run ledger <span class="count">${g.runs.length}</span></h2>
+        ${g.runs.length? `<div class="twrap"><table><thead><tr>
+          ${TH("turn","turn ordinal")}${TH("todo","todo worked")}${TH("run","run id")}${TH("outcome","terminal state + verify receipt + failure kind")}${TH("tok in/out","input / output tokens")}${TH("cost","turn cost")}${TH("evidence","what landed")}${TH("when","recorded at")}
+        </tr></thead><tbody>${runRows}</tbody></table></div>`:`<div class="empty card">No runs recorded yet</div>`}
       </div>
-      <div class="sect"><h2>Semantic history <span class="count">latest</span></h2>
+      <div class="sect"><h2 data-tip="bounded goal-level semantic history (recent public-safe event summaries)">Semantic history</h2>
         ${semRows? `<div class="twrap"><table><tbody>${semRows}</tbody></table></div>`:`<div class="empty card">No semantic events</div>`}
-      </div>
-    </div>
+      </div>`;
+    return;
+  }
 
-    <div class="sect"><h2>Run ledger <span class="count">latest ${Math.min(40,g.runs.length)} of ${g.runs.length}</span></h2>
-      ${g.runs.length? `<div class="twrap"><table><thead><tr><th>turn</th><th>todo</th><th>run</th><th>outcome</th><th>tok in/out</th><th>cost</th><th>evidence</th><th>when</th></tr></thead><tbody>${runRows}</tbody></table></div>`:`<div class="empty card">No runs recorded yet</div>`}
-    </div>
-
-    <div class="sect"><h2>Event ledger <span class="count">newest first · ${g.event_count} total</span></h2>
+  if(dTab === "events"){
+    el.innerHTML = `<div class="sect"><h2 data-tip="the canonical event-sourced ledger — goal state is a replay of these events">Event ledger <span class="count">newest first · ${g.event_count} total</span></h2>
       <div id="events"><div class="empty card">loading…</div></div></div>`;
-
-  renderGraph(g);
+    renderEvents();
+    return;
+  }
 }
 
 function renderEvents(){
   const el = $("#events"); if(!el) return;
   if(!EVENTS || !EVENTS.length){ el.innerHTML = `<div class="empty card">No events</div>`; return; }
-  el.innerHTML = `<div class="twrap"><table><thead><tr><th>when</th><th>kind</th><th>event id</th><th>payload</th></tr></thead><tbody>
-    ${EVENTS.map(e => `<tr><td class="mono" title="${tsLocal(e.ts)}">${ago(e.ts)}</td><td>${badge(e.kind,"b-mut")}</td>
+  el.innerHTML = `<div class="twrap"><table><thead><tr>${TH("when","event timestamp")}${TH("kind","event type")}${TH("event id","content-derived id (idempotent append)")}${TH("payload","full event body")}</tr></thead><tbody>
+    ${EVENTS.map(e => `<tr><td class="mono" data-tip="${tsLocal(e.ts)}" style="white-space:nowrap">${ago(e.ts)}</td><td>${badge(e.kind,"b-mut","event type")}</td>
       <td class="mono">${esc((e.event_id||"").slice(0,16))}</td>
       <td><details><summary class="mono" style="cursor:pointer;color:var(--tx-2)">${esc(summarizeEvent(e))}</summary>
         <pre class="raw">${esc(JSON.stringify(e.event,null,1))}</pre></details></td></tr>`).join("")}
@@ -517,11 +633,15 @@ function inspectTodo(id){
   const t = (DETAIL.todos||[]).find(x=>x.id===id); if(!t) return;
   const row = (k,v) => v!=null && v!=="" && v!==false ? `<div class="fgroup"><div class="fk">${k}</div><div class="fv">${v}</div></div>` : "";
   const monos = (k,v) => v!=null && v!=="" ? `<div class="fgroup"><div class="fk">${k}</div><div class="fv mono">${esc(v)}</div></div>` : "";
+  const cost = t.runs? `<div class="fgroup"><div class="fk" data-tip="aggregated over ${t.runs} turn(s) on this todo">runs · tokens · cost</div>
+    <div class="fv mono">${t.runs} runs · ${tok(t.tokens_in)}↓ ${tok(t.tokens_out)}↑ · ${money(t.cost)}</div></div>` : "";
+  const span = t.first_run_at? `<div class="fgroup"><div class="fk">activity window</div><div class="fv mono">${tsLocal(t.first_run_at)} → ${tsLocal(t.last_run_at)}</div></div>` : "";
   openDrawer(`Todo · ${esc(t.id)}`, `
     <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px">${statusBadge(t.status)}${classBadge(t.class)}
-      <span class="prio prio-${esc(t.priority)}">${esc(t.priority)}</span>${badge(t.role,"b-mut")}
-      ${t.blocked?badge("blocked","b-bad"):""}${t.archive_state==="archived"?badge("archived","b-mut"):""}</div>
+      <span class="prio prio-${esc(t.priority)}" data-tip="priority P0/P1/P2">${esc(t.priority)}</span>${badge(t.role,"b-mut","owner role: agent or user")}
+      ${t.blocked?badge("blocked","b-bad","held by an open gate/blocker/predecessor"):""}${t.archive_state==="archived"?badge("archived","b-mut"):""}</div>
     <div class="fgroup"><div class="fk">text</div><div class="fv">${esc(t.text)}</div></div>
+    ${cost}${span}
     ${row("gate question", esc(t.gate_question))}${row("decision", esc(t.decision))}${row("note", esc(t.note))}
     ${row("blocked by", t.blocked_by.map(esc).join(", "))}
     ${row("successors", t.successor_ids.map(esc).join(", "))}${row("closure intent", t.no_follow_up?"no follow-up":"")}
@@ -539,7 +659,7 @@ function inspectTodo(id){
   `);
 }
 
-/* ── dependency graph (layered DAG, no libs) ─────────── */
+/* ── dependency graph (layered DAG, auto-height, no libs) ── */
 function renderGraph(g){
   const el = $("#graph"); if(!el) return;
   const todos = g.todos.filter(t=>t.archive_state!=="archived");
@@ -547,14 +667,11 @@ function renderGraph(g){
   const edges = [];
   for(const t of todos){ for(const pred of (t.blocked_by||[])){ if(todos.find(x=>x.id===pred)) edges.push([pred, t.id]); }
     for(const s of (t.successor_ids||[])){ if(todos.find(x=>x.id===s)) edges.push([t.id, s]); } }
-  // longest-path layering over the DAG (fallback: index order on cycles)
-  const layer = {}; const byId = Object.fromEntries(todos.map(t=>[t.id,t]));
-  const indeg = {}; todos.forEach(t=>indeg[t.id]=0); edges.forEach(([a,b])=>indeg[b]=(indeg[b]||0)+1);
   const memo = {};
   function depth(id, seen){ if(memo[id]!=null) return memo[id]; if(seen.has(id)) return 0;
     seen.add(id); const preds = edges.filter(e=>e[1]===id).map(e=>e[0]);
     const d = preds.length? Math.max(...preds.map(p=>depth(p,seen)))+1 : 0; seen.delete(id); memo[id]=d; return d; }
-  todos.forEach(t=>{ layer[t.id] = edges.length? depth(t.id, new Set()) : 0; });
+  const layer = {}; todos.forEach(t=>{ layer[t.id] = edges.length? depth(t.id, new Set()) : 0; });
   const layers = []; todos.forEach(t=>{ (layers[layer[t.id]] = layers[layer[t.id]]||[]).push(t); });
   layers.forEach(l=>l.sort((a,b)=>a.index-b.index));
   const W = 218, H = 54, GX = 64, GY = 22;
@@ -570,14 +687,15 @@ function renderGraph(g){
   const clsGlyph = c => ({user_gate:"◆", user_action:"◇", monitor:"◔", blocker:"✕", advancement:"▸"}[c]||"▸");
   const nodes = todos.map(t => { const p = pos[t.id]; const label = (t.title||t.text||t.id);
     const short = label.length>34? label.slice(0,33)+"…" : label;
-    return `<g class="gnode" data-id="${esc(t.id)}" transform="translate(${p.x},${p.y})" onclick="inspectTodo('${esc(t.id)}')">
+    const tipTxt = `${t.id} · ${t.priority} · ${t.status} · ${t.class.replace(/_/g," ")}${t.text? "\n"+t.text:""}`;
+    return `<g class="gnode" data-id="${esc(t.id)}" transform="translate(${p.x},${p.y})" data-tip="${esc(tipTxt)}" onclick="inspectTodo('${esc(t.id)}')">
       <rect width="${W}" height="${H}" style="stroke:${stColor(t.status)};stroke-width:${t.status==="open"?1.8:1}"></rect>
       <text x="10" y="21">${clsGlyph(t.class)} ${esc(short)}</text>
       <text class="gsub" x="10" y="39">${esc(t.id)} · ${esc(t.priority)} · ${esc(t.status)}${t.claimed_by?" · "+esc(t.claimed_by):""}</text></g>`; }).join("");
   const paths = edges.map(([a,b]) => { const p1 = pos[a], p2 = pos[b]; if(!p1||!p2) return "";
     const x1 = p1.x+W, y1 = p1.y+H/2, x2 = p2.x, y2 = p2.y+H/2; const mx = (x1+x2)/2;
     return `<path class="gedge" d="M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}"/>`; }).join("");
-  el.innerHTML = `<div style="overflow-x:auto"><svg width="${Math.max(width,300)}" height="${Math.max(height,60)}">
+  el.innerHTML = `<div style="overflow:auto"><svg width="${Math.max(width,300)}" height="${Math.max(height,60)}" style="display:block">
     <defs><marker id="arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
     <path d="M0,0 L8,4 L0,8 z" fill="#2e3d4d"/></marker></defs>${paths}${nodes}</svg></div>`;
 }

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -215,7 +215,6 @@ pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font:
       <button class="tab" data-view="detail" id="tab-detail" style="display:none" onclick="showView('detail')">Goal</button>
     </nav>
     <div class="hdr-right">
-      <span class="hdr-model" data-tip="Model used for NEW `future loop run` turns (from agent settings.json default_model or --model flag). Past runs record only token/cost deltas, not the model.">model <span class="mv" id="hdr-model">—</span></span>
       <span id="root-path" class="mono" data-tip="Loop state root: the project-local .future/loop directory this dashboard reads (override with FUTURE_LOOP_ROOT or --root)."></span>
       <span class="live" id="live" data-tip="Live connection to the dashboard server (SSE push; falls back to polling). Green = receiving updates."><span class="dot"></span><span id="live-txt">connecting</span></span>
       <span id="clock" class="mono"></span>
@@ -301,7 +300,6 @@ function connect(){
   let es;
   try { es = new EventSource("/api/stream"); } catch(e){ return pollLoop(); }
   es.addEventListener("overview", ev => { OVERVIEW = JSON.parse(ev.data); setLive(true);
-    if(OVERVIEW.model && OVERVIEW.model.default_model) $("#hdr-model").textContent = OVERVIEW.model.default_model;
     renderOverview(); syncDetailTab(); });
   es.addEventListener("goals", ev => { if(OVERVIEW) OVERVIEW.goals = JSON.parse(ev.data);
     if(DETAIL_ID) loadDetail(DETAIL_ID, true); });
@@ -345,7 +343,6 @@ const TIP = {
 function renderOverview(){
   const o = OVERVIEW; if(!o) return;
   $("#root-path").textContent = shorten(o.root);
-  if(o.model && o.model.default_model) $("#hdr-model").textContent = o.model.default_model;
   const t = o.totals;
   const goalRows = o.goals.map(g => {
     const pct = g.todos_total ? Math.round(100*g.todos_done/g.todos_total) : 0;
@@ -379,7 +376,7 @@ function renderOverview(){
     </div>
     ${attn}
     <div class="sect"><h2>Goals <span class="count">${t.goals}</span></h2>
-      ${o.goals.length? `<div class="goals">${goalRows}</div>` : `<div class="empty card">No goals yet — <code>future loop goal init --objective "…"</code></div>`}
+      ${o.goals.length? `<div class="goals">${goalRows}</div>` : `<div class="empty card">No goals yet — <code>future loop goal init --objective \"…\"</code></div>`}
     </div>`;
 }
 
@@ -389,30 +386,6 @@ async function loadDetail(id, soft){
   renderDetail();
   try { EVENTS = await api("/api/goals/"+encodeURIComponent(id)+"/events?limit=150"); } catch(e){ EVENTS = null; }
   renderEvents();
-}
-async function gateResolve(todoId, question){
-  openDrawer(`Resolve gate`, `
-    <div class="fgroup"><div class="fk">gate question</div><div class="fv">${esc(question||todoId)}</div></div>
-    <div class="fgroup"><div class="fk">decision *</div><textarea id="gate-dec" rows="3" placeholder="approve / reject / a concrete decision…"></textarea></div>
-    <div class="fgroup"><div class="fk">note (optional)</div><input type="text" id="gate-note" placeholder="context for the record"></div>
-    <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:6px">
-      <button class="btn" onclick="closeDrawer()">Cancel</button>
-      <button class="btn primary" onclick="doGateResolve('${esc(todoId)}')">Resolve gate</button></div>`);
-}
-async function doGateResolve(todoId){
-  const decision = $("#gate-dec").value.trim(); if(!decision) return toast("decision is required", true);
-  const note = $("#gate-note").value.trim();
-  try { const r = await api("/api/goals/"+encodeURIComponent(DETAIL_ID)+"/gate",
-    {method:"POST", headers:{"content-type":"application/json"}, body: JSON.stringify({todo_id: todoId, decision, note: note||undefined})});
-    toast(r.message||"gate resolved"); closeDrawer(); loadDetail(DETAIL_ID, true);
-  } catch(e){ toast(e.message, true); }
-}
-async function goalCancel(){
-  if(!confirm("Cancel this goal? Automation stops; state is retained.")) return;
-  try { const r = await api("/api/goals/"+encodeURIComponent(DETAIL_ID)+"/lifecycle",
-    {method:"POST", headers:{"content-type":"application/json"}, body: JSON.stringify({action:"cancel", reason:"cancelled from web ui"})});
-    toast(r.message); loadDetail(DETAIL_ID, true);
-  } catch(e){ toast(e.message, true); }
 }
 function openDrawer(title, html){ $("#drawer-head").innerHTML = `<b style="font-size:13px">${title}</b><button class="x" onclick="closeDrawer()">✕</button>`;
   $("#drawer-body").innerHTML = html; $("#drawer").classList.add("open"); }
@@ -453,8 +426,7 @@ function renderDetail(){
       <button class="btn" onclick="location.hash=''">← Overview</button>
       ${statusBadge(g.status)} ${g.terminal? badge("terminal closure","b-info","validated closure: every todo done/superseded, closure intent declared, no acceptance gaps"):""}
       <span class="chip" data-tip="goal id">${esc(g.goal_id)}</span>
-      <span style="flex:1"></span>
-      ${g.status!=="cancelled" && !g.terminal ? `<button class="btn danger" data-tip="stop automation for this goal (state retained for audit)" onclick="goalCancel()">Cancel goal</button>`:""}
+      <span class="badge b-mut" data-tip="This dashboard is read-only. Resolve gates and cancel goals from the future loop CLI." style="margin-left:auto">read-only</span>
     </div>
     <div class="dhead"><div class="obj">${esc(g.objective)}<div class="path" data-tip="goal working directory · created at · ledger length">${esc(shorten(g.cwd))} · created ${tsLocal(g.created_at)} · ${g.event_count} ledger events</div></div></div>
     <div class="dtabs">${tabs}</div>
@@ -497,9 +469,9 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
         </dl></div>
     </div>
     ${gates.length? `<div class="sect"><h2 data-tip="${esc(TIP.openGates)}">Open gates <span class="count">${gates.length} — all work frozen</span></h2>
-      <div class="twrap"><table><thead><tr>${TH("id","gate todo id")}${TH("question","the concrete decision a human must make")}<th></th></tr></thead><tbody>
+      <div class="twrap"><table><thead><tr>${TH("id","gate todo id")}${TH("question","the concrete decision a human must make")}${TH("resolve via CLI","read-only dashboard — resolve with the future loop CLI")}</tr></thead><tbody>
       ${gates.map(t=>`<tr><td class="mono">${esc(t.id)}</td><td>${esc(t.gate_question||t.text)}</td>
-        <td><button class="btn primary" onclick='gateResolve(${JSON.stringify(t.id)}, ${JSON.stringify(t.gate_question||t.text)})'>Resolve</button></td></tr>`).join("")}
+        <td><code class="mono" style="font-size:11px;color:var(--tx-2)" data-tip="run this in a terminal to resolve the gate">future loop gate resolve --goal ${esc(g.goal_id)} --todo-id ${esc(t.id)} --decision \"…\"</code></td></tr>`).join("")}
       </tbody></table></div></div>`:""}
     <div class="sect"><h2 data-tip="Todo dependency DAG — an arrow A→B means A blocks B (B cannot run until A is done/superseded). Click a node for full detail.">Dependency graph <span class="count">${g.todos.length} nodes</span></h2>
       <div class="panel" style="padding:6px"><div id="graph"></div></div></div>`;
@@ -519,28 +491,25 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
       return `<tr class="clickable" onclick='inspectTodo(${JSON.stringify(t.id)})'>
         <td class="mono" style="white-space:nowrap">${esc(t.id)}</td>
         <td><span class="prio prio-${esc(t.priority)}" data-tip="priority: P0 highest — the kernel sorts the frontier by priority first">${esc(t.priority)}</span></td>
-        <td class="ttitle"><div class="t" data-tip="${esc(t.text)}">${esc(t.title||t.text)}</div>${gateQ}${dec}${lease}${val}${blockedBy}</td>
+        <td class="ttitle"><div class="t" data-tip="${esc(t.text)}">${esc(t.title||t.text)}${t.failed_attempts? ` <span class="chip" data-tip="failed validation attempts / budget before replan">${t.failed_attempts}/${t.max_validation_attempts}</span>`:""}</div>${gateQ}${dec}${lease}${val}${blockedBy}</td>
         <td>${classBadge(t.class)}</td><td>${statusBadge(t.status)}</td>
         <td class="num" data-tip="turns on this todo">${t.runs||"—"}</td>
         <td class="num" data-tip="input tokens (LLM in)">${t.runs? tok(t.tokens_in):"—"}</td>
         <td class="num" data-tip="output tokens (LLM out)">${t.runs? tok(t.tokens_out):"—"}</td>
         <td class="num" data-tip="LLM cost spent on this todo">${t.runs? money(t.cost):"—"}</td>
         <td class="mono" style="white-space:nowrap">${span}</td>
-        <td>${dv? statusBadge(dv.outcome):""}${unvalidated.has(t.id)? badge("unvalidated","b-bad","completed past its --verify gate (never exited 0) — does NOT count toward terminal closure"):""}</td>
-        <td style="white-space:nowrap">${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick="event.stopPropagation();gateResolve('${esc(t.id)}', ${JSON.stringify(t.gate_question||t.text)})">Resolve</button>`:""}
-          ${t.failed_attempts? `<span class="chip" data-tip="failed validation attempts / budget before replan">${t.failed_attempts}/${t.max_validation_attempts}</span>`:""}</td></tr>`;
+        <td>${dv? statusBadge(dv.outcome):""}${unvalidated.has(t.id)? badge("unvalidated","b-bad","completed past its --verify gate (never exited 0) — does NOT count toward terminal closure"):""}</td></tr>`;
     }).join("");
     el.innerHTML = `<div class="sect"><h2>Todos <span class="count">${g.todos.length} · ${g.todos.filter(t=>t.status==="open").length} open</span></h2>
       <div class="twrap"><table><thead><tr>
         ${TH("id","todo id (goal-scoped)")}${TH("pri","priority P0/P1/P2 — the decision kernel sorts by it first")}${TH("todo","title / gate question / lease / verify / blockers")}${TH("class","advancement · user_gate · user_action · monitor · blocker")}${TH("status","open · done · superseded · deferred · blocked")}
-        ${TH("runs","bounded turns spent on this todo")}${TH("tok in","input tokens (LLM)")}${TH("tok out","output tokens (LLM)")}${TH("cost","LLM cost on this todo")}${TH("first → latest run","when work on this todo started / last happened")}${TH("delivery","post-delivery outcome: delivered → verified/failed/rework")}<th></th></tr></thead>
+        ${TH("runs","bounded turns spent on this todo")}${TH("tok in","input tokens (LLM)")}${TH("tok out","output tokens (LLM)")}${TH("cost","LLM cost on this todo")}${TH("first → latest run","when work on this todo started / last happened")}${TH("delivery","post-delivery outcome: delivered → verified/failed/rework")}</tr></thead>
       <tbody>${rows}</tbody></table></div></div>`;
     return;
   }
 
   if(dTab === "agents"){
     const agentRows = g.agents.map(a => `<tr><td class="mono">${esc(a.id)}</td>
-      <td><span class="chip" data-tip="model for NEW runs by this worker (loop-wide default: agent settings.json default_model or --model flag; not recorded per past run)">${esc(a.model||"—")}</span></td>
       <td>${a.capabilities.length? a.capabilities.map(c=>`<span class="chip" data-tip="declared capability">${esc(c)}</span> `).join(""):"—"}</td>
       <td class="mono">${a.active_leases.length? a.active_leases.map(x=>`<span class="chip" data-tip="todo currently leased to this worker">${esc(x)}</span>`).join(" "):"—"}</td>
       <td class="num" data-tip="turns executed">${a.runs||"—"}</td>
@@ -562,7 +531,7 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
     el.innerHTML = `
       <div class="sect"><h2 data-tip="Registered worker identities for this goal (one lane per --agent-id). Model/cost/tokens aggregated from the run ledger.">Workers <span class="count">${g.agents.length}</span></h2>
         ${g.agents.length? `<div class="twrap"><table><thead><tr>
-          ${TH("worker","agent id (registered peer)")}${TH("model","model for new runs — loop-wide default, not recorded per past run")}${TH("capabilities","declared capabilities (metadata)")}${TH("active leases","todos this worker currently holds")}${TH("runs","turns executed")}${TH("tok in","input tokens")}${TH("tok out","output tokens")}${TH("cost","LLM cost")}${TH("first → latest run","activity window")}${TH("heartbeat","last scheduler heartbeat — silence past threshold raises a liveness alert")}
+          ${TH("worker","agent id (registered peer)")}${TH("capabilities","declared capabilities (metadata)")}${TH("active leases","todos this worker currently holds")}${TH("runs","turns executed")}${TH("tok in","input tokens")}${TH("tok out","output tokens")}${TH("cost","LLM cost")}${TH("first → latest run","activity window")}${TH("heartbeat","last scheduler heartbeat — silence past threshold raises a liveness alert")}
           </tr></thead><tbody>${agentRows}</tbody></table></div>`:`<div class="empty card">No agents registered</div>`}
       </div>
       ${alerts? `<div class="sect"><h2 data-tip="scheduler heartbeat went silent past the threshold — the host automation may be dead">Liveness alerts</h2><div class="twrap"><table><thead><tr>${TH("agent","worker id")}${TH("silent / threshold","elapsed silence vs alert threshold")}${TH("seq","consecutive breach count")}${TH("when","alert time")}</tr></thead><tbody>${alerts}</tbody></table></div></div>`:""}
@@ -655,7 +624,7 @@ function inspectTodo(id){
     ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false?" · HOLDER DEAD":"") : null)}
     ${row("evidence", esc(t.evidence))}
     <div class="fgroup"><div class="fk">timestamps</div><div class="fv mono">updated ${tsLocal(t.updated_at)}${t.completed_at?" · completed "+tsLocal(t.completed_at):""}</div></div>
-    ${t.status==="open"&&t.class==="user_gate"? `<button class="btn primary" onclick='gateResolve(${JSON.stringify(t.id)}, ${JSON.stringify(t.gate_question||t.text)})'>Resolve gate</button>`:""}
+    ${t.status==="open"&&t.class==="user_gate"? `<div class="fgroup"><div class="fk">resolve (CLI)</div><div class="fv mono" style="font-size:11px">future loop gate resolve --goal ${esc(DETAIL_ID)} --todo-id ${esc(t.id)} --decision \"…\"</div></div>`:""}
   `);
 }
 

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -158,6 +158,20 @@ td .sub { color: var(--tx-3); font-size: 11px; margin-top: 2px; }
 th.tip { text-decoration: underline dotted var(--tx-3); text-underline-offset: 3px; cursor: help; }
 
 /* ── graph ──────────────────────────────────────────── */
+.gvport { position: relative; height: 440px; overflow: hidden; border-radius: 8px; cursor: grab;
+  background: radial-gradient(circle at 1px 1px, #1a232e 1px, transparent 1px) 0 0/22px 22px, var(--bg-1); }
+.gvport.dragging { cursor: grabbing; }
+/* Fullscreen via a body class so position:fixed is never affected by an
+   ancestor's transform/filter (which would make fixed behave like absolute). */
+.gvport.full { position: fixed !important; top: 14px; left: 14px; right: 14px; bottom: 14px;
+  width: auto; height: auto; z-index: 120;
+  border: 1px solid var(--line-2); box-shadow: 0 24px 90px rgba(0,0,0,.65); border-radius: 10px; }
+body.gv-full { overflow: hidden; }
+.gcontrols { position: absolute; top: 10px; right: 10px; display: flex; gap: 6px; z-index: 5; }
+.gcontrols button { width: 28px; height: 28px; background: var(--bg-3); border: 1px solid var(--line-2);
+  color: var(--tx); border-radius: 6px; font-size: 14px; line-height: 1; }
+.gcontrols button:hover { background: var(--bg-2); border-color: var(--acc); }
+.gvport .hint { position: absolute; left: 12px; bottom: 8px; color: var(--tx-3); font-size: 10.5px; pointer-events: none; }
 .gnode { cursor: pointer; }
 .gnode rect { fill: var(--bg-2); stroke: var(--line-2); rx: 6; }
 .gnode.selected rect { stroke: var(--acc); stroke-width: 2; }
@@ -200,6 +214,7 @@ textarea:focus, input[type=text]:focus { outline: 1px solid var(--acc); }
 .spark i.hot { background: var(--acc); }
 .legend { display: flex; gap: 14px; color: var(--tx-3); font-size: 11px; margin-top: 6px; flex-wrap: wrap; }
 .legend b { font-weight: 550; }
+.subnote { color: var(--tx-3); font-size: 11.5px; margin: -6px 0 10px; }
 pre.raw { background: var(--bg-2); border-radius: 7px; padding: 10px 12px; font: 10.5px/1.5 var(--mono);
   overflow-x: auto; max-height: 320px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
 .sev-high { color: #f08a8a; } .sev-action { color: #f0c06a; } .sev-info { color: #7cb9f5; }
@@ -482,7 +497,7 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
   if(dTab === "todos"){
     const rows = g.todos.map(t => {
       const dv = deliveriesByTodo[t.id];
-      const lease = t.claimed_by ? `<div class="sub" data-tip="current lease holder + expiry${t.holder_alive===false?" · the holding process is DEAD (auto-reclaimed on next claim)":""}">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
+      const lease = t.claimed_by ? `<div class="sub" data-tip="A lease is the bounded execution window a worker holds on this todo. Each lease records the worker's process id (pid); if that process is no longer alive, the lease is orphaned and auto-reclaimed — this one is orphaned (holder process is dead).">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
       const val = t.validator ? `<div class="sub mono" data-tip="independent verify command run after each turn; exit 0 = validated${t.passed_validation?" · passed":""}">✓ ${esc(t.validator)}${t.passed_validation?" · passed":(t.status==="done"?" · <span class='sev-high'>UNVALIDATED</span>":"")}</div>` : "";
       const gateQ = t.gate_question ? `<div class="sub">❓ ${esc(t.gate_question)}</div>` : "";
       const dec = t.decision ? `<div class="sub">→ ${esc(t.decision)}</div>` : "";
@@ -562,6 +577,7 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
     const semRows = (g.semantic_history||[]).slice(-30).reverse().map(s => `<tr>
       <td class="mono" style="white-space:nowrap">${ago(s.ts)}</td><td>${badge(s.kind||"evt","b-mut","semantic event kind")}</td><td class="ttitle"><div class="t" data-tip="${esc(s.summary||s.text||"")}">${esc(s.summary||s.text||JSON.stringify(s))}</div></td></tr>`).join("");
     el.innerHTML = `
+      <p class="subnote">A <b>run</b> is one bounded turn a worker executes on a todo: the agent acts, evidence is written back, and the ledger records tokens / cost / tools / validation for that turn. This table is the spend + outcome history of every turn on the goal.</p>
       <div class="sect"><h2 data-tip="every bounded turn: validation receipt, failure classification, tokens, cost, evidence">Run ledger <span class="count">${g.runs.length}</span></h2>
         ${g.runs.length? `<div class="twrap"><table><thead><tr>
           ${TH("turn","turn ordinal")}${TH("todo","todo worked")}${TH("run","run id")}${TH("outcome","terminal state + verify receipt + failure kind")}${TH("tok in/out","input / output tokens")}${TH("cost","turn cost")}${TH("evidence","what landed")}${TH("when","recorded at")}
@@ -574,7 +590,9 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
   }
 
   if(dTab === "events"){
-    el.innerHTML = `<div class="sect"><h2 data-tip="the canonical event-sourced ledger — goal state is a replay of these events">Event ledger <span class="count">newest first · ${g.event_count} total</span></h2>
+    el.innerHTML = `
+      <p class="subnote">The <b>event ledger</b> is the source of truth: an append-only log of everything that ever happened to the goal (todo added/completed, gate resolved, run recorded, lease claimed…). The whole goal state — todos, statuses, spend — is just a <i>replay</i> of these events. Newest first.</p>
+      <div class="sect"><h2 data-tip="the canonical event-sourced ledger — goal state is a replay of these events">Event ledger <span class="count">newest first · ${g.event_count} total</span></h2>
       <div id="events"><div class="empty card">loading…</div></div></div>`;
     renderEvents();
     return;
@@ -621,14 +639,15 @@ function inspectTodo(id){
     ${row("monitor due", t.monitor_due_at? tsLocal(t.monitor_due_at)+" ("+ago(t.monitor_due_at)+")" : null)}
     ${row("no-change polls", t.consecutive_no_change || null)}
     ${row("resume when", esc(t.resume_when_text))}
-    ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false?" · HOLDER DEAD":"") : null)}
+    ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false?" · holder process dead (orphaned lease, auto-reclaimed)":"") : null)}
     ${row("evidence", esc(t.evidence))}
     <div class="fgroup"><div class="fk">timestamps</div><div class="fv mono">updated ${tsLocal(t.updated_at)}${t.completed_at?" · completed "+tsLocal(t.completed_at):""}</div></div>
     ${t.status==="open"&&t.class==="user_gate"? `<div class="fgroup"><div class="fk">resolve (CLI)</div><div class="fv mono" style="font-size:11px">future loop gate resolve --goal ${esc(DETAIL_ID)} --todo-id ${esc(t.id)} --decision \"…\"</div></div>`:""}
   `);
 }
 
-/* ── dependency graph (layered DAG, auto-height, no libs) ── */
+/* ── dependency graph (layered DAG, zoom/pan/fullscreen, no libs) ── */
+let GV = {scale: 1, x: 0, y: 0, drag: null, built: false};
 function renderGraph(g){
   const el = $("#graph"); if(!el) return;
   const todos = g.todos.filter(t=>t.archive_state!=="archived");
@@ -664,9 +683,82 @@ function renderGraph(g){
   const paths = edges.map(([a,b]) => { const p1 = pos[a], p2 = pos[b]; if(!p1||!p2) return "";
     const x1 = p1.x+W, y1 = p1.y+H/2, x2 = p2.x, y2 = p2.y+H/2; const mx = (x1+x2)/2;
     return `<path class="gedge" d="M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}"/>`; }).join("");
-  el.innerHTML = `<div style="overflow:auto"><svg width="${Math.max(width,300)}" height="${Math.max(height,60)}" style="display:block">
-    <defs><marker id="arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
-    <path d="M0,0 L8,4 L0,8 z" fill="#2e3d4d"/></marker></defs>${paths}${nodes}</svg></div>`;
+
+  const NS = "http://www.w3.org/2000/svg";
+  el.innerHTML = `<div class="gvport" id="gvport">
+      <div class="gcontrols">
+        <button id="gzout" data-tip="zoom out">−</button>
+        <button id="gzreset" data-tip="fit / reset view">⤾</button>
+        <button id="gzin" data-tip="zoom in">+</button>
+        <button id="gzfull" data-tip="fullscreen (esc to exit)">⛶</button>
+      </div>
+      <div class="hint">scroll to zoom · drag to pan · double-click empty to fit · click a node for detail</div>
+    </div>`;
+  const port = $("#gvport");
+  const svg = document.createElementNS(NS, "svg");
+  svg.setAttribute("width", "100%"); svg.setAttribute("height", "100%"); svg.style.display = "block";
+  svg.innerHTML = `<defs><marker id="arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+    <path d="M0,0 L8,4 L0,8 z" fill="#2e3d4d"/></marker></defs>`;
+  const world = document.createElementNS(NS, "g");
+  world.innerHTML = paths + nodes;
+  svg.appendChild(world);
+  port.appendChild(svg);
+
+  const gw = width, gh = height;
+  function apply(){ world.setAttribute("transform", `translate(${GV.x},${GV.y}) scale(${GV.scale})`); }
+  function fit(){
+    const pw = port.clientWidth || 600, ph = port.clientHeight || 440;
+    GV.scale = Math.min(pw/gw, ph/gh, 1.6) * 0.94;
+    GV.x = (pw - gw*GV.scale)/2; GV.y = (ph - gh*GV.scale)/2;
+    apply();
+  }
+  fit();
+  // Re-fit when entering/exiting fullscreen (class toggle is sync but the
+  // resize lands in the same frame, so a rAF is enough — no arbitrary delay).
+  function refitSoon(){ requestAnimationFrame(() => requestAnimationFrame(fit)); }
+
+  // zoom (wheel, centered on cursor)
+  port.addEventListener("wheel", e => {
+    e.preventDefault();
+    const r = port.getBoundingClientRect();
+    const mx = e.clientX - r.left, my = e.clientY - r.top;
+    const factor = e.deltaY < 0 ? 1.12 : 1/1.12;
+    const ns = Math.min(4, Math.max(0.15, GV.scale * factor));
+    GV.x = mx - (mx - GV.x) * (ns/GV.scale);
+    GV.y = my - (my - GV.y) * (ns/GV.scale);
+    GV.scale = ns; apply();
+  }, {passive:false});
+  // pan (drag on empty space)
+  port.addEventListener("mousedown", e => {
+    if(e.target.closest(".gnode") || e.target.closest(".gcontrols")) return;
+    GV.drag = {sx: e.clientX, sy: e.clientY, ox: GV.x, oy: GV.y};
+    port.classList.add("dragging");
+    e.preventDefault();
+  });
+  window.addEventListener("mousemove", e => { if(!GV.drag) return;
+    GV.x = GV.drag.ox + (e.clientX - GV.drag.sx);
+    GV.y = GV.drag.oy + (e.clientY - GV.drag.sy); apply(); });
+  window.addEventListener("mouseup", () => { GV.drag = null; port.classList.remove("dragging"); });
+  port.addEventListener("dblclick", e => { if(!e.target.closest(".gnode")) fit(); });
+  // controls
+  $("#gzin").onclick = () => { GV.scale = Math.min(4, GV.scale*1.25); apply(); };
+  $("#gzout").onclick = () => { GV.scale = Math.max(0.15, GV.scale/1.25); apply(); };
+  $("#gzreset").onclick = fit;
+  $("#gzfull").onclick = () => {
+    const on = port.classList.toggle("full");
+    document.body.classList.toggle("gv-full", on);
+    refitSoon();
+  };
+  if(!GV.escBound){ GV.escBound = true;
+    document.addEventListener("keydown", e => { if(e.key === "Escape") {
+      const f = document.querySelector(".gvport.full");
+      if(f){ f.classList.remove("full"); document.body.classList.remove("gv-full");
+        // re-fit the now-small canvas
+        if(typeof GV.refit === "function") GV.refit();
+      }
+    }});
+  }
+  GV.refit = refitSoon;
 }
 
 /* ── boot ────────────────────────────────────────────── */

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -333,8 +333,14 @@ function showView(v){ for(const t of document.querySelectorAll(".tab")) t.classL
 function syncDetailTab(){ const t = $("#tab-detail"); if(DETAIL_ID){ t.style.display=""; t.textContent = "Goal · "+DETAIL_ID.slice(0,14); } }
 
 function openGoal(id){ location.hash = "#/goal/"+id; }
+let lastGoalKey = null;
 async function route(){ const m = location.hash.match(/^#\/goal\/(.+)$/);
-  if(m){ DETAIL_ID = decodeURIComponent(m[1]); syncDetailTab(); showView("detail"); await loadDetail(DETAIL_ID); }
+  if(m){ const gid = decodeURIComponent(m[1]);
+    if(gid !== lastGoalKey){ lastGoalKey = gid; // different goal → fresh graph view
+      GV.built = false; GV.userSet = false; GV.full = false; GV.scale = 1; GV.x = 0; GV.y = 0;
+      document.body.classList.remove("gv-full");
+    }
+    DETAIL_ID = gid; syncDetailTab(); showView("detail"); await loadDetail(DETAIL_ID); }
   else { DETAIL_ID = null; syncDetailTab(); $("#tab-detail").style.display="none"; showView("overview"); } }
 window.addEventListener("hashchange", route);
 
@@ -647,7 +653,9 @@ function inspectTodo(id){
 }
 
 /* ── dependency graph (layered DAG, zoom/pan/fullscreen, no libs) ── */
-let GV = {scale: 1, x: 0, y: 0, drag: null, built: false};
+// Graph view state survives re-renders (SSE refresh / tab switches / data
+// updates must NOT reset the user's zoom, pan, or fullscreen).
+let GV = {scale: 1, x: 0, y: 0, drag: null, built: false, userSet: false, full: false, ac: null};
 function renderGraph(g){
   const el = $("#graph"); if(!el) return;
   const todos = g.todos.filter(t=>t.archive_state!=="archived");
@@ -712,10 +720,15 @@ function renderGraph(g){
     GV.x = (pw - gw*GV.scale)/2; GV.y = (ph - gh*GV.scale)/2;
     apply();
   }
-  fit();
-  // Re-fit when entering/exiting fullscreen (class toggle is sync but the
-  // resize lands in the same frame, so a rAF is enough — no arbitrary delay).
-  function refitSoon(){ requestAnimationFrame(() => requestAnimationFrame(fit)); }
+  // First build fits; rebuilds restore the user's view instead of resetting
+  // it (SVG is 100%×100%, so the transform is viewport-size independent).
+  if(!GV.built){
+    fit();
+    GV.built = true;
+  } else {
+    apply();
+    if(GV.full){ port.classList.add("full"); document.body.classList.add("gv-full"); }
+  }
 
   // zoom (wheel, centered on cursor)
   port.addEventListener("wheel", e => {
@@ -726,7 +739,7 @@ function renderGraph(g){
     const ns = Math.min(4, Math.max(0.15, GV.scale * factor));
     GV.x = mx - (mx - GV.x) * (ns/GV.scale);
     GV.y = my - (my - GV.y) * (ns/GV.scale);
-    GV.scale = ns; apply();
+    GV.scale = ns; GV.userSet = true; apply();
   }, {passive:false});
   // pan (drag on empty space)
   port.addEventListener("mousedown", e => {
@@ -735,30 +748,37 @@ function renderGraph(g){
     port.classList.add("dragging");
     e.preventDefault();
   });
+  // Window-level pan listeners must not accumulate across rebuilds.
+  if(GV.ac) GV.ac.abort();
+  GV.ac = new AbortController();
+  const sig = {signal: GV.ac.signal};
   window.addEventListener("mousemove", e => { if(!GV.drag) return;
     GV.x = GV.drag.ox + (e.clientX - GV.drag.sx);
-    GV.y = GV.drag.oy + (e.clientY - GV.drag.sy); apply(); });
-  window.addEventListener("mouseup", () => { GV.drag = null; port.classList.remove("dragging"); });
-  port.addEventListener("dblclick", e => { if(!e.target.closest(".gnode")) fit(); });
+    GV.y = GV.drag.oy + (e.clientY - GV.drag.sy);
+    GV.userSet = true; apply(); }, sig);
+  window.addEventListener("mouseup", () => { GV.drag = null; port.classList.remove("dragging"); }, sig);
+  port.addEventListener("dblclick", e => { if(!e.target.closest(".gnode")) { fit(); GV.userSet = true; } });
   // controls
-  $("#gzin").onclick = () => { GV.scale = Math.min(4, GV.scale*1.25); apply(); };
-  $("#gzout").onclick = () => { GV.scale = Math.max(0.15, GV.scale/1.25); apply(); };
-  $("#gzreset").onclick = fit;
+  $("#gzin").onclick = () => { GV.scale = Math.min(4, GV.scale*1.25); GV.userSet = true; apply(); };
+  $("#gzout").onclick = () => { GV.scale = Math.max(0.15, GV.scale/1.25); GV.userSet = true; apply(); };
+  $("#gzreset").onclick = () => { fit(); GV.userSet = true; };
   $("#gzfull").onclick = () => {
     const on = port.classList.toggle("full");
     document.body.classList.toggle("gv-full", on);
-    refitSoon();
+    GV.full = on;
+    // Untouched graph: refit to the new viewport (the small-viewport fit
+    // would leave it in a corner). After user interaction, keep their view.
+    if(!GV.userSet){ requestAnimationFrame(fit); }
   };
   if(!GV.escBound){ GV.escBound = true;
     document.addEventListener("keydown", e => { if(e.key === "Escape") {
       const f = document.querySelector(".gvport.full");
-      if(f){ f.classList.remove("full"); document.body.classList.remove("gv-full");
-        // re-fit the now-small canvas
-        if(typeof GV.refit === "function") GV.refit();
+      if(f){ f.classList.remove("full"); document.body.classList.remove("gv-full"); GV.full = false;
+        if(!GV.userSet && GV.fitFn) requestAnimationFrame(GV.fitFn);
       }
     }});
   }
-  GV.refit = refitSoon;
+  GV.fitFn = fit;
 }
 
 /* ── boot ────────────────────────────────────────────── */

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -287,6 +287,12 @@ fn route(req: &Request, root: &str) -> Vec<u8> {
             Err(e) => error_response(500, &format!("{e:#}")),
         };
     }
+    if req.method == "GET" && path == "/api/config" {
+        return json_response(
+            200,
+            &serde_json::json!({"ok": true, "data": api::model_config()}),
+        );
+    }
     // /api/goals/{id}/... segments
     let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
     if segments.len() >= 2 && segments[0] == "api" && segments[1] == "goals" {

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -1,0 +1,402 @@
+//! Minimal async HTTP/1.1 server on raw tokio TCP — loopback only, no
+//! external web framework (keeps the loop crate dependency-free of axum /
+//! hyper for a local dashboard). Handles GET/POST, JSON responses, path
+//! prefixes, and long-lived SSE streams.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+
+use super::api;
+
+/// Live-state fingerprint pushed over SSE whenever it changes.
+struct Snapshot {
+    overview: serde_json::Value,
+    goals: serde_json::Value,
+}
+
+fn snapshot(store: &crate::store::Store) -> Snapshot {
+    // A read failure must never kill the stream — push empty payloads and
+    // let the next tick retry (the CLI keeps working regardless).
+    let overview = api::overview(store)
+        .ok()
+        .and_then(|o| serde_json::to_value(o).ok())
+        .unwrap_or_else(|| serde_json::json!({"error": "projection failed"}));
+    let goals = api::goals_push(store)
+        .ok()
+        .and_then(|g| serde_json::to_value(g).ok())
+        .unwrap_or_else(|| serde_json::json!([]));
+    Snapshot { overview, goals }
+}
+
+fn fingerprint(s: &Snapshot) -> String {
+    // Cheap change detector: serialize once per tick (projections are small).
+    // `content_digest` already returns a hex string — no extra formatting.
+    format!(
+        "{}:{}",
+        crate::store::content_digest(s.overview.to_string().as_bytes()),
+        crate::store::content_digest(s.goals.to_string().as_bytes())
+    )
+}
+
+pub async fn run_server(root: String, port: u16, open_browser: bool) -> Result<()> {
+    let addr = format!("127.0.0.1:{port}");
+    let listener = TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("bind {addr} (is another `future loop ui` already running?)"))?;
+    let port = listener.local_addr()?.port();
+    let root = Arc::new(root);
+    let (tx, _) = watch::channel(fingerprint(&snapshot(&crate::store::Store::open(&root)?)));
+    let generation = Arc::new(AtomicU64::new(0));
+
+    // Broadcaster: recompute projections; push only when content changed.
+    {
+        let root = root.clone();
+        let tx = tx.clone();
+        let generation = generation.clone();
+        tokio::spawn(async move {
+            let mut last = tx.borrow().clone();
+            loop {
+                tokio::time::sleep(Duration::from_millis(1200)).await;
+                generation.fetch_add(1, Ordering::Relaxed);
+                let Ok(store) = crate::store::Store::open(&root) else {
+                    continue;
+                };
+                let fp = fingerprint(&snapshot(&store));
+                if fp != last {
+                    last = fp.clone();
+                    let _ = tx.send(fp);
+                }
+            }
+        });
+    }
+
+    println!("future loop ui — dashboard at http://127.0.0.1:{port}/  (root {root})");
+    println!("Ctrl-C to stop; state is read live from the loop ledger.");
+    if open_browser {
+        open_in_browser(&format!("http://127.0.0.1:{port}/"));
+    }
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let root = root.clone();
+        let rx = tx.subscribe();
+        tokio::spawn(async move {
+            let _ = handle(stream, root, rx).await;
+        });
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn open_in_browser(url: &str) {
+    let _ = std::process::Command::new("open").arg(url).spawn();
+}
+#[cfg(target_os = "windows")]
+fn open_in_browser(url: &str) {
+    let _ = std::process::Command::new("rundll32")
+        .args(["url.dll,FileProtocolHandler", url])
+        .spawn();
+}
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_in_browser(url: &str) {
+    let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+}
+
+const MAX_HEADER_BYTES: usize = 64 * 1024;
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+struct Request {
+    method: String,
+    path: String,
+    query: String,
+    body: Vec<u8>,
+}
+
+async fn read_request(stream: &mut TcpStream) -> Result<Option<Request>> {
+    let mut buf = Vec::with_capacity(8192);
+    let mut chunk = [0u8; 8192];
+    // Read headers.
+    let header_end = loop {
+        if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+            break pos + 4;
+        }
+        if buf.len() > MAX_HEADER_BYTES {
+            anyhow::bail!("headers too large");
+        }
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Ok(None); // peer closed before a full request
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    };
+    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or_default();
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let target = parts.next().unwrap_or_default().to_string();
+    let (path, query) = match target.split_once('?') {
+        Some((p, q)) => (p.to_string(), q.to_string()),
+        None => (target.clone(), String::new()),
+    };
+    let mut content_length = 0usize;
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                content_length = value.trim().parse().unwrap_or(0);
+            }
+        }
+    }
+    if content_length > MAX_BODY_BYTES {
+        anyhow::bail!("body too large");
+    }
+    let mut body = buf.split_off(header_end);
+    while body.len() < content_length {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+    body.truncate(content_length);
+    Ok(Some(Request {
+        method,
+        path,
+        query,
+        body,
+    }))
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn json_response(status: u16, value: &serde_json::Value) -> Vec<u8> {
+    let body = value.to_string();
+    respond(
+        status,
+        "application/json; charset=utf-8",
+        body.as_bytes(),
+        &[],
+    )
+}
+
+fn error_response(status: u16, message: &str) -> Vec<u8> {
+    json_response(status, &serde_json::json!({"ok": false, "error": message}))
+}
+
+fn respond(
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+    extra_headers: &[(&str, &str)],
+) -> Vec<u8> {
+    let reason = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        500 => "Internal Server Error",
+        _ => "OK",
+    };
+    let mut out = format!(
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\ncache-control: no-store\r\n",
+        body.len()
+    );
+    for (k, v) in extra_headers {
+        out.push_str(&format!("{k}: {v}\r\n"));
+    }
+    out.push_str("connection: close\r\n\r\n");
+    let mut bytes = out.into_bytes();
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn query_param(query: &str, key: &str) -> Option<String> {
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == key {
+                return Some(percent_decode(v));
+            }
+        }
+    }
+    None
+}
+
+fn percent_decode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(v);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+async fn handle(
+    mut stream: TcpStream,
+    root: Arc<String>,
+    rx: watch::Receiver<String>,
+) -> Result<()> {
+    stream.set_nodelay(true)?;
+    let Some(req) = read_request(&mut stream).await? else {
+        return Ok(());
+    };
+
+    // SSE: long-lived, bypasses the normal response path.
+    if req.method == "GET" && req.path == "/api/stream" {
+        return serve_sse(stream, root, rx).await;
+    }
+
+    let response = route(&req, &root);
+    stream.write_all(&response).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+fn route(req: &Request, root: &str) -> Vec<u8> {
+    let store = match crate::store::Store::open(root) {
+        Ok(s) => s,
+        Err(e) => return error_response(500, &format!("open store: {e:#}")),
+    };
+    let path = req.path.trim_end_matches('/');
+    if req.method == "GET" && (path.is_empty() || path == "/index.html") {
+        return respond(
+            200,
+            "text/html; charset=utf-8",
+            super::page::PAGE.as_bytes(),
+            &[],
+        );
+    }
+    if req.method == "GET" && path == "/api/overview" {
+        return match api::overview(&store) {
+            Ok(o) => json_response(200, &serde_json::json!({"ok": true, "data": o})),
+            Err(e) => error_response(500, &format!("{e:#}")),
+        };
+    }
+    // /api/goals/{id}/... segments
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() >= 2 && segments[0] == "api" && segments[1] == "goals" {
+        let goal_id = percent_decode(segments[2]);
+        match (req.method.as_str(), segments.get(3).copied()) {
+            ("GET", None) => {
+                return match api::goal_detail(&store, &goal_id) {
+                    Ok(Some(d)) => json_response(200, &serde_json::json!({"ok": true, "data": d})),
+                    Ok(None) => error_response(404, &format!("goal {goal_id} not found")),
+                    Err(e) => error_response(500, &format!("{e:#}")),
+                };
+            }
+            ("GET", Some("runs")) => {
+                let limit = query_param(&req.query, "limit")
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(200);
+                return match api::runs_page(&store, &goal_id, limit) {
+                    Ok(Some(r)) => json_response(200, &serde_json::json!({"ok": true, "data": r})),
+                    Ok(None) => error_response(404, &format!("goal {goal_id} not found")),
+                    Err(e) => error_response(500, &format!("{e:#}")),
+                };
+            }
+            ("GET", Some("events")) => {
+                let limit = query_param(&req.query, "limit")
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(200);
+                return match api::events_page(&store, &goal_id, limit) {
+                    Ok(Some(r)) => json_response(200, &serde_json::json!({"ok": true, "data": r})),
+                    Ok(None) => error_response(404, &format!("goal {goal_id} not found")),
+                    Err(e) => error_response(500, &format!("{e:#}")),
+                };
+            }
+            ("POST", Some("gate")) => {
+                return post_json(&req.body, root, &goal_id, PostKind::Gate);
+            }
+            ("POST", Some("lifecycle")) => {
+                return post_json(&req.body, root, &goal_id, PostKind::Lifecycle);
+            }
+            _ => return error_response(404, "unknown route"),
+        }
+    }
+    error_response(404, "unknown route")
+}
+
+enum PostKind {
+    Gate,
+    Lifecycle,
+}
+
+fn post_json(body: &[u8], root: &str, goal_id: &str, kind: PostKind) -> Vec<u8> {
+    // Mutations need a mutable store (append takes &mut self).
+    let mut store = match crate::store::Store::open(root) {
+        Ok(s) => s,
+        Err(e) => return error_response(500, &format!("open store: {e:#}")),
+    };
+    let result: Result<String> = (|| match kind {
+        PostKind::Gate => {
+            let body: api::GateResolveBody = serde_json::from_slice(body)
+                .context("invalid JSON body (expected {\"todo_id\",\"decision\"})")?;
+            api::resolve_gate(&mut store, goal_id, &body)
+        }
+        PostKind::Lifecycle => {
+            let body: api::LifecycleBody = serde_json::from_slice(body)
+                .context("invalid JSON body (expected {\"action\":\"cancel\"})")?;
+            api::set_lifecycle(&mut store, goal_id, &body)
+        }
+    })();
+    match result {
+        Ok(message) => json_response(200, &serde_json::json!({"ok": true, "message": message})),
+        Err(e) => error_response(400, &format!("{e:#}")),
+    }
+}
+
+async fn send_snapshot(stream: &mut TcpStream, root: &str) -> Result<()> {
+    let store = crate::store::Store::open(root)?;
+    let snap = snapshot(&store);
+    let frame = format!(
+        "event: overview\ndata: {}\n\nevent: goals\ndata: {}\n\n",
+        snap.overview, snap.goals
+    );
+    stream.write_all(frame.as_bytes()).await?;
+    Ok(())
+}
+
+async fn serve_sse(
+    mut stream: TcpStream,
+    root: Arc<String>,
+    mut rx: watch::Receiver<String>,
+) -> Result<()> {
+    let head = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncache-control: no-store\r\nconnection: keep-alive\r\n\r\n";
+    stream.write_all(head.as_bytes()).await?;
+    // Initial payload so the page renders without waiting for the first tick.
+    if send_snapshot(&mut stream, &root).await.is_err() {
+        return Ok(());
+    }
+    loop {
+        // Push on change; heartbeat comment keeps proxies/clients alive.
+        let changed = tokio::time::timeout(Duration::from_secs(15), rx.changed()).await;
+        match changed {
+            Ok(Ok(())) => {
+                if send_snapshot(&mut stream, &root).await.is_err() {
+                    return Ok(());
+                }
+            }
+            Ok(Err(_)) => return Ok(()), // broadcaster gone
+            Err(_) => {
+                if stream.write_all(b": ping\n\n").await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -23,10 +23,16 @@ struct Snapshot {
 fn snapshot(store: &crate::store::Store) -> Snapshot {
     // A read failure must never kill the stream — push empty payloads and
     // let the next tick retry (the CLI keeps working regardless).
-    let overview = api::overview(store)
+    let mut overview = api::overview(store)
         .ok()
         .and_then(|o| serde_json::to_value(o).ok())
         .unwrap_or_else(|| serde_json::json!({"error": "projection failed"}));
+    // `generated_at` is the wall-clock read time: it changes every tick and
+    // would make the change detector fire forever, re-rendering the page
+    // (and resetting graph zoom/pan/fullscreen) even when state is idle.
+    if let Some(obj) = overview.as_object_mut() {
+        obj.remove("generated_at");
+    }
     let goals = api::goals_push(store)
         .ok()
         .and_then(|g| serde_json::to_value(g).ok())

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -77,7 +77,7 @@ pub async fn run_server(root: String, port: u16, open_browser: bool) -> Result<(
     }
 
     println!("future loop ui — dashboard at http://127.0.0.1:{port}/  (root {root})");
-    println!("Ctrl-C to stop; state is read live from the loop ledger.");
+    println!("read-only; state is projected live from the loop ledger. Ctrl-C to stop.");
     if open_browser {
         open_in_browser(&format!("http://127.0.0.1:{port}/"));
     }
@@ -108,19 +108,17 @@ fn open_in_browser(url: &str) {
 }
 
 const MAX_HEADER_BYTES: usize = 64 * 1024;
-const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 struct Request {
     method: String,
     path: String,
     query: String,
-    body: Vec<u8>,
 }
 
 async fn read_request(stream: &mut TcpStream) -> Result<Option<Request>> {
     let mut buf = Vec::with_capacity(8192);
     let mut chunk = [0u8; 8192];
-    // Read headers.
+    // Read headers (read-only dashboard: no request bodies are consumed).
     let header_end = loop {
         if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
             break pos + 4;
@@ -144,31 +142,10 @@ async fn read_request(stream: &mut TcpStream) -> Result<Option<Request>> {
         Some((p, q)) => (p.to_string(), q.to_string()),
         None => (target.clone(), String::new()),
     };
-    let mut content_length = 0usize;
-    for line in lines {
-        if let Some((name, value)) = line.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("content-length") {
-                content_length = value.trim().parse().unwrap_or(0);
-            }
-        }
-    }
-    if content_length > MAX_BODY_BYTES {
-        anyhow::bail!("body too large");
-    }
-    let mut body = buf.split_off(header_end);
-    while body.len() < content_length {
-        let n = stream.read(&mut chunk).await?;
-        if n == 0 {
-            break;
-        }
-        body.extend_from_slice(&chunk[..n]);
-    }
-    body.truncate(content_length);
     Ok(Some(Request {
         method,
         path,
         query,
-        body,
     }))
 }
 
@@ -261,6 +238,15 @@ async fn handle(
         return serve_sse(stream, root, rx).await;
     }
 
+    // Read-only dashboard: reject any non-GET before routing.
+    if req.method != "GET" {
+        let body = serde_json::json!({"ok": false, "error": "read-only dashboard — use the `future loop` CLI for mutations"});
+        let response = json_response(405, &body);
+        stream.write_all(&response).await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+
     let response = route(&req, &root);
     stream.write_all(&response).await?;
     stream.shutdown().await?;
@@ -286,12 +272,6 @@ fn route(req: &Request, root: &str) -> Vec<u8> {
             Ok(o) => json_response(200, &serde_json::json!({"ok": true, "data": o})),
             Err(e) => error_response(500, &format!("{e:#}")),
         };
-    }
-    if req.method == "GET" && path == "/api/config" {
-        return json_response(
-            200,
-            &serde_json::json!({"ok": true, "data": api::model_config()}),
-        );
     }
     // /api/goals/{id}/... segments
     let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
@@ -325,45 +305,10 @@ fn route(req: &Request, root: &str) -> Vec<u8> {
                     Err(e) => error_response(500, &format!("{e:#}")),
                 };
             }
-            ("POST", Some("gate")) => {
-                return post_json(&req.body, root, &goal_id, PostKind::Gate);
-            }
-            ("POST", Some("lifecycle")) => {
-                return post_json(&req.body, root, &goal_id, PostKind::Lifecycle);
-            }
             _ => return error_response(404, "unknown route"),
         }
     }
     error_response(404, "unknown route")
-}
-
-enum PostKind {
-    Gate,
-    Lifecycle,
-}
-
-fn post_json(body: &[u8], root: &str, goal_id: &str, kind: PostKind) -> Vec<u8> {
-    // Mutations need a mutable store (append takes &mut self).
-    let mut store = match crate::store::Store::open(root) {
-        Ok(s) => s,
-        Err(e) => return error_response(500, &format!("open store: {e:#}")),
-    };
-    let result: Result<String> = (|| match kind {
-        PostKind::Gate => {
-            let body: api::GateResolveBody = serde_json::from_slice(body)
-                .context("invalid JSON body (expected {\"todo_id\",\"decision\"})")?;
-            api::resolve_gate(&mut store, goal_id, &body)
-        }
-        PostKind::Lifecycle => {
-            let body: api::LifecycleBody = serde_json::from_slice(body)
-                .context("invalid JSON body (expected {\"action\":\"cancel\"})")?;
-            api::set_lifecycle(&mut store, goal_id, &body)
-        }
-    })();
-    match result {
-        Ok(message) => json_response(200, &serde_json::json!({"ok": true, "message": message})),
-        Err(e) => error_response(400, &format!("{e:#}")),
-    }
 }
 
 async fn send_snapshot(stream: &mut TcpStream, root: &str) -> Result<()> {


### PR DESCRIPTION
## What

`future loop ui` — a local **read-only** web dashboard for the loop control plane, served on `127.0.0.1` (default :7717). Zero new dependencies: raw tokio TCP HTTP + an embedded vanilla-JS SPA, with SSE live updates (polling fallback). Every payload is replayed from the `.future/loop/` event ledger per request, so the page never drifts from CLI state.

### Overview
- Fleet totals (active/terminal/cancelled goals, open gates, 24h/7d runs · cost · quota slots)
- Attention queue (severity, waiting-on, recommended action) with triage-sorted goal cards

### Goal detail (tabbed)
- **Board**: kernel should-run decision (reason + reason_code + waiting-on), next action, spend & throughput (14-day sparkline, token/cost/slot buckets, 7-day outcome split), open gates, todo dependency DAG
- **Todos**: full table with per-todo rollup — runs, tok in/out, cost, first→latest run activity window, verify/acceptance/lease/evidence detail
- **Workers**: agent leases, heartbeats, liveness alerts, per-worker cost/token rollup, delivery closure, replan obligations, acceptance gaps
- **Runs** / **Events**: run ledger (validation receipts, failure kinds, tokens, cost, evidence), semantic history, raw event ledger

### Interaction
- Dependency graph: scroll-to-zoom, drag-to-pan, +/−/fit/fullscreen controls; **state survives SSE re-renders** (fingerprints are stable — see fix commit)
- Hover tooltips on every column header, badge, and concept; one-line glossaries for run / event / lease (holder dead) concepts

### Hard constraints (per review request)
- **Read-only**: only GET endpoints exist; every other method is a 405. Mutations (gate resolve, goal cancel) stay in the CLI — the page shows the exact `future loop` command instead.
- **Data source**: every projection reads exclusively from `.future/loop/` (event-ledger replay). No agent config / other paths are read.

### Commits
1. `feat(loop): future loop ui — local web dashboard` — server (raw tokio HTTP + SSE), projections, embedded SPA
2. `feat(loop ui): tabs, cost columns, auto-height graph, tooltips`
3. `refactor(loop ui): strict read-only dashboard over .future/loop only`
4. `feat(loop ui): zoomable/pannable/fullscreen dependency graph + concept glossaries`
5. `fix(loop ui): stable SSE fingerprints + graph view state preservation` — fixes the re-render loop that reset zoom/pan/fullscreen seconds after the user set them

### Testing
- `make lint-rust` green (rustfmt 1.97 + clippy `-D warnings` workspace-wide)
- `cargo test -p future-loop` — all 61 suites green
- `make test-desktop`, `test-desktop-rust`, `test-channels`, `test-cli`, `test-tui`, `test-mobile` green
- Manual: Chrome CDP checks — tabs render, tooltips fire, graph zoom/pan/fullscreen preserved across idle ticks AND across real data changes; POST/PUT → 405, ledger untouched
- Note: `test-agent` has a pre-existing parallel flake cluster (different tests fail each run, all green standalone) — reproduced identically on origin/main, unrelated to this branch