### PR TITLE
test(loop): clear webui per-line coverage gaps to 7 waived lines (W2)

### DIFF
--- a/orchestration/loop/Cargo.toml
+++ b/orchestration/loop/Cargo.toml
@@ -21,7 +21,8 @@ path = "src/main.rs"
 # e.g. the unified `future` CLI) does NOT need protoc.
 future-rpc = { path = "../../packages/rpc" }
 tonic.workspace = true
-tokio.workspace = true
+# test-util: paused time (tokio::time::advance) for the webui server/SSE tests.
+tokio = { workspace = true, features = ["test-util"] }
 tokio-stream.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -1180,4 +1180,151 @@ mod tests {
         let ov = overview(&store).unwrap();
         assert_eq!(ov.totals.goals, 0);
     }
+
+    #[test]
+    fn spend_view_cutoff_boundaries_cover_old_runs() {
+        let (store, _dir, gid) = open_store_with_goal();
+        // A run older than the 7-day window folds into `total` only; the
+        // `recorded_at >= cutoff_7d` false branch (the `}` on the if) is the
+        // otherwise-unreachable skip edge when every run is fresh.
+        let old = now_epoch().saturating_sub(8 * 24 * 3600);
+        store
+            .append_run(&gid, &rec("T1", "old-run", old, FailureKind::None, 0.1))
+            .unwrap();
+        let detail = goal_detail(&store, &gid).unwrap().unwrap();
+        assert_eq!(detail.spend.total.runs, 5);
+        assert_eq!(detail.spend.runs_7d.runs, 4);
+        assert_eq!(detail.spend.runs_24h.runs, 4);
+        // The old run is excluded from the 7d outcomes split.
+        assert_eq!(detail.spend.outcomes_7d.succeeded, 1);
+    }
+
+    #[test]
+    fn overview_ranks_and_totals_across_goal_states() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Store::open(&dir.path().to_string_lossy()).unwrap();
+
+        fn register(store: &mut Store, goal: &Goal, todos: Vec<Todo>) {
+            let ts = goal.created_at;
+            store.register(goal).unwrap();
+            store
+                .append(crate::store::Event::GoalStarted {
+                    goal_id: goal.goal_id.clone(),
+                    ts,
+                })
+                .unwrap();
+            for t in todos {
+                store
+                    .append(crate::store::Event::TodoAdded {
+                        goal_id: goal.goal_id.clone(),
+                        todo: t,
+                        ts,
+                    })
+                    .unwrap();
+            }
+        }
+
+        // 1. Cancelled → rank 3 + totals.cancelled.
+        let cancelled = Goal::new("g_cancel", "cancelled obj", "/tmp");
+        register(&mut store, &cancelled, vec![]);
+        store
+            .append(crate::store::Event::GoalCancelled {
+                goal_id: "g_cancel".into(),
+                reason: "test".into(),
+                ts: cancelled.created_at,
+            })
+            .unwrap();
+
+        // 2. Terminal (single validated-complete todo) → rank 3 + totals.terminal.
+        let mut terminal = Goal::new("g_term", "terminal obj", "/tmp");
+        let mut done = Todo::advancement("T1", "done");
+        done.complete(true, vec![]);
+        terminal.add(done.clone());
+        register(&mut store, &terminal, vec![done]);
+
+        // 3. Open user gate → rank 0.
+        let mut gate = Goal::new("g_gate", "gate obj", "/tmp");
+        let g = Todo::user_gate("G1", "approve?", &["T3"]);
+        gate.add(g.clone());
+        register(&mut store, &gate, vec![g]);
+
+        // 4. Liveness breach without a gate → severity "high" → rank 1.
+        let mut live = Goal::new("g_live", "live obj", "/tmp");
+        let open = Todo::advancement("T1", "work");
+        live.add(open.clone());
+        register(&mut store, &live, vec![open]);
+        store
+            .append(crate::store::Event::AutomationLivenessAlert {
+                goal_id: "g_live".into(),
+                agent_id: "stuck".into(),
+                elapsed_secs: 100,
+                threshold_secs: 60,
+                consecutive: 1,
+                ts: 200,
+            })
+            .unwrap();
+
+        // 5. Plain open advancement → severity "action" → rank 2.
+        let mut plain = Goal::new("g_plain", "plain obj", "/tmp");
+        let t = Todo::advancement("T1", "work");
+        plain.add(t.clone());
+        register(&mut store, &plain, vec![t]);
+
+        let ov = overview(&store).unwrap();
+        assert_eq!(ov.totals.goals, 5);
+        assert_eq!(ov.totals.cancelled, 1);
+        assert_eq!(ov.totals.terminal, 1);
+        assert_eq!(ov.totals.active, 3);
+
+        // Triage rank: gate(0) < high(1) < action(2) < terminal/cancelled(3).
+        assert_eq!(ov.goals[0].goal_id, "g_gate");
+        assert_eq!(ov.goals[1].goal_id, "g_live");
+        assert_eq!(ov.goals[2].goal_id, "g_plain");
+        let tail: Vec<&str> = ov.goals[3..].iter().map(|c| c.goal_id.as_str()).collect();
+        assert!(tail.contains(&"g_term") && tail.contains(&"g_cancel"));
+    }
+
+    #[test]
+    fn scan_active_runs_edge_case_lines() {
+        let root = tempfile::tempdir().unwrap();
+        let p = root.path();
+        let runs = p.join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+
+        // A directory with a `.live.jsonl` name → read_to_string fails (649).
+        std::fs::create_dir(runs.join("dir.live.jsonl")).unwrap();
+
+        // Valid JSON but no `type` field → skipped (667).
+        std::fs::write(runs.join("notype.live.jsonl"), b"{\"foo\":1}\n").unwrap();
+
+        // Header without `wall_ts` → the wall_ts if-let else branch (674).
+        std::fs::write(
+            runs.join("nowallts.live.jsonl"),
+            b"{\"type\":\"run_header\",\"goal_id\":\"g1\",\"run_id\":\"r1\"}\n",
+        )
+        .unwrap();
+
+        // `usage` line without a `usage` object (708) + unknown type arm (713).
+        std::fs::write(
+            runs.join("misc.live.jsonl"),
+            concat!(
+                "{\"type\":\"run_header\",\"goal_id\":\"g1\",\"run_id\":\"r2\",\"wall_ts\":1}\n",
+                "{\"type\":\"usage\",\"wall_ts\":2}\n",
+                "{\"type\":\"mystery\",\"wall_ts\":3}\n",
+            ),
+        )
+        .unwrap();
+
+        let views = scan_active_runs(p.to_str().unwrap(), "g1");
+        let ids: Vec<&str> = views.iter().map(|v| v.run_id.as_str()).collect();
+        assert!(ids.contains(&"r1"));
+        assert!(ids.contains(&"r2"));
+        assert!(!ids.contains(&"notype") && !ids.contains(&"dir"));
+
+        // The no-wall_ts run is inactive with no timestamps.
+        let r1 = views.iter().find(|v| v.run_id == "r1").unwrap();
+        assert!(!r1.active);
+        assert_eq!(r1.started_at, None);
+        assert_eq!(r1.last_activity_at, None);
+    }
 }

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -608,4 +608,291 @@ mod tests {
         assert!(String::from_utf8_lossy(&buf).contains("405"));
         let _ = server.await;
     }
+
+    #[tokio::test]
+    async fn handle_peer_closed_before_request_is_ok() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, _rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        client.write_all(b"GET /partial").await.unwrap();
+        drop(client);
+        let (stream, _) = listener.accept().await.unwrap();
+        let rx = tx.subscribe();
+        handle(stream, Arc::new(root), rx).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_request_rejects_oversized_headers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let write_task = tokio::spawn(async move {
+            let big = vec![b'a'; MAX_HEADER_BYTES + 8192];
+            let _ = client.write_all(&big).await;
+        });
+        assert!(read_request(&mut stream).await.is_err());
+        let _ = write_task.await;
+    }
+
+    #[test]
+    fn route_runs_events_missing_goal_404_and_corrupt_ledger_500() {
+        let (root, _dir) = store_root();
+        // Missing goal → 404 on the runs/events sub-routes.
+        let runs404 = route(
+            &Request {
+                method: "GET".into(),
+                path: "/api/goals/nope/runs".into(),
+                query: String::new(),
+            },
+            &root,
+        );
+        assert!(String::from_utf8_lossy(&runs404).contains("404 Not Found"));
+        let events404 = route(
+            &Request {
+                method: "GET".into(),
+                path: "/api/goals/nope/events".into(),
+                query: String::new(),
+            },
+            &root,
+        );
+        assert!(String::from_utf8_lossy(&events404).contains("404 Not Found"));
+
+        // Corrupt g1's ledger → replay fails → 500 for detail and runs.
+        let store = Store::open(&root).unwrap();
+        std::fs::write(store.goal_dir("g1").join("events.jsonl"), "not-json\n").unwrap();
+        let detail = route(
+            &Request {
+                method: "GET".into(),
+                path: "/api/goals/g1".into(),
+                query: String::new(),
+            },
+            &root,
+        );
+        assert!(String::from_utf8_lossy(&detail).contains("500"));
+        let runs500 = route(
+            &Request {
+                method: "GET".into(),
+                path: "/api/goals/g1/runs".into(),
+                query: String::new(),
+            },
+            &root,
+        );
+        assert!(String::from_utf8_lossy(&runs500).contains("500"));
+    }
+
+    #[tokio::test]
+    async fn send_snapshot_writes_a_frame() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
+        send_snapshot(&mut stream, &root).await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        let text = String::from_utf8_lossy(&buf);
+        assert!(text.contains("event: overview"));
+        assert!(text.contains("event: goals"));
+    }
+
+    #[tokio::test]
+    async fn serve_sse_writes_head_snapshot_and_exits_when_gone() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(tx); // broadcaster gone → serve_sse exits after the initial snapshot.
+        let server = tokio::spawn(async move { serve_sse(stream, Arc::new(root), rx).await });
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        let text = String::from_utf8_lossy(&buf);
+        assert!(text.contains("text/event-stream"));
+        assert!(text.contains("event: overview"));
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn serve_sse_pushes_on_broadcaster_change() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let server = tokio::spawn(async move { serve_sse(stream, Arc::new(root), rx).await });
+        // A broadcaster push triggers the changed() arm; dropping the sender
+        // afterwards lets serve_sse exit on the gone arm.
+        let _ = tx.send("changed-fp".to_string());
+        drop(tx);
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        assert!(String::from_utf8_lossy(&buf).contains("event: overview"));
+        let _ = server.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn serve_sse_sends_ping_on_timeout() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let server = tokio::spawn(async move { serve_sse(stream, Arc::new(root), rx).await });
+        // Let serve_sse write the head + initial snapshot and register its
+        // 15s heartbeat timeout before advancing the paused clock.
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        // Advance past the 15s heartbeat timeout → serve_sse wakes and writes
+        // the ping comment.
+        tokio::time::advance(std::time::Duration::from_secs(16)).await;
+        // Let serve_sse observe the elapsed timeout and write the ping BEFORE
+        // dropping the sender (otherwise rx.changed() sees the drop first and
+        // exits on the gone arm without writing a ping).
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        drop(tx);
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        assert!(String::from_utf8_lossy(&buf).contains(": ping"));
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn run_server_bind_failure_returns_err() {
+        let (root, _dir) = store_root();
+        // Hold a port, then ask run_server to bind the same one → bind fails.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(run_server(root, port, false).await.is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_server_serves_and_broadcaster_ticks() {
+        let (root, _dir) = store_root();
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let server_root = root.clone();
+        let handle = tokio::spawn(async move { run_server(server_root, port, false).await });
+
+        // Poll until the server has bound and is accepting.
+        let mut client = None;
+        for _ in 0..500 {
+            if let Ok(c) = tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+                client = Some(c);
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let mut client = client.expect("server binds and accepts");
+        client
+            .write_all(b"GET /api/overview HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        assert!(String::from_utf8_lossy(&buf).contains("200 OK"));
+
+        // First broadcaster tick: computes the initial fingerprint.
+        tokio::time::advance(std::time::Duration::from_millis(1300)).await;
+        // Append a todo → the projection changes → the next tick's fingerprint
+        // differs and the broadcaster pushes (tx.send path).
+        let mut store = Store::open(&root).unwrap();
+        store
+            .append(crate::store::Event::TodoAdded {
+                goal_id: "g1".into(),
+                todo: crate::state::Todo::advancement("T2", "more work"),
+                ts: crate::state::now_epoch(),
+            })
+            .unwrap();
+        tokio::time::advance(std::time::Duration::from_millis(1300)).await;
+        // Corrupt the store root so the next tick hits the open-failure retry.
+        std::fs::remove_dir_all(&root).unwrap();
+        std::fs::write(&root, b"x").unwrap();
+        tokio::time::advance(std::time::Duration::from_millis(1300)).await;
+
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn handle_routes_to_sse_stream() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET /api/stream HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(tx); // broadcaster gone → serve_sse exits after the initial snapshot.
+        let server = tokio::spawn(async move { handle(stream, Arc::new(root), rx).await });
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        let text = String::from_utf8_lossy(&buf);
+        assert!(text.contains("text/event-stream"));
+        assert!(text.contains("event: overview"));
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn serve_sse_returns_when_initial_snapshot_fails() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(tx);
+        // Invalid root → the initial send_snapshot's Store::open fails.
+        let server = tokio::spawn(async move {
+            serve_sse(stream, Arc::new("/nonexistent/not/a/store".to_string()), rx).await
+        });
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).await.unwrap();
+        // The SSE head is still written before the snapshot attempt.
+        assert!(String::from_utf8_lossy(&buf).contains("text/event-stream"));
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn serve_sse_returns_when_change_snapshot_fails() {
+        let (root, _dir) = store_root();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = watch::channel(String::new());
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let root_arc = Arc::new(root.clone());
+        let server = tokio::spawn(async move { serve_sse(stream, root_arc, rx).await });
+
+        // Synchronize: read the SSE head, then yield until the initial
+        // snapshot has been written (Store::open succeeded on the valid root).
+        let mut head = [0u8; 100];
+        client.read_exact(&mut head).await.unwrap();
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        // Invalidate the store (turn the root into a FILE so Store::open's
+        // create_dir_all fails), then push a change: the changed() arm
+        // re-snapshots and Store::open fails → serve_sse returns.
+        std::fs::remove_dir_all(&root).unwrap();
+        std::fs::write(&root, b"x").unwrap();
+        let _ = tx.send("changed".to_string());
+        drop(tx);
+        let mut buf = head.to_vec();
+        client.read_to_end(&mut buf).await.unwrap();
+        let _ = server.await;
+    }
 }


### PR DESCRIPTION
## Summary

W2 loop webui 清零（todo_6fdf75b308c1）：把 `webui/api.rs` + `webui/server.rs` 的 per-line 覆盖从 **87 DA:0 → 7 DA:0**（口径 A：lcov DA:0）。

- **api.rs**: 19 → 0 — 补 spend_view 截止边界（旧 run）、overview 多 goal 状态 rank/totals（cancelled/terminal/gate/liveness/action）、scan_active_runs 边角（read 失败/no-type/no-wall_ts/usage 无对象/未知 type）。
- **server.rs**: 74 → 7 — `run_server`（bind 失败 + broadcaster tick + fingerprint 变更 + store 删除 open-failure retry，用 start_paused+advance）、handle SSE 路由、read_request 超大头、peer-closed、send_snapshot、serve_sse 初始/change/gone/timeout-ping 四臂、route runs/events 404 + 损坏 ledger 500。
- **Cargo.toml**: 启用 tokio `test-util`（paused time）用于 SSE 心跳测试。

## 剩余 7 行（正式豁免，见 coverage/acceptance-waivers.md §11 ①）

| 行 | 内容 | 类 |
|---|---|---|
| 88, 102-104 | `open_browser` 打开浏览器（macOS `open` spawn） | W7 OS side effect |
| 279 | `/api/overview` Err 臂（`api::overview` 永不返 Err） | W5 死臂 |
| 311 | `/api/goals/{id}/events` Err 臂（`raw_ledger_lines` 恒 Ok） | W5 死臂 |
| 354 | `serve_sse` ping 写失败臂 | W3 注入 |

## 验证

- `cargo test -p future-loop` 全绿（含 35 个 webui 测试）。
- `cargo llvm-cov -p future-loop --lcov`：webui DA:0 = 7（全在 server.rs，已豁免）。
- `cargo fmt` / `cargo clippy -p future-loop --all-targets` 净。
