### PR TITLE
fix: harden runtime reliability and previews

### DIFF
--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -293,7 +293,16 @@ impl Loop {
                             // derived from the app template (model_registry =
                             // None, e.g. tests) fall back to a fresh Registry
                             // so behaviour matches the pre-cache code.
-                            let provider_limit_phase = crate::compaction::CompactionPhase::MidTurn;
+                            // A rejected first prompt is still pre-turn: no
+                            // model response or tool result exists yet, so do
+                            // not replace that user input with a lossy
+                            // checkpoint. Once a completed model/tool round
+                            // exists, recovery may summarize the active turn.
+                            let provider_limit_phase = if turn == 0 {
+                                crate::compaction::CompactionPhase::PreTurn
+                            } else {
+                                crate::compaction::CompactionPhase::MidTurn
+                            };
                             let provider_limit_operation_id =
                                 format!("cmp_{}", crate::utils::generate_entry_id());
                             let Some(manager) = &self.context_manager else {

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -156,11 +156,13 @@ impl Loop {
                     // The retry below must use exactly the checkpoint produced
                     // for this failed model step. A second automatic checkpoint
                     // here could hide a non-context provider failure in a loop.
-                    Ok(crate::compaction::ContextPreparation::Unchanged { prompt: projected })
+                    Ok(crate::compaction::ContextPreparation::Unchanged {
+                        prompt: projected.clone(),
+                    })
                 } else {
                     manager
                         .prepare_semantic_with_lifecycle(
-                            projected,
+                            projected.clone(),
                             automatic_trigger,
                             automatic_phase,
                             None,
@@ -172,7 +174,9 @@ impl Loop {
                         .await
                 }
             } else {
-                Ok(crate::compaction::ContextPreparation::Unchanged { prompt: projected })
+                Ok(crate::compaction::ContextPreparation::Unchanged {
+                    prompt: projected.clone(),
+                })
             };
             let prompt = match prepared {
                 Ok(crate::compaction::ContextPreparation::Unchanged { prompt }) => prompt,
@@ -203,7 +207,19 @@ impl Loop {
                         phase: automatic_phase,
                         error: error.to_string(),
                     });
-                    return Err(anyhow!(error));
+                    if matches!(
+                        error,
+                        crate::compaction::ContextError::InvalidSummary
+                            | crate::compaction::ContextError::SummaryFailed(_)
+                    ) {
+                        // Automatic semantic summarization is opportunistic.
+                        // Keep the current projection and let the model request
+                        // run; a real provider context-limit response below has
+                        // its own emergency recovery path.
+                        projected
+                    } else {
+                        return Err(anyhow!(error));
+                    }
                 }
             };
             let work_messages: Vec<AgentMessage> = prompt
@@ -642,7 +658,7 @@ impl Loop {
                     }
                     ModelStreamEvent::Finish { reason, usage } => {
                         saw_terminal_event = true;
-                        if reason == FinishReason::Incomplete {
+                        if matches!(reason, FinishReason::Incomplete | FinishReason::Length) {
                             stream_truncated = true;
                         }
                         if let Some(ref usage) = usage {
@@ -1803,6 +1819,32 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn run_marks_length_stop_as_incomplete() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![
+            ev_text("cut off at max tokens"),
+            ModelStreamEvent::Finish {
+                reason: FinishReason::Length,
+                usage: None,
+            },
+        ])]);
+        let loop_ = Loop::new(provider, "mock");
+        let (text, _) = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "cut off at max tokens");
+        assert!(loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn truncated_stream_with_tool_calls_appends_placeholder_results() {
         let provider = ScriptedProvider::new(vec![Script::Events(vec![
             ev_toolcall_start(0, "call_1", "echo", "{}"),
@@ -2121,9 +2163,9 @@ mod tests {
             // The model-fit guard is mandatory and independent from optional
             // automatic compaction between tool turns.
             enabled: false,
-            reserve_tokens: 1,
+            reserve_tokens: 8_191,
             keep_recent_tokens: 1,
-            context_window: 1,
+            context_window: 8_192,
             model: "small".into(),
         });
         loop_.preflight_context_check = true;
@@ -2177,9 +2219,9 @@ mod tests {
         let mut loop_ = Loop::new(provider, "mock");
         loop_.context_manager = Some(crate::compaction::ContextManager {
             enabled: true,
-            reserve_tokens: 1,
+            reserve_tokens: 8_191,
             keep_recent_tokens: 1,
-            context_window: 1,
+            context_window: 8_192,
             model: "mock".into(),
         });
         let mut messages = user_messages("old");
@@ -2216,14 +2258,55 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn checkpoint_commit_failure_emits_compaction_failed_after_started() {
-        let provider = ScriptedProvider::new(vec![]);
+    async fn automatic_summary_failure_keeps_history_and_runs_the_model() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![ev_text("ok"), ev_stop()])]);
         let mut loop_ = Loop::new(provider, "mock");
         loop_.context_manager = Some(crate::compaction::ContextManager {
             enabled: true,
             reserve_tokens: 1,
             keep_recent_tokens: 1,
             context_window: 1,
+            model: "mock".into(),
+        });
+        let mut messages = user_messages("old");
+        messages.push(AgentMessage {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::text("older reply")],
+            ..Default::default()
+        });
+        messages.push(AgentMessage::new_user("user", serde_json::json!("latest")));
+        let failed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (text, final_messages) = loop_
+            .run_streaming_with_messages(
+                messages,
+                &StreamContext::default(),
+                noop_on_text,
+                {
+                    let failed = failed.clone();
+                    move |event| {
+                        if matches!(event, RunEvent::CompactionFailed { .. }) {
+                            failed.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    }
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "ok");
+        assert!(failed.load(std::sync::atomic::Ordering::Relaxed));
+        assert_eq!(final_messages.len(), 4, "uncompacted history must survive");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn checkpoint_commit_failure_emits_compaction_failed_after_started() {
+        let provider = ScriptedProvider::new(vec![]);
+        let mut loop_ = Loop::new(provider, "mock");
+        loop_.context_manager = Some(crate::compaction::ContextManager {
+            enabled: true,
+            reserve_tokens: 8_191,
+            keep_recent_tokens: 1,
+            context_window: 8_192,
             model: "mock".into(),
         });
         let mut messages = user_messages("old");

--- a/agent/src/compaction/mod.rs
+++ b/agent/src/compaction/mod.rs
@@ -153,6 +153,8 @@ pub enum ContextError {
     NoValidBoundary,
     #[error("context compaction produced an empty summary")]
     InvalidSummary,
+    #[error("context compaction summary failed: {0}")]
+    SummaryFailed(String),
     #[error("context compaction was cancelled")]
     Cancelled,
 }
@@ -169,8 +171,9 @@ pub struct ContextManager {
 impl ContextManager {
     /// Prepare context with a model-generated semantic summary. The selected
     /// session model/provider is reused with tools disabled; no hidden
-    /// compaction model is involved. Provider failures fall back to a richer
-    /// deterministic summary, while cancellation remains observable.
+    /// compaction model is involved. Provider failures remain observable so
+    /// callers do not commit a lossy checkpoint. Only the provider-context-
+    /// limit recovery path may use the deterministic emergency summary.
     pub async fn prepare_semantic(
         &self,
         prompt: PromptContext,

--- a/agent/src/compaction/semantic.rs
+++ b/agent/src/compaction/semantic.rs
@@ -132,13 +132,20 @@ pub(super) async fn prepare(
         Ok(summary) if valid_summary(&summary) => (summary, "semantic-v1"),
         Err(SummaryCallError::Cancelled) => return Err(ContextError::Cancelled),
         Ok(_) => {
-            tracing::warn!(
-                "semantic compaction returned an invalid summary; using emergency summary"
-            );
+            if plan.trigger != CompactionTrigger::ProviderContextLimit {
+                return Err(ContextError::InvalidSummary);
+            }
+            tracing::warn!("provider context-limit recovery received an invalid semantic summary; using emergency summary");
             (emergency_summary(&plan), "deterministic-emergency-v1")
         }
         Err(SummaryCallError::ContextLimit(error)) | Err(SummaryCallError::Other(error)) => {
-            tracing::warn!(error, "semantic compaction failed; using emergency summary");
+            if plan.trigger != CompactionTrigger::ProviderContextLimit {
+                return Err(ContextError::SummaryFailed(error));
+            }
+            tracing::warn!(
+                error,
+                "provider context-limit recovery compaction failed; using emergency summary"
+            );
             (emergency_summary(&plan), "deterministic-emergency-v1")
         }
     };
@@ -219,16 +226,32 @@ fn plan(
     } else {
         manager.keep_recent_tokens.max(1) as u64
     };
-    let cut = turn_aware_cut(
+    // Once a task is already in progress, retaining an oversized latest tool
+    // result can leave the "compacted" prompt above the model limit. In that
+    // case it is safer to summarize the complete active turn and continue from
+    // the structured handoff. Do not do this before the first model request:
+    // a lone, oversized user prompt has not been acted on yet and must not be
+    // silently replaced by a lossy summary.
+    let allow_full_active_turn = trigger == CompactionTrigger::Manual
+        || (phase == CompactionPhase::MidTurn
+            && matches!(
+                trigger,
+                CompactionTrigger::Automatic | CompactionTrigger::ProviderContextLimit
+            ));
+    let mut cut = turn_aware_cut(
         &prompt.messages,
         &costs,
         keep_recent_tokens,
         compact_all_when_every_turn_fits,
     )
+    .or_else(|| allow_full_active_turn.then_some(prompt.messages.len()))
     .ok_or(ContextError::NoValidBoundary)?;
+    if allow_full_active_turn && costs[cut..].iter().copied().sum::<u64>() > keep_recent_tokens {
+        cut = prompt.messages.len();
+    }
     if cut == 0
         || cut > prompt.messages.len()
-        || (cut == prompt.messages.len() && !compact_all_when_every_turn_fits)
+        || (cut == prompt.messages.len() && !allow_full_active_turn)
     {
         return Err(ContextError::NoValidBoundary);
     }
@@ -1029,9 +1052,7 @@ mod tests {
         }
     }
 
-    fn projected(role: &str, text: &str, id: &str) -> ProjectedMessage {
-        let mut message =
-            AgentMessage::new_user(role, serde_json::json!([{ "type": "text", "text": text }]));
+    fn projected_message(mut message: AgentMessage, id: &str) -> ProjectedMessage {
         message
             .metadata
             .get_or_insert_with(serde_json::Map::new)
@@ -1043,6 +1064,13 @@ mod tests {
             message,
             source_entry_ids: vec![id.to_string()],
         }
+    }
+
+    fn projected(role: &str, text: &str, id: &str) -> ProjectedMessage {
+        projected_message(
+            AgentMessage::new_user(role, serde_json::json!([{ "type": "text", "text": text }])),
+            id,
+        )
     }
 
     fn test_prompt() -> PromptContext {
@@ -1134,6 +1162,100 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].model, "old-model");
         assert!(requests[0].tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mid_turn_compaction_summarizes_an_oversized_active_tool_tail() {
+        let provider = ScriptedProvider::new([ScriptedReply::Summary(VALID_SUMMARY)]);
+        let prompt = PromptContext {
+            messages: vec![
+                projected("user", "audit the repository", "e1"),
+                projected_message(
+                    AgentMessage {
+                        role: "assistant".to_string(),
+                        content: vec![ContentBlock::tool_call(
+                            "call-1",
+                            "read",
+                            serde_json::json!({"path": "large.rs"}),
+                            Default::default(),
+                        )],
+                        ..Default::default()
+                    },
+                    "e2",
+                ),
+                projected_message(
+                    AgentMessage {
+                        role: "tool".to_string(),
+                        content: vec![ContentBlock::tool_result(
+                            "call-1",
+                            "x".repeat(20_000),
+                            false,
+                        )],
+                        ..Default::default()
+                    },
+                    "e3",
+                ),
+            ],
+            usage: ContextUsage {
+                input_tokens: Some(10_000),
+                estimated_input_tokens: 10_000,
+                context_window: 8_000,
+                ..Default::default()
+            },
+        };
+
+        let ContextPreparation::Compacted { prompt, checkpoint } = test_manager()
+            .prepare_semantic_with_phase(
+                prompt,
+                CompactionTrigger::Automatic,
+                CompactionPhase::MidTurn,
+                None,
+                &provider,
+                &AtomicBool::new(false),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected full active-turn compaction")
+        };
+
+        assert_eq!(checkpoint.covered_from_entry_id.as_deref(), Some("e1"));
+        assert_eq!(checkpoint.cutoff_entry_id.as_deref(), Some("e3"));
+        assert_eq!(checkpoint.phase, Some(CompactionPhase::MidTurn));
+        assert_eq!(
+            prompt.messages.len(),
+            1,
+            "the structured summary continues the task"
+        );
+        assert!(checkpoint.tokens_after < checkpoint.tokens_before);
+    }
+
+    #[tokio::test]
+    async fn pre_turn_compaction_does_not_replace_an_unseen_user_prompt() {
+        let provider = ScriptedProvider::new([]);
+        let prompt = PromptContext {
+            messages: vec![projected("user", &"x".repeat(40_000), "e1")],
+            usage: ContextUsage {
+                input_tokens: Some(10_000),
+                estimated_input_tokens: 10_000,
+                context_window: 8_000,
+                ..Default::default()
+            },
+        };
+
+        let result = test_manager()
+            .prepare_semantic_with_phase(
+                prompt,
+                CompactionTrigger::Automatic,
+                CompactionPhase::PreTurn,
+                None,
+                &provider,
+                &AtomicBool::new(false),
+            )
+            .await;
+
+        assert_eq!(result.unwrap_err(), ContextError::NoValidBoundary);
+        assert!(provider.requests.lock().is_empty());
     }
 
     #[tokio::test]
@@ -1261,9 +1383,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_retryable_failure_uses_deterministic_emergency_summary() {
+    async fn non_retryable_failure_does_not_commit_automatic_checkpoint() {
         let provider = ScriptedProvider::new([ScriptedReply::Error("authentication failed")]);
-        let prepared = test_manager()
+        let error = test_manager()
             .prepare_semantic(
                 test_prompt(),
                 CompactionTrigger::Automatic,
@@ -1272,15 +1394,53 @@ mod tests {
                 &AtomicBool::new(false),
             )
             .await
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ContextError::SummaryFailed("authentication failed".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_context_limit_failure_uses_deterministic_emergency_summary() {
+        let provider = ScriptedProvider::new([ScriptedReply::Error("authentication failed")]);
+        let prepared = test_manager()
+            .prepare_semantic(
+                test_prompt(),
+                CompactionTrigger::ProviderContextLimit,
+                Some("preserve the exact user constraints"),
+                &provider,
+                &AtomicBool::new(false),
+            )
+            .await
             .unwrap();
         let ContextPreparation::Compacted { checkpoint, .. } = prepared else {
-            panic!("expected compaction")
+            panic!("expected emergency provider-limit compaction")
         };
         assert_eq!(checkpoint.algorithm_version, "deterministic-emergency-v1");
         let ContentBlock::Text { text } = &checkpoint.summary[0] else {
             panic!("expected text summary")
         };
         assert!(text.contains("preserve the exact user constraints"));
+    }
+
+    #[tokio::test]
+    async fn manual_failure_does_not_replace_the_full_history() {
+        let provider = ScriptedProvider::new([ScriptedReply::Error("authentication failed")]);
+        let error = test_manager()
+            .prepare_semantic(
+                test_prompt(),
+                CompactionTrigger::Manual,
+                None,
+                &provider,
+                &AtomicBool::new(false),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ContextError::SummaryFailed("authentication failed".to_string())
+        );
     }
 
     #[tokio::test]

--- a/agent/src/llm/adapters/anthropic.rs
+++ b/agent/src/llm/adapters/anthropic.rs
@@ -1,6 +1,7 @@
 use super::{data_url, namespaced_metadata, parse_json_arguments, ProtocolAdapter};
 use crate::llm::schema::{
-    ApiProtocol, FinishReason, ModelRequest, ModelStreamEvent, ProtocolConfig, ResolvedModelTarget,
+    AnthropicThinkingMode, ApiProtocol, FinishReason, ModelRequest, ModelStreamEvent,
+    ProtocolConfig, ResolvedModelTarget,
 };
 use crate::llm::sse::SseFrame;
 use crate::types::{ContentBlock, ProviderMetadata, Usage};
@@ -52,7 +53,7 @@ impl ProtocolAdapter for AnthropicMessagesAdapter {
     }
 
     fn build_body(&self, target: &ResolvedModelTarget, request: &ModelRequest) -> Result<Value> {
-        let ProtocolConfig::AnthropicMessages(_) = &target.protocol else {
+        let ProtocolConfig::AnthropicMessages(config) = &target.protocol else {
             bail!("Anthropic Messages adapter received a non-anthropic target")
         };
         let messages = lower_messages(request)?;
@@ -87,15 +88,23 @@ impl ProtocolAdapter for AnthropicMessagesAdapter {
                     .collect(),
             );
         }
-        let thinking_budget = target
-            .generation
-            .thinking_budget
-            .min(max_tokens.saturating_sub(1));
-        if thinking_budget >= MIN_THINKING_BUDGET_TOKENS {
-            body["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": thinking_budget,
+        let thinking_enabled = target.generation.thinking_budget >= MIN_THINKING_BUDGET_TOKENS;
+        if thinking_enabled && config.thinking_mode == AnthropicThinkingMode::Adaptive {
+            body["thinking"] = json!({"type": "adaptive"});
+            body["output_config"] = json!({
+                "effort": anthropic_effort(&target.generation.thinking_level),
             });
+        } else if thinking_enabled {
+            let thinking_budget = target
+                .generation
+                .thinking_budget
+                .min(max_tokens.saturating_sub(1));
+            if thinking_budget >= MIN_THINKING_BUDGET_TOKENS {
+                body["thinking"] = json!({
+                    "type": "enabled",
+                    "budget_tokens": thinking_budget,
+                });
+            }
         } else if let Some(temperature) = target.generation.temperature {
             body["temperature"] = json!(temperature);
         }
@@ -475,11 +484,24 @@ fn update_usage(usage: &mut Usage, value: &Value) {
 
 fn map_finish_reason(reason: &str) -> FinishReason {
     match reason {
-        "end_turn" | "stop_sequence" | "pause_turn" => FinishReason::Stop,
+        "end_turn" | "stop_sequence" => FinishReason::Stop,
         "tool_use" => FinishReason::ToolCalls,
-        "max_tokens" => FinishReason::Length,
+        "max_tokens" | "model_context_window_exceeded" => FinishReason::Length,
+        // FutureOS does not currently send Anthropic server tools, so it
+        // cannot replay their opaque pause payload unchanged. Never surface a
+        // paused server-tool turn as a completed assistant response.
+        "pause_turn" => FinishReason::Incomplete,
         "refusal" => FinishReason::Refusal,
         other => FinishReason::Unknown(other.to_string()),
+    }
+}
+
+fn anthropic_effort(level: &str) -> &'static str {
+    match level {
+        "minimal" | "low" => "low",
+        "medium" => "medium",
+        "xhigh" => "max",
+        _ => "high",
     }
 }
 
@@ -505,6 +527,17 @@ mod tests {
                 ..Default::default()
             },
         }
+    }
+
+    fn adaptive_target(level: &str) -> ResolvedModelTarget {
+        let mut target = target(None, 16_000);
+        target.generation.thinking_level = level.to_string();
+        target.protocol =
+            ProtocolConfig::AnthropicMessages(crate::llm::schema::AnthropicMessagesConfig {
+                thinking_mode: AnthropicThinkingMode::Adaptive,
+                ..Default::default()
+            });
+        target
     }
 
     fn empty_request() -> ModelRequest {
@@ -534,6 +567,25 @@ mod tests {
             )
             .unwrap();
         assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn adaptive_thinking_uses_effort_instead_of_manual_budget() {
+        let body = AnthropicMessagesAdapter
+            .build_body(&adaptive_target("xhigh"), &empty_request())
+            .unwrap();
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "max");
+        assert!(body["thinking"].get("budget_tokens").is_none());
+    }
+
+    #[test]
+    fn anthropic_stop_reasons_preserve_truncation() {
+        assert_eq!(map_finish_reason("pause_turn"), FinishReason::Incomplete);
+        assert_eq!(
+            map_finish_reason("model_context_window_exceeded"),
+            FinishReason::Length
+        );
     }
 
     fn frame(event: &str, data: Value) -> SseFrame {

--- a/agent/src/llm/schema.rs
+++ b/agent/src/llm/schema.rs
@@ -111,15 +111,24 @@ impl Default for OpenAiResponsesConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AnthropicThinkingMode {
+    #[default]
+    Manual,
+    Adaptive,
+}
+
 #[derive(Debug, Clone)]
 pub struct AnthropicMessagesConfig {
     pub version: String,
+    pub thinking_mode: AnthropicThinkingMode,
 }
 
 impl Default for AnthropicMessagesConfig {
     fn default() -> Self {
         Self {
             version: "2023-06-01".to_string(),
+            thinking_mode: AnthropicThinkingMode::Manual,
         }
     }
 }
@@ -291,7 +300,7 @@ impl ResolvedModelTarget {
                 ProtocolConfig::OpenAiResponses(OpenAiResponsesConfig::default())
             }
             ApiProtocol::AnthropicMessages => {
-                ProtocolConfig::AnthropicMessages(AnthropicMessagesConfig::default())
+                ProtocolConfig::AnthropicMessages(parse_anthropic_config(model)?)
             }
         };
         let auth = match api {
@@ -362,6 +371,57 @@ impl ResolvedModelTarget {
             },
         }
     }
+}
+
+fn parse_anthropic_config(model: &crate::models::Model) -> Result<AnthropicMessagesConfig> {
+    let configured = match model.compat.get("anthropicThinkingMode") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => Some(value.as_str()),
+        Some(_) => {
+            bail!(
+                "provider `{}` model `{}` compat.anthropicThinkingMode must be a string",
+                model.provider,
+                model.id
+            )
+        }
+    };
+    let thinking_mode = match configured {
+        Some("manual") => AnthropicThinkingMode::Manual,
+        Some("adaptive") => AnthropicThinkingMode::Adaptive,
+        Some(other) => {
+            bail!(
+                "provider `{}` model `{}` has unsupported compat.anthropicThinkingMode `{other}`",
+                model.provider,
+                model.id
+            )
+        }
+        None if anthropic_model_uses_adaptive_thinking(&model.id) => {
+            AnthropicThinkingMode::Adaptive
+        }
+        None => AnthropicThinkingMode::Manual,
+    };
+    Ok(AnthropicMessagesConfig {
+        thinking_mode,
+        ..Default::default()
+    })
+}
+
+fn anthropic_model_uses_adaptive_thinking(model_id: &str) -> bool {
+    let id = model_id.to_ascii_lowercase().replace('.', "-");
+    [
+        "opus-4-6",
+        "opus-4-7",
+        "opus-4-8",
+        "opus-5",
+        "sonnet-4-6",
+        "sonnet-5",
+        "fable-5",
+        "mythos-5",
+        "opus-latest",
+        "sonnet-latest",
+    ]
+    .iter()
+    .any(|marker| id.contains(marker))
 }
 
 fn parse_chat_config(model: &crate::models::Model) -> Result<OpenAiChatConfig> {
@@ -530,5 +590,30 @@ mod tests {
             panic!("chat protocol expected")
         };
         assert_eq!(chat.reasoning, ChatReasoningFormat::None);
+    }
+
+    #[test]
+    fn anthropic_thinking_mode_uses_model_generation_with_explicit_override() {
+        let mut model = crate::models::Model {
+            id: "claude-opus-4-8".into(),
+            provider: "anthropic".into(),
+            api: "anthropic".into(),
+            ..Default::default()
+        };
+        let target = ResolvedModelTarget::from_model(&model, "key".into(), None, None).unwrap();
+        let ProtocolConfig::AnthropicMessages(config) = target.protocol else {
+            panic!("Anthropic protocol expected")
+        };
+        assert_eq!(config.thinking_mode, AnthropicThinkingMode::Adaptive);
+
+        model.compat.insert(
+            "anthropicThinkingMode".into(),
+            Value::String("manual".into()),
+        );
+        let target = ResolvedModelTarget::from_model(&model, "key".into(), None, None).unwrap();
+        let ProtocolConfig::AnthropicMessages(config) = target.protocol else {
+            panic!("Anthropic protocol expected")
+        };
+        assert_eq!(config.thinking_mode, AnthropicThinkingMode::Manual);
     }
 }

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -2829,6 +2829,7 @@ mod tests {
     #[test]
     fn compact_with_real_history_reports_summary() {
         let mut session = make_test_session("compact");
+        session.agent_loop.try_write().unwrap().provider = Arc::new(SummaryProvider);
         let mut events = session.broadcaster.subscribe();
         session.model = "glm-4.5v".to_string(); // 64k catalog window
         session

--- a/desktop/src-tauri/src/commands/files.rs
+++ b/desktop/src-tauri/src/commands/files.rs
@@ -195,29 +195,64 @@ pub fn validate_image_attachment(path: String) -> Result<(), crate::AppError> {
     Ok(())
 }
 
-/// Hard ceiling for [`read_file_base64`]: the whole file is buffered in memory
-/// (×1.33 as base64), so a caller-supplied limit must never be able to raise it.
-const READ_BASE64_MAX_BYTES: u64 = 25 * 1024 * 1024;
+const IMAGE_PREVIEW_MAX_BYTES: u64 = 25 * 1024 * 1024;
 
-/// Read a whole file as base64 (for client-side PDF text extraction). Errors if
-/// the file exceeds `max_bytes` (default and cap 25MB) — extraction targets must
-/// be small.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagePreviewAsset {
+    path: String,
+    version: String,
+}
+
+/// Validate one local image path and expose exactly that canonical file through
+/// Tauri's asset protocol. The WebView then reads the bytes directly instead of
+/// receiving a 1.33x Base64 string over JSON IPC.
 #[tauri::command]
-pub fn read_file_base64(path: String, max_bytes: Option<u64>) -> Result<String, crate::AppError> {
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
+pub fn prepare_image_preview(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<ImagePreviewAsset, crate::AppError> {
+    prepare_image_preview_with(&app, &path)
+}
+
+fn prepare_image_preview_with<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    path: &str,
+) -> Result<ImagePreviewAsset, crate::AppError> {
+    use tauri::Manager;
+
+    let (canonical, size) = validate_image_preview_path(path)?;
+    app.asset_protocol_scope()
+        .allow_file(&canonical)
+        .map_err(|error| format!("failed to authorize image preview path: {error}"))?;
+    Ok(ImagePreviewAsset {
+        path: canonical.display().to_string(),
+        // The asset URL is path-based. Give every preparation a fresh version so
+        // reopening a changed file never reuses an old WebView cache entry.
+        version: format!("{}-{size}", unique_stamp()),
+    })
+}
+
+fn validate_image_preview_path(path: &str) -> Result<(PathBuf, u64), crate::AppError> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
         return Err("path cannot be empty.".to_string().into());
     }
     ensure_path_allowed(Path::new(trimmed))?;
-    let meta = std::fs::metadata(trimmed)?;
-    let limit = max_bytes
-        .unwrap_or(READ_BASE64_MAX_BYTES)
-        .clamp(1, READ_BASE64_MAX_BYTES);
-    if meta.len() > limit {
-        return Err(format!("File too large ({} bytes; limit {}).", meta.len(), limit).into());
+    let canonical = Path::new(trimmed).canonicalize()?;
+    let meta = std::fs::metadata(&canonical)?;
+    if !meta.is_file() {
+        return Err("image preview path must be a file.".to_string().into());
     }
-    Ok(STANDARD.encode(std::fs::read(trimmed)?))
+    if meta.len() > IMAGE_PREVIEW_MAX_BYTES {
+        return Err(format!(
+            "File too large ({} bytes; limit {}).",
+            meta.len(),
+            IMAGE_PREVIEW_MAX_BYTES
+        )
+        .into());
+    }
+    Ok((canonical, meta.len()))
 }
 
 /// A filesystem-safe, process-unique stamp (`<nanos>-<seq>`). The atomic seq
@@ -339,7 +374,7 @@ pub fn import_ephemeral_image(
     }
     // Guard the source: a copy-out of a protected credential file (e.g.
     // auth.json) would otherwise defeat `ensure_path_allowed` — the copy lands
-    // under a non-credential name/dir and becomes readable via read_file_base64.
+    // under a non-credential name/dir and becomes readable via the asset protocol.
     ensure_path_allowed(Path::new(source))?;
     let dir = crate::store::thread_images_dir(&thread_id)?.join("origin");
     std::fs::create_dir_all(&dir)?;
@@ -853,16 +888,39 @@ mod tests {
     }
 
     #[test]
-    fn read_file_base64_covers_edges() {
-        let root = future_root("base64");
-        assert!(read_file_base64("   ".into(), None).is_err());
+    fn validate_image_preview_path_covers_edges() {
+        let root = future_root("image_preview");
+        assert!(validate_image_preview_path("   ").is_err());
         let big = sparse_large(&root, "big.bin");
-        assert!(read_file_base64(big.display().to_string(), None).is_err());
+        assert!(validate_image_preview_path(&big.display().to_string()).is_err());
 
-        let small = root.join("small.txt");
+        let small = root.join("small.png");
         fs::write(&small, b"hello").unwrap();
-        let encoded = read_file_base64(small.display().to_string(), None).unwrap();
-        assert_eq!(encoded, "aGVsbG8=");
+        let (canonical, size) = validate_image_preview_path(&small.display().to_string()).unwrap();
+        assert_eq!(canonical, small.canonicalize().unwrap());
+        assert_eq!(size, 5);
+    }
+
+    #[test]
+    fn prepare_image_preview_authorizes_only_the_canonical_file() {
+        use tauri::Manager;
+
+        let root = future_root("image_preview_scope");
+        let source = root.join("source.png");
+        let other = root.join("other.png");
+        fs::write(&source, b"image bytes").unwrap();
+        fs::write(&other, b"other image bytes").unwrap();
+        let app = tauri::test::mock_app();
+
+        let asset =
+            prepare_image_preview_with(app.handle(), &source.display().to_string()).unwrap();
+        let refreshed =
+            prepare_image_preview_with(app.handle(), &source.display().to_string()).unwrap();
+        let canonical = source.canonicalize().unwrap();
+        assert_eq!(asset.path, canonical.display().to_string());
+        assert_ne!(asset.version, refreshed.version);
+        assert!(app.asset_protocol_scope().is_allowed(&canonical));
+        assert!(!app.asset_protocol_scope().is_allowed(other));
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/files.rs
+++ b/desktop/src-tauri/src/commands/files.rs
@@ -843,17 +843,21 @@ mod tests {
         let lock = crate::TEST_HOME_LOCK
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        // The test harness always has HOME set; `USERPROFILE` is a Windows-only
-        // fallback absent on macOS/Linux, so removing both and restoring HOME
-        // verbatim leaves the process-global state unchanged.
-        let old_home = std::env::var("HOME").unwrap();
+        // Other tests can intentionally leave HOME unset. Preserve its exact
+        // prior state; USERPROFILE is a Windows-only fallback absent on
+        // macOS/Linux.
+        let old_home = std::env::var_os("HOME");
         std::env::remove_var("HOME");
         std::env::remove_var("USERPROFILE");
 
         let file = write_under(&future_root("no_home"), "ok.txt");
         assert!(ensure_path_allowed(&file).is_ok());
 
-        std::env::set_var("HOME", old_home);
+        if let Some(old_home) = old_home {
+            std::env::set_var("HOME", old_home);
+        } else {
+            std::env::remove_var("HOME");
+        }
         std::env::remove_var("USERPROFILE");
         drop(lock);
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -762,7 +762,7 @@ pub fn run() {
             read_text_file_preview,
             inspect_attachment,
             validate_image_attachment,
-            read_file_base64,
+            prepare_image_preview,
             generate_image_thumbnail,
             import_ephemeral_image,
             delete_temp_attachment,

--- a/desktop/src/features/filepreview/FilePreviewOverlay.tsx
+++ b/desktop/src/features/filepreview/FilePreviewOverlay.tsx
@@ -60,21 +60,21 @@ export function FilePreviewOverlay({
       {kind === "image"
         ? (
             <div className="relative z-10 flex max-h-full max-w-full items-center justify-center">
-              <ImagePreview name={name} onError={handleError} path={path} />
+              <ImagePreview key={path} name={name} onError={handleError} path={path} />
             </div>
           )
         : null}
       {kind === "markdown"
         ? (
             <div className="relative z-10 max-h-full w-full max-w-3xl overflow-y-auto rounded-lg bg-surface shadow-panel">
-              <MarkdownPreview onError={handleError} path={path} />
+              <MarkdownPreview key={path} onError={handleError} path={path} />
             </div>
           )
         : null}
       {kind === "json"
         ? (
             <div className="relative z-10 w-full max-w-5xl overflow-hidden rounded-lg bg-surface shadow-panel">
-              <JsonPreview onError={handleError} path={path} />
+              <JsonPreview key={path} onError={handleError} path={path} />
             </div>
           )
         : null}

--- a/desktop/src/features/filepreview/ImagePreview.tsx
+++ b/desktop/src/features/filepreview/ImagePreview.tsx
@@ -1,16 +1,15 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { readFileBase64 } from "../../integrations/storage/files";
+import { prepareImagePreviewUrl } from "../../integrations/storage/files";
 import { useAsyncResource } from "../../lib/useAsyncResource";
-import { imageMimeForPath } from "./previewKind";
 import { PreviewNotice } from "./PreviewNotice";
+import { usePreviewLoadingGate } from "./usePreviewLoadingGate";
 
 /**
  * Renders a local image at its natural size, shrinking to fit the overlay when
  * larger (`max-h/w-full`) and never upscaling. Bytes come through the backend
- * (`read_file_base64`, 25MB cap) rather than the asset protocol, so paths
- * outside the workspace still preview; a read failure (missing/too large) routes
- * back to `onError`.
+ * through a path-validated Tauri asset URL (25MB cap), so paths outside the
+ * workspace still preview without copying or Base64-encoding their bytes.
  */
 export function ImagePreview({
   path,
@@ -22,8 +21,8 @@ export function ImagePreview({
   onError: () => void;
 }) {
   const { t } = useTranslation("markdown");
-  const { data: base64, error, loading } = useAsyncResource<string | null>(
-    () => readFileBase64({ path }),
+  const { data: src, error, loading } = useAsyncResource<string | null>(
+    () => prepareImagePreviewUrl(path),
     [path],
     null,
   );
@@ -32,29 +31,44 @@ export function ImagePreview({
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
+  const readySrc = loading || error ? null : src;
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const imageLoaded = readySrc !== null && loadedSrc === readySrc;
+  const imageFailed = readySrc !== null && failedSrc === readySrc;
+  const gate = usePreviewLoadingGate(loading || (readySrc !== null && !imageLoaded && !imageFailed));
+  const failed = Boolean(error || imageFailed);
+
   // A read failure (missing/too large) routes back to `onError` so the overlay
-  // falls back to the OS default handler.
+  // falls back to the OS default handler. If the loading notice became visible,
+  // wait for its minimum display window before closing the overlay.
   useEffect(() => {
-    if (error)
+    if (failed && gate.showContent)
       onErrorRef.current();
-  }, [error]);
+  }, [failed, gate.showContent]);
 
-  const src = loading || error || base64 == null
-    ? null
-    : `data:${imageMimeForPath(path)};base64,${base64}`;
-
-  if (!src)
-    return <PreviewNotice message={t("filePreview.loading")} />;
+  if (!readySrc && !gate.showLoading)
+    return null;
 
   return (
-    // Cap against the viewport (a definite length) rather than `max-h/w-full`:
-    // the image's parent is content-sized, so a percentage max would resolve to
-    // "no limit" and the image would overflow. The inset leaves breathing room.
-    <img
-      alt={name}
-      className="max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] rounded-md object-contain shadow-panel"
-      onError={onError}
-      src={src}
-    />
+    <>
+      {gate.showLoading ? <PreviewNotice message={t("filePreview.loading")} /> : null}
+      {readySrc
+        ? (
+            // Keep the image mounted while hidden so browser decoding is part
+            // of the loading interval, not a blank frame after it.
+            <img
+              alt={name}
+              aria-hidden={!gate.showContent || failed}
+              className={gate.showContent && !failed
+                ? "visible max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] rounded-md object-contain shadow-panel"
+                : "fixed left-0 top-0 size-px invisible"}
+              onError={() => setFailedSrc(readySrc)}
+              onLoad={() => setLoadedSrc(readySrc)}
+              src={readySrc}
+            />
+          )
+        : null}
+    </>
   );
 }

--- a/desktop/src/features/filepreview/JsonPreview.tsx
+++ b/desktop/src/features/filepreview/JsonPreview.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { readTextFilePreview } from "../../integrations/storage/files";
 import { useAsyncResource } from "../../lib/useAsyncResource";
 import { PreviewNotice } from "./PreviewNotice";
+import { usePreviewLoadingGate } from "./usePreviewLoadingGate";
 
 const ROW_HEIGHT = 22;
 const OVERSCAN_ROWS = 24;
@@ -29,11 +30,12 @@ export function JsonPreview({
   );
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
+  const gate = usePreviewLoadingGate(loading);
 
   useEffect(() => {
-    if (error)
+    if (error && gate.showContent)
       onErrorRef.current();
-  }, [error]);
+  }, [error, gate.showContent]);
 
   const prepared = useMemo(() => {
     if (!result)
@@ -54,8 +56,11 @@ export function JsonPreview({
     return { formatted, sourceLimited, validationError, validUtf8: result.validUtf8 };
   }, [result]);
 
-  if (loading || error || !prepared)
+  if (gate.showLoading)
     return <PreviewNotice message={t("filePreview.loading")} />;
+
+  if (!gate.showContent || error || !prepared)
+    return null;
 
   return (
     <div className="flex h-[min(80vh,48rem)] min-h-0 flex-col bg-surface text-sm text-ink">

--- a/desktop/src/features/filepreview/MarkdownPreview.tsx
+++ b/desktop/src/features/filepreview/MarkdownPreview.tsx
@@ -4,6 +4,7 @@ import { readTextFilePreview } from "../../integrations/storage/files";
 import { useAsyncResource } from "../../lib/useAsyncResource";
 import { MarkdownContent } from "../markdown/MarkdownContent";
 import { PreviewNotice } from "./PreviewNotice";
+import { usePreviewLoadingGate } from "./usePreviewLoadingGate";
 
 /**
  * Renders a local `.md` file with the same renderer the chat uses
@@ -28,18 +29,22 @@ export function MarkdownPreview({
   // re-fire when callers pass a fresh callback each render.
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
+  const gate = usePreviewLoadingGate(loading);
 
   // A read failure routes to `onError` so the overlay falls back to the OS
   // default handler.
   useEffect(() => {
-    if (error)
+    if (error && gate.showContent)
       onErrorRef.current();
-  }, [error]);
+  }, [error, gate.showContent]);
 
   const content = loading || error || result == null ? null : result.content;
 
-  if (content == null)
+  if (gate.showLoading)
     return <PreviewNotice message={t("filePreview.loading")} />;
+
+  if (!gate.showContent || content == null)
+    return null;
 
   // The surface/rounded frame lives on the scroll container (in FilePreviewOverlay)
   // so its rounded corners stay visible at top and bottom while the text scrolls.

--- a/desktop/src/features/filepreview/filepreview.test.tsx
+++ b/desktop/src/features/filepreview/filepreview.test.tsx
@@ -2,18 +2,24 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { flushAsync } from "../../test/renderHook";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushAsync, renderHook } from "../../test/renderHook";
 import { FilePreviewOverlay } from "./FilePreviewOverlay";
 import { ImagePreview } from "./ImagePreview";
 import { JsonPreview } from "./JsonPreview";
 import { MarkdownPreview } from "./MarkdownPreview";
 import { imageMimeForPath, previewKindForPath } from "./previewKind";
 import { PreviewNotice } from "./PreviewNotice";
+import {
+  PREVIEW_LOADING_DELAY_MS,
+  PREVIEW_LOADING_MIN_VISIBLE_MS,
+  usePreviewLoadingGate,
+} from "./usePreviewLoadingGate";
 
 const invokeMock = vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>(() => Promise.resolve(null));
 
 vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset:${path}`,
   invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
@@ -22,6 +28,10 @@ vi.mock("@tauri-apps/api/core", () => ({
 beforeEach(() => {
   invokeMock.mockReset();
   invokeMock.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 function mount(node: React.ReactElement) {
@@ -66,18 +76,56 @@ describe("previewNotice", () => {
   });
 });
 
+describe("previewLoadingGate", () => {
+  it("keeps a preview that finishes within 200ms free of a loading notice", () => {
+    vi.useFakeTimers();
+    let loading = true;
+    const hook = renderHook(() => usePreviewLoadingGate(loading));
+
+    expect(hook.current).toEqual({ showContent: false, showLoading: false });
+    act(() => vi.advanceTimersByTime(PREVIEW_LOADING_DELAY_MS - 1));
+    loading = false;
+    hook.rerender();
+
+    expect(hook.current).toEqual({ showContent: true, showLoading: false });
+    hook.unmount();
+  });
+
+  it("holds a visible loading notice for at least 300ms", () => {
+    vi.useFakeTimers();
+    let loading = true;
+    const hook = renderHook(() => usePreviewLoadingGate(loading));
+
+    act(() => vi.advanceTimersByTime(PREVIEW_LOADING_DELAY_MS));
+    expect(hook.current).toEqual({ showContent: false, showLoading: true });
+
+    loading = false;
+    hook.rerender();
+    act(() => vi.advanceTimersByTime(PREVIEW_LOADING_MIN_VISIBLE_MS - 1));
+    expect(hook.current).toEqual({ showContent: false, showLoading: true });
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(hook.current).toEqual({ showContent: true, showLoading: false });
+    hook.unmount();
+  });
+});
+
 describe("imagePreview", () => {
-  it("shows a loading notice, then the image", async () => {
-    invokeMock.mockResolvedValue("QUJD");
+  it("keeps a fast load quiet until the image has decoded", async () => {
+    invokeMock.mockResolvedValue({ path: "/w/pic.png", version: "1" });
     const { container, cleanup } = mount(createElement(ImagePreview, {
       path: "/w/pic.png",
       name: "pic.png",
       onError: vi.fn(),
     }));
-    expect(container.textContent).toContain("Loading");
+    expect(container.textContent).not.toContain("Loading");
     await flushAsync();
     const img = container.querySelector("img")!;
-    expect(img.getAttribute("src")).toBe("data:image/png;base64,QUJD");
+    expect(img.getAttribute("src")).toBe("asset:/w/pic.png?v=1");
+    expect(img.className).toContain("invisible");
+    act(() => img.dispatchEvent(new Event("load")));
+    await flushAsync();
+    expect(img.className).toContain("visible");
     cleanup();
   });
 
@@ -95,7 +143,7 @@ describe("imagePreview", () => {
   });
 
   it("img onError also routes to onError", async () => {
-    invokeMock.mockResolvedValue("QUJD");
+    invokeMock.mockResolvedValue({ path: "/w/pic.png", version: "1" });
     const onError = vi.fn();
     const { container, cleanup } = mount(createElement(ImagePreview, {
       path: "/w/pic.png",
@@ -106,6 +154,7 @@ describe("imagePreview", () => {
     act(() => {
       container.querySelector("img")!.dispatchEvent(new Event("error"));
     });
+    await flushAsync();
     expect(onError).toHaveBeenCalled();
     cleanup();
   });
@@ -118,6 +167,7 @@ describe("markdownPreview", () => {
       path: "/w/doc.md",
       onError: vi.fn(),
     }));
+    expect(container.textContent).not.toContain("Loading");
     await flushAsync();
     expect(container.querySelector("h1")?.textContent).toBe("Title");
     cleanup();
@@ -145,6 +195,7 @@ describe("jsonPreview", () => {
       path: "/w/data.json",
       onError: vi.fn(),
     }));
+    expect(container.textContent).not.toContain("Loading");
     await flushAsync();
     expect(container.textContent).toContain("900719925474099312345");
     expect(container.textContent).toContain("true");
@@ -179,7 +230,7 @@ describe("filePreviewOverlay", () => {
   });
 
   it("renders the image preview with a close button", async () => {
-    invokeMock.mockResolvedValue("QUJD");
+    invokeMock.mockResolvedValue({ path: "/w/a.png", version: "1" });
     const onClose = vi.fn();
     const { container, cleanup } = mount(createElement(FilePreviewOverlay, {
       path: "/w/a.png",
@@ -189,7 +240,10 @@ describe("filePreviewOverlay", () => {
       onClose,
     }));
     await flushAsync();
-    expect(container.querySelector("img")).not.toBeNull();
+    const image = container.querySelector("img")!;
+    act(() => image.dispatchEvent(new Event("load")));
+    await flushAsync();
+    expect(image.className).toContain("visible");
     const closeButton = container.querySelector("button[aria-label]")!;
     act(() => {
       closeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/desktop/src/features/filepreview/usePreviewLoadingGate.ts
+++ b/desktop/src/features/filepreview/usePreviewLoadingGate.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react";
+
+export const PREVIEW_LOADING_DELAY_MS = 200;
+export const PREVIEW_LOADING_MIN_VISIBLE_MS = 300;
+
+type PreviewLoadingPhase = "quiet" | "loading" | "ready";
+
+/**
+ * Keeps fast previews free of loading-state flashes. A load gets a short quiet
+ * window; if it outlasts that window the indicator is shown, and once visible
+ * it is held long enough to be perceived as a stable state.
+ */
+export function usePreviewLoadingGate(loading: boolean) {
+  const [phase, setPhase] = useState<PreviewLoadingPhase>(loading ? "quiet" : "ready");
+  const shownAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (loading) {
+      shownAtRef.current = null;
+      setPhase("quiet");
+      const showTimer = window.setTimeout(() => {
+        shownAtRef.current = performance.now();
+        setPhase("loading");
+      }, PREVIEW_LOADING_DELAY_MS);
+      return () => window.clearTimeout(showTimer);
+    }
+
+    const shownAt = shownAtRef.current;
+    if (shownAt === null) {
+      setPhase("ready");
+      return;
+    }
+
+    const remaining = PREVIEW_LOADING_MIN_VISIBLE_MS - (performance.now() - shownAt);
+    if (remaining <= 0) {
+      shownAtRef.current = null;
+      setPhase("ready");
+      return;
+    }
+
+    const readyTimer = window.setTimeout(() => {
+      shownAtRef.current = null;
+      setPhase("ready");
+    }, remaining);
+    return () => window.clearTimeout(readyTimer);
+  }, [loading]);
+
+  return {
+    showContent: phase === "ready",
+    showLoading: phase === "loading",
+  };
+}

--- a/desktop/src/features/markdown/MarkdownContentBlocks.test.tsx
+++ b/desktop/src/features/markdown/MarkdownContentBlocks.test.tsx
@@ -11,7 +11,7 @@ const resolveReferencesMock = vi.fn<(w: string, refs: unknown[]) => Promise<Arra
   () => Promise.resolve([]),
 );
 const resolvePreviewLinkMock = vi.fn<(base: string, target: string) => Promise<{ path: string; name: string }>>();
-const readFileBase64Mock = vi.fn<(path: string) => Promise<string>>(() => Promise.resolve("QUJD"));
+const prepareImagePreviewUrlMock = vi.fn<(path: string) => Promise<string>>(path => Promise.resolve(`asset:${path}`));
 
 vi.mock("../../integrations/storage/markdownReferences", () => ({
   resolveMarkdownReferences: (w: string, refs: unknown[]) => resolveReferencesMock(w, refs),
@@ -20,7 +20,7 @@ vi.mock("../../integrations/storage/markdownReferences", () => ({
 vi.mock("../../integrations/storage/files", () => ({
   openPath: () => Promise.resolve(),
   openExternalUrl: () => Promise.resolve(),
-  readFileBase64: ({ path }: { path: string }) => readFileBase64Mock(path),
+  prepareImagePreviewUrl: (path: string) => prepareImagePreviewUrlMock(path),
   readTextFilePreview: () => Promise.resolve({ content: "", size: 0, truncated: false }),
   resolvePreviewLinkPath: (base: string, target: string) => resolvePreviewLinkMock(base, target),
 }));
@@ -182,8 +182,8 @@ describe("markdownContent reference resolution", () => {
     }));
     await flushStore();
     await flushAsync();
-    expect(container.querySelector("img")?.getAttribute("src")).toBe("data:image/png;base64,QUJD");
-    expect(readFileBase64Mock).toHaveBeenCalledWith("/w/assets/pic.png");
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("asset:/w/assets/pic.png");
+    expect(prepareImagePreviewUrlMock).toHaveBeenCalledWith("/w/assets/pic.png");
     cleanup();
   });
 
@@ -195,7 +195,7 @@ describe("markdownContent reference resolution", () => {
     }));
     await flushAsync();
     await flushAsync();
-    expect(container.querySelector("img")?.getAttribute("src")).toBe("data:image/png;base64,QUJD");
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("asset:/w/assets/pic.png");
     cleanup();
   });
 

--- a/desktop/src/features/markdown/MarkdownMath.test.tsx
+++ b/desktop/src/features/markdown/MarkdownMath.test.tsx
@@ -10,7 +10,7 @@ vi.mock("../../integrations/storage/markdownReferences", () => ({
 vi.mock("../../integrations/storage/files", () => ({
   openPath: () => Promise.resolve(),
   openExternalUrl: () => Promise.resolve(),
-  readFileBase64: () => Promise.resolve("QUJD"),
+  prepareImagePreviewUrl: (path: string) => Promise.resolve(`asset:${path}`),
   readTextFilePreview: () => Promise.resolve({ content: "", size: 0, truncated: false }),
   resolvePreviewLinkPath: () => Promise.resolve(null),
 }));

--- a/desktop/src/features/markdown/renderers/MarkdownImage.tsx
+++ b/desktop/src/features/markdown/renderers/MarkdownImage.tsx
@@ -2,10 +2,9 @@ import type { StoredFile } from "../../../integrations/storage/types";
 import { localFilePath } from "@future-os/markdown";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { readFileBase64 } from "../../../integrations/storage/files";
+import { prepareImagePreviewUrl } from "../../../integrations/storage/files";
 import { isStoredFile } from "../../../integrations/storage/typeGuards";
 import { useAsyncResource } from "../../../lib/useAsyncResource";
-import { imageMimeForPath } from "../../filepreview/previewKind";
 import { useFutureReference } from "../futureReferenceStore";
 import { usePreviewMarkdown } from "../PreviewMarkdownContext";
 import { usePreviewLinkPath } from "../usePreviewLinkPath";
@@ -45,7 +44,7 @@ function WorkspaceLocalImage({
   const resolved = useFutureReference(workspaceId, { targetId: target, targetType: "file" });
   // Only inline images that live inside the workspace: a model-authored absolute
   // path (e.g. `![x](/etc/passwd)`) must not become a read-arbitrary-file channel
-  // through readFileBase64. Out-of-workspace targets render as a fallback chip.
+  // through the asset protocol. Out-of-workspace targets render as a fallback chip.
   const file = resolved?.status === "resolved" && resolved.targetType === "file"
     && isStoredFile(resolved.data) && resolved.data.insideWorkspace
     ? resolved.data
@@ -79,15 +78,15 @@ function PreviewLocalImage({
 }
 
 function ResolvedLocalImage({ alt, file, title }: { alt: string; file: StoredFile; title?: string }) {
-  const { data: base64, error, loading } = useAsyncResource<string | null>(
-    () => readFileBase64({ path: file.path }),
+  const { data: imageUrl, error, loading } = useAsyncResource<string | null>(
+    () => prepareImagePreviewUrl(file.path),
     [file.path],
     null,
   );
   const [failedPath, setFailedPath] = useState<string | null>(null);
   const failed = failedPath === file.path;
 
-  if (loading || error || !base64 || failed)
+  if (loading || error || !imageUrl || failed)
     return <LocalImageFallback alt={alt} path={file.path} />;
 
   return (
@@ -95,7 +94,7 @@ function ResolvedLocalImage({ alt, file, title }: { alt: string; file: StoredFil
       alt={alt}
       className="my-2 max-h-80 max-w-full rounded-md border border-line-soft object-contain"
       onError={() => setFailedPath(file.path)}
-      src={`data:${imageMimeForPath(file.path)};base64,${base64}`}
+      src={imageUrl}
       title={title ?? file.path}
     />
   );

--- a/desktop/src/integrations/storage/files.ts
+++ b/desktop/src/integrations/storage/files.ts
@@ -1,3 +1,4 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { invokeCommand } from "../tauri/invoke";
 
 /** One entry in a directory listing from {@link listDirectory}. */
@@ -79,11 +80,10 @@ export async function validateImageAttachment(path: string) {
   return invokeCommand<void>("validate_image_attachment", { path });
 }
 
-export async function readFileBase64(input: { path: string; maxBytes?: number | null }) {
-  return invokeCommand<string>("read_file_base64", {
-    maxBytes: input.maxBytes ?? null,
-    path: input.path,
-  });
+export async function prepareImagePreviewUrl(path: string) {
+  const asset = await invokeCommand<{ path: string; version: string }>("prepare_image_preview", { path });
+  const url = convertFileSrc(asset.path);
+  return `${url}${url.includes("?") ? "&" : "?"}v=${encodeURIComponent(asset.version)}`;
 }
 
 /**

--- a/desktop/src/integrations/storage/storage.test.ts
+++ b/desktop/src/integrations/storage/storage.test.ts
@@ -17,7 +17,7 @@ import {
   listDirectory,
   openExternalUrl,
   openPath,
-  readFileBase64,
+  prepareImagePreviewUrl,
   readTextFilePreview,
   resolvePreviewLinkPath,
   savePastedImage,
@@ -78,6 +78,7 @@ import {
 const invokeMock = vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>();
 
 vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset:${path}`,
   invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
@@ -162,10 +163,9 @@ describe("storage invoke wrappers", () => {
     expect(invokeMock).toHaveBeenLastCalledWith("inspect_attachment", { path: "/a" });
     await validateImageAttachment("/i");
     expect(invokeMock).toHaveBeenLastCalledWith("validate_image_attachment", { path: "/i" });
-    await readFileBase64({ path: "/f", maxBytes: 8 });
-    expect(invokeMock).toHaveBeenLastCalledWith("read_file_base64", { maxBytes: 8, path: "/f" });
-    await readFileBase64({ path: "/f" });
-    expect(invokeMock).toHaveBeenLastCalledWith("read_file_base64", { maxBytes: null, path: "/f" });
+    invokeMock.mockResolvedValueOnce({ path: "/f", version: "10-8" });
+    await expect(prepareImagePreviewUrl("/f")).resolves.toBe("asset:/f?v=10-8");
+    expect(invokeMock).toHaveBeenLastCalledWith("prepare_image_preview", { path: "/f" });
     await generateImageThumbnail({ threadId: "t", sourcePath: "/s" });
     expect(invokeMock).toHaveBeenLastCalledWith("generate_image_thumbnail", { sourcePath: "/s", threadId: "t" });
     await importEphemeralImage({ threadId: "t", path: "/s", name: "n" });

--- a/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
@@ -1,3 +1,10 @@
+import {
+  clearPendingContinuation,
+  loadPendingContinuation,
+  savePendingContinuation,
+  type PendingContinuation,
+} from "../pendingContinuationStorage";
+
 const mockData = new Map<string, string>();
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
@@ -9,13 +16,6 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
     mockData.delete(key);
   }),
 }));
-
-import {
-  clearPendingContinuation,
-  loadPendingContinuation,
-  savePendingContinuation,
-  type PendingContinuation,
-} from "../pendingContinuationStorage";
 
 const pending: PendingContinuation = {
   version: 1,

--- a/mobile/src/remote/__tests__/storage.test.ts
+++ b/mobile/src/remote/__tests__/storage.test.ts
@@ -88,6 +88,26 @@ describe("credential storage", () => {
     await clearCredentials();
     expect(mockedStore.deleteItemAsync).toHaveBeenCalledTimes(8);
   });
+
+  test("serializes clear behind an in-flight credential save", async () => {
+    let finishSeedWrite: (() => void) | undefined;
+    mockedStore.setItemAsync.mockImplementation(async key => {
+      if (key !== "futureos.remote.seed.v1") return;
+      await new Promise<void>(resolve => {
+        finishSeedWrite = resolve;
+      });
+    });
+
+    const save = saveCredentials(credentials);
+    const clear = clearCredentials();
+    await Promise.resolve();
+    expect(mockedStore.deleteItemAsync).not.toHaveBeenCalled();
+
+    finishSeedWrite?.();
+    await save;
+    await clear;
+    expect(mockedStore.deleteItemAsync).toHaveBeenCalledTimes(8);
+  });
 });
 
 describe("device / model / thinking preferences", () => {

--- a/mobile/src/remote/__tests__/usePromptOutbox.test.ts
+++ b/mobile/src/remote/__tests__/usePromptOutbox.test.ts
@@ -1,0 +1,148 @@
+import React from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import type { RemoteClient } from "../client";
+import { loadPendingContinuation, savePendingContinuation } from "../pendingContinuationStorage";
+import { savePendingPrompt } from "../pendingPromptStorage";
+import type { RemoteCredentials } from "../types";
+import { usePromptOutbox } from "../usePromptOutbox";
+
+const mockData = new Map<string, string>();
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (key: string) => mockData.get(key) ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      mockData.set(key, value);
+    }),
+    removeItem: jest.fn(async (key: string) => {
+      mockData.delete(key);
+    }),
+  },
+}));
+
+const credentials: RemoteCredentials = {
+  pairId: "pair",
+  deviceId: "device",
+  seed: "seed",
+  userJwt: "jwt",
+  refreshToken: "refresh",
+  natsWsUrl: "wss://example.test",
+  tokenUrl: "https://example.test/token",
+  expectedDesktopId: "desktop",
+  expectedDesktopPublicKey: "public-key",
+};
+
+describe("usePromptOutbox recovery", () => {
+  beforeEach(() => {
+    mockData.clear();
+    jest.clearAllMocks();
+  });
+
+  async function mountOutbox() {
+    const requestRetry = jest.fn(async (request: { promptId?: string }) => ({
+      data:
+        request.promptId === "prompt-1"
+          ? { sessionId: "session-1", threadId: "thread-1", runId: "run-1" }
+          : { sessionId: "session-2", threadId: "thread-2", runId: "run-2" },
+    }));
+    const reconcileSession = jest.fn();
+    const refreshSessions = jest.fn(async () => {});
+    const clientRef = {
+      current: { requestRetry } as unknown as RemoteClient,
+    };
+    const credentialsRef = { current: credentials };
+    const selectedRef = { current: "session-1" };
+    const streamingRef = { current: {} };
+    const conversationEpochRef = { current: 1 };
+    const syncEngineRef = { current: null };
+    const setSelectedSessionId = jest.fn();
+    const setDraft = jest.fn();
+    const setDraftMode = jest.fn();
+    const setDraftWorkspaceId = jest.fn();
+    const recordError = jest.fn();
+    let renderer: ReactTestRenderer | null = null;
+
+    function Harness() {
+      usePromptOutbox({
+        clientRef,
+        credentialsRef,
+        selectedRef,
+        streamingRef,
+        conversationEpochRef,
+        syncEngineRef,
+        phase: "ready",
+        draft: true,
+        draftMode: "chat",
+        draftWorkspaceId: "",
+        modelId: "provider/model",
+        thinkingLevel: "medium",
+        fileTransferSupported: true,
+        promptReceiptSupported: true,
+        setSelectedSessionId,
+        setDraft,
+        setDraftMode,
+        setDraftWorkspaceId,
+        refreshSessions,
+        reconcileSession,
+        recordError,
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(React.createElement(Harness));
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    return { requestRetry, reconcileSession, refreshSessions, renderer: renderer! };
+  }
+
+  it("reconciles a prompt while an existing conversation and draft are active", async () => {
+    await savePendingPrompt({
+      version: 1,
+      commandId: "prompt-1",
+      draftKey: "session-1",
+      sessionId: "session-1",
+      text: "hello",
+      attachments: [],
+      modelId: "provider/model",
+      thinkingLevel: "medium",
+      mode: "chat",
+      workspaceId: "",
+      createdAt: 1,
+    });
+    const { requestRetry, reconcileSession, refreshSessions, renderer } = await mountOutbox();
+
+    expect(requestRetry).toHaveBeenCalledWith(
+      { type: "get_prompt_receipt", promptId: "prompt-1" },
+      "list",
+    );
+    expect(reconcileSession).toHaveBeenCalledWith("session-1", "reconnect");
+    expect(refreshSessions).toHaveBeenCalledTimes(1);
+
+    await act(async () => renderer.unmount());
+  });
+
+  it("automatically reconciles a durable continuation after reconnect", async () => {
+    await savePendingContinuation({
+      version: 1,
+      commandId: "continue-1",
+      sessionId: "session-2",
+      sourceRunId: "failed-run",
+      createdAt: 2,
+    });
+    await expect(loadPendingContinuation()).resolves.toMatchObject({ commandId: "continue-1" });
+    const { requestRetry, reconcileSession, refreshSessions, renderer } = await mountOutbox();
+
+    expect(requestRetry).toHaveBeenCalledWith(
+      { type: "get_prompt_receipt", promptId: "continue-1" },
+      "list",
+    );
+    expect(reconcileSession).toHaveBeenCalledWith("session-2", "reconnect", "run-2");
+    expect(refreshSessions).toHaveBeenCalledTimes(1);
+
+    await act(async () => renderer.unmount());
+  });
+});

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -40,7 +40,7 @@ interface HandshakeConfirmation {
 }
 
 export interface RemoteClientCallbacks {
-  onCredentials(credentials: RemoteCredentials): void;
+  onCredentials(credentials: RemoteCredentials): Promise<void>;
   onEvent(event: StreamEvent, sessionId: string): void;
   onEventDecodeFailure(sessionId: string, error: Error): void;
   onPresence(presence: Presence): void;
@@ -229,10 +229,14 @@ export class RemoteClient {
     this.signal({ type: "open_started" });
     const generation = ++this.generation;
     try {
+      const previous = this.credentials;
       const fresh = await ensureFreshCredentials(this.credentials);
       if (this.stopped || generation !== this.generation) return;
       this.credentials = fresh;
-      this.callbacks.onCredentials(fresh);
+      if (fresh !== previous) {
+        await this.callbacks.onCredentials(fresh);
+        if (this.stopped || generation !== this.generation) return;
+      }
       await this.connectSocket(generation);
       if (
         this.stopped ||
@@ -347,7 +351,8 @@ export class RemoteClient {
       const fresh = await refreshCredentials(this.credentials);
       if (this.stopped) return;
       this.credentials = fresh;
-      this.callbacks.onCredentials(fresh);
+      await this.callbacks.onCredentials(fresh);
+      if (this.stopped) return;
       // Re-open with the fresh token while retaining the old generation until
       // the replacement passes its readiness barrier. The FSM is already in
       // refreshing, so this does not expose a second ready connection.

--- a/mobile/src/remote/storage.ts
+++ b/mobile/src/remote/storage.ts
@@ -24,43 +24,65 @@ const secureOptions: SecureStore.SecureStoreOptions = {
   keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
 };
 
-export async function loadCredentials(): Promise<RemoteCredentials | null> {
-  const entries = await Promise.all(
-    Object.entries(CREDENTIAL_KEYS).map(async ([field, key]) => [
-      field,
-      await SecureStore.getItemAsync(key, secureOptions),
-    ]),
+// SecureStore has no multi-key transaction. Keep credential bundle operations
+// in call order so readers never observe an in-process partial write, and an
+// older clear cannot race a newer pair and delete fields that were just written.
+let credentialOperationQueue: Promise<void> = Promise.resolve();
+
+function enqueueCredentialOperation<T>(operation: () => Promise<T>): Promise<T> {
+  const result = credentialOperationQueue.then(operation, operation);
+  credentialOperationQueue = result.then(
+    () => undefined,
+    () => undefined,
   );
-  if (entries.every(([, value]) => value == null)) return null;
-  if (entries.some(([, value]) => value == null)) {
-    await clearCredentials();
-    return null;
-  }
-  const deviceId = await loadDeviceId();
-  if (deviceId == null) {
-    // A credential bundle without its device identity is corrupt; clear it so a
-    // fresh pair re-establishes both.
-    await clearCredentials();
-    return null;
-  }
-  return { ...Object.fromEntries(entries), deviceId } as unknown as RemoteCredentials;
+  return result;
 }
 
-export async function saveCredentials(credentials: RemoteCredentials): Promise<void> {
-  const { deviceId, ...rest } = credentials;
-  const fields = Object.keys(CREDENTIAL_KEYS) as (keyof typeof rest)[];
-  await Promise.all([
-    ...fields.map(field =>
-      SecureStore.setItemAsync(CREDENTIAL_KEYS[field], rest[field], secureOptions),
-    ),
-    saveDeviceId(deviceId),
-  ]);
-}
-
-export async function clearCredentials(): Promise<void> {
+async function deleteCredentialFields(): Promise<void> {
   await Promise.all(
     Object.values(CREDENTIAL_KEYS).map(key => SecureStore.deleteItemAsync(key, secureOptions)),
   );
+}
+
+export async function loadCredentials(): Promise<RemoteCredentials | null> {
+  return enqueueCredentialOperation(async () => {
+    const entries = await Promise.all(
+      Object.entries(CREDENTIAL_KEYS).map(async ([field, key]) => [
+        field,
+        await SecureStore.getItemAsync(key, secureOptions),
+      ]),
+    );
+    if (entries.every(([, value]) => value == null)) return null;
+    if (entries.some(([, value]) => value == null)) {
+      await deleteCredentialFields();
+      return null;
+    }
+    const deviceId = await loadDeviceId();
+    if (deviceId == null) {
+      // A credential bundle without its device identity is corrupt; clear it so a
+      // fresh pair re-establishes both.
+      await deleteCredentialFields();
+      return null;
+    }
+    return { ...Object.fromEntries(entries), deviceId } as unknown as RemoteCredentials;
+  });
+}
+
+export async function saveCredentials(credentials: RemoteCredentials): Promise<void> {
+  return enqueueCredentialOperation(async () => {
+    const { deviceId, ...rest } = credentials;
+    const fields = Object.keys(CREDENTIAL_KEYS) as (keyof typeof rest)[];
+    await Promise.all([
+      ...fields.map(field =>
+        SecureStore.setItemAsync(CREDENTIAL_KEYS[field], rest[field], secureOptions),
+      ),
+      saveDeviceId(deviceId),
+    ]);
+  });
+}
+
+export async function clearCredentials(): Promise<void> {
+  return enqueueCredentialOperation(deleteCredentialFields);
 }
 
 export async function loadDeviceId(): Promise<string | null> {

--- a/mobile/src/remote/usePromptOutbox.ts
+++ b/mobile/src/remote/usePromptOutbox.ts
@@ -92,6 +92,29 @@ async function deliverPendingPrompt(
   ).data;
 }
 
+async function deliverPendingContinuation(
+  client: RemoteClient,
+  pending: PendingContinuation,
+  checkReceipt: boolean,
+  receiptSupported: boolean,
+): Promise<PromptAck> {
+  if (checkReceipt && receiptSupported) {
+    const receipt = await pendingPromptReceipt(client, pending.commandId);
+    if (receipt) return receipt;
+  }
+  return (
+    await client.requestRetry<PromptAck>(
+      {
+        id: pending.commandId,
+        type: "continue_run",
+        sessionId: pending.sessionId,
+        runId: pending.sourceRunId,
+      },
+      pending.sessionId,
+    )
+  ).data;
+}
+
 interface PromptOutboxOptions {
   clientRef: MutableRefObject<RemoteClient | null>;
   credentialsRef: MutableRefObject<RemoteCredentials | null>;
@@ -317,10 +340,6 @@ export function usePromptOutbox({
     refreshSessions,
   ]);
 
-  useEffect(() => {
-    if (phase === "ready" && !selectedRef.current && !draft) void recoverPendingPrompt();
-  }, [draft, phase, recoverPendingPrompt, selectedRef]);
-
   const continueRun = useCallback(
     async (sessionId: string, runId: string) => {
       const inFlight = continuationInFlightRef.current;
@@ -335,10 +354,12 @@ export function usePromptOutbox({
         const client = clientRef.current;
         if (!client) throw new Error("not_connected");
         let pending = await loadPendingContinuation();
+        let checkReceipt = pending !== null;
         if (pending && (pending.sessionId !== sessionId || pending.sourceRunId !== runId)) {
           if (promptReceiptSupported) await pendingPromptReceipt(client, pending.commandId);
           await clearPendingContinuation(pending.commandId);
           pending = null;
+          checkReceipt = false;
         }
         if (!pending) {
           pending = {
@@ -351,10 +372,7 @@ export function usePromptOutbox({
           await savePendingContinuation(pending);
         }
         try {
-          await client.requestRetry<PromptAck>(
-            { id: pending.commandId, type: "continue_run", sessionId, runId },
-            sessionId,
-          );
+          await deliverPendingContinuation(client, pending, checkReceipt, promptReceiptSupported);
           await clearPendingContinuation(pending.commandId);
         } catch (continueError) {
           if (!isTransientNatsRequestError(continueError)) {
@@ -379,6 +397,60 @@ export function usePromptOutbox({
     },
     [clientRef, promptReceiptSupported],
   );
+
+  const recoverPendingContinuation = useCallback(async () => {
+    const client = clientRef.current;
+    if (!client || !credentialsRef.current || continuationInFlightRef.current) return;
+    const pending = await loadPendingContinuation();
+    if (!pending || continuationInFlightRef.current) return;
+
+    const operation = (async () => {
+      try {
+        const receipt = await deliverPendingContinuation(
+          client,
+          pending,
+          true,
+          promptReceiptSupported,
+        );
+        await clearPendingContinuation(pending.commandId);
+        void refreshSessions();
+        reconcileSession(receipt.sessionId || pending.sessionId, "reconnect", receipt.runId);
+      } catch (recoveryError) {
+        if (!isTransientNatsRequestError(recoveryError)) {
+          await clearPendingContinuation(pending.commandId);
+          recordError(recoveryError);
+        }
+      }
+    })();
+
+    continuationInFlightRef.current = {
+      sessionId: pending.sessionId,
+      sourceRunId: pending.sourceRunId,
+      promise: operation,
+    };
+    try {
+      await operation;
+    } finally {
+      if (continuationInFlightRef.current?.promise === operation) {
+        continuationInFlightRef.current = null;
+      }
+    }
+  }, [
+    clientRef,
+    credentialsRef,
+    promptReceiptSupported,
+    reconcileSession,
+    recordError,
+    refreshSessions,
+  ]);
+
+  useEffect(() => {
+    if (phase !== "ready") return;
+    void (async () => {
+      await recoverPendingPrompt();
+      await recoverPendingContinuation();
+    })();
+  }, [phase, recoverPendingContinuation, recoverPendingPrompt]);
 
   return { sending, sendMessage, continueRun };
 }

--- a/mobile/src/remote/useRemoteConnection.ts
+++ b/mobile/src/remote/useRemoteConnection.ts
@@ -107,14 +107,18 @@ export function useRemoteConnection({
   const connect = useCallback(
     async (nextCredentials: RemoteCredentials) => {
       await clientRef.current?.close();
+      // A successful pair must mean its credentials are durable. In
+      // particular, do not let the UI report success while SecureStore writes
+      // are still in flight and can be lost on immediate process suspension.
+      await saveCredentials(nextCredentials);
       credentialsRef.current = nextCredentials;
       setCredentials(nextCredentials);
       setError(null);
       setCapabilities(new Set());
       const client = new RemoteClient(nextCredentials, {
-        onCredentials: next => {
+        onCredentials: async next => {
+          await saveCredentials(next);
           setCredentials(next);
-          void saveCredentials(next);
         },
         onEvent: handleEvent,
         onEventDecodeFailure: (sessionId, decodeError) => {


### PR DESCRIPTION
## Summary
- make mobile prompt delivery durable across reconnects and acknowledge only matching submissions
- harden mid-turn context compaction and Anthropic thinking/stream compatibility
- eliminate flashing file previews and replace Base64 image IPC with path-validated Tauri asset URLs

## Validation
- make lint
- cargo test --manifest-path agent/Cargo.toml compaction::
- cargo test --manifest-path agent/Cargo.toml anthropic
- cargo test --manifest-path agent/Cargo.toml --test compaction_persist
- npm --prefix mobile test -- --no-watchman (28 suites, 382 tests)
- npm --prefix desktop test -- --run (57 files, 609 tests)
- focused Tauri image-preview asset-scope test