### PR TITLE
feat(loop): push dead-worker notice to supervisor on scheduler tick

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -165,6 +165,15 @@ channel. Both directions ride the same event-sourced state:
   transition, so re-sends across runs dedup. The durable user gate remains the
   authoritative intervention channel if no supervisor is registered.
 
+- **Infra stops + dead workers:** a worker that exits before reaching a
+  turn-boundary writeback (gRPC transport loss, `--max-turn-secs` timeout,
+  incomplete-retry budget exhaustion) also reports an `infra_stopped` note.
+  A worker that dies outright (SIGKILL / crash / host failure) executes no
+  code, so the periodic `scheduler tick` detects the orphaned lease (dead
+  holder pid) and pushes a `host_died` note to the registered supervisor,
+  prompting the orchestrator to relaunch rather than only discovering the dead
+  worker on its next `status` poll.
+
 ## Loop state is CLI-first
 
 The control plane is driven and observed through the **`future loop` CLI** —

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -133,7 +133,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "status" => cmd_status(&store, &args[1..]),
         "ui" => cmd_webui(&args[1..]).await,
         "quota" => cmd_quota(&store, &args[1..]),
-        "scheduler" => cmd_scheduler(&mut store, &args[1..]),
+        "scheduler" => cmd_scheduler(&mut store, &args[1..]).await,
         "store" => cmd_store(&mut store, &args[1..]),
         "backfill" => cmd_backfill(&mut store, &args[1..]),
         "privacy" => cmd_privacy(&store, &args[1..]),
@@ -2887,9 +2887,9 @@ fn quota_spend(store: &Store, args: &[String]) -> Result<()> {
 
 /// `loopx scheduler <tick|show|record-host-failure> --goal G [--agent-id A]`
 /// — drive the persisted scheduler state machine across decision cycles.
-fn cmd_scheduler(store: &mut Store, args: &[String]) -> Result<()> {
+async fn cmd_scheduler(store: &mut Store, args: &[String]) -> Result<()> {
     match args.first().map(|s| s.as_str()) {
-        Some("tick") => scheduler_tick(store, &args[1..]),
+        Some("tick") => scheduler_tick(store, &args[1..]).await,
         Some("show") => scheduler_show(store, &args[1..]),
         Some("record-host-failure") => scheduler_record_failure(store, &args[1..]),
         Some("ack") => scheduler_ack(store, &args[1..]),
@@ -2986,9 +2986,9 @@ fn scheduler_scope(
 /// [--progression 15,30,60] [--action tick_next]` — load the persisted state
 /// (or bootstrap it from the cadence profile), advance the progression, and
 /// write the new state. Restart-safe: progression persists across cycles.
-/// P1-3: each tick also lands a `SchedulerTicked` heartbeat (liveness) and
-/// projects the monitor poll plan (tick-driven poll policy executor).
-fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
+/// P1-3: each tick also lands a `SchedulerTicked` heartbeat (liveness), the
+/// monitor poll plan, and a dead-worker push (see [`notify_dead_holders`]).
+async fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
     let mut cadence_class = "monitor_backoff".to_string();
     let mut progression: Vec<i64> = vec![];
     let mut action = "tick_next".to_string();
@@ -3056,6 +3056,7 @@ fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
         );
         record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
         print_monitor_poll_plan(store, &goal_id)?;
+        notify_dead_holders(store, &goal_id).await?;
         return Ok(());
     }
 
@@ -3069,6 +3070,7 @@ fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
     }
     record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
     print_monitor_poll_plan(store, &goal_id)?;
+    notify_dead_holders(store, &goal_id).await?;
     Ok(())
 }
 
@@ -3818,6 +3820,49 @@ pub async fn notify_infra_stop(
         &format!("infra_stopped:{todo_id}:{kind}"),
     )
     .await;
+}
+
+/// Dead-worker push (the host-died case the recoverable infra stops above
+/// cannot reach): a worker that died mid-slice (SIGKILL / crash / host
+/// failure) executes no code, so the `transport` / `timeout` /
+/// `incomplete_budget` reports never fire. The scheduler tick is the periodic
+/// trigger that notices a lease whose holder pid is gone and pushes a report
+/// to the registered supervisor, so the orchestrator is prompted to relaunch
+/// rather than only discovering the dead worker on its next `status` poll.
+/// Best-effort: no supervisor, no reachable agent, or no dead holders is a
+/// no-op (the tick itself never fails over a lost notification).
+#[doc(hidden)] // test-visible seam
+pub async fn notify_dead_holders(store: &mut Store, goal_id: &str) -> Result<()> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(());
+    };
+    let Some(supervisor) = goal.supervisor_session_id.clone() else {
+        return Ok(());
+    };
+    let dead: Vec<(String, u32)> = crate::work_items::task_lease::dead_holder_todos(&goal)
+        .into_iter()
+        .filter_map(|t| t.holder_pid.map(|pid| (t.id.clone(), pid)))
+        .collect();
+    if dead.is_empty() {
+        return Ok(());
+    }
+    let Ok(mut client) =
+        crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await
+    else {
+        return Ok(());
+    };
+    for (todo_id, pid) in dead {
+        notify_supervisor(
+            &mut client,
+            Some(supervisor.as_str()),
+            &format!(
+                "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion (host_died) — holder pid {pid} is gone (no release); relaunch to reclaim the lease"
+            ),
+            &format!("infra_stopped:{todo_id}:host_died:{pid}"),
+        )
+        .await;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/orchestration/loop/src/work_items/task_lease.rs
+++ b/orchestration/loop/src/work_items/task_lease.rs
@@ -185,6 +185,25 @@ pub fn expire(todo: &mut Todo, now: u64) -> Result<LeaseOp> {
     }
 }
 
+/// Todos stranded by a dead lease holder: `claimed_by` is set (a worker
+/// claimed the slice), the todo is still open, and the recorded `holder_pid`
+/// no longer answers `kill -0` (SIGKILL / crash / host failure without a
+/// release). These are the candidates the scheduler tick reports up-channel
+/// so the orchestrator can relaunch a dead worker instead of only discovering
+/// it on a later poll. A completed/superseded todo with a stale orphaned
+/// lease is NOT stranded — it no longer needs a live worker.
+pub fn dead_holder_todos(goal: &crate::state::Goal) -> Vec<&crate::state::Todo> {
+    goal.todos
+        .iter()
+        .filter(|t| {
+            t.status == TodoStatus::Open
+                && t.claimed_by.is_some()
+                && t.holder_pid
+                    .is_some_and(|pid| !crate::compat::pid_alive(pid))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,5 +318,49 @@ mod tests {
         assert_eq!(normalize_ttl(0).unwrap(), DEFAULT_TASK_LEASE_TTL_SECONDS);
         assert!(normalize_ttl(MAX_TASK_LEASE_TTL_SECONDS + 1).is_err());
         assert_eq!(normalize_ttl(120).unwrap(), 120);
+    }
+
+    /// Spawn a child, kill it, reap it — its pid is now guaranteed dead.
+    #[cfg(unix)]
+    fn dead_pid() -> u32 {
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("sleep 30")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        pid
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dead_holder_todos_detects_stranded_open_leases() {
+        let mut goal = crate::state::Goal::new("g1", "objective", "/tmp");
+        let dead = dead_pid();
+
+        // A dead holder on an OPEN todo is stranded.
+        let mut stranded = Todo::advancement("t1", "work");
+        stranded.claimed_by = Some("alice".into());
+        stranded.holder_pid = Some(dead);
+        stranded.status = TodoStatus::Open;
+        // A live holder (our own pid) is not stranded.
+        let mut live = Todo::advancement("t2", "work");
+        live.claimed_by = Some("bob".into());
+        live.holder_pid = Some(std::process::id());
+        live.status = TodoStatus::Open;
+        // A completed todo with a stale dead lease is harmless, not stranded.
+        let mut done = Todo::advancement("t3", "work");
+        done.claimed_by = Some("carol".into());
+        done.holder_pid = Some(dead);
+        done.status = TodoStatus::Done;
+        goal.todos = vec![stranded, live, done];
+
+        let ids: Vec<&str> = dead_holder_todos(&goal)
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["t1"]);
     }
 }

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -16,6 +16,20 @@ fn rt() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
+/// Spawn a child, kill it, reap it — its pid is now guaranteed dead.
+#[cfg(unix)]
+fn dead_pid() -> u32 {
+    let mut child = std::process::Command::new("sh")
+        .arg("-c")
+        .arg("sleep 30")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    child.kill().unwrap();
+    child.wait().unwrap();
+    pid
+}
+
 fn mock_env(state: MockState) -> (tokio::runtime::Runtime, common::mock_agent::SharedState) {
     let rt = rt();
     let (addr, shared) = rt.block_on(spawn_mock(state));
@@ -599,6 +613,52 @@ fn notify_supervisor_enqueues_to_registered_session_only() {
         assert_eq!(calls[0].1, "enqueue_if_busy");
     });
     std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+/// The dead-worker push: a claimed todo whose holder process is gone is
+/// reported to the registered supervisor via an `infra_stopped` prompt.
+#[cfg(unix)]
+#[test]
+fn notify_dead_holders_pushes_to_registered_supervisor() {
+    let _cr = cli_root();
+    let gid = init_goal(&_cr, "dead worker push");
+    cli_ok(&[
+        "supervisor",
+        "register",
+        "--goal",
+        &gid,
+        "--session-id",
+        "sup-sess",
+    ]);
+    let todo_id = first_todo_id(&_cr.root, &gid);
+    let mut store = open_store(&_cr);
+    // Inject a claimed todo whose holder process is gone (SIGKILL without a
+    // release) — the exact state a crashed worker leaves behind.
+    store
+        .append(future_loop::store::Event::TodoClaimed {
+            goal_id: gid.clone(),
+            todo_id: todo_id.clone(),
+            agent_id: "w1".to_string(),
+            lease_expires_at: now_epoch() + 3600,
+            holder_pid: Some(dead_pid()),
+            ts: now_epoch(),
+        })
+        .unwrap();
+
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(MockState::default()));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    rt.block_on(async {
+        future_loop::console::notify_dead_holders(&mut store, &gid)
+            .await
+            .unwrap();
+    });
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+
+    let calls = shared.lock().unwrap().prompt_calls.clone();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "sup-sess");
+    assert_eq!(calls[0].1, "enqueue_if_busy");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes the last gap in the loop's worker→supervisor push channel: a worker
killed by SIGKILL / crash / host failure executes **no code**, so the existing
infra-stop reports (`transport` / `timeout` / `incomplete_budget`) never
fire. The orchestrator only discovers the dead worker on its next `status`
poll.

This change makes the periodic `scheduler tick` — the same trigger that
already lands the `SchedulerTicked` liveness heartbeat — scan for open todos
whose lease holder pid no longer answers `kill -0`, and enqueue an
`infra_stopped:<todo>:host_died:<pid>` report to the registered supervisor
session (`enqueue_if_busy`).

## Changes

- `task_lease.rs`: new pure helper `dead_holder_todos(goal)` — open todos
  with a claimed-by + dead holder pid (a completed/superseded todo with a
  stale orphaned lease is NOT stranded).
- `console.rs`: `scheduler tick` is now async and calls
  `notify_dead_holders` after landing the heartbeat + poll plan. Best-effort:
  no supervisor / no reachable agent / no dead holders is a no-op (the tick
  itself never fails over a lost notification).
- `console_sweep.rs`: integration test asserting the report lands on the
  registered supervisor's session.
- `docs/loop-control-plane.md`: document the dead-worker push.

## Validation

- `make lint-rust` ✅ (workspace fmt + clippy `-D warnings` + desktop)
- `cargo test -p future-loop` ✅ (all suites)

## Companion

Skill doc updated in futuregene/future-skills#22 (merged); submodule pointer
bumped in this branch.