### PR TITLE
loop: retain agent session after run instead of deleting it

### DIFF
--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -302,10 +302,10 @@ impl AgentClient {
             .ok_or_else(|| anyhow!("prompt response missing run_id: {resp}"))
     }
 
-    /// Delete the agent session backing this run — closes its persistence
+    /// Delete the agent session backing a run — closes its persistence
     /// journal and reclaims the on-disk session state (~/.future/agent/sessions/).
-    /// The agent session is a per-run scratch workspace (context is replayed
-    /// via the turn envelope), so `run` deletes it when the run ends.
+    /// The loop no longer deletes sessions at run end (they are retained for
+    /// explicit resume); this is the operator-visible hook to reclaim one.
     /// Fails with a retryable error if the session still has an active run.
     pub async fn delete_session(&mut self, session_id: &str) -> Result<()> {
         self.call("delete_session", session_id, Default::default())

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3619,11 +3619,10 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         client.set_thinking_level(&session_id, &l).await?;
     }
 
-    // Run the turn loop. Session lifecycle: the kernel no longer blindly
-    // deletes the session — it records the retention state (id + failure
-    // classification + resumable advisory) on the goal and lets the NEXT
-    // caller decide. Deletion happens only when the session is NOT resumable
-    // (HardError / science failure / zombie — its reasoning state is broken).
+    // Run the turn loop. Session lifecycle: the session is never deleted —
+    // the kernel records the retention state (id + failure classification +
+    // resumable advisory) on the goal and lets the NEXT caller decide
+    // resume-vs-fresh via --session-policy / --resume-session.
     let mut last_failure_kind: Option<crate::state::FailureKind> = None;
     // Down-channel steering: watch the ledger for supervisor steering
     // instructions targeting THIS worker and abort the session mid-turn so the
@@ -3683,16 +3682,18 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
 
-    // Delete the session ONLY when it is not resumable — a resumable session
-    // (infra interruption) is kept on the agent for the next caller to resume,
-    // so its accumulated exploration is not thrown away.
-    if !resumable {
-        if let Err(e) = client.delete_session(&session_id).await {
-            println!("   ⚠ session cleanup failed (best-effort): {e}");
-        }
-    } else {
+    // Session retention: never delete the agent session. The session (and its
+    // accumulated exploration) stays on the agent; the NEXT caller decides
+    // resume-vs-fresh. A resumable session (infra interruption) is also picked
+    // up by the default `auto` policy; a non-resumable one must be resumed
+    // explicitly.
+    if resumable {
         println!(
             "   ⤺ session {session_id} retained (resumable) — next `run` with default policy will resume it"
+        );
+    } else {
+        println!(
+            "   ⤺ session {session_id} retained — resume it with --session-policy resume or --resume-session"
         );
     }
     result
@@ -3752,7 +3753,7 @@ fn claim_selected_with_lease(
 }
 
 /// One `run` = one bounded turn loop against a fresh agent session. `cmd_run`
-/// owns the session lifecycle (create before, delete after); this function
+/// owns the session lifecycle (create before, retain after); this function
 /// only executes turns and writes back their ledger effects.
 ///
 /// `max_incomplete_retries`: consecutive `incomplete` turns (model stream
@@ -3761,7 +3762,7 @@ fn claim_selected_with_lease(
 ///
 /// `last_failure_kind`: out-parameter set to the failure classification of the
 /// LAST executed turn (`None` when no turn ran this invocation) — the caller
-/// uses it to decide session retention (resume vs delete), never the kernel.
+/// uses it to decide session retention (resume vs fresh), never the kernel.
 ///
 /// Enqueue an intervention report to the registered supervisor session (the
 /// up channel). `dedup_key` doubles as the idempotency key: re-sending the

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -366,17 +366,23 @@ fn run_with_time_budget_success_path() {
 }
 
 #[test]
-fn run_session_cleanup_failure_is_a_warning() {
+fn run_retains_session() {
     let cr = cli_root();
-    let mut st = MockState {
+    let (_rt, shared) = mock_env(MockState {
         events: completed_events("mock-run-1"),
         ..Default::default()
-    };
-    st.fail_commands.insert("delete_session".to_string());
-    let (_rt, _shared) = mock_env(st);
-    let goal = init_goal(&cr, "cleanup warning");
-    // The run still succeeds; the cleanup failure is best-effort.
+    });
+    let goal = init_goal(&cr, "retain session");
     cli_ok(&["run", "--goal", &goal, "--anonymous"]);
+    // The agent session is NOT deleted when the run ends.
+    assert!(
+        shared
+            .lock()
+            .unwrap()
+            .live_sessions
+            .contains("mock-session-1"),
+        "session must be retained after a completed run"
+    );
 }
 
 // ── status print arms ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`future loop run` previously deleted the agent session when a run ended non-resumably (e.g. a todo completed). This threw away the session's accumulated exploration.

## Change

Retain the session after every run. The next caller decides resume-vs-fresh via `--session-policy` / `--resume-session`; a resumable session (infra interruption) is picked up by the default `auto` policy, a non-resumable one must be resumed explicitly.

- `orchestration/loop/src/console.rs`: drop the `delete_session` call at run end; always retain.
- `orchestration/loop/src/agent_client.rs`: update `delete_session` doc (it's now the operator-visible reclaim hook, not called by the loop).
- `tests/console_sweep.rs`: replace the cleanup-warning test with `run_retains_session` asserting the session survives a completed run.

## Verification

- `cargo clippy -p future-loop --all-targets` clean
- `cargo test -p future-loop` all pass