### PR TITLE
test(cli): cover list_providers/set_auth RPC methods + simplify agent_end run filter

### DIFF
--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -452,13 +452,10 @@ impl RunClient {
             }
             events.push(event_json);
             if message.r#type == "agent_end" {
-                // Only the targeted run's terminal ends a filtered stream; an
-                // empty run_id is treated as a match (see the filter above).
-                if let Some(target) = target_run_id {
-                    if !message.run_id.is_empty() && message.run_id != target {
-                        continue;
-                    }
-                }
+                // Only the targeted run's terminal ends a filtered stream. The
+                // per-event filter above already skipped any foreign run_id, so
+                // by this point run_id is either empty or the target (no
+                // re-check needed).
                 break;
             }
         }
@@ -1136,12 +1133,30 @@ mod tests {
             .insert("new_session".into(), "{\"sessionId\":\"s9\"}".into());
         agent
             .responses
+            .insert("list_providers".into(), "{\"providers\":[]}".into());
+        agent
+            .responses
+            .insert("set_auth".into(), "{\"ok\":true}".into());
+        agent
+            .responses
             .insert("notify".into(), "not json at all".into());
         let addr = spawn_mock(agent.clone()).await;
         let client = RunClient::new(&addr);
 
         assert_eq!(client.get_agent_info().await.unwrap()["version"], "1.0");
         assert!(client.list_models().await.unwrap()["models"].is_array());
+        assert!(client.list_providers().await.unwrap()["providers"].is_array());
+        assert_eq!(
+            client
+                .set_auth(future_rpc::proto::AuthUpdate {
+                    provider: "builtin".to_string(),
+                    key: "k".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()["ok"],
+            true
+        );
         let state = client.get_state(Some("s1")).await.unwrap();
         assert_eq!(state["model"], "m1");
         let state = client.get_state(None).await.unwrap();


### PR DESCRIPTION
## 变更内容

覆盖率清理，无功能行为变化。

- 补 `RunClient::list_providers` / `set_auth` 两个 RPC 封装方法的测试覆盖（mock 响应 + 断言）。
- 简化 `stream_events` 中 `agent_end` 处理：删除不可达的 `run_id` 复检分支——上游逐事件 filter 已跳过外部 `run_id`，走到这里 `run_id` 要么为空、要么就是 target。

## 测试

`cargo test -p future-cli --lib rpc::tests`：41 passed, 0 failed。