### PR TITLE
test(loop,tui): recover orphaned console.rs + tui cursor_report coverage (W1/W9)

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -7836,6 +7836,66 @@ mod coverage_tests {
                 consecutive: 1,
                 ts: 1,
             },
+            Event::TurnNoProgress {
+                goal_id: "g".into(),
+                todo_id: todo_id.into(),
+                agent_id: Some("a".into()),
+                idle_secs: 60,
+                tool_calls_total: 3,
+                ts: 1,
+            },
+            Event::MultiAgentContractSet {
+                goal_id: "g".into(),
+                contract: crate::agents::multi_agent::MultiAgentContract {
+                    schema_version: crate::agents::multi_agent::MULTI_AGENT_CONTRACT_SCHEMA_VERSION
+                        .to_string(),
+                    peers: [(
+                        "p".to_string(),
+                        crate::agents::multi_agent::PeerRole {
+                            backup_for: None,
+                            capabilities: vec![],
+                            workspaces: vec![],
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                    handoff_rules: vec![],
+                    collectives: Default::default(),
+                },
+                ts: 1,
+            },
+            Event::AgentRecipeAdded {
+                goal_id: "g".into(),
+                recipe: crate::agents::multi_agent::AgentRecipe {
+                    schema_version: crate::agents::multi_agent::MULTI_AGENT_RECIPE_SCHEMA_VERSION
+                        .to_string(),
+                    name: "r".into(),
+                    capabilities: vec!["shell".into()],
+                    workspaces: vec![],
+                    priority: crate::state::Priority::P1,
+                },
+                ts: 1,
+            },
+            Event::SuccessionOccurred {
+                goal_id: "g".into(),
+                primary: "p".into(),
+                backup: "b".into(),
+                reason: "offline".into(),
+                ts: 1,
+            },
+            Event::ReplanRuleSetUpdated {
+                goal_id: "g".into(),
+                rule_set_version:
+                    crate::decision::goal_frontier::replan_rules::DEFAULT_REPLAN_RULE_SET_VERSION
+                        .to_string(),
+                rule_ids: vec!["r1".into()],
+                ts: 1,
+            },
+            Event::WorkerStopped {
+                goal_id: "g".into(),
+                agent_id: Some("a".into()),
+                ts: 1,
+            },
         ]
     }
 
@@ -8286,6 +8346,15 @@ mod cli_quirks_tests {
         let registry = build_cli_registry();
         let help = render_command_help(&registry, "nope-not-a-command", false);
         assert!(help.contains("unknown command"), "got: {help}");
+    }
+
+    #[test]
+    fn render_command_help_marks_experimental_commands() {
+        let mut registry = CommandRegistry::new();
+        let ops = registry.group("ops", "operations");
+        registry.command_experimental(ops, "doctor-x", "experimental probe", "doctor-x --goal G");
+        let help = render_command_help(&registry, "doctor-x", true);
+        assert!(help.contains("(experimental)"), "got: {help}");
     }
 
     #[test]
@@ -8956,6 +9025,44 @@ mod read_model_repair_cli_tests {
         let text = describe_event(&targeted);
         assert!(text.contains("worker-a"), "got: {text}");
     }
+
+    #[test]
+    fn describe_event_renders_anonymous_agent_fallbacks() {
+        let stopped = describe_event(&Event::WorkerStopped {
+            goal_id: "g1".to_string(),
+            agent_id: None,
+            ts: 1,
+        });
+        assert!(
+            stopped.contains("worker_stopped agent=broadcast"),
+            "got: {stopped}"
+        );
+
+        let no_progress = describe_event(&Event::TurnNoProgress {
+            goal_id: "g1".to_string(),
+            todo_id: "t1".to_string(),
+            agent_id: None,
+            idle_secs: 900,
+            tool_calls_total: 0,
+            ts: 1,
+        });
+        assert!(
+            no_progress.contains("agent=anonymous"),
+            "got: {no_progress}"
+        );
+
+        let heartbeat = describe_event(&Event::HeartbeatReceiptRecorded {
+            goal_id: "g1".to_string(),
+            agent_id: None,
+            turn_instance_id: "ti".to_string(),
+            todo_id: None,
+            decision: "run".to_string(),
+            reason_code: String::new(),
+            ts: 1,
+        });
+        assert!(heartbeat.contains("agent=anonymous"), "got: {heartbeat}");
+        assert!(heartbeat.contains("todo=-"), "got: {heartbeat}");
+    }
 }
 #[cfg(test)]
 mod event_touch_filter_tests {
@@ -9392,5 +9499,56 @@ mod todo_verify_hint_tests {
         let (stopped_m, off_m) = super::worker_stop_requested(&missing, 7, Some("worker-a"));
         assert!(!stopped_m);
         assert_eq!(off_m, 7);
+    }
+
+    #[test]
+    fn worker_stop_requested_read_error_and_foreign_agent_arms() {
+        let dir = tempfile::tempdir().unwrap();
+        let events = dir.path().join("events.jsonl");
+
+        // Non-UTF8 content → read_to_string fails → no stop, offset unchanged.
+        std::fs::write(&events, [0xffu8, 0xfe, 0xfd]).unwrap();
+        let (stopped, off) = super::worker_stop_requested(&events, 0, Some("worker-a"));
+        assert!(!stopped);
+        assert_eq!(off, 0);
+
+        // A non-JSON line is skipped; a stop targeting a NAMED worker is
+        // ignored by an anonymous caller (agent_id None).
+        std::fs::write(
+            &events,
+            "{broken\n{\"kind\":\"worker_stopped\",\"agent_id\":\"worker-a\",\"ts\":1}\n",
+        )
+        .unwrap();
+        let (stopped_anon, _) = super::worker_stop_requested(&events, 0, None);
+        assert!(!stopped_anon, "anonymous caller ignores targeted stops");
+    }
+
+    #[test]
+    fn scan_worker_sessions_skips_bad_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let runs = dir.path().join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+
+        // Path filter: a non-`.live.jsonl` file and a directory are skipped.
+        std::fs::write(runs.join("notes.txt"), "not a run\n").unwrap();
+        std::fs::create_dir_all(runs.join("subdir")).unwrap();
+        // Non-UTF8 content → read_to_string fails → skipped.
+        std::fs::write(runs.join("bad.live.jsonl"), [0xffu8, 0xfe, 0xfd]).unwrap();
+        // Empty file → no first line → skipped.
+        std::fs::write(runs.join("empty.live.jsonl"), "").unwrap();
+        // Non-JSON first line → skipped.
+        std::fs::write(runs.join("broken.live.jsonl"), "{broken\n").unwrap();
+        // run_header with no agent_id → skipped.
+        std::fs::write(
+            runs.join("noagent.live.jsonl"),
+            "{\"type\":\"run_header\",\"goal_id\":\"g1\"}\n",
+        )
+        .unwrap();
+
+        let sessions = super::scan_worker_sessions(&runs, "g1");
+        assert!(
+            sessions.is_empty(),
+            "all bad files must be skipped: {sessions:?}"
+        );
     }
 }

--- a/orchestration/loop/tests/console_drive_cov100c.rs
+++ b/orchestration/loop/tests/console_drive_cov100c.rs
@@ -1,0 +1,567 @@
+//! Coverage drive for the remaining per-line `console.rs` gaps: parse-table
+//! `_ => {}` swallow arms (fed the global `--include-experimental` flag),
+//! priority default arms, succession `--reason` filter, empty collective
+//! ledgers, idempotent `todo complete`, ledger-read-note rendering, and the
+//! `ui` success argument-parsing paths (bind-failure exit keeps the test
+//! synchronous).
+
+mod common;
+
+use common::mock_agent::{completed_events, spawn_mock, AttachPlan, MockState};
+use common::{
+    add_todo, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store, run_record,
+};
+use future_loop::state::now_epoch;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+#[cfg(unix)]
+fn dead_pid() -> u32 {
+    let mut child = std::process::Command::new("sh")
+        .arg("-c")
+        .arg("sleep 30")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    child.kill().unwrap();
+    child.wait().unwrap();
+    pid
+}
+
+/// A valid two-peer contract with one collective (crew).
+fn contract_json() -> String {
+    serde_json::json!({
+        "schema_version": "multi_agent_contract_v0",
+        "peers": {
+            "primary": {"capabilities": ["shell"], "workspaces": ["/ws/p"]},
+            "backup": {"backup_for": "primary", "capabilities": [], "workspaces": ["/ws/b"]}
+        },
+        "handoff_rules": [{"from_event": "lease_expired", "to_role": "backup"}],
+        "collectives": {"crew": ["primary", "backup"]}
+    })
+    .to_string()
+}
+
+/// A contract with peers but NO collectives (drives the empty-ledger branch).
+fn contract_without_collectives_json() -> String {
+    serde_json::json!({
+        "schema_version": "multi_agent_contract_v0",
+        "peers": {
+            "primary": {"capabilities": ["shell"], "workspaces": ["/ws/p"]}
+        },
+        "handoff_rules": [],
+        "collectives": {}
+    })
+    .to_string()
+}
+
+// ── parse_pairs `_ => {}` swallow arms (global --include-experimental) ─────
+
+#[test]
+fn agent_contract_set_swallows_global_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "contract global flag");
+    // `--include-experimental` flows through reject_unknown_flags and hits the
+    // parse_pairs `_ => {}` arm.
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_json(),
+        "--include-experimental",
+    ]);
+}
+
+#[test]
+fn agent_recipe_add_default_priority_and_global_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "recipe priority + global flag");
+    // `--priority P1` hits the `_ => Priority::P1` default arm; the trailing
+    // `--include-experimental` hits the `_ => {}` swallow arm.
+    cli_ok(&[
+        "agent",
+        "recipe",
+        "add",
+        "--goal",
+        &gid,
+        "--name",
+        "deployer",
+        "--priority",
+        "P1",
+        "--capability",
+        "shell",
+        "--include-experimental",
+    ]);
+}
+
+// ── succession --reason filter ─────────────────────────────────────────────
+
+#[test]
+fn agent_succession_show_reason_filter() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "succession reason filter");
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_json(),
+    ]);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "primary"]);
+    cli_ok(&[
+        "agent",
+        "succession",
+        "show",
+        "--goal",
+        &gid,
+        "--reason",
+        "lease_expired",
+    ]);
+}
+
+// ── empty collective ledger ────────────────────────────────────────────────
+
+#[test]
+fn agent_collective_show_without_collectives() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "collective empty");
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_without_collectives_json(),
+    ]);
+    // No collectives → the "no collectives in the contract" branch.
+    cli_ok(&["agent", "collective", "show", "--goal", &gid]);
+}
+
+// ── idempotent todo complete ───────────────────────────────────────────────
+
+#[test]
+fn todo_complete_is_idempotent() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "complete twice");
+    let tid = add_todo(&cr, &gid, "do the thing");
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &tid,
+        "--no-follow-up",
+        "--evidence",
+        "landed the artifact",
+    ]);
+    // Second completion hits the "already done — nothing to do" branch.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &tid,
+        "--no-follow-up",
+        "--evidence",
+        "landed the artifact",
+    ]);
+}
+
+// ── ledger read-note rendering (status + diagnose) ─────────────────────────
+
+#[test]
+fn status_and_diagnose_render_ledger_read_note() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "ledger read note");
+    let store = open_store(&cr);
+    let path = store.goal_dir(&gid).join("events.jsonl");
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"{\"kind\":\"future_unknown_kind_v99\",\"goal_id\":\"g\",\"ts\":1}\n")
+        .unwrap();
+    drop(store);
+    cli_ok(&["status", "--goal", &gid]);
+    cli_ok(&["diagnose", "--goal", &gid]);
+}
+
+// ── ui argument-parsing success paths (bind failure keeps it synchronous) ──
+
+#[test]
+fn webui_parses_no_open_port_and_root() {
+    let cr = cli_root();
+    // Occupy a port so `run_server`'s bind fails after the args parse; this
+    // exercises `--no-open` / `--port` / `--root` without blocking on accept.
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = l.local_addr().unwrap().port();
+    let err = cli_err(&[
+        "ui",
+        "--no-open",
+        "--port",
+        &port.to_string(),
+        "--root",
+        &cr.root,
+    ]);
+    assert!(err.contains("bind"), "expected bind failure, got: {err}");
+}
+
+// ── reject_unknown_flags error arms (per-command `)?;` lines) ─────────────
+
+#[test]
+fn agent_recipe_add_rejects_unknown_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "recipe unknown flag");
+    assert!(
+        cli_err(&["agent", "recipe", "add", "--goal", &gid, "--name", "n", "--bogus", "x",])
+            .contains("unknown flag `--bogus`")
+    );
+}
+
+#[test]
+fn agent_succession_show_rejects_unknown_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "succession unknown flag");
+    assert!(cli_err(&[
+        "agent",
+        "succession",
+        "show",
+        "--goal",
+        &gid,
+        "--bogus",
+        "x",
+    ])
+    .contains("unknown flag `--bogus`"));
+}
+
+#[test]
+fn agent_collective_show_rejects_unknown_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "collective unknown flag");
+    assert!(cli_err(&[
+        "agent",
+        "collective",
+        "show",
+        "--goal",
+        &gid,
+        "--bogus",
+        "x",
+    ])
+    .contains("unknown flag `--bogus`"));
+}
+
+// ── notify_dead_holders connect-failure arm ──────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn notify_dead_holders_returns_when_connect_fails() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "dead holders connect fail");
+    cli_ok(&[
+        "supervisor",
+        "register",
+        "--goal",
+        &gid,
+        "--session-id",
+        "sup-sess",
+    ]);
+    let todo_id = first_todo_id(&cr.root, &gid);
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::TodoClaimed {
+            goal_id: gid.clone(),
+            todo_id: todo_id.clone(),
+            agent_id: "w1".to_string(),
+            lease_expires_at: future_loop::state::now_epoch() + 3600,
+            holder_pid: Some(dead_pid()),
+            ts: future_loop::state::now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+
+    // Point the agent addr at a dead port so connect fails (defensive arm).
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", "127.0.0.1:1");
+    let mut store = open_store(&cr);
+    let rt = rt();
+    rt.block_on(async {
+        future_loop::console::notify_dead_holders(&mut store, &gid)
+            .await
+            .unwrap();
+    });
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+// ── steer_worker_poll_once offset + anonymous-target arms ────────────────
+
+#[test]
+fn steer_worker_poll_once_offset_and_anonymous_target_arms() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "steer offset arms");
+    let events_path = open_store(&cr).goal_dir(&gid).join("events.jsonl");
+    let rt = rt();
+    rt.block_on(async {
+        // File exists but has not grown past offset → meta.len() <= offset.
+        std::fs::write(
+            &events_path,
+            "{\"kind\":\"worker_steered\",\"instruction\":\"x\",\"ts\":1}\n",
+        )
+        .unwrap();
+        let len = std::fs::metadata(&events_path).unwrap().len();
+        let mut client = None;
+        let off = future_loop::console::steer_worker_poll_once(
+            &events_path,
+            len,
+            Some("worker-a"),
+            &mut client,
+            "sess",
+        )
+        .await;
+        assert_eq!(off, len);
+
+        // A targeted steer ignored by an anonymous caller (None + Some(target)).
+        std::fs::write(
+            &events_path,
+            "{\"kind\":\"worker_steered\",\"agent_id\":\"worker-a\",\"instruction\":\"y\",\"ts\":2}\n",
+        )
+        .unwrap();
+        let mut client = None;
+        let _ = future_loop::console::steer_worker_poll_once(
+            &events_path,
+            0,
+            None,
+            &mut client,
+            "sess",
+        )
+        .await;
+        assert!(client.is_none(), "anonymous caller ignores a targeted steer");
+    });
+}
+
+// ── run session resume (--resume-session) + transport error with budget ────
+
+#[test]
+fn run_resumes_alive_session_via_flag() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "resume alive");
+    let mut st = MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    };
+    st.live_sessions.insert("resume-me".to_string());
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(st));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    cli_ok(&[
+        "run",
+        "--goal",
+        &gid,
+        "--anonymous",
+        "--resume-session",
+        "resume-me",
+        "--max-turns",
+        "3",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+#[test]
+fn run_falls_back_to_fresh_for_dead_session() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "resume dead");
+    // sessions_created > 0 activates the mock's get_state "not found" path;
+    // the id is NOT in live_sessions, so session_alive probes false.
+    let st = MockState {
+        events: completed_events("mock-run-1"),
+        sessions_created: 1,
+        ..Default::default()
+    };
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(st));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    cli_ok(&[
+        "run",
+        "--goal",
+        &gid,
+        "--anonymous",
+        "--resume-session",
+        "dead-session",
+        "--max-turns",
+        "3",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+#[test]
+fn run_transport_error_with_turn_budget() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "transport with budget");
+    // A non-DataLoss mid-stream error under a wall-clock turn budget hits the
+    // `Ok(Err(e))` arm of the timeout match (transport stop + resumable mark).
+    let st = MockState {
+        stream_attach_plan: vec![AttachPlan::HardErrorAfter(0)],
+        ..Default::default()
+    };
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(st));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    let err = cli_err(&[
+        "run",
+        "--goal",
+        &gid,
+        "--anonymous",
+        "--max-turns",
+        "1",
+        "--max-turn-secs",
+        "5",
+    ]);
+    assert!(err.contains("stream error"), "{err}");
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+#[test]
+fn run_anonymous_ignores_targeted_steer() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "anonymous targeted steer");
+    // A steer targeting a NAMED worker is ignored by an anonymous run: the
+    // (None, Some(_)) => false arm in the steer-note match.
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::WorkerSteered {
+            goal_id: gid.clone(),
+            agent_id: Some("worker-x".to_string()),
+            instruction: "do something".to_string(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    }));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    cli_ok(&["run", "--goal", &gid, "--anonymous", "--max-turns", "3"]);
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+#[test]
+fn frontier_show_terminal_yes() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "frontier terminal");
+    let tid = first_todo_id(&cr.root, &gid);
+    // Close the only todo with closure intent → no gaps → terminal judgement.
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &tid,
+        "--no-follow-up",
+        "--evidence",
+        "closed",
+    ]);
+    cli_ok(&["frontier", "show", "--goal", &gid]);
+}
+
+// ── frontier show with runs + semantic history ────────────────────────────
+
+#[test]
+fn frontier_show_with_runs_and_semantic_history() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "frontier runs");
+    let first = first_todo_id(&cr.root, &gid);
+    let mut store = open_store(&cr);
+    // runs.jsonl → goal.history (outcome_segments); RunRecorded → semantic
+    // history (the RUN_LANDED fold).
+    let rec = run_record(&first, "completed", now_epoch());
+    store.append_run(&gid, &rec).unwrap();
+    store
+        .append(future_loop::store::Event::RunRecorded {
+            goal_id: gid.clone(),
+            record: rec,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+    cli_ok(&["frontier", "show", "--goal", &gid]);
+}
+
+// ── worker list "running" status + worker stop abort/delete failures ──────
+
+fn run_header(agent: &str, session: &str, ts: u64, goal: &str) -> String {
+    format!(
+        "{{\"type\":\"run_header\",\"idx\":0,\"wall_ts\":{ts},\"run_id\":\"r-{session}\",\"session_id\":\"{session}\",\"agent_id\":\"{agent}\",\"todo_id\":\"todo-{agent}\",\"goal_id\":\"{goal}\"}}\n"
+    )
+}
+
+fn seed_live_run(root: &str, goal: &str, agent: &str, session: &str) {
+    let runs = std::path::Path::new(root).join("runs");
+    std::fs::create_dir_all(&runs).unwrap();
+    std::fs::write(
+        runs.join(format!("{session}.live.jsonl")),
+        run_header(agent, session, 100, goal),
+    )
+    .unwrap();
+}
+
+#[test]
+fn worker_list_shows_running_when_streaming() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "worker running");
+    seed_live_run(&cr.root, &gid, "worker-a", "sess-a");
+
+    let mut st = MockState::default();
+    st.raw.insert(
+        "list_streaming_sessions".to_string(),
+        "{\"sessionIds\":[\"sess-a\"]}".to_string(),
+    );
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(st));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    cli_ok(&["worker", "list", "--goal", &gid]);
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+#[test]
+fn worker_stop_abort_and_delete_failures() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "worker stop failures");
+    seed_live_run(&cr.root, &gid, "worker-a", "sess-a");
+
+    let st = MockState {
+        fail_commands: ["abort".to_string(), "delete_session".to_string()]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(st));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+    // Abort fails → "abort failed" arm; --delete makes delete_session fail too.
+    cli_ok(&[
+        "worker",
+        "stop",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "worker-a",
+        "--delete",
+    ]);
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}

--- a/orchestration/loop/tests/console_drive_g12.rs
+++ b/orchestration/loop/tests/console_drive_g12.rs
@@ -1,0 +1,783 @@
+//! Coverage drive for the G12 multi-agent CLI surface (`agent contract /
+//! recipe / succession / collective`), `replan rules`, `frontier`, and the
+//! `worker list/stop` + `scan_worker_sessions` error paths that per-line
+//! coverage still shows as DA:0.
+
+mod common;
+
+use common::mock_agent::{spawn_mock, MockState};
+use common::{add_todo, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
+use future_loop::state::now_epoch;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// A valid two-peer contract with one backup chain + one collective.
+fn contract_json() -> String {
+    serde_json::json!({
+        "schema_version": "multi_agent_contract_v0",
+        "peers": {
+            "primary": {"capabilities": ["shell"], "workspaces": ["/ws/p"]},
+            "backup": {"backup_for": "primary", "capabilities": [], "workspaces": ["/ws/b"]}
+        },
+        "handoff_rules": [{"from_event": "lease_expired", "to_role": "backup"}],
+        "collectives": {"crew": ["primary", "backup"]}
+    })
+    .to_string()
+}
+
+// ── agent contract set/show ────────────────────────────────────────────────
+
+#[test]
+fn agent_contract_set_and_show_text_and_json() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "contract surface");
+
+    // Missing --goal fails.
+    assert!(cli_err(&["agent", "contract", "set"]).contains("--goal required"));
+    // Neither --contract nor --contract-file fails.
+    assert!(cli_err(&["agent", "contract", "set", "--goal", &gid]).contains("contract required"));
+    // Malformed JSON fails.
+    assert!(cli_err(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        "{not-json",
+    ])
+    .contains("parse contract JSON"));
+    // Missing goal on show fails.
+    assert!(cli_err(&["agent", "contract", "show"]).contains("--goal required"));
+    // Unknown subcommand fails.
+    assert!(cli_err(&["agent", "contract", "bogus", "--goal", &gid])
+        .contains("unknown agent contract subcommand"));
+
+    // Set via inline JSON.
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_json(),
+    ]);
+
+    // show text (contract present, no issues).
+    cli_ok(&["agent", "contract", "show", "--goal", &gid]);
+    // show JSON.
+    cli_ok(&[
+        "agent", "contract", "show", "--goal", &gid, "--format", "json",
+    ]);
+
+    // Re-set via a contract file.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("contract.json");
+    std::fs::write(&path, contract_json()).unwrap();
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract-file",
+        path.to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn agent_contract_show_without_contract_and_with_issues() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "contract no-set");
+    // No contract set yet → the None arm.
+    cli_ok(&["agent", "contract", "show", "--goal", &gid]);
+
+    // Inject a drifted contract (schema mismatch) directly so `show` renders
+    // validation issues.
+    let mut store = open_store(&cr);
+    let mut contract: future_loop::agents::multi_agent::MultiAgentContract =
+        serde_json::from_str(&contract_json()).unwrap();
+    contract.schema_version = "wrong_version".to_string();
+    store
+        .append(future_loop::store::Event::MultiAgentContractSet {
+            goal_id: gid.clone(),
+            contract,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+    cli_ok(&["agent", "contract", "show", "--goal", &gid]);
+}
+
+// ── agent recipe add/show ──────────────────────────────────────────────────
+
+#[test]
+fn agent_recipe_add_and_show() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "recipe surface");
+
+    assert!(cli_err(&["agent", "recipe", "add"]).contains("--goal required"));
+    assert!(cli_err(&["agent", "recipe", "add", "--goal", &gid]).contains("--name required"));
+    assert!(cli_err(&["agent", "recipe", "bogus"]).contains("unknown agent recipe subcommand"));
+    // Goal must exist.
+    assert!(cli_err(&[
+        "agent",
+        "recipe",
+        "add",
+        "--goal",
+        "goal_nope",
+        "--name",
+        "r"
+    ])
+    .contains("not found"));
+
+    cli_ok(&[
+        "agent",
+        "recipe",
+        "add",
+        "--goal",
+        &gid,
+        "--name",
+        "r1",
+        "--capabilities",
+        "shell,github",
+        "--workspace",
+        "/ws/a,/ws/b",
+        "--priority",
+        "P0",
+    ]);
+    // Priority P2 path + default P1 path.
+    cli_ok(&[
+        "agent",
+        "recipe",
+        "add",
+        "--goal",
+        &gid,
+        "--name",
+        "r2",
+        "--priority",
+        "P2",
+    ]);
+    cli_ok(&["agent", "recipe", "add", "--goal", &gid, "--name", "r3"]);
+
+    // show text (recipes present).
+    cli_ok(&["agent", "recipe", "show", "--goal", &gid]);
+    // show filtered by name.
+    cli_ok(&["agent", "recipe", "show", "--goal", &gid, "--name", "r1"]);
+    // show JSON.
+    cli_ok(&[
+        "agent", "recipe", "show", "--goal", &gid, "--format", "json",
+    ]);
+    // show with a name that matches nothing → empty arm.
+    cli_ok(&["agent", "recipe", "show", "--goal", &gid, "--name", "ghost"]);
+}
+
+// ── agent succession show/apply ────────────────────────────────────────────
+
+#[test]
+fn agent_succession_show_and_apply() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "succession surface");
+
+    // No contract → error (subcommand check happens after contract resolution).
+    assert!(cli_err(&["agent", "succession", "show", "--goal", &gid])
+        .contains("no multi-agent contract set"));
+
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_json(),
+    ]);
+    // Unknown subcommand (contract now present).
+    assert!(cli_err(&["agent", "succession", "bogus", "--goal", &gid])
+        .contains("unknown agent succession subcommand"));
+    // Register the primary (the backup's `backup_for` target).
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "primary"]);
+
+    // No succession triggers yet → empty show (text + json).
+    cli_ok(&["agent", "succession", "show", "--goal", &gid]);
+    cli_ok(&[
+        "agent",
+        "succession",
+        "show",
+        "--goal",
+        &gid,
+        "--format",
+        "json",
+    ]);
+
+    // Seed an expired lease held by the primary → succession candidate.
+    let onboarding = first_todo_id(&cr.root, &gid);
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::TodoClaimed {
+            goal_id: gid.clone(),
+            todo_id: onboarding.clone(),
+            agent_id: "primary".to_string(),
+            lease_expires_at: 1, // long past → expired
+            holder_pid: None,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+
+    // apply records the succession.
+    cli_ok(&["agent", "succession", "apply", "--goal", &gid]);
+    // show now surfaces the recorded succession.
+    cli_ok(&["agent", "succession", "show", "--goal", &gid]);
+    // apply again is idempotent (already recorded).
+    cli_ok(&["agent", "succession", "apply", "--goal", &gid]);
+    // apply with a non-matching --primary filter → no candidates.
+    cli_ok(&[
+        "agent",
+        "succession",
+        "apply",
+        "--goal",
+        &gid,
+        "--primary",
+        "ghost",
+    ]);
+}
+
+// ── agent collective show ──────────────────────────────────────────────────
+
+#[test]
+fn agent_collective_show_text_and_json() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "collective surface");
+
+    assert!(
+        cli_err(&["agent", "collective", "bogus"]).contains("unknown agent collective subcommand")
+    );
+    // No contract → error.
+    assert!(cli_err(&["agent", "collective", "show", "--goal", &gid])
+        .contains("no multi-agent contract set"));
+
+    cli_ok(&[
+        "agent",
+        "contract",
+        "set",
+        "--goal",
+        &gid,
+        "--contract",
+        &contract_json(),
+    ]);
+
+    // Unknown collective name → error.
+    assert!(cli_err(&[
+        "agent",
+        "collective",
+        "show",
+        "--goal",
+        &gid,
+        "--collective",
+        "ghost",
+    ])
+    .contains("is not part of the contract"));
+
+    // No turn ledger yet → empty text + json.
+    cli_ok(&["agent", "collective", "show", "--goal", &gid]);
+    cli_ok(&[
+        "agent",
+        "collective",
+        "show",
+        "--goal",
+        &gid,
+        "--format",
+        "json",
+    ]);
+}
+
+// ── replan rules set/show ──────────────────────────────────────────────────
+
+#[test]
+fn replan_rules_set_and_show() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "replan rules surface");
+
+    assert!(cli_err(&["replan", "rules", "bogus"]).contains("must be `show` or `set`"));
+    assert!(cli_err(&["replan", "rules", "show"]).contains("--goal required"));
+    assert!(cli_err(&["replan", "rules", "set", "--goal", "goal_nope"]).contains("not found"));
+
+    // show text + json on a fresh goal.
+    cli_ok(&["replan", "rules", "show", "--goal", &gid]);
+    cli_ok(&[
+        "replan", "rules", "show", "--goal", &gid, "--format", "json",
+    ]);
+
+    // set with ids (including an unknown id → warning arm).
+    cli_ok(&[
+        "replan",
+        "rules",
+        "set",
+        "--goal",
+        &gid,
+        "--rule-ids",
+        "totally_unknown_rule,replan_required",
+    ]);
+    // set reset (empty string → default set).
+    cli_ok(&["replan", "rules", "set", "--goal", &gid, "--rule-ids", ""]);
+}
+
+// ── frontier show ──────────────────────────────────────────────────────────
+
+#[test]
+fn frontier_show_text_and_json() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "frontier surface");
+
+    assert!(cli_err(&["frontier", "bogus", "--goal", &gid]).contains("must be `show`"));
+    assert!(cli_err(&["frontier", "show"]).contains("--goal required"));
+    assert!(cli_err(&["frontier", "show", "--goal", "goal_nope"]).contains("not found"));
+
+    cli_ok(&["frontier", "show", "--goal", &gid]);
+    cli_ok(&["frontier", "show", "--goal", &gid, "--format", "json"]);
+}
+
+// ── worker list/stop ───────────────────────────────────────────────────────
+
+fn run_header(agent: &str, session: &str, ts: u64, goal: &str) -> String {
+    format!(
+        "{{\"type\":\"run_header\",\"idx\":0,\"wall_ts\":{ts},\"run_id\":\"r-{session}\",\"session_id\":\"{session}\",\"agent_id\":\"{agent}\",\"todo_id\":\"todo-{agent}\",\"goal_id\":\"{goal}\"}}\n"
+    )
+}
+
+#[test]
+fn worker_list_text_and_json_and_unknown_subcommand() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "worker surface");
+
+    assert!(cli_err(&["worker", "bogus", "--goal", &gid]).contains("unknown worker subcommand"));
+    assert!(cli_err(&["worker", "list"]).contains("--goal required"));
+
+    // No run_header files, no agent reachable → idle registered agents only.
+    cli_ok(&["worker", "list", "--goal", &gid]);
+    cli_ok(&["worker", "list", "--goal", &gid, "--format", "json"]);
+}
+
+#[test]
+fn worker_stop_target_all_and_no_sessions() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "worker stop surface");
+
+    // Neither --agent-id nor --all → error.
+    assert!(cli_err(&["worker", "stop", "--goal", &gid]).contains("--agent-id"));
+    assert!(cli_err(&["worker", "stop"]).contains("--goal required"));
+
+    // No sessions → early "nothing to stop" (before gRPC connect).
+    cli_ok(&["worker", "stop", "--goal", &gid, "--agent-id", "w1"]);
+    cli_ok(&["worker", "stop", "--goal", &gid, "--all"]);
+}
+
+#[test]
+fn worker_stop_aborts_live_sessions_via_grpc() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "worker stop abort");
+    // Seed a run_header for worker-a under the goal's runs dir.
+    let runs = std::path::Path::new(&cr.root).join("runs");
+    std::fs::create_dir_all(&runs).unwrap();
+    std::fs::write(
+        runs.join("ra.live.jsonl"),
+        run_header("worker-a", "sess-a", 100, &gid),
+    )
+    .unwrap();
+
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(MockState::default()));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+
+    // Targeted stop with --delete reclaims the session.
+    cli_ok(&[
+        "worker",
+        "stop",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "worker-a",
+        "--delete",
+    ]);
+    let recorded = shared.lock().unwrap().recorded.clone();
+    assert!(recorded.contains(&"abort".to_string()), "{recorded:?}");
+    assert!(
+        recorded.contains(&"delete_session".to_string()),
+        "{recorded:?}"
+    );
+
+    // Broadcast stop reaches the same session (no --delete → no delete call).
+    let n = shared.lock().unwrap().recorded.len();
+    cli_ok(&["worker", "stop", "--goal", &gid, "--all"]);
+    assert!(shared.lock().unwrap().recorded.len() > n);
+
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+// ── supervisor steer + attention succession hints ──────────────────────────
+
+#[test]
+fn supervisor_steer_records_and_renders() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "supervisor steer");
+
+    assert!(cli_err(&["supervisor", "steer", "--goal", &gid]).contains("--instruction required"));
+    cli_ok(&[
+        "supervisor",
+        "steer",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "worker-a",
+        "--instruction",
+        "re-check",
+    ]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    assert_eq!(g.pending_steer.as_ref().unwrap().instruction, "re-check");
+}
+
+#[test]
+fn attention_with_succession_hints() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "attention succession");
+    // attention requires --goal or --all.
+    assert!(cli_err(&["attention"]).contains("--goal"));
+
+    // A goal with a recorded succession exercises the succession-attention
+    // join (the `?` on that extend line).
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::SuccessionOccurred {
+            goal_id: gid.clone(),
+            primary: "p".to_string(),
+            backup: "b".to_string(),
+            reason: "offline".to_string(),
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+    cli_ok(&["attention", "--goal", &gid]);
+}
+
+// ── remaining error arms ───────────────────────────────────────────────────
+
+#[test]
+fn todo_add_acceptance_and_empty_text_and_bare_blocks() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo add arms");
+
+    // Empty text.
+    assert!(cli_err(&["todo", "add", "--goal", &gid, "--text", "  "]).contains("non-empty"));
+    // Bare --blocks reads as "true".
+    assert!(
+        cli_err(&["todo", "add", "--goal", &gid, "--text", "x", "--blocks",])
+            .contains("--blocks requires")
+    );
+    // --acceptance is a valid todo-add flag (the parse arm + assignment).
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "scored task",
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    let store = open_store(&cr);
+    let g = store.replay(&gid).unwrap().unwrap();
+    let t = g
+        .todos
+        .iter()
+        .find(|t| t.text.contains("scored task"))
+        .unwrap();
+    assert_eq!(t.acceptance.as_deref(), Some("attempt,scored"));
+}
+
+#[test]
+fn todo_claim_not_open_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo claim not open");
+    let onboarding = first_todo_id(&cr.root, &gid);
+    cli_ok(&["agent", "register", "--goal", &gid, "--agent-id", "a1"]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+        "--evidence",
+        "closed",
+    ]);
+    let err = cli_err(&[
+        "todo",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &onboarding,
+        "--agent-id",
+        "a1",
+    ]);
+    assert!(err.contains("not open"), "{err}");
+}
+
+#[test]
+fn agent_onboard_recipe_conflict_and_missing() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "onboard recipe arms");
+    // Recipe + explicit workspace conflict.
+    assert!(cli_err(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "a1",
+        "--recipe",
+        "r1",
+        "--workspace",
+        "/ws",
+    ])
+    .contains("conflicts with an explicit --workspace"));
+    // Recipe not found.
+    assert!(cli_err(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "a1",
+        "--recipe",
+        "ghost",
+    ])
+    .contains("no agent recipe named"));
+    // Happy path: recipe applies cleanly.
+    cli_ok(&["agent", "recipe", "add", "--goal", &gid, "--name", "r1"]);
+    cli_ok(&[
+        "agent",
+        "onboard",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "a1",
+        "--recipe",
+        "r1",
+    ]);
+}
+
+#[test]
+fn todo_complete_superseded_arm() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "complete superseded");
+    let t = add_todo(&cr, &gid, "will be superseded");
+    cli_ok(&["todo", "supersede", "--goal", &gid, "--todo-id", &t]);
+    let err = cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--no-follow-up",
+        "--evidence",
+        "x",
+    ]);
+    assert!(err.contains("was superseded"), "{err}");
+}
+
+#[test]
+fn lease_claim_requires_open_and_rejects_active_lease() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "lease claim arms");
+    let onboarding = first_todo_id(&cr.root, &gid);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &onboarding,
+        "--no-follow-up",
+        "--evidence",
+        "closed",
+    ]);
+    assert!(cli_err(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &onboarding,
+        "--agent-id",
+        "a1",
+    ])
+    .contains("requires an open todo"));
+
+    let t = add_todo(&cr, &gid, "lease contended");
+    cli_ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "a1",
+    ]);
+    assert!(cli_err(&[
+        "lease",
+        "claim",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--agent-id",
+        "a2",
+    ])
+    .contains("active lease held by another agent"));
+}
+
+#[test]
+fn todo_update_bare_blocks_and_bad_priority() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "todo update arms");
+    let t = add_todo(&cr, &gid, "update me");
+    assert!(cli_err(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--blocks",
+    ])
+    .contains("--blocks requires"));
+    assert!(cli_err(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &t,
+        "--priority",
+        "P9",
+    ])
+    .contains("unknown --priority"));
+}
+
+#[test]
+fn store_verify_reports_skipped_unknown_kinds() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "store verify unknown kind");
+    let store = open_store(&cr);
+    let path = store.goal_dir(&gid).join("events.jsonl");
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"{\"kind\":\"future_unknown_kind_v99\",\"goal_id\":\"g\",\"ts\":1}\n")
+        .unwrap();
+    drop(store);
+    cli_ok(&["store", "verify", "--goal", &gid]);
+}
+
+// ── webui argument parsing arms ────────────────────────────────────────────
+
+#[test]
+fn webui_argument_parsing_arms() {
+    let _cr = cli_root();
+    assert!(cli_err(&["ui", "--port"]).contains("--port requires a value"));
+    assert!(cli_err(&["ui", "--port", "not-a-number"]).contains("--port must be 0-65535"));
+    assert!(cli_err(&["ui", "--root"]).contains("--root requires a value"));
+    // A positional (non-flag) argument hits the match's `other` arm.
+    assert!(cli_err(&["ui", "positional"]).contains("unknown argument"));
+}
+
+// ── print_status_json turn_no_progress fields ──────────────────────────────
+
+#[test]
+fn status_json_renders_turn_no_progress_fields() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "status json no-progress");
+    let mut store = open_store(&cr);
+    store
+        .append(future_loop::store::Event::TurnNoProgress {
+            goal_id: gid.clone(),
+            todo_id: "t1".to_string(),
+            agent_id: Some("a1".to_string()),
+            idle_secs: 42,
+            tool_calls_total: 2,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    drop(store);
+    cli_ok(&["status", "--goal", &gid, "--format", "json"]);
+}
+
+// ── notify_dead_holders early-return arms ──────────────────────────────────
+
+#[test]
+fn notify_dead_holders_early_returns() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "dead holders early");
+    let mut store = open_store(&cr);
+    let rt = rt();
+    let (addr, _shared) = rt.block_on(spawn_mock(MockState::default()));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
+
+    rt.block_on(async {
+        // No goal → replay returns None → early return.
+        future_loop::console::notify_dead_holders(&mut store, "goal_nope")
+            .await
+            .unwrap();
+        // Goal exists but no supervisor → early return.
+        future_loop::console::notify_dead_holders(&mut store, &gid)
+            .await
+            .unwrap();
+        // Supervisor registered but no dead holders → early return.
+        store
+            .append(future_loop::store::Event::SupervisorRegistered {
+                goal_id: gid.clone(),
+                session_id: "sup".to_string(),
+                ts: now_epoch(),
+            })
+            .unwrap();
+        future_loop::console::notify_dead_holders(&mut store, &gid)
+            .await
+            .unwrap();
+    });
+    std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+}
+
+// ── run session-policy validation + resume-session parsing ─────────────────
+
+#[test]
+fn run_rejects_bad_session_policy() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "run session policy");
+    let err = cli_err(&[
+        "run",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "a1",
+        "--session-policy",
+        "bogus",
+    ]);
+    assert!(
+        err.contains("--session-policy must be auto | fresh | resume"),
+        "{err}"
+    );
+}

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -5128,6 +5128,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cursor_report_without_pending_query_is_consumed_silently() {
+        // A well-formed DSR report arriving with NO pending query (the
+        // cursor_recheck_row snapshot was already taken or never issued) must
+        // be consumed without forcing a redraw — exercises the None arm of
+        // the `if let Some(expected) = self.cursor_recheck_row.take()` guard.
+        let (mut app, _rx) = running_app(100, 10);
+        app.do_render();
+        app.render_now = false;
+        assert!(app.cursor_recheck_row.is_none());
+        app.handle_input("\x1b[5;1R"); // well-formed, no pending query
+        assert!(!app.render_now, "no pending query → no forced redraw");
+    }
+
+    #[tokio::test]
     async fn streaming_tick_rechecks_cursor_position() {
         // While streaming, on_tick issues a DSR cursor query once per
         // CURSOR_RECHECK_INTERVAL and then waits until the next window.


### PR DESCRIPTION
The W1 (console.rs) and W9 (tui cursor_report) clearing work was committed to `claude/cov100` but that branch was deleted before a PR opened, so it never reached main. Recover the 4 genuinely-unmerged files from the dangling commits and land them.

- `console.rs`: +158 lines in-module coverage_tests
- `console_drive_cov100c.rs`: +567 (new file)
- `console_drive_g12.rs`: +783 (new file)
- `tui/app.rs`: +14 (cursor_report None-arm)

43 new integration tests + 70 lib tests + 1 tui test pass locally.