### PR TITLE
feat(loop): surface model-stream truncation context; fix dead-holder UI alarm; keep evidence head+tail

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -23,6 +23,25 @@ pub type PersistCallback = Arc<dyn Fn(&mut crate::types::AgentMessage) + Send + 
 pub type CheckpointCallback =
     Arc<dyn Fn(&crate::compaction::ContextCheckpoint) -> Result<()> + Send + Sync>;
 
+/// How far a run had progressed when its model stream was judged truncated,
+/// and how the truncation was detected. Captured at the truncation point so
+/// the run commit path can surface it on `run_terminal` / `agent_end` — this
+/// is what lets an orchestrator tell "cut off mid-work" (worth resuming) from
+/// "model went silent immediately" (likely a prompt/connection problem).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct StreamTruncation {
+    /// LLM turns completed inside this run before the stream cut off.
+    pub turns_so_far: i32,
+    /// Length (chars) of the accumulated assistant text prefix at cut-off.
+    pub output_len: usize,
+    /// Tool calls the model had emitted (executed or not) before cut-off.
+    pub tool_calls_so_far: usize,
+    /// `idle_timeout` = the stream went silent for a whole idle window;
+    /// `finish_incomplete` = the provider sent an explicit incomplete finish;
+    /// `eof_no_terminal` = the stream closed without any terminal event.
+    pub detected_by: String,
+}
+
 /// Per-session state passed into `run_streaming_with_messages`.  Callbacks
 /// are session-specific (they capture session_id, messages_arc, broadcaster)
 /// and must NOT be stored on the shared Loop — otherwise concurrent sessions
@@ -63,6 +82,13 @@ pub struct Loop {
     /// Read by the run commit path so both the journal and `agent_end` preserve
     /// `incomplete` instead of presenting a truncated prefix as completed.
     pub stream_incomplete: Arc<AtomicBool>,
+    /// Context captured at the moment the stream was judged truncated: how far
+    /// the run had progressed (turns, output length, tool calls produced) and
+    /// how the truncation was detected. Surfaced on `run_terminal` / `agent_end`
+    /// so orchestrators can tell "cut off mid-work" (worth resuming) from
+    /// "model went silent immediately" (likely a prompt/connection problem).
+    /// Empty when the run ended cleanly.
+    pub stream_truncation: Arc<parking_lot::Mutex<Option<StreamTruncation>>>,
     /// Cached model registry — avoids re-deserialising the 906-model catalog
     /// on auto-compaction checks and image-support queries inside the hot loop.
     pub model_registry: Option<Arc<parking_lot::RwLock<crate::models::Registry>>>,
@@ -94,6 +120,7 @@ impl Loop {
             cumulative_cost: Arc::new(parking_lot::Mutex::new(0.0)),
             last_prompt_tokens: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             stream_incomplete: Arc::new(AtomicBool::new(false)),
+            stream_truncation: Arc::new(parking_lot::Mutex::new(None)),
             model_registry: None,
             preflight_context_check: false,
         }

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -420,6 +420,9 @@ impl Loop {
             // The accumulated text is a prefix, not a finished answer.
             let mut stream_truncated = false;
             let mut saw_terminal_event = false;
+            // How the truncation was first detected, for the run-terminal
+            // context. Set at the same moment `stream_truncated` flips.
+            let mut truncation_detected_by: Option<&'static str> = None;
 
             loop {
                 let (stream_idle, complete_tool_call_idle) =
@@ -473,6 +476,11 @@ impl Loop {
                         // which is not a timeout.)
                         if event_timed_out || !saw_terminal_event {
                             stream_truncated = true;
+                            truncation_detected_by.get_or_insert(if event_timed_out {
+                                "idle_timeout"
+                            } else {
+                                "eof_no_terminal"
+                            });
                         }
                         break;
                     }
@@ -644,6 +652,7 @@ impl Loop {
                         saw_terminal_event = true;
                         if reason == FinishReason::Incomplete {
                             stream_truncated = true;
+                            truncation_detected_by.get_or_insert("finish_incomplete");
                         }
                         if let Some(ref usage) = usage {
                             self.process_usage_event(usage, &mut total_usage);
@@ -834,6 +843,19 @@ impl Loop {
             if stream_truncated {
                 self.stream_incomplete
                     .store(true, std::sync::atomic::Ordering::SeqCst);
+                // Capture how far the run had progressed and how the cut was
+                // detected, so the run commit path can surface it on
+                // `run_terminal` / `agent_end`. "Cut off mid-work" (turns or
+                // tool calls > 0) is worth resuming; "silent immediately" is
+                // more likely a prompt/connection problem.
+                *self.stream_truncation.lock() = Some(crate::agent::StreamTruncation {
+                    turns_so_far: turn as i32,
+                    output_len: assistant_text.len(),
+                    tool_calls_so_far: agent_tool_calls.len(),
+                    detected_by: truncation_detected_by
+                        .unwrap_or("eof_no_terminal")
+                        .to_string(),
+                });
                 if self.verbose {
                     tracing::warn!(
                         "[agent] stream truncated turns={} output_len={}",
@@ -1800,6 +1822,42 @@ mod tests {
         assert!(loop_
             .stream_incomplete
             .load(std::sync::atomic::Ordering::SeqCst));
+        // Truncation context captured: detected via an explicit incomplete
+        // finish, zero turns/tools progressed past the first stream.
+        let trunc = loop_.stream_truncation.lock().clone().expect("truncation");
+        assert_eq!(trunc.detected_by, "finish_incomplete");
+        assert_eq!(trunc.tool_calls_so_far, 0);
+        assert_eq!(trunc.output_len, "cut off".len());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn truncation_context_records_tool_progress() {
+        // A stream that produced a tool call before being cut off records the
+        // progress, distinguishing "cut off mid-work" from "silent at once".
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![
+            ev_text("working"),
+            ev_toolcall_start(0, "call_1", "echo", "{}"),
+            ev_toolcall_end(),
+            ModelStreamEvent::Finish {
+                reason: FinishReason::Incomplete,
+                usage: None,
+            },
+        ])]);
+        let loop_ = Loop::new(provider, "mock");
+        let _ = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        let trunc = loop_.stream_truncation.lock().clone().expect("truncation");
+        assert_eq!(trunc.detected_by, "finish_incomplete");
+        assert_eq!(trunc.tool_calls_so_far, 1);
+        assert_eq!(trunc.output_len, "working".len());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -561,6 +561,8 @@ impl ServerSession {
         run_loop
             .stream_incomplete
             .store(false, std::sync::atomic::Ordering::SeqCst);
+        // Reset any prior run's truncation context — it is per-run.
+        *run_loop.stream_truncation.lock() = None;
         // Stamp run identity on the message itself, not just the journal
         // entry: the terminal history rewrite regenerates entries from the
         // in-memory messages, so identity injected only at the entry layer
@@ -863,6 +865,10 @@ impl ServerSession {
             let stream_incomplete = run_loop
                 .stream_incomplete
                 .load(std::sync::atomic::Ordering::SeqCst);
+            // Truncation context (how far the run progressed before the model
+            // stream cut off) — surfaced on `run_terminal` / `agent_end` when
+            // the run ended incomplete.
+            let stream_truncation = run_loop.stream_truncation.lock().clone();
             if let Some(error) = broadcaster.persistence_error() {
                 let _ = runtime.mark_persistence_degraded(&task_lease, &error);
                 return;
@@ -910,6 +916,7 @@ impl ServerSession {
             // still needed after the task completes (terminal event dispatch).
             let commit_run_id = task_lease.run_id.clone();
             let commit_run_error = run_error.clone();
+            let commit_truncation = stream_truncation.clone();
             let persistence_task = tokio::task::spawn_blocking(move || {
                 if is_ephemeral {
                     return anyhow::Ok(());
@@ -968,12 +975,13 @@ impl ServerSession {
                     task_lease.epoch,
                     task_lease.run_sequence,
                 );
-                let terminal = crate::session::SessionEntry::run_terminal(
+                let terminal = crate::session::SessionEntry::run_terminal_with_truncation(
                     &commit_run_id,
                     terminal_state,
                     run_output_tokens,
                     run_duration_ms,
                     commit_run_error.as_deref(),
+                    commit_truncation.as_ref(),
                 );
 
                 // Append-only fast path: terminal marker + refreshed session_info,
@@ -1056,6 +1064,14 @@ impl ServerSession {
                     });
                     if stream_incomplete {
                         data["reason"] = serde_json::Value::String("incomplete".to_string());
+                    }
+                    if let Some(t) = &stream_truncation {
+                        data["truncation"] = serde_json::json!({
+                            "turns_so_far": t.turns_so_far,
+                            "output_len": t.output_len,
+                            "tool_calls_so_far": t.tool_calls_so_far,
+                            "detected_by": t.detected_by,
+                        });
                     }
                     broadcaster.broadcast(crate::rpc::SseEvent {
                         event_type: "agent_end".to_string(),

--- a/agent/src/session/entry.rs
+++ b/agent/src/session/entry.rs
@@ -202,14 +202,29 @@ impl SessionEntry {
 
     /// Marker written at a run's commit boundary. `content` carries
     /// `{ run_id, state, run_tokens, run_duration_ms }` plus `error` when
-    /// `state` is `error`. A run is only recoverable as completed once this
-    /// marker is durable.
+    /// `state` is `error`, plus `truncation` when `state` is `incomplete`.
+    /// A run is only recoverable as completed once this marker is durable.
     pub fn run_terminal(
         run_id: &str,
         state: &str,
         run_tokens: i64,
         run_duration_ms: i64,
         error: Option<&str>,
+    ) -> Self {
+        Self::run_terminal_with_truncation(run_id, state, run_tokens, run_duration_ms, error, None)
+    }
+
+    /// `run_terminal` with an optional truncation context (set only when the
+    /// run ended `incomplete` because the model stream cut off). The context
+    /// records how far the run had progressed so consumers can tell "cut off
+    /// mid-work" from "model went silent immediately".
+    pub fn run_terminal_with_truncation(
+        run_id: &str,
+        state: &str,
+        run_tokens: i64,
+        run_duration_ms: i64,
+        error: Option<&str>,
+        truncation: Option<&crate::agent::StreamTruncation>,
     ) -> Self {
         let mut content = serde_json::json!({
             "run_id": run_id,
@@ -219,6 +234,14 @@ impl SessionEntry {
         });
         if let Some(error) = error {
             content["error"] = serde_json::Value::String(error.to_string());
+        }
+        if let Some(t) = truncation {
+            content["truncation"] = serde_json::json!({
+                "turns_so_far": t.turns_so_far,
+                "output_len": t.output_len,
+                "tool_calls_so_far": t.tool_calls_so_far,
+                "detected_by": t.detected_by,
+            });
         }
         Self {
             id: generate_entry_id(),

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -33,6 +33,13 @@ pub struct RunSummary {
     /// usage payload from agent_end, when present.
     pub usage: Option<Value>,
     pub duration_ms: Option<i64>,
+    /// Sub-classification of an `incomplete` terminal state. Set from the
+    /// agent's `agent_end.truncation` block when the AGENT judged the model
+    /// stream truncated (it carries turn/tool progress); `None` when the turn
+    /// ended any other way OR when the loop saw the event stream close without
+    /// a terminal event (no `agent_end` at all — the loop's own "closed
+    /// without a state" case, distinct from an agent-reported truncation).
+    pub truncation: Option<Value>,
 }
 
 /// Cumulative token/cost accounting for a session (from get_state).
@@ -356,6 +363,7 @@ impl AgentClient {
             text: String::new(),
             usage: None,
             duration_ms: None,
+            truncation: None,
         };
         // O5: resume cursor (last event idx actually observed) and the
         // original gap error (carried if the retry also fails).
@@ -526,6 +534,10 @@ async fn consume_run_stream(
                     .to_string();
                 summary.usage = data.get("usage").cloned();
                 summary.duration_ms = data.get("duration_ms").and_then(|v| v.as_i64());
+                // The agent's own truncation verdict (model stream cut off
+                // mid-run) — carries turn/tool progress. Distinct from the
+                // loop's "stream closed without a terminal event" case below.
+                summary.truncation = data.get("truncation").cloned();
                 return StreamOutcome::Done;
             }
             "error" => {

--- a/orchestration/loop/src/agents/lane.rs
+++ b/orchestration/loop/src/agents/lane.rs
@@ -90,6 +90,7 @@ mod tests {
             spend_source: None,
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -7202,6 +7202,7 @@ mod coverage_tests {
             recorded_at: 1_700_000_000,
             spend_source: Some("run".to_string()),
             failure_kind: None,
+            truncation: None,
             validation: None,
         }
     }
@@ -8049,6 +8050,7 @@ mod cli_quirks_tests {
                     recorded_at: 2,
                     spend_source: None,
                     failure_kind: None,
+                    truncation: None,
                 },
                 ts: 2,
             }),
@@ -8756,6 +8758,7 @@ mod residual_branch_tests {
             recorded_at: 1,
             spend_source: Some("run".into()),
             failure_kind: None,
+            truncation: None,
             validation: None,
         };
         std::fs::write(

--- a/orchestration/loop/src/decision/goal_frontier/outcome_continuity.rs
+++ b/orchestration/loop/src/decision/goal_frontier/outcome_continuity.rs
@@ -111,6 +111,7 @@ mod tests {
             recorded_at: at,
             spend_source: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/decision/oscillation.rs
+++ b/orchestration/loop/src/decision/oscillation.rs
@@ -179,6 +179,7 @@ mod tests {
                 }
             }),
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -13,6 +13,27 @@ use crate::state::{
     ValidationStatus,
 };
 
+/// Evidence is a summary the orchestrator reads to decide what a worker
+/// actually landed — it is NOT a full transcript. Truncating head-only loses
+/// the conclusion (workers state findings last), so keep a bounded head AND
+/// tail with an explicit elision marker. Bounded because evidence is replayed
+/// into every subsequent turn envelope.
+pub fn truncate_evidence(text: &str, max: usize) -> String {
+    if text.len() <= max {
+        return text.to_string();
+    }
+    // The elision marker is a 3-byte '…'. Head gets the bulk (context /
+    // approach); tail keeps the conclusion. All bounds are BYTE bounds
+    // (str::len), so they hold against any UTF-8 content.
+    const MARK: &str = "…";
+    let head_bytes = max * 3 / 4;
+    let tail_bytes = max - head_bytes - MARK.len();
+    let head = &text[..text.floor_char_boundary(head_bytes)];
+    let tail_start = text.floor_char_boundary(text.len() - tail_bytes);
+    let tail = &text[tail_start..];
+    format!("{head}{MARK}{tail}")
+}
+
 /// Backoff (seconds) a turn sleeps before the run exits when it ended in an
 /// HTTP 429 (engine overloaded / rate-limited). Relaunching immediately after
 /// a 429 re-hits the same throttle and burns turns without progress — a short
@@ -284,7 +305,7 @@ pub async fn execute_turn(
         tokens_out_delta: after.tokens_out.saturating_sub(before.tokens_out),
         cost_delta: (after.cost - before.cost).max(0.0),
         tools: summary.tools,
-        evidence: crate::decision::truncate(&summary.text, 2_000),
+        evidence: truncate_evidence(&summary.text, 4_000),
         recorded_at: now_epoch(),
         // G-7: stamped by the caller (main.rs writeback) with the mode-based
         // spend source before the record hits the ledger.
@@ -292,6 +313,10 @@ pub async fn execute_turn(
         // A: failure classification, stamped at writeback (None until then).
         failure_kind: None,
         validation: None,
+        // A1: the agent's own truncation verdict (model stream cut off
+        // mid-run) with turn/tool progress; `None` when the loop merely saw
+        // the event stream close without a terminal event.
+        truncation: summary.truncation,
     };
     // Independent validator (if any) runs after a completed turn; a failed or
     // interrupted turn never runs the validator (no material result to check).
@@ -423,6 +448,7 @@ mod validator_tests {
                 recorded_at: 0,
                 spend_source: Some("run".into()),
                 failure_kind: None,
+                truncation: None,
                 validation: None,
             }
         }
@@ -463,5 +489,23 @@ mod validator_tests {
         assert!(incomplete_continue_note(4, 3, "T1").is_none());
         // a zero bound disables retries entirely
         assert!(incomplete_continue_note(1, 0, "T1").is_none());
+    }
+
+    #[test]
+    fn truncate_evidence_keeps_head_and_tail() {
+        use super::truncate_evidence;
+        // Short enough: unchanged.
+        let short = "short evidence";
+        assert_eq!(truncate_evidence(short, 100), short);
+
+        // Long: keeps the head and the tail with an elision marker, and
+        // stays within the budget.
+        let body = "a".repeat(200);
+        let text = format!("{body}END-MARKER");
+        let out = truncate_evidence(&text, 100);
+        assert!(out.len() <= 100, "len {} > 100", out.len());
+        assert!(out.contains('…'), "elision marker: {out}");
+        assert!(out.starts_with('a'), "keeps head: {out}");
+        assert!(out.ends_with("END-MARKER"), "keeps tail: {out}");
     }
 }

--- a/orchestration/loop/src/quota/slot_accounting.rs
+++ b/orchestration/loop/src/quota/slot_accounting.rs
@@ -152,6 +152,7 @@ mod tests {
             spend_source: source.map(|s| s.to_string()),
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/quota/usage_summary.rs
+++ b/orchestration/loop/src/quota/usage_summary.rs
@@ -204,6 +204,7 @@ mod tests {
             spend_source: Some(source.to_string()),
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/runtime/run_compaction.rs
+++ b/orchestration/loop/src/runtime/run_compaction.rs
@@ -184,6 +184,7 @@ mod tests {
             spend_source: Some("run".to_string()),
             validation: None,
             failure_kind: None,
+            truncation: None,
         };
         let compact = compact_run_record(&record);
         assert_eq!(compact["terminal_state"], "completed");

--- a/orchestration/loop/src/runtime/stale_latest_run.rs
+++ b/orchestration/loop/src/runtime/stale_latest_run.rs
@@ -77,6 +77,7 @@ mod tests {
             spend_source: Some("run".to_string()),
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -562,6 +562,13 @@ pub struct RunRecord {
     /// by [`Goal::failure_kind_of`].
     #[serde(default)]
     pub failure_kind: Option<FailureKind>,
+    /// A1: the agent's own truncation verdict for an `incomplete` turn — the
+    /// `agent_end.truncation` block (turn/tool progress + how the cut was
+    /// detected). `None` on legacy lines, on non-incomplete turns, and when
+    /// the loop saw the event stream close without a terminal event (the
+    /// loop-side "no agent_end" case, distinct from an agent-reported cut).
+    #[serde(default)]
+    pub truncation: Option<serde_json::Value>,
 }
 
 /// Failure classification — WHY a turn did not deliver a verified outcome.

--- a/orchestration/loop/src/turn_envelope.rs
+++ b/orchestration/loop/src/turn_envelope.rs
@@ -146,6 +146,7 @@ mod tests {
             spend_source: Some("run".to_string()),
             validation: None,
             failure_kind: None,
+            truncation: None,
         };
         let msg = compose_turn_message(&g, g.todo("T1").unwrap(), Some(&prev));
         assert!(msg.contains("Evidence from the previous turn (todo T0)"));

--- a/orchestration/loop/src/webui/page.rs
+++ b/orchestration/loop/src/webui/page.rs
@@ -528,7 +528,7 @@ function renderDTab(g, d, gates, unvalidated, deliveriesByTodo, openObl){
   if(dTab === "todos"){
     const rows = g.todos.map(t => {
       const dv = deliveriesByTodo[t.id];
-      const lease = t.claimed_by ? `<div class="sub" data-tip="A lease is the bounded execution window a worker holds on this todo. Each lease records the worker's process id (pid); if that process is no longer alive, the lease is orphaned and auto-reclaimed — this one is orphaned (holder process is dead).">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false?" · <span class='sev-high'>holder dead</span>":""}</div>` : "";
+      const lease = t.claimed_by ? `<div class="sub" data-tip="A lease is the bounded execution window a worker holds on this todo. Each lease records the worker's process id (pid); if that process is no longer alive, the lease is orphaned and auto-reclaimed — this one is orphaned (holder process is dead).">lease ${esc(t.claimed_by)} · exp ${ago(t.lease_expires_at)}${t.holder_alive===false && (t.status==="open"||t.status==="deferred"||t.status==="blocked") ? " · <span class='sev-high'>holder dead</span>" : (t.holder_alive===false? " · holder process dead (closed)":"")}</div>` : "";
       const val = t.validator ? `<div class="sub mono" data-tip="independent verify command run after each turn; exit 0 = validated${t.passed_validation?" · passed":""}">✓ ${esc(t.validator)}${t.passed_validation?" · passed":(t.status==="done"?" · <span class='sev-high'>UNVALIDATED</span>":"")}</div>` : "";
       const gateQ = t.gate_question ? `<div class="sub">❓ ${esc(t.gate_question)}</div>` : "";
       const dec = t.decision ? `<div class="sub">→ ${esc(t.decision)}</div>` : "";
@@ -671,7 +671,7 @@ function inspectTodo(id){
     ${row("monitor due", t.monitor_due_at? tsLocal(t.monitor_due_at)+" ("+ago(t.monitor_due_at)+")" : null)}
     ${row("no-change polls", t.consecutive_no_change || null)}
     ${row("resume when", esc(t.resume_when_text))}
-    ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false?" · holder process dead (orphaned lease, auto-reclaimed)":"") : null)}
+    ${row("lease", t.claimed_by? t.claimed_by+" · expires "+tsLocal(t.lease_expires_at)+" ("+ago(t.lease_expires_at)+")"+(t.holder_alive===false ? (t.status==="open"||t.status==="deferred"||t.status==="blocked" ? " · holder process dead (orphaned lease, auto-reclaimed)" : " · holder process dead (closed)") : "") : null)}
     ${row("evidence", esc(t.evidence))}
     <div class="fgroup"><div class="fk">timestamps</div><div class="fv mono">updated ${tsLocal(t.updated_at)}${t.completed_at?" · completed "+tsLocal(t.completed_at):""}</div></div>
     ${t.status==="open"&&t.class==="user_gate"? `<div class="fgroup"><div class="fk">resolve (CLI)</div><div class="fv mono" style="font-size:11px">future loop gate resolve --goal ${esc(DETAIL_ID)} --todo-id ${esc(t.id)} --decision \"…\"</div></div>`:""}

--- a/orchestration/loop/src/work_items/delivery.rs
+++ b/orchestration/loop/src/work_items/delivery.rs
@@ -181,6 +181,7 @@ mod tests {
             spend_source: None,
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 

--- a/orchestration/loop/src/worker_bridge.rs
+++ b/orchestration/loop/src/worker_bridge.rs
@@ -137,6 +137,7 @@ pub async fn run_bridge(store: &mut Store, opts: &BridgeOptions) -> Result<()> {
             // A: failure classification, stamped at writeback (None until then).
             failure_kind: None,
             validation: None,
+            truncation: None,
         };
         // Completion contract: last remaining todo closes with no-follow-up;
         // otherwise remaining todos become successors.

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -39,6 +39,7 @@ fn sample_record(state: &str) -> RunRecord {
         spend_source: None,
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 
@@ -589,6 +590,84 @@ fn execute_turn_error_turn_skips_validator() {
         .unwrap();
         assert_eq!(record.terminal_state, "error");
         assert!(record.validation.is_none(), "failed turn never validates");
+    });
+}
+
+/// A1: an `incomplete` `agent_end` carrying the agent's own truncation block
+/// (turn/tool progress + how the cut was detected) is surfaced on the
+/// `RunRecord.truncation` field — distinguishing "cut off mid-work" from the
+/// loop's "stream closed without a terminal event" (which leaves it `None`).
+#[test]
+fn execute_turn_surfaces_agent_truncation_on_incomplete() {
+    rt().block_on(async {
+        let events = vec![ev(
+            "mock-run-1",
+            0,
+            "agent_end",
+            "{\"state\":\"incomplete\",\"reason\":\"incomplete\",\"truncation\":{\"turns_so_far\":0,\"output_len\":8,\"tool_calls_so_far\":3,\"detected_by\":\"finish_incomplete\"}}",
+        )];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, todo) = sample_goal_with_todo();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            None,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(record.terminal_state, "incomplete");
+        let trunc = record.truncation.expect("agent truncation surfaced");
+        assert_eq!(trunc["tool_calls_so_far"], 3);
+        assert_eq!(trunc["detected_by"], "finish_incomplete");
+    });
+}
+
+/// A1: an `incomplete` turn where the loop saw the event stream close without
+/// any `agent_end` leaves `truncation` `None` — it is the loop's own "no
+/// terminal event" case, not an agent-reported mid-work cut.
+#[test]
+fn execute_turn_leaves_truncation_none_without_agent_end() {
+    rt().block_on(async {
+        let events = vec![ev("mock-run-1", 0, "text_chunk", "{\"text\":\"partial\"}")];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let (goal, todo) = sample_goal_with_todo();
+        let record = execute_turn(
+            &mut client,
+            "sess",
+            &goal,
+            None,
+            &todo,
+            1,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(record.terminal_state, "incomplete");
+        assert!(record.truncation.is_none(), "no agent_end → no truncation");
     });
 }
 

--- a/orchestration/loop/tests/agents_scope_contract.rs
+++ b/orchestration/loop/tests/agents_scope_contract.rs
@@ -218,6 +218,7 @@ fn agent_lane_recommendation_attributes_runs_to_claiming_agent() {
         spend_source: Some("run".into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     }];
     let rec = compact_agent_lane_recommendation(&goal, "agent-a").unwrap();
     assert_eq!(rec.agent_id, "agent-a");

--- a/orchestration/loop/tests/attention_inbox_contract.rs
+++ b/orchestration/loop/tests/attention_inbox_contract.rs
@@ -32,6 +32,7 @@ fn run(evidence: &str) -> RunRecord {
         spend_source: None,
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/automation_liveness_contract.rs
+++ b/orchestration/loop/tests/automation_liveness_contract.rs
@@ -394,6 +394,7 @@ fn run_path_writeback_uses_the_same_cadence_derivation() {
         spend_source: Some("heartbeat".into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     };
     let before = future_loop::state::now_epoch();
     future_loop::executor::writeback(&mut goal, &record, Some(false), None);

--- a/orchestration/loop/tests/cli_projection_contract.rs
+++ b/orchestration/loop/tests/cli_projection_contract.rs
@@ -59,6 +59,7 @@ fn turn_envelope_includes_prior_evidence_and_gate_decisions() {
         spend_source: Some("run".into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     };
     let msg = compose_turn_message(&goal, goal.todo("T2").unwrap(), Some(&prev));
     assert!(msg.contains("Resolved gate decision(s): G1: approved"));

--- a/orchestration/loop/tests/common/mod.rs
+++ b/orchestration/loop/tests/common/mod.rs
@@ -127,5 +127,6 @@ pub fn run_record(todo_id: &str, state: &str, recorded_at: u64) -> future_loop::
         spend_source: Some("run".to_string()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }

--- a/orchestration/loop/tests/decision_contract.rs
+++ b/orchestration/loop/tests/decision_contract.rs
@@ -35,6 +35,7 @@ fn run_record(turn: u32, todo_id: &str, state: &str) -> RunRecord {
         spend_source: None,
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/delivery_outcome_contract.rs
+++ b/orchestration/loop/tests/delivery_outcome_contract.rs
@@ -89,6 +89,7 @@ fn run_record(turn: u32) -> RunRecord {
         spend_source: None,
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/goal_frontier_contract.rs
+++ b/orchestration/loop/tests/goal_frontier_contract.rs
@@ -68,6 +68,7 @@ fn run(turn: u32, todo_id: &str, at: u64, tools: &[&str], evidence: &str) -> Run
         recorded_at: at,
         spend_source: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/monitor_poll_contract.rs
+++ b/orchestration/loop/tests/monitor_poll_contract.rs
@@ -208,6 +208,7 @@ fn no_change_polls_never_enter_the_spend_ledger() {
         spend_source: Some("heartbeat".into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     };
     future_loop::executor::writeback(&mut goal, &record, Some(false), None);
     assert_eq!(goal.history.len(), 0, "no-change polls are quota-neutral");
@@ -217,6 +218,7 @@ fn no_change_polls_never_enter_the_spend_ledger() {
         spend_source: Some("heartbeat".into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
         ..record
     };
     future_loop::executor::writeback(&mut goal, &record2, Some(true), None);

--- a/orchestration/loop/tests/oscillation_contract.rs
+++ b/orchestration/loop/tests/oscillation_contract.rs
@@ -43,6 +43,7 @@ fn delivery(turn: u32, ts: u64, validation_ok: Option<bool>) -> RunRecord {
             }
         }),
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/outcome_floor_contract.rs
+++ b/orchestration/loop/tests/outcome_floor_contract.rs
@@ -25,6 +25,7 @@ fn run_record(turn: u32, todo_id: &str, state: &str, tools: usize, evidence: &st
         spend_source: None,
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/productized_features_contract.rs
+++ b/orchestration/loop/tests/productized_features_contract.rs
@@ -35,6 +35,7 @@ fn run_record(todo_id: &str, terminal: &str) -> RunRecord {
         spend_source: Some("run".to_string()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 

--- a/orchestration/loop/tests/quota_contract.rs
+++ b/orchestration/loop/tests/quota_contract.rs
@@ -37,6 +37,7 @@ fn record(recorded_at: u64, source: &str, tools: bool, evidence: bool) -> RunRec
         spend_source: Some(source.into()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     }
 }
 
@@ -98,6 +99,7 @@ fn legacy_records_default_to_completed_run_classification() {
         validation: None,
         terminal_state: "completed".into(),
         failure_kind: None,
+        truncation: None,
         ..record(0, "run", false, false)
     };
     assert_eq!(slot_spend(&legacy), 1, "legacy completed runs still spend");
@@ -106,6 +108,7 @@ fn legacy_records_default_to_completed_run_classification() {
         validation: None,
         terminal_state: "error".into(),
         failure_kind: None,
+        truncation: None,
         ..record(0, "run", false, false)
     };
     assert_eq!(

--- a/orchestration/loop/tests/run_lifecycle_contract.rs
+++ b/orchestration/loop/tests/run_lifecycle_contract.rs
@@ -259,6 +259,7 @@ fn stale_latest_run_warns_and_clears() {
         spend_source: Some("run".to_string()),
         validation: None,
         failure_kind: None,
+        truncation: None,
     };
     record.recorded_at = 1_000;
     store.append_run("g1", &record).unwrap();

--- a/orchestration/loop/tests/store_contract.rs
+++ b/orchestration/loop/tests/store_contract.rs
@@ -248,6 +248,7 @@ mod crate_helper {
             spend_source: None,
             validation: None,
             failure_kind: None,
+            truncation: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a class of worker-observability gaps surfaced by a real ASC run: an `incomplete` turn carried no information about *where* the model stream died, a completed todo still showed an alarming "holder dead", and worker evidence was cut head-only so the conclusion (written last) was lost. Plus two skill-doc corrections.

## A1 — model-stream truncation context (agent + loop, no wire-contract change)

Before, a turn that ended `incomplete` could mean either "the model produced tool calls / text and then died mid-work" or "the model went silent immediately" — but the loop could not tell them apart (`RunSummary.terminal_state` just said `incomplete`, and a stream that closed without `agent_end` was indistinguishable from an agent-reported cut).

- **agent**: captures `StreamTruncation { turns_so_far, output_len, tool_calls_so_far, detected_by }` at the moment the stream is judged truncated (`Loop.stream_truncation`), and writes it into `run_terminal` / `agent_end` as a `truncation` block (`run_terminal_with_truncation`).
- **loop**: reads `agent_end.truncation` into `RunSummary.truncation` → `RunRecord.truncation`. An agent-reported cut carries progress; the loop's own "stream closed without a terminal event" case leaves it `None`.

## A2 — webui: no "holder dead" alarm on closed todos

A completed todo can still hold a stale (orphaned) lease whose process is gone. The UI flagged that with a red `holder dead` marker regardless of todo state, which read as "this task failed". Now an orphaned lease on an active todo keeps the red marker, but on a `done`/`superseded` todo it is labelled `holder process dead (closed)` — harmless history, not an alarm.

## A3 — evidence keeps head + tail

`RunRecord.evidence` was `truncate(&text, 2_000)` — head-only, so the worker's conclusion (written last) was dropped. New `truncate_evidence` keeps a bounded head **and** tail (byte-safe UTF-8 boundary, explicit `…` elision), raised to 4 KB.

## Skill docs (out-of-repo, noted for the record)

- `future-loop/SKILL.md`: document the three infra-stop reports (`infra_stopped:<todo>:<kind>` — `transport` / `timeout` / `incomplete_budget`), the `holder dead` ≠ failed semantics, and a "don't trust the push channel 100%" fallback.
- `asc-solver/SKILL.md` + the live `SHARED.md`: resolve the trace session id from the injected `session: <id>` line / `Current session ID`, never `ls -t` mtime guessing (wrong under parallel workers).

## Tests

- agent: truncation context capture on `Finish(Incomplete)` (2 tests).
- loop: `agent_end.truncation` → `RunRecord.truncation`, and `None` when no `agent_end` (2 tests).
- loop: `truncate_evidence` head+tail (1 test).

## Validation

- `make lint-rust` (workspace + src-tauri, `-D warnings`) green.
- `cargo test -p future-agent -p future-loop` green; the four `future-agent` lib tests that flake under full parallel run (`torn/partial cache reads`, approval / shell-sandbox variants) are pre-existing concurrency flakes — untouched files, pass in isolation.
