### PR TITLE
fix(loop): stop DataLoss "event stream gap" on thinking-heavy turns

### DIFF
--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -574,10 +574,10 @@ mod tests {
         broadcaster.start_run("run-lag".to_string(), 7);
         let receiver = broadcaster.subscribe();
 
-        // The production broadcast channel holds 256 events. Keeping this
-        // receiver idle while publishing more than that deterministically
-        // produces BroadcastStreamRecvError::Lagged on its first read.
-        for idx in 0..300 {
+        // Keeping this receiver idle while publishing past the ring capacity
+        // deterministically produces BroadcastStreamRecvError::Lagged on its
+        // first read (one more event than the ring holds overflows it).
+        for idx in 0..=(crate::rpc::BROADCAST_RING_CAPACITY as u64) {
             broadcaster.broadcast(SseEvent::new(
                 "text_chunk",
                 serde_json::json!({"text": idx.to_string()}),
@@ -1062,8 +1062,8 @@ mod tests {
             state: grpc_app_state(false),
         };
         // Subscribe with a type filter, then overflow the broadcast channel
-        // (capacity 256) without draining: the next poll yields Lagged,
-        // which must bypass the filter and surface as DataLoss.
+        // without draining: the next poll yields Lagged, which must bypass
+        // the filter and surface as DataLoss.
         let response = service
             .stream_events(tonic::Request::new(proto::StreamRequest {
                 session_id: "default".to_string(),
@@ -1076,7 +1076,7 @@ mod tests {
             let sess = service.state.get_session("default").unwrap();
             let sess = sess.read();
             sess.broadcaster.start_run("run-flood".to_string(), 1);
-            for idx in 0..300 {
+            for idx in 0..=(crate::rpc::BROADCAST_RING_CAPACITY as u64) {
                 sess.broadcaster.broadcast(SseEvent::new(
                     "text_chunk",
                     serde_json::json!({"text": idx.to_string()}),

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, LazyLock};
 
 pub use approval::{ApprovalDecision, ApprovalDecisionStatus, ApprovalGate};
 pub use commands::handle_command_internal;
-pub use protocol::{RpcCommand, RpcResponse, SseBroadcaster, SseEvent};
+pub use protocol::{RpcCommand, RpcResponse, SseBroadcaster, SseEvent, BROADCAST_RING_CAPACITY};
 pub use session::ServerSession;
 
 /// Provider/auth configuration is process-wide Agent state, not chat state.

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -208,6 +208,13 @@ impl RpcResponse {
 /// is effectively disconnected and should reconnect.
 const MAX_RUN_EVENTS: usize = 2_000;
 
+/// Live-subscriber broadcast ring capacity. Sized for high-reasoning model
+/// bursts (measured ~3.4k `thinking_delta` events/sec at xhigh), not the
+/// nominal ~15-30 events/sec of a normal turn. A receiver falling further
+/// than this behind gets `RecvError::Lagged`, which the gRPC layer surfaces
+/// as a `DataLoss` "event stream gap".
+pub const BROADCAST_RING_CAPACITY: usize = 4_096;
+
 struct RunState {
     run_id: String,
     epoch: i64,
@@ -275,11 +282,8 @@ pub struct SseBroadcaster {
 
 impl SseBroadcaster {
     pub fn new() -> Self {
-        // 256 slots is enough — measured rate is ~15-30 events/sec during
-        // streaming, so 256 slots tolerates ~10s of client lag.  A client
-        // behind by more than 256 events is effectively disconnected and
-        // should resync via `events_since` anyway.
-        let (tx, _) = broadcast::channel(256);
+        // Ring sized for high-reasoning model bursts — see BROADCAST_RING_CAPACITY.
+        let (tx, _) = broadcast::channel(BROADCAST_RING_CAPACITY);
         Self {
             tx,
             run: std::sync::Arc::new(parking_lot::Mutex::new(RunState {

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -488,7 +488,25 @@ async fn consume_run_stream(
     live_log: Option<&std::path::Path>,
     progress: Option<&TurnProgressTracker>,
 ) -> StreamOutcome {
+    use std::io::Write;
     use tokio_stream::StreamExt;
+    // One buffered writer for the whole subscription. The previous code
+    // opened + appended + closed the live-log file once per event; a
+    // thinking-heavy turn emits tens of thousands of deltas, so that path
+    // cost ~50k open/close syscalls and starved the event drain — which then
+    // lagged the agent's bounded broadcast ring and died with `DataLoss`
+    // ("event stream gap"). Reusing a single buffered handle keeps the drain
+    // ahead of the event rate. Best-effort: a failed open degrades to no-tee
+    // (the live log is observational, not load-bearing).
+    let mut live_writer: Option<std::io::BufWriter<std::fs::File>> = live_log
+        .and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()
+        })
+        .map(std::io::BufWriter::new);
     let mut last_idx: i64 = -1;
     while let Some(ev) = stream.next().await {
         let ev = match ev {
@@ -506,7 +524,7 @@ async fn consume_run_stream(
         let Some(data) = parse_data(&ev) else {
             continue;
         };
-        if let Some(path) = live_log {
+        if let Some(writer) = live_writer.as_mut() {
             let wall_ts = crate::state::now_epoch();
             let mut line = serde_json::json!({
                 "type": ev.r#type.as_str(),
@@ -526,14 +544,7 @@ async fn consume_run_stream(
                     line["usage"] = u.clone();
                 }
             }
-            let _ = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(path)
-                .map(|mut f| {
-                    use std::io::Write;
-                    let _ = writeln!(f, "{}", line);
-                });
+            let _ = writeln!(writer, "{}", line);
         }
         // O3: fold tool_start into the progress tracker (write-class
         // starts reset the idle clock; all starts count).
@@ -586,6 +597,9 @@ async fn consume_run_stream(
             }
             _ => {}
         }
+    }
+    if let Some(mut writer) = live_writer {
+        let _ = writer.flush();
     }
     StreamOutcome::Closed
 }


### PR DESCRIPTION
## Problem

`future loop run` workers died mid-turn with `DataLoss` / `"event stream gap"` on long, thinking-heavy turns. The recurrence looked ~every 10 minutes, but there is no 10-minute timer — it's the time a high-reasoning model takes to reach a `thinking_delta` burst that overflows the agent's broadcast ring.

## Root cause (measured)

A DMRG turn on `deepseek-v4-pro @ xhigh` emitted **56,433 events in 26 min**, with a peak of **~3,440 events/sec** (48,584 `thinking_delta` + 7,769 `tool_delta`). Two hot paths couldn't keep up:

1. **loop consumer** (`agent_client.rs::consume_run_stream`) opened + appended + closed the live-log file **once per event** — ~56k open/close syscalls per turn, starving the event drain.
2. **agent broadcast ring** was sized **256** slots on the assumption of "~15–30 events/sec" — a burst overflows it in well under a second of transient lag.

Producer out-paced the consumer → `RecvError::Lagged` → `DataLoss` → loop's fixed 2s reconnect retried into the still-ongoing burst → second `DataLoss` → turn terminated.

## Fix

- **loop**: hold a single `BufWriter<File>` for the whole subscription instead of open/close per event (failed open degrades to no-tee; live log is observational).
- **agent**: raise the ring 256 → 4096 via a named `BROADCAST_RING_CAPACITY` constant (single source of truth); both lag tests now derive their overflow count from it.

## Not changed (deliberate)

- The agent journal's per-event `sync_data` was left alone: it's **not** the bottleneck (the producer out-produced a ~3.4k evt/s consumer, so fsync is sub-ms here), and batching it would weaken the "journal committed before broadcast" crash-safety invariant.

## Verification

- `cargo fmt --check` (loop + agent) — clean
- `cargo clippy --all-targets -p future-loop -p future-agent` — clean
- `cargo test -p future-agent --lib grpc::` — 16 passed
- `cargo test -p future-agent --lib rpc::protocol` — 55 passed
- `cargo test -p future-loop --lib executor` — 7 passed