### PR TITLE
test(cli): reap fake browser child processes spawned by browser tests

### DIFF
--- a/cli/src/browser/safari/safari_manager.rs
+++ b/cli/src/browser/safari/safari_manager.rs
@@ -234,6 +234,21 @@ mod tests {
         }
     }
 
+    /// Kill a spawned child on drop (macOS/Linux `kill`). Prevents the
+    /// `fake_driver.py` processes launched by tests from leaking as orphans.
+    #[cfg(unix)]
+    struct KillChild(Option<i64>);
+    #[cfg(unix)]
+    impl Drop for KillChild {
+        fn drop(&mut self) {
+            if let Some(pid) = self.0 {
+                let _ = std::process::Command::new("kill")
+                    .arg(pid.to_string())
+                    .status();
+            }
+        }
+    }
+
     fn set_driver_override(path: &str) -> OverrideReset {
         *SAFARIDRIVER_PATH_OVERRIDE.lock().unwrap() = Some(path.to_string());
         OverrideReset
@@ -466,6 +481,12 @@ socketserver.TCPServer(("127.0.0.1", port), H).serve_forever()
         let result = safari_start(free_port().await, Some("http://x/"))
             .await
             .expect("start");
+        // Reap the fake-driver child this test spawned on exit (even on panic).
+        let driver_pid = match &result.connection {
+            BrowserConnectionConfig::Webdriver { driver_pid, .. } => *driver_pid,
+            _ => None,
+        };
+        let _kill = KillChild(driver_pid);
         assert_eq!(result.status, "started");
         assert_eq!(result.connection.session_id(), Some("fake-sid"));
         assert!(matches!(

--- a/cli/src/commands/browser_tools.rs
+++ b/cli/src/commands/browser_tools.rs
@@ -66,6 +66,12 @@ pub fn is_browser_tool(name: &str) -> bool {
 static BROWSER_LAUNCHER_OVERRIDE: std::sync::Mutex<Option<Option<(String, String)>>> =
     std::sync::Mutex::new(None);
 
+/// Test-only record of browser child PIDs spawned by `browser_start`, so tests
+/// can reap the `fake_chrome.py` processes they launch (those `serve_forever()`
+/// fakes otherwise leak as orphans across repeated test runs).
+#[cfg(test)]
+static SPAWNED_BROWSER_PIDS: std::sync::Mutex<Vec<u32>> = std::sync::Mutex::new(Vec::new());
+
 /// `findBrowserLauncher`, honoring the test override.
 fn launcher_for(executable_path: Option<&str>) -> Option<(String, String)> {
     #[cfg(test)]
@@ -188,12 +194,22 @@ async fn browser_start(args: &Map<String, Value>) -> Result<LocalToolResult, Str
     #[cfg(not(windows))]
     {
         // `spawn(..., { detached: true, stdio: "ignore" })` + `child.unref()`.
-        let _ = tokio::process::Command::new(&command)
+        let child = tokio::process::Command::new(&command)
             .args(&chrome_args)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();
+        #[cfg(test)]
+        if let Ok(child) = &child {
+            if let Some(pid) = child.id() {
+                SPAWNED_BROWSER_PIDS.lock().unwrap().push(pid);
+            }
+        }
+        // Non-test builds intentionally detach + unref the child (matches the
+        // TS `child.unref()` semantics); the handle is otherwise unused there.
+        #[cfg(not(test))]
+        drop(child);
     }
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -1061,6 +1077,22 @@ mod tests {
         InternalTypeResult,
     };
     use crate::browser::browser_state::load_browser_config;
+
+    /// Kill every browser child PID recorded by `browser_start` on drop, so the
+    /// `fake_chrome.py` fakes launched by tests don't leak as orphan processes.
+    #[cfg(unix)]
+    struct SpawnedBrowserCleanup;
+    #[cfg(unix)]
+    impl Drop for SpawnedBrowserCleanup {
+        fn drop(&mut self) {
+            let pids = std::mem::take(&mut *SPAWNED_BROWSER_PIDS.lock().unwrap());
+            for pid in pids {
+                let _ = std::process::Command::new("kill")
+                    .arg(pid.to_string())
+                    .status();
+            }
+        }
+    }
 
     // ── MockSession ───────────────────────────────────────────────────
 
@@ -2317,6 +2349,9 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn start_launch_becomes_reachable_reports_started() {
+        // Reap the fake-chrome child this test spawns on exit (even on panic).
+        let _cleanup = SpawnedBrowserCleanup;
+        SPAWNED_BROWSER_PIDS.lock().unwrap().clear();
         let (_g, _e, dir) = isolated_home().await;
         // Fake chrome: a python script serving /json/version on the port
         // given via --remote-debugging-port.


### PR DESCRIPTION
## Problem

The `browser start` tests launch long-lived Python fakes to stand in for Chrome and safaridriver:

- `cli/src/commands/browser_tools.rs` → `fake_chrome.py` (`serve_forever()`)
- `cli/src/browser/safari/safari_manager.rs` → `fake_driver.py` (`serve_forever()`)

Neither test killed the child it spawned, so **every test run leaked one orphan process** (reparented to pid 1). On my dev machine this had accumulated to **222 stray Python interpreters over ~15 days** (113 `fake_chrome.py` + 109 `fake_driver.py`), found while investigating high process counts.

Two distinct causes:

1. **browser_tools.rs** — production `browser_start` deliberately drops the `Child` handle (the browser is detached with `spawn` + unref so it outlives the CLI invocation), so nothing tracked the PID.
2. **safari_manager.rs** — `safari_start` records `driver_pid` into the browser config, but **nothing ever kills it**: there is no stop/quit command anywhere in the codebase.

## Fix

Production behavior is correct as-is (a user's browser *should* outlive the CLI call), so the fix stays in the tests — RAII drop guards, so cleanup also runs when a test panics:

- **`browser_tools.rs`**: record spawned browser PIDs in a `#[cfg(test)]` static (`SPAWNED_BROWSER_PIDS`), and add a `SpawnedBrowserCleanup` drop guard that kills them. Non-test builds `drop(child)` to preserve the previous detach semantics and keep the release build warning-free.
- **`safari_manager.rs`**: add a `KillChild` drop guard and hand it the `driver_pid` returned by `safari_start`.

Both guards are `#[cfg(unix)]`, matching the `#[cfg(unix)]` gate already on the two affected tests.

## Verification

- `cargo build --release -p future-cli` — 0 warnings
- `make lint-rust` equivalent, all four steps on the pinned 1.97.0 toolchain:
  - `cargo fmt --check --all` ✅
  - `cargo clippy --workspace --all-targets -- -D warnings` ✅
  - `cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml` ✅
  - `cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings` ✅
- `cargo test -p future-cli -- --test-threads=1` → **703 passed, 0 failed**
- **Zero** `fake_chrome.py` / `fake_driver.py` processes remain after a full suite run (previously one of each per run).

## Notes

- Scope is test-only cleanup; no production code path changes behavior.
- Unrelated pre-existing flake seen once during verification: `chromium_page::tests::create_page_times_out_when_target_never_discovered` asserts `started.elapsed().as_secs() >= 5` against a 5 s timeout (measured 5.04 s in isolation), so it truncates to 4 and fails under load. Passes in isolation and on the full-suite re-run; that file is untouched by this PR.