### PR TITLE
fix(agent): de-flake parallel test races + add flaky-stress workflow

### DIFF
--- a/.github/workflows/flaky-stress.yml
+++ b/.github/workflows/flaky-stress.yml
@@ -1,0 +1,71 @@
+name: Flaky stress
+
+permissions: read-all
+
+# Parallel flake hunt: every push to the hunt branch spawns one independent
+# run (deliberately NO concurrency group — accumulation of samples is the
+# point). Each run executes the test suites twice in a fresh VM: flakes that
+# depend on intra-process timing (mock-server accept races, Mutex-poison
+# cascades, tmp-path collisions, singleton-lock contention) are probabilistic
+# and need dozens of executions to surface.
+#
+# Also dispatchable once this file lands on the default branch:
+#   gh workflow run flaky-stress.yml --ref <branch>
+
+on:
+  push:
+    branches:
+      - 'claude/flaky-hunt'
+  workflow_dispatch:
+
+jobs:
+  stress:
+    name: flaky-stress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+          cache-on-failure: true
+          cache-all-crates: true
+
+      # Same minimal dep set as the workspace rust-tests groups: mold is
+      # pinned by .cargo/config.toml, pkg-config/build-essential/binutils
+      # cover build scripts and linkers.
+      - name: Install Linux deps
+        run: |
+          bash scripts/ci/install-apt-packages.sh \
+            build-essential \
+            binutils \
+            mold \
+            pkg-config
+
+      # agent: the observed flake cluster (sync_future_models_cache
+      # Option::unwrap on None + two approval PoisonErrors) lives here.
+      - name: Stress agent tests
+        env:
+          CARGO_PROFILE_TEST_DEBUG: 1
+        run: |
+          for i in 1 2; do
+            echo "=== agent pass $i ==="
+            cargo test -p future-agent
+          done
+
+      # tui + cli: the documented embedded-agent singleton-lock flake
+      # (cli/tests/bin.rs) surfaces under intra-binary parallelism here.
+      - name: Stress tui+cli tests
+        env:
+          CARGO_PROFILE_TEST_DEBUG: 1
+        run: |
+          for i in 1 2; do
+            echo "=== tui+cli pass $i ==="
+            cargo test -p future-tui -p future-cli
+          done

--- a/.github/workflows/flaky-stress.yml
+++ b/.github/workflows/flaky-stress.yml
@@ -13,9 +13,6 @@ permissions: read-all
 #   gh workflow run flaky-stress.yml --ref <branch>
 
 on:
-  push:
-    branches:
-      - 'claude/flaky-hunt'
   workflow_dispatch:
 
 jobs:

--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -523,7 +523,16 @@ fn save_future_models_cache_inner(cache: &FutureModelsCache) {
     // polls models every 10s; a test reading right after a background
     // refresh) observe an empty/partial file. Rename swaps the contents
     // atomically within the same directory on all supported platforms.
-    let tmp = path.with_extension("tmp");
+    // The temp name MUST be unique per writer: a fixed `models.tmp` shared
+    // by two concurrent writers lets their write/rename interleavings leave
+    // a torn file at the final path (flaky "disk cache load returned None
+    // right after a successful sync" under parallel tests).
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let tmp = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
     if std::fs::write(&tmp, json).is_ok() {
         let _ = std::fs::rename(&tmp, &path);
     }

--- a/agent/src/rpc/approval.rs
+++ b/agent/src/rpc/approval.rs
@@ -2156,7 +2156,7 @@ gpg: 密钥区块资源 '/Users/x/.gnupg/pubring.kbx': Operation not permitted
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_file_tool_cancelled_and_rejected_with_note() {
-        let _home_guard = crate::HOME_ENV_LOCK.lock().unwrap();
+        let _home_guard = crate::test_support::home_env_lock();
         let ws = temp_ws("file-cancel");
         let sandbox = enabled(&ws);
         let broadcaster = SseBroadcaster::new();
@@ -2290,7 +2290,7 @@ gpg: 密钥区块资源 '/Users/x/.gnupg/pubring.kbx': Operation not permitted
 
     #[test]
     fn approval_shape_edit_tool_variants() {
-        let _home_guard = crate::HOME_ENV_LOCK.lock().unwrap();
+        let _home_guard = crate::test_support::home_env_lock();
         let ws = temp_ws("shape-edit");
         let sandbox = enabled(&ws);
         // Canonicalize: the resolved workspace is canonical (macOS symlinks

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -61,16 +61,25 @@ impl<'a> PromptText<'a> {
 /// Test-only hook fired by `start_next_scheduled` right after it peeks the
 /// front queued run, keyed on that run id, so a test can reorder/drain the
 /// queue before `prompt_internal` calls `start_next` (FIFO-mismatch / empty
-/// dequeue defensive arms).
+/// dequeue defensive arms). One slot per run id: parallel tests with
+/// distinct run ids never overwrite or consume each other's hook (a single
+/// shared `Option` slot would race — the last test to arm it wins and the
+/// other test's peek finds nothing).
 #[cfg(test)]
-type SessionHook = Option<(String, Box<dyn Fn(&mut ServerSession) + Send>)>;
+type ScheduledDequeueHook = Box<dyn Fn(&mut ServerSession) + Send>;
 
 #[cfg(test)]
-static SCHEDULED_DEQUEUE_HOOK: parking_lot::Mutex<SessionHook> = parking_lot::Mutex::new(None);
+static SCHEDULED_DEQUEUE_HOOK: std::sync::LazyLock<
+    parking_lot::Mutex<std::collections::HashMap<String, ScheduledDequeueHook>>,
+> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
 
 /// Test-only hook fired by `prompt_internal` right before `runtime.spawn`,
 /// keyed on the accepted run id, so a test can occupy the task slot and
-/// reach the spawn double-occupancy error arm.
+/// reach the spawn double-occupancy error arm. Single-slot `Option`: exactly
+/// one test uses it, so no cross-test arm/consume race exists.
+#[cfg(test)]
+type SessionHook = Option<(String, Box<dyn Fn(&mut ServerSession) + Send>)>;
+
 #[cfg(test)]
 static RUN_SPAWN_HOOK: parking_lot::Mutex<SessionHook> = parking_lot::Mutex::new(None);
 
@@ -332,11 +341,9 @@ impl ServerSession {
         debug_assert_eq!(snapshot.settings.model, payload.settings.model);
         #[cfg(test)]
         {
-            let mut slot = SCHEDULED_DEQUEUE_HOOK.lock();
-            if matches!(slot.as_ref(), Some((sid, _)) if sid == &request.run_id) {
-                if let Some((_, hook)) = slot.take() {
-                    hook(self);
-                }
+            let mut slots = SCHEDULED_DEQUEUE_HOOK.lock();
+            if let Some(hook) = slots.remove(&request.run_id) {
+                hook(self);
             }
         }
         let lease = self.prompt_internal(

--- a/agent/src/rpc/session_prompt/tests.rs
+++ b/agent/src/rpc/session_prompt/tests.rs
@@ -1554,7 +1554,7 @@ async fn enqueue_prompt_releases_active_when_scheduled_start_fails() {
 async fn scheduled_run_fifo_mismatch_reports_error() {
     let fixture = run_fixture(ScriptedProvider::new(vec![text_turn("x")]), "fifo-mismatch");
     let mut session = fixture.session;
-    *super::SCHEDULED_DEQUEUE_HOOK.lock() = Some((
+    super::SCHEDULED_DEQUEUE_HOOK.lock().insert(
         "run-a".to_string(),
         Box::new(|sess: &mut crate::rpc::ServerSession| {
             // Queue a foreign run and move run-a to the back, so start_next
@@ -1569,7 +1569,7 @@ async fn scheduled_run_fifo_mismatch_reports_error() {
                 .unwrap();
             sess.scheduler.test_move_front_to_back();
         }),
-    ));
+    );
     let result = session.enqueue_prompt(
         "hi",
         &[],
@@ -1585,19 +1585,22 @@ async fn scheduled_run_fifo_mismatch_reports_error() {
 async fn scheduled_run_empty_dequeue_reports_error() {
     let fixture = run_fixture(ScriptedProvider::new(vec![text_turn("x")]), "empty-dequeue");
     let mut session = fixture.session;
-    *super::SCHEDULED_DEQUEUE_HOOK.lock() = Some((
-        "run-a".to_string(),
+    // Distinct run id from scheduled_run_fifo_mismatch_reports_error: the
+    // hook map is keyed per run id, so two parallel tests arm their own
+    // slots and can never overwrite or consume each other's hook.
+    super::SCHEDULED_DEQUEUE_HOOK.lock().insert(
+        "run-b".to_string(),
         Box::new(|sess: &mut crate::rpc::ServerSession| {
             // Drain the queue after the peek, so start_next finds nothing.
             sess.scheduler
                 .cancel_all_queued(crate::runtime::QueuedCancellationReason::Cancelled);
         }),
-    ));
+    );
     let result = session.enqueue_prompt(
         "hi",
         &[],
         &[],
-        Some("run-a"),
+        Some("run-b"),
         "req-a",
         crate::runtime::BusyPolicy::EnqueueIfBusy,
     );

--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -2724,7 +2724,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)] // HOME must stay pinned across awaits
     #[tokio::test(flavor = "current_thread")]
     async fn shell_sandbox_denial_post_hoc_denied_returns_annotated_output() {
-        let _home_guard = crate::HOME_ENV_LOCK.lock().unwrap();
+        let _home_guard = crate::test_support::home_env_lock();
         let ws =
             std::env::temp_dir().join(format!("futureos-esc3-{}", crate::utils::generate_id()));
         std::fs::create_dir_all(&ws).unwrap();


### PR DESCRIPTION
## What

10 parallel CI stress runs (20 executions of the agent suite, 20 of tui/cli) surfaced and validated these fixes.

## Flakes found & fixed

1. **`session_prompt` scheduled-run hook race** (reproduced: 1 failure in 20 stress executions; locally 2/5): `SCHEDULED_DEQUEUE_HOOK` was a single shared `Option` slot. Two hook tests running in parallel overwrote/consumed each other's armed hook (last writer wins) → one test's `enqueue_prompt` missed its hook and returned `Ok` → flaky `result.is_err()` in `scheduled_run_fifo_mismatch_reports_error` / `scheduled_run_empty_dequeue_reports_error`. Fix: the slot is now a per-run-id `HashMap`; each test arms its own key and consumption removes by key.

2. **Future-models cache torn write** (observed on main CI as `sync_future_models_cache_warms_disk_and_memory` panicking with `load_future_models_cache()` → None right after a successful sync): the atomic tmp+rename save used ONE fixed tmp name (`models.tmp`). Two concurrent writers (e.g. a background refresh thread resolving `$HOME` into an active test's redirected home) corrupt each other through the shared tmp file — write/rename interleavings can leave a torn file at the final path. Fix: unique tmp name per writer (pid + atomic seq).

3. **HOME_ENV_LOCK poison cascade** (the two `PoisonError` approval failures in the same CI run were victims of #2): `approval.rs` (2 sites) + `tools/mod.rs` still locked the plain Mutex with `.lock().unwrap()`; any panic while the lock was held poisoned it and every later `.unwrap()` failed with `PoisonError`. Fix: use the poison-tolerant `test_support::home_env_lock()` helper everywhere (matches the existing convention).

## Validation

- New `flaky-stress.yml` workflow (dispatch-only): one run = agent suite 2× + tui/cli suite 2× in a fresh VM.
- Before the fixes: 10 runs → 1 failure (`fifo_mismatch`).
- After the fixes: 10 runs (20 more executions each) → **10/10 green**.
- Local: agent lib suite 3× green (1400 tests), hook tests 20× green, fmt + clippy clean.

The known `cli/tests/bin.rs` singleton-lock flake (documented in memory) did not reproduce in 40 tui/cli executions — left alone.