### PR TITLE
fix(loop): report worker stops to supervisor on transport/timeout/incomplete-budget exits

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3785,6 +3785,32 @@ pub async fn notify_supervisor(
     }
 }
 
+/// Report a worker stop that never reached a turn-boundary writeback (a
+/// transport failure propagating before writeback, or a wall-clock budget
+/// truncation returning early). Both exits skip the normal ②/③ up-channel
+/// reports, so the supervisor would otherwise be left polling a worker that
+/// already stopped. Idempotency is keyed on `todo_id` + `kind`, so a relaunch
+/// that hits the same stop re-notifies only once.
+#[doc(hidden)] // test-visible seam
+pub async fn notify_infra_stop(
+    client: &mut crate::agent_client::AgentClient,
+    supervisor_session_id: Option<&str>,
+    goal_id: &str,
+    todo_id: &str,
+    kind: &str,
+    detail: &str,
+) {
+    notify_supervisor(
+        client,
+        supervisor_session_id,
+        &format!(
+            "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion ({kind}) — {detail}"
+        ),
+        &format!("infra_stopped:{todo_id}:{kind}"),
+    )
+    .await;
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_turns(
     client: &mut crate::agent_client::AgentClient,
@@ -3970,12 +3996,48 @@ async fn run_turns(
             match tokio::time::timeout(std::time::Duration::from_secs(max_turn_secs), turn_future)
                 .await
             {
-                Ok(r) => r?,
+                Ok(r) => match r {
+                    Ok(rec) => rec,
+                    Err(e) => {
+                        // A gRPC transport failure (h2 reset, stream error,
+                        // connect loss …) never reached a writeback, so the
+                        // ②/③ up-channel reports are skipped. Report the
+                        // infra stop and mark it resumable before
+                        // re-propagating, so the supervisor isn't left
+                        // polling a dead worker.
+                        *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
+                        notify_infra_stop(
+                            client,
+                            goal.supervisor_session_id.as_deref(),
+                            goal_id,
+                            &todo_id,
+                            "transport",
+                            &format!("{e}"),
+                        )
+                        .await;
+                        return Err(e);
+                    }
+                },
                 Err(_) => {
                     // O3: budget truncation is a turn end — evaluate the
                     // no-progress window against the observed tool starts
                     // before stopping the run.
                     record_no_progress_if_idle(store, goal_id, &todo_id, agent_id, &progress)?;
+                    // A turn that outlives its wall-clock budget is an infra
+                    // stop, not a science result: mark it resumable so the
+                    // session's reasoning state is retained for the next
+                    // launch, and report it up-channel (the early return
+                    // otherwise skips the ②/③ reports).
+                    *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
+                    notify_infra_stop(
+                        client,
+                        goal.supervisor_session_id.as_deref(),
+                        goal_id,
+                        &todo_id,
+                        "timeout",
+                        &format!("turn exceeded --max-turn-secs ({max_turn_secs}s)"),
+                    )
+                    .await;
                     println!(
                         "   ⏱ turn exceeded --max-turn-secs ({max_turn_secs}s) — stopping run gracefully; relaunch to continue"
                     );
@@ -3983,7 +4045,22 @@ async fn run_turns(
                 }
             }
         } else {
-            turn_future.await?
+            match turn_future.await {
+                Ok(rec) => rec,
+                Err(e) => {
+                    *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
+                    notify_infra_stop(
+                        client,
+                        goal.supervisor_session_id.as_deref(),
+                        goal_id,
+                        &todo_id,
+                        "transport",
+                        &format!("{e}"),
+                    )
+                    .await;
+                    return Err(e);
+                }
+            }
         };
         println!(
             "   run={} state={} tools=[{}] cost=¥{:.4}",
@@ -4211,6 +4288,22 @@ async fn run_turns(
                     println!(
                         "   ✘ incomplete retry budget exhausted ({streak}/{max_incomplete_retries}) — the model stream keeps truncating mid-turn; stopping (relaunch later or reduce --thinking-level)"
                     );
+                    // A worker that exhausts its incomplete-retry budget
+                    // stops mid-task: report it up-channel (the `break`
+                    // otherwise leaves the supervisor blind to the stop).
+                    // Keyed on the streak so a relaunch that re-exhausts
+                    // re-notifies at the new streak value.
+                    notify_infra_stop(
+                        client,
+                        g.supervisor_session_id.as_deref(),
+                        goal_id,
+                        &todo_id,
+                        "incomplete_budget",
+                        &format!(
+                            "the model stream keeps truncating mid-turn ({streak}/{max_incomplete_retries})"
+                        ),
+                    )
+                    .await;
                     break;
                 }
             }

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -7,7 +7,7 @@
 
 mod common;
 
-use common::mock_agent::{completed_events, ev, spawn_mock, MockState};
+use common::mock_agent::{completed_events, ev, spawn_mock, AttachPlan, MockState};
 #[cfg(unix)]
 use common::todo_id_by_text;
 use common::{add_todo, cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
@@ -592,6 +592,169 @@ fn run_notifies_supervisor_on_hard_failure() {
     let reports: Vec<_> = calls.iter().filter(|(sid, _)| sid == "sup-sess").collect();
     assert_eq!(reports.len(), 1, "one failure report: {calls:?}");
     assert_eq!(reports[0].1, "enqueue_if_busy");
+}
+
+/// A registered supervisor receives a report when a worker exhausts its
+/// incomplete-retry budget: the stream closes before `agent_end` on every
+/// turn (terminal_state=incomplete), and after N consecutive turns the run
+/// `break`s — previously silently, leaving the supervisor blind to the stop.
+///
+/// The mock assigns run ids `mock-run-1`, `mock-run-2`, … on successive
+/// prompts, and its replay loop sends every scripted event whose `run_id`
+/// matches the current run; events that never match (and no `agent_end`)
+/// produce the incomplete state on every turn.
+#[test]
+fn run_notifies_supervisor_on_incomplete_budget_exhausted() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        // One tool event bound to a run id the mock never serves: every turn
+        // sees a stream with no matching events and no agent_end → incomplete.
+        events: vec![ev(
+            "mock-run-x",
+            0,
+            "tool_start",
+            "{\"tool_name\":\"write\"}",
+        )],
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "notify on incomplete budget");
+    cli_ok(&[
+        "supervisor",
+        "register",
+        "--goal",
+        &goal,
+        "--session-id",
+        "sup-sess",
+    ]);
+    // One todo, --max-turns 5, budget 2: turn1 + turn2 incomplete → break at
+    // the exhausted budget (turn 2), not at max-turns.
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turns",
+        "5",
+        "--max-incomplete-retries",
+        "2",
+    ]);
+    let st = shared.lock().unwrap();
+    let reports: Vec<_> = st
+        .prompt_calls
+        .iter()
+        .zip(st.prompt_messages.iter())
+        .filter(|((sid, _), _)| sid == "sup-sess")
+        .collect();
+    assert_eq!(
+        reports.len(),
+        1,
+        "one incomplete-budget report: {:?}",
+        st.prompt_calls
+    );
+    assert_eq!(reports[0].0 .1, "enqueue_if_busy");
+    assert!(
+        reports[0]
+            .1
+            .contains("stopped before completion (incomplete_budget)"),
+        "incomplete-budget stop reported: {}",
+        reports[0].1
+    );
+}
+
+/// A registered supervisor receives a report when the worker dies on a gRPC
+/// transport failure (h2 reset / mid-stream non-gap error). This exit never
+/// reaches a writeback, so without this report the supervisor would be left
+/// polling a worker that already stopped.
+#[test]
+fn run_notifies_supervisor_on_transport_error() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        // A non-DataLoss mid-stream error: no reconnect, the turn fails.
+        stream_attach_plan: vec![AttachPlan::HardErrorAfter(0)],
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "notify on transport");
+    cli_ok(&[
+        "supervisor",
+        "register",
+        "--goal",
+        &goal,
+        "--session-id",
+        "sup-sess",
+    ]);
+    let err = cli_err(&["run", "--goal", &goal, "--anonymous", "--max-turns", "1"]);
+    assert!(err.contains("stream error"), "{err}");
+    let st = shared.lock().unwrap();
+    let reports: Vec<_> = st
+        .prompt_calls
+        .iter()
+        .zip(st.prompt_messages.iter())
+        .filter(|((sid, _), _)| sid == "sup-sess")
+        .collect();
+    assert_eq!(
+        reports.len(),
+        1,
+        "one transport report: {:?}",
+        st.prompt_calls
+    );
+    assert_eq!(reports[0].0 .1, "enqueue_if_busy");
+    assert!(
+        reports[0]
+            .1
+            .contains("stopped before completion (transport)"),
+        "transport stop reported: {}",
+        reports[0].1
+    );
+}
+
+/// A registered supervisor receives a report when a turn outlives its
+/// wall-clock budget (--max-turn-secs). The early return previously skipped
+/// the ②/③ reports, leaving the supervisor blind to the stop.
+#[test]
+fn run_notifies_supervisor_on_timeout() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        hang_stream: true,
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "notify on timeout");
+    cli_ok(&[
+        "supervisor",
+        "register",
+        "--goal",
+        &goal,
+        "--session-id",
+        "sup-sess",
+    ]);
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--anonymous",
+        "--max-turn-secs",
+        "1",
+        "--max-turns",
+        "3",
+    ]);
+    let st = shared.lock().unwrap();
+    let reports: Vec<_> = st
+        .prompt_calls
+        .iter()
+        .zip(st.prompt_messages.iter())
+        .filter(|((sid, _), _)| sid == "sup-sess")
+        .collect();
+    assert_eq!(
+        reports.len(),
+        1,
+        "one timeout report: {:?}",
+        st.prompt_calls
+    );
+    assert_eq!(reports[0].0 .1, "enqueue_if_busy");
+    assert!(
+        reports[0].1.contains("stopped before completion (timeout)"),
+        "timeout stop reported: {}",
+        reports[0].1
+    );
 }
 
 /// A registered supervisor receives a report when a user gate opens


### PR DESCRIPTION
## Problem

A loop worker that stops **before reaching a turn-boundary writeback** never triggers the up-channel supervisor report, so the orchestrator session is left blind until it polls `status` / `ps`:

- **gRPC transport failure** (h2 reset / non-gap stream error): `run_turn` returns `Err`, propagated with `?` straight past the completion/failure `notify_supervisor` calls — no run record, no report.
- **`--max-turn-secs` wall-clock truncation**: returns `Ok(())` early, also skipping the reports; it additionally left `last_failure_kind` unset, so `cmd_run` classified it as "no turn ran" and **deleted the session** instead of retaining it for resume.
- **incomplete-retry-budget exhaustion**: `break`s the turn loop silently.

Observed in the wild: two workers died on h2 protocol errors and a third hit the 90-minute turn budget; the orchestrator only found out by manual inspection.

## Fix

- Add `notify_infra_stop` (dedup-keyed on `todo_id` + stop kind) and call it on all three exits so the supervisor is told the worker stopped.
- Mark transport errors and budget truncations `InfraRecoverable` so the session is retained for resume (mirrors the existing 429/incomplete handling).

## Tests

New end-to-end tests in `agent_run_drive.rs` drive the real `run` loop against the mock agent with a registered supervisor and assert the enqueued `enqueue_if_busy` report:

- `run_notifies_supervisor_on_transport_error`
- `run_notifies_supervisor_on_timeout`
- `run_notifies_supervisor_on_incomplete_budget_exhausted`

`make lint-rust` (workspace + src-tauri, `-D warnings`) green; future-loop / agent / channel / cli / tui / desktop-rust suites all pass (the intermittent `torn/partial cache reads` agent flake passes on rerun and is unrelated — no agent/channel code touched).
