### PR TITLE
fix(tui): re-anchor cursor after terminal reset (tmux attach desync)

### DIFF
--- a/tui/examples/mock_agent.rs
+++ b/tui/examples/mock_agent.rs
@@ -98,6 +98,10 @@ const REPLY_TEXT: &str =
 struct MockAgent {
     /// Active event subscribers (one channel per stream_events connection).
     subs: Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<StreamEvent>>>>,
+    /// Delay between streamed prompt events (ms). 0 (default) keeps the
+    /// golden-screen timing deterministic; used by the tmux attach repro to
+    /// keep the reply streaming while a client detaches/reattaches.
+    stream_delay_ms: u64,
 }
 
 impl MockAgent {
@@ -120,6 +124,7 @@ impl MockAgent {
     fn schedule_prompt_events(&self, prompt_text: &str) {
         let subs = self.subs.clone();
         let prompt_text = prompt_text.to_string();
+        let stream_delay_ms = self.stream_delay_ms;
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let events = [
@@ -153,6 +158,9 @@ impl MockAgent {
             ];
             let senders: Vec<mpsc::UnboundedSender<StreamEvent>> = subs.lock().unwrap().clone();
             for (idx, (ty, data)) in events.iter().enumerate() {
+                if idx > 0 && stream_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(stream_delay_ms)).await;
+                }
                 let event = StreamEvent {
                     r#type: (*ty).into(),
                     data: data.clone(),
@@ -219,6 +227,7 @@ impl FutureAgent for MockAgent {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut port = 50051u16;
+    let mut stream_delay_ms = 0u64;
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -227,8 +236,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     port = v.parse().unwrap_or(50051);
                 }
             }
+            "--stream-delay-ms" => {
+                if let Some(v) = args.next() {
+                    stream_delay_ms = v.parse().unwrap_or(0);
+                }
+            }
             "--help" | "-h" => {
-                println!("usage: mock_agent --port <port>");
+                println!("usage: mock_agent --port <port> [--stream-delay-ms <ms>]");
                 return Ok(());
             }
             other => {
@@ -241,6 +255,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("127.0.0.1:{port}");
     let agent = MockAgent {
         subs: Arc::new(std::sync::Mutex::new(Vec::new())),
+        stream_delay_ms,
     };
     println!("mock agent listening on {addr}");
     Server::builder()

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1343,7 +1343,14 @@ impl<T: TerminalIo> App<T> {
         if let Some(d) = self.resize_deadline {
             if now >= d {
                 self.resize_deadline = None;
-                self.request_render(false);
+                // A terminal resize is our only reliable in-band signal that
+                // the terminal was externally reset (e.g. a tmux client
+                // attach that changed the pane size). Force a full redraw:
+                // the differential renderer moves the cursor relative to the
+                // last-tracked row, so after an external reset it would
+                // otherwise keep writing to the wrong rows ("A / AB / ABC"
+                // scrolling). A full redraw re-anchors the cursor.
+                self.request_render(true);
             }
         }
 
@@ -1881,6 +1888,21 @@ impl<T: TerminalIo> App<T> {
 
     /// Receives complete sequences from the terminal's StdinBuffer.
     pub fn handle_input(&mut self, data: &str) {
+        // Terminal focus events. A tmux client attach (or window focus
+        // regain) can reset the terminal's cursor position out from under the
+        // differential renderer — its relative cursor moves are keyed to the
+        // last-tracked row, so the next frame would otherwise write each
+        // growing stream line on a fresh row ("A / AB / ABC / ABCD"
+        // scrolling). Focus-in is the standard signal to force a full redraw
+        // and re-anchor the cursor.
+        if data == "\x1b[I" {
+            self.request_render(true);
+            return;
+        }
+        if data == "\x1b[O" {
+            return;
+        }
+
         // Cell size response.
         if self.consume_cell_size_response(data) {
             self.request_render(false);
@@ -4276,6 +4298,130 @@ mod tests {
         app.terminal.writes.borrow().join("")
     }
 
+    // ─── Cursor-tracking terminal (tmux-attach desync repro) ───────────
+
+    /// Track the terminal's cursor *row* by replaying the ANSI the app writes.
+    /// Columns and SGR/OSC are ignored; only row-changing sequences matter
+    /// (LF, CUU/CUD, CUP/home). This mirrors what a real terminal does — and
+    /// what tmux's screen buffer does — so we can simulate an external cursor
+    /// reset (a client attach) and observe the differential renderer diverge.
+    fn track_row(mut row: usize, chunk: &str) -> usize {
+        let bytes = chunk.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\n' => {
+                    row += 1;
+                    i += 1;
+                }
+                b'\r' => i += 1, // CR: no row change
+                0x1b => {
+                    if bytes.get(i + 1) == Some(&b'[') {
+                        let start = i + 2;
+                        let mut j = start;
+                        while j < bytes.len() && !(0x40..=0x7e).contains(&bytes[j]) {
+                            j += 1;
+                        }
+                        if j < bytes.len() {
+                            let params = std::str::from_utf8(&bytes[start..j]).unwrap_or("");
+                            match bytes[j] as char {
+                                'A' => {
+                                    let n: usize = params.parse().unwrap_or(1);
+                                    row = row.saturating_sub(n);
+                                }
+                                'B' => {
+                                    let n: usize = params.parse().unwrap_or(1);
+                                    row += n;
+                                }
+                                'H' | 'f' => {
+                                    if params.is_empty() {
+                                        row = 0;
+                                    } else if let Some((r, _)) = params.split_once(';') {
+                                        row = r.parse::<usize>().unwrap_or(1).saturating_sub(1);
+                                    }
+                                }
+                                _ => {} // J/K/G/m/h/l/... — no row change
+                            }
+                            i = j + 1;
+                            continue;
+                        }
+                    }
+                    // OSC / unknown escape: skip the ESC byte; the rest falls
+                    // through as ordinary (row-neutral) bytes.
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+        }
+        row
+    }
+
+    struct TrackingTerminal {
+        writes: Rc<RefCell<Vec<String>>>,
+        cursor_row: Rc<RefCell<usize>>,
+        cols: u16,
+        rows: u16,
+        on_input: Option<Box<dyn FnMut(String) + Send + 'static>>,
+        on_resize: Option<Box<dyn FnMut() + Send + 'static>>,
+    }
+
+    impl TerminalIo for TrackingTerminal {
+        fn write(&self, data: &str) {
+            self.writes.borrow_mut().push(data.to_string());
+            let mut row = *self.cursor_row.borrow();
+            row = track_row(row, data);
+            *self.cursor_row.borrow_mut() = row;
+        }
+        fn columns(&self) -> u16 {
+            self.cols
+        }
+        fn rows(&self) -> u16 {
+            self.rows
+        }
+        fn hide_cursor(&self) {}
+        fn show_cursor(&self) {}
+        fn start(
+            &mut self,
+            on_input: Box<dyn FnMut(String) + Send + 'static>,
+            on_resize: Box<dyn FnMut() + Send + 'static>,
+        ) -> std::io::Result<()> {
+            self.on_input = Some(on_input);
+            self.on_resize = Some(on_resize);
+            Ok(())
+        }
+        fn stop(&mut self) {}
+        fn drain_input(&mut self, _max_ms: u64, _idle_ms: u64) {}
+        fn set_exit_signal_callback(&mut self, _cb: Option<Box<dyn FnMut() + Send + 'static>>) {}
+    }
+
+    fn make_tracking_app(
+        cols: u16,
+        rows: u16,
+    ) -> (
+        App<TrackingTerminal>,
+        mpsc::UnboundedReceiver<UiCmd>,
+        Rc<RefCell<usize>>,
+    ) {
+        let (op_tx, op_rx) = mpsc::unbounded_channel();
+        let (client, _events, _conn) = GrpcClient::new("127.0.0.1:1");
+        let cursor_row = Rc::new(RefCell::new(0usize));
+        let app = App::new(
+            TrackingTerminal {
+                writes: Rc::new(RefCell::new(Vec::new())),
+                cursor_row: Rc::clone(&cursor_row),
+                cols,
+                rows,
+                on_input: None,
+                on_resize: None,
+            },
+            Arc::new(client),
+            op_tx,
+            &CliOptions::default(),
+            std::env::temp_dir().join("tui-test-settings.json"),
+        );
+        (app, op_rx, cursor_row)
+    }
+
     // ─── Pure helpers ──────────────────────────────────────────────────
 
     #[test]
@@ -4812,6 +4958,108 @@ mod tests {
         app.request_render(true);
         assert!(app.previous_lines.is_empty());
         assert!(app.render_now);
+    }
+
+    #[tokio::test]
+    async fn resize_forces_full_redraw_even_when_size_unchanged() {
+        // A resize (SIGWINCH, e.g. a size-changing tmux client attach) is the
+        // only reliable in-band signal that the terminal was externally reset.
+        // It must force a full redraw (clear screen) so the differential
+        // renderer re-anchors its cursor even when the new size is identical
+        // (spurious SIGWINCH) — otherwise the relative cursor moves would
+        // keep writing growing stream lines onto fresh rows.
+        let (mut app, _rx) = running_app(100, 30);
+        app.do_render();
+        app.terminal.writes.borrow_mut().clear();
+
+        app.request_resize_render();
+        // Make the debounce deadline due, then tick once.
+        app.resize_deadline = Some(Instant::now() - Duration::from_millis(1));
+        app.on_tick();
+
+        let out = render_writes(&app);
+        assert!(
+            out.contains("\x1b[2J"),
+            "resize must force a full redraw with clear, got: {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn focus_in_forces_full_redraw() {
+        // Focus-in (\x1b[I) is the standard signal for "the terminal was just
+        // re-shown" (tmux attach with focus-events on). It must force a full
+        // redraw so a desynced cursor is re-anchored.
+        let (mut app, _rx) = running_app(100, 30);
+        app.do_render();
+        app.terminal.writes.borrow_mut().clear();
+
+        app.handle_input("\x1b[I");
+        app.on_tick(); // request_render(true) set render_now; flush it
+
+        let out = render_writes(&app);
+        assert!(
+            out.contains("\x1b[2J"),
+            "focus-in must force a full redraw with clear, got: {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn focus_out_is_ignored() {
+        // Focus-out (\x1b[O) carries no redraw obligation; it must be swallowed
+        // before key parsing (which would otherwise treat it as an unknown key).
+        let (mut app, _rx) = running_app(100, 30);
+        app.do_render();
+        app.terminal.writes.borrow_mut().clear();
+        app.handle_input("\x1b[O");
+        assert!(!app.render_now);
+        assert!(!app.render_requested);
+    }
+
+    #[tokio::test]
+    async fn attach_desync_scrolls_stream_and_full_redraw_reanchors() {
+        // End-to-end reproduction of the tmux-attach bug: the differential
+        // renderer moves the cursor relative to `hardware_cursor_row`. When a
+        // tmux client attach resets the terminal's real cursor without a
+        // SIGWINCH (same size), the next diff frame writes its growing stream
+        // line on the wrong row — the "A / AB / ABC / ABCD" scrolling symptom.
+        // A forced full redraw (focus-in) must re-anchor the real cursor to the
+        // app's belief.
+        let (mut app, _rx, cursor) = make_tracking_app(100, 10);
+        app.running = true;
+        app.chat
+            .add_message(ChatMessage::new("u".into(), ChatRole::User, "prompt"));
+        app.chat
+            .add_message(ChatMessage::new("a".into(), ChatRole::Assistant, ""));
+        app.do_render();
+        // Sanity: after a clean render, the terminal's real cursor matches the
+        // app's tracked cursor (the escape sequences landed where the app
+        // believed they would).
+        assert_eq!(*cursor.borrow(), app.hardware_cursor_row);
+
+        // External reset (attach): the terminal's real cursor moves without the
+        // app observing it.
+        *cursor.borrow_mut() = 0;
+
+        // Stream a delta through the differential renderer.
+        app.chat.append_to_last_message("hello");
+        app.do_render();
+        // The relative move was applied from the wrong base row, so the real
+        // cursor no longer matches the app's belief.
+        assert_ne!(
+            *cursor.borrow(),
+            app.hardware_cursor_row,
+            "an externally-reset cursor must desync the differential renderer"
+        );
+
+        // The fix: a focus-in (tmux attach with focus-events on) forces a full
+        // redraw, re-anchoring the real cursor to the app's belief.
+        app.handle_input("\x1b[I");
+        app.on_tick();
+        assert_eq!(
+            *cursor.borrow(),
+            app.hardware_cursor_row,
+            "a full redraw must re-anchor the real cursor"
+        );
     }
 
     #[tokio::test]

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -429,6 +429,11 @@ type InputListener = Box<dyn FnMut(&str) -> Option<InputListenerResult> + 'stati
 
 const MIN_RENDER_INTERVAL: Duration = Duration::from_millis(33);
 const RESIZE_DEBOUNCE: Duration = Duration::from_millis(150);
+/// Cadence for the DSR cursor-position recheck while streaming. A tmux
+/// client attach can reset the terminal's cursor without any signal when the
+/// pane size is unchanged and focus-events are off; periodically re-reading
+/// the real cursor position is the last-resort net that catches that case.
+const CURSOR_RECHECK_INTERVAL: Duration = Duration::from_millis(1000);
 const SEGMENT_RESET: &str = "\x1b[0m\x1b]8;;\x07"; // SGR reset + OSC 8 close
 
 /// `crypto.randomUUID()`.
@@ -569,6 +574,8 @@ pub struct App<T: TerminalIo> {
     resize_deadline: Option<Instant>,
     ac_query_deadline: Option<Instant>,
     pending_ac_query: Option<(String, usize)>,
+    cursor_recheck_at: Instant,
+    cursor_recheck_row: Option<usize>,
     timers: Vec<(Instant, TimerId)>,
     previous_width: usize,
     previous_height: usize,
@@ -656,6 +663,8 @@ impl<T: TerminalIo> App<T> {
             resize_deadline: None,
             ac_query_deadline: None,
             pending_ac_query: None,
+            cursor_recheck_at: Instant::now(),
+            cursor_recheck_row: None,
             timers: Vec::new(),
             previous_width: 0,
             previous_height: 0,
@@ -1363,6 +1372,15 @@ impl<T: TerminalIo> App<T> {
             }
         }
 
+        // While streaming, periodically re-read the terminal's real cursor
+        // position (DSR \x1b[6n). If it diverged from our tracked row — a
+        // tmux client attach that reset the cursor with no SIGWINCH and no
+        // focus event — the response forces a full redraw to re-anchor.
+        if self.state.streaming && now >= self.cursor_recheck_at {
+            self.cursor_recheck_at = now + CURSOR_RECHECK_INTERVAL;
+            self.query_cursor_position();
+        }
+
         let mut due = Vec::new();
         self.timers.retain(|(at, id)| {
             if *at <= now {
@@ -1906,6 +1924,11 @@ impl<T: TerminalIo> App<T> {
         // Cell size response.
         if self.consume_cell_size_response(data) {
             self.request_render(false);
+            return;
+        }
+
+        // DSR cursor-position response (polling net for cursor desync).
+        if self.consume_cursor_position_response(data) {
             return;
         }
 
@@ -3704,6 +3727,40 @@ impl<T: TerminalIo> App<T> {
         self.terminal.write("\x1b[16t");
     }
 
+    /// Ask the terminal for its real cursor position (DSR / CPR). The
+    /// expected row is snapshotted now: the terminal answers with the cursor
+    /// position at the moment it processes this query (before any render that
+    /// runs later in the same tick), so we must compare the answer against
+    /// the row we tracked when the query was issued — not the row after any
+    /// intervening render moved the cursor.
+    fn query_cursor_position(&mut self) {
+        self.cursor_recheck_row = Some(self.hardware_cursor_row);
+        self.terminal.write("\x1b[6n");
+    }
+
+    /// Parse a DSR cursor-position report (`\x1b[{row};{col}R`, 1-based) and
+    /// force a full redraw if the terminal's real row diverged from the row
+    /// snapshotted when the query was sent. This is the polling net for a
+    /// tmux attach that reset the cursor without a SIGWINCH or focus event.
+    fn consume_cursor_position_response(&mut self, data: &str) -> bool {
+        static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let re = RE.get_or_init(|| Regex::new(r"^\x1b\[(\d+);(\d+)R$").unwrap());
+        let Some(caps) = re.captures(data) else {
+            return false;
+        };
+        let reported_row = caps[1].parse::<usize>().unwrap_or(0);
+        if reported_row == 0 {
+            return true; // malformed row — consume, don't act
+        }
+        let real_row = reported_row - 1; // DSR is 1-based; we track 0-based
+        if let Some(expected) = self.cursor_recheck_row.take() {
+            if real_row != expected {
+                self.request_render(true);
+            }
+        }
+        true
+    }
+
     fn consume_cell_size_response(&mut self, data: &str) -> bool {
         static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
         let re = RE.get_or_init(|| Regex::new(r"^\x1b\[6;(\d+);(\d+)t$").unwrap());
@@ -5013,6 +5070,86 @@ mod tests {
         app.handle_input("\x1b[O");
         assert!(!app.render_now);
         assert!(!app.render_requested);
+    }
+
+    #[tokio::test]
+    async fn cursor_position_report_forces_redraw_on_divergence() {
+        // DSR is the polling net for an attach that reset the cursor with no
+        // SIGWINCH and no focus event. A report that matches the row
+        // snapshotted at query time is consumed silently; a diverged row
+        // forces a full redraw.
+        let (mut app, _rx) = running_app(100, 10);
+        app.do_render();
+        let synced_row = app.hardware_cursor_row;
+        app.terminal.writes.borrow_mut().clear();
+
+        // In sync: query snapshots the expected row, the matching report is
+        // consumed without forcing a redraw.
+        app.query_cursor_position();
+        app.handle_input(&format!("\x1b[{};1R", synced_row + 1));
+        assert!(!app.render_now);
+        assert!(!app.previous_lines.is_empty());
+
+        // Diverged (external reset): the report forces a full redraw.
+        app.query_cursor_position();
+        app.handle_input(&format!("\x1b[{};1R", synced_row + 2));
+        assert!(app.render_now);
+        assert!(app.previous_lines.is_empty());
+
+        // A stray report with no pending query is consumed without acting.
+        app.render_now = false;
+        app.render_requested = false;
+        app.handle_input("\x1b[0;1R"); // malformed row too
+        assert!(!app.render_now);
+    }
+
+    #[tokio::test]
+    async fn cursor_report_compares_against_query_snapshot_not_current_row() {
+        // The terminal answers the DSR query with the cursor position at the
+        // moment it processes the query. A render can run between issuing the
+        // query and receiving the answer, moving the cursor; comparing the
+        // answer against the *current* row would be a false positive and
+        // cause a spurious full redraw every time content grows during
+        // streaming. The query-time snapshot must be the comparison basis.
+        let (mut app, _rx) = running_app(100, 10);
+        app.do_render();
+        let snapshot_row = app.hardware_cursor_row;
+        app.query_cursor_position(); // snapshot = snapshot_row
+
+        // A render then grows the content and moves the cursor.
+        app.chat
+            .add_message(ChatMessage::new("x".into(), ChatRole::User, "more"));
+        app.do_render();
+        assert_ne!(app.hardware_cursor_row, snapshot_row);
+
+        // The answer matches the query-time snapshot → silent no-op.
+        app.handle_input(&format!("\x1b[{};1R", snapshot_row + 1));
+        assert!(!app.render_now);
+    }
+
+    #[tokio::test]
+    async fn streaming_tick_rechecks_cursor_position() {
+        // While streaming, on_tick issues a DSR cursor query once per
+        // CURSOR_RECHECK_INTERVAL and then waits until the next window.
+        let (mut app, _rx) = running_app(100, 10);
+        app.do_render();
+        app.terminal.writes.borrow_mut().clear();
+        app.state.streaming = true;
+        app.cursor_recheck_at = Instant::now() - Duration::from_millis(1);
+        app.on_tick();
+        assert!(render_writes(&app).contains("\x1b[6n"));
+
+        // Not queried again immediately (deadline pushed forward).
+        app.terminal.writes.borrow_mut().clear();
+        app.on_tick();
+        assert!(!render_writes(&app).contains("\x1b[6n"));
+
+        // Not queried when not streaming, even past the deadline.
+        app.state.streaming = false;
+        app.cursor_recheck_at = Instant::now() - Duration::from_millis(1);
+        app.terminal.writes.borrow_mut().clear();
+        app.on_tick();
+        assert!(!render_writes(&app).contains("\x1b[6n"));
     }
 
     #[tokio::test]

--- a/tui/src/terminal.rs
+++ b/tui/src/terminal.rs
@@ -195,10 +195,12 @@ impl Terminal {
         self.backend.enable_raw()?;
         self.raw_enabled = true;
 
-        // Enter the alternate screen, enable bracketed paste, refresh size.
-        // On failure, restore the terminal before returning.
+        // Enter the alternate screen, enable bracketed paste + focus
+        // reporting, refresh size. On failure, restore the terminal before
+        // returning.
         write_str(&self.write_lock, "\x1b[?1049h");
         write_str(&self.write_lock, "\x1b[?2004h");
+        write_str(&self.write_lock, "\x1b[?1004h");
         self.refresh_size();
 
         self.stop_flag.store(false, Ordering::SeqCst);
@@ -391,8 +393,9 @@ impl Terminal {
             write_str(&self.write_lock, TERMINAL_PROGRESS_CLEAR_SEQUENCE);
         }
 
-        // Disable bracketed paste mode.
+        // Disable bracketed paste mode and focus reporting.
         write_str(&self.write_lock, "\x1b[?2004l");
+        write_str(&self.write_lock, "\x1b[?1004l");
 
         // Disable Kitty keyboard protocol.
         if self.kitty_active.load(Ordering::SeqCst) {
@@ -582,6 +585,7 @@ fn restore_terminal_for_exit(
 ) {
     write_str(write_lock, "\x1b[?25h");
     write_str(write_lock, "\x1b[?2004l");
+    write_str(write_lock, "\x1b[?1004l");
     if kitty_active.load(Ordering::SeqCst) {
         write_str(write_lock, "\x1b[<u");
         kitty_active.store(false, Ordering::SeqCst);


### PR DESCRIPTION
## Problem

Under tmux, after an SSH session re-attaches, the TUI sometimes shows a streamed reply scrolling as `A / AB / ABC / ABCD` — the growing line lands on a new row every frame instead of updating in place.

## Root cause

The differential renderer (`tui/src/app.rs::do_render`) moves the cursor with relative escape codes (`\x1b[nA` / `\x1b[nB`) keyed to an internal `hardware_cursor_row`. It only full-redraws on an actual width/height change, so an attach that resets the terminal's real cursor **without** a SIGWINCH (same pane size) and without focus-events leaves the two permanently out of sync. Every subsequent diff frame then writes the growing stream line on a fresh row.

## Fix

Force a full redraw (which re-anchors the cursor) on every reliable in-band signal, plus a polling net for the signal-less case:

1. **Resize** (`SIGWINCH`): the debounced resize handler now calls `request_render(true)` instead of `request_render(false)` — even a spurious/same-size resize clears the diff baseline.
2. **Focus events**: enable xterm focus reporting (`\x1b[?1004h`, disabled on stop/exit) and force a full redraw on focus-in (`\x1b[I`); focus-out (`\x1b[O`) is swallowed.
3. **DSR cursor recheck** (signal-less attach): while streaming, re-read the terminal's real cursor row via `\x1b[6n` once per second and force a full redraw on divergence. The comparison uses the row snapshotted *at query time*, not the current tracked row — the terminal answers with the position at the moment it processes the query, and a render may run in between, so comparing against the current row would cause a spurious full redraw whenever content grows.

Also adds `--stream-delay-ms` to the mock agent so a reply can be kept streaming across a detach/attach for future tmux-based repros.

## Tests

- `resize_forces_full_redraw_even_when_size_unchanged`
- `focus_in_forces_full_redraw`, `focus_out_is_ignored`
- `cursor_position_report_forces_redraw_on_divergence`
- `cursor_report_compares_against_query_snapshot_not_current_row` (guards the false-positive race)
- `streaming_tick_rechecks_cursor_position`
- `attach_desync_scrolls_stream_and_full_redraw_reanchors` (cursor-tracking terminal end-to-end repro)

## Verification

- `make lint-rust` — CI's Rust fmt + clippy (workspace + desktop/src-tauri, `--all-targets`, `-D warnings`): clean
- `make test-tui` — 817 lib + integration + doc tests: pass
- `make test-desktop-rust` — 1020 + 1 pass
- Live tmux probe confirms `\x1b[6n` fires while streaming and the final screen renders coherently

Note: the tmux golden-screen test still reports the pre-existing `ctrl+o expand/collapse` drift (from #128; goldens are pinned at #114) — unrelated to this change, and this change introduces no new golden drift.