### PR TITLE
feat(loop): Coordination class + todo owner scope to stop worker claim-stealing

### DIFF
--- a/orchestration/loop/src/compat.rs
+++ b/orchestration/loop/src/compat.rs
@@ -43,6 +43,7 @@ pub fn future_loop_task_class(c: TaskClass) -> &'static str {
         TaskClass::UserAction => "user_action",
         TaskClass::Monitor => "continuous_monitor",
         TaskClass::Blocker => "blocker",
+        TaskClass::Coordination => "coordination",
     }
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -742,6 +742,7 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     let mut verify: Option<String> = None;
     let mut max_validation_attempts: Option<u32> = None;
     let mut acceptance: Option<String> = None;
+    let mut owner: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
@@ -760,6 +761,7 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             "--monitor-policy",
             "--monitor-target",
             "--note",
+            "--owner",
             "--priority",
             "--required-write-scope",
             "--resume-when",
@@ -791,6 +793,8 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             acceptance = Some(v);
         } else if k == "--max-validation-attempts" {
             max_validation_attempts = v.parse().ok();
+        } else if k == "--owner" {
+            owner = Some(v);
         } else if k == "--goal" {
             goal_id = Some(v);
         } else if k == "--role" {
@@ -833,12 +837,13 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
         ("agent", "advancement")
             | ("agent", "monitor")
             | ("agent", "blocker")
+            | ("agent", "coordination")
             | (_, "user_gate")
             | ("user", "user_action")
     );
     if !valid_combo {
         bail!(
-            "unknown --role/--class combo `{role}`/`{class}` (agent: advancement|monitor|blocker; user_gate: any role; user: user_action)"
+            "unknown --role/--class combo `{role}`/`{class}` (agent: advancement|monitor|blocker|coordination; user_gate: any role; user: user_action)"
         );
     }
     if let Some(p) = &priority {
@@ -877,8 +882,14 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
             let b: Vec<&str> = blocks.iter().map(|s| s.as_str()).collect();
             Todo::blocker(&id, &text, &b)
         }
+        ("agent", "coordination") => Todo::coordination(&id, &text),
         _ => Todo::advancement(&id, &text),
     };
+    // Owner assignment: `--owner X` declares this todo is for agent X (see
+    // `Todo::owner`). Optional — absent = shared pool.
+    if let Some(aid) = &owner {
+        todo = todo.owned_by(aid);
+    }
     // Apply --blocks for every task class (previously only user_gate/blocker
     // attached them; advancement/monitor silently dropped the dependency chain).
     if !blocks.is_empty() {
@@ -2700,6 +2711,7 @@ fn status_label(t: &Todo) -> &'static str {
             TaskClass::UserAction => "action",
             TaskClass::Monitor => "monitor",
             TaskClass::Blocker => "blocker",
+            TaskClass::Coordination => "coord",
         }
     }
 }
@@ -7467,6 +7479,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
     let mut resume_when = None;
     let mut blocks: Option<Vec<String>> = None;
     let mut acceptance: Option<String> = None;
+    let mut owner: Option<String> = None;
     reject_unknown_flags(
         args,
         &[
@@ -7475,6 +7488,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
             "--evidence",
             "--goal",
             "--note",
+            "--owner",
             "--priority",
             "--resume-when",
             "--status",
@@ -7514,6 +7528,8 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
             });
         } else if k == "--acceptance" {
             acceptance = Some(v);
+        } else if k == "--owner" {
+            owner = Some(v);
         }
     });
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
@@ -7573,6 +7589,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
         resume_when: resume_when_parsed,
         blocks: blocks.clone(),
         acceptance: acceptance.clone(),
+        owner: owner.clone(),
         ts: crate::state::now_epoch(),
     })?;
     refresh_next_action(store, &goal_id)?;
@@ -7646,6 +7663,7 @@ mod coverage_tests {
                 resume_when: None,
                 blocks: None,
                 acceptance: None,
+                owner: None,
                 ts: 1,
             },
             Event::GoalCancelled {
@@ -7960,6 +7978,7 @@ mod coverage_tests {
             (TaskClass::UserAction, "action"),
             (TaskClass::Monitor, "monitor"),
             (TaskClass::Blocker, "blocker"),
+            (TaskClass::Coordination, "coord"),
         ] {
             let mut t = Todo::advancement("t", "x");
             t.class = class;

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -69,6 +69,15 @@ pub enum TaskClass {
     /// on another lane) that gates dependent todos until resolved.
     #[serde(rename = "blocker")]
     Blocker,
+    /// Orchestration bookkeeping (goal parent / summary / final-validation
+    /// todos): NOT agent work. Never enters the worker `run` frontier — the
+    /// orchestrator completes it directly. Keeping it a distinct class (rather
+    /// than an `Advancement` with an owner) makes the frontier / attention /
+    /// status projections treat it as coordination, and prevents a worker's
+    /// `run` from auto-claiming the goal's own summary todo once its lease
+    /// lapses (the "worker steals the orchestrator's todo" failure mode).
+    #[serde(rename = "coordination")]
+    Coordination,
 }
 
 /// Lifecycle status — reference values open/done/blocked/deferred, plus our
@@ -144,6 +153,16 @@ pub struct Todo {
     pub no_follow_up: bool,
     /// Completion evidence (LoopX: recorded on the todo at complete time).
     pub evidence: Option<String>,
+    /// Expected owner (LoopX: assignment) — the agent id this todo is *for*.
+    /// Orthogonal to the claim/lease below: `owner` is a durable assignment
+    /// ("who should do this"), while `claimed_by`/`lease_expires_at` is the
+    /// live lock ("who is doing it right now"). An `owner`-scoped todo is only
+    /// runnable by that agent even after its lease lapses (a lease expiry
+    /// releases the lock, never the assignment); `None` = shared pool
+    /// (first-claim-wins, the pre-existing behavior). Absent on old ledgers →
+    /// deserializes as `None`.
+    #[serde(default)]
+    pub owner: Option<String>,
     /// Claim/lease (reference task-lease): which agent lane owns this slice and
     /// when the lease expires. Expired leases return the todo to the frontier.
     pub claimed_by: Option<String>,
@@ -266,6 +285,23 @@ impl Todo {
         t.blocking(blocks)
     }
 
+    /// Orchestration bookkeeping todo (goal parent / summary / final
+    /// validation): never enters the worker run frontier (see `TaskClass::
+    /// Coordination`). The orchestrator completes it directly with
+    /// `todo complete`.
+    pub fn coordination(id: &str, text: &str) -> Self {
+        Self::new(id, text, TaskClass::Coordination)
+    }
+
+    /// Declare the expected owner (LoopX assignment — "this todo is for
+    /// agent X"). `owner`-scoped todos are only runnable by that agent; the
+    /// scope survives lease expiry (lease releases the lock, not the
+    /// assignment). See `Todo::owner`.
+    pub fn owned_by(mut self, agent_id: &str) -> Self {
+        self.owner = Some(agent_id.to_string());
+        self
+    }
+
     fn new(id: &str, text: &str, class: TaskClass) -> Self {
         let now = now_epoch();
         let role = match class {
@@ -296,6 +332,7 @@ impl Todo {
             successor_ids: vec![],
             no_follow_up: false,
             evidence: None,
+            owner: None,
             claimed_by: None,
             lease_expires_at: None,
             holder_pid: None,
@@ -1094,6 +1131,10 @@ impl Goal {
             (t.class == TaskClass::Advancement
                 && (t.status == TodoStatus::Open || t.is_due_deferred(now_sys)))
                 && !t.claimed_by_other(agent_id, now)
+                // Owner scope: an `owner`-scoped todo is only runnable by its
+                // owner (the scope survives lease expiry — see `Todo::owner`).
+                // `None` owner = shared pool (first-claim-wins).
+                && (t.owner.is_none() || t.owner.as_deref() == agent_id)
                 && !self.is_blocked(t)
         })
     }

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -195,6 +195,10 @@ pub enum Event {
         /// clears it, absent leaves it untouched. See `Todo::acceptance`.
         #[serde(default)]
         acceptance: Option<String>,
+        /// Expected owner (`--owner X`); `Some("")` clears the assignment,
+        /// absent leaves it untouched. See `Todo::owner`.
+        #[serde(default)]
+        owner: Option<String>,
         ts: u64,
     },
     /// Stop automation while retaining state (the reference: goal cancel).
@@ -1489,12 +1493,16 @@ fn apply(goal: &mut Goal, event: Event) {
             resume_when,
             blocks,
             acceptance,
+            owner,
             ts,
             ..
         } => {
             if let Some(t) = goal.todo_mut(&todo_id) {
                 if let Some(x) = text {
                     t.text = x;
+                }
+                if let Some(o) = owner {
+                    t.owner = if o.trim().is_empty() { None } else { Some(o) };
                 }
                 if let Some(x) = evidence {
                     t.evidence = Some(x);

--- a/orchestration/loop/src/webui/api.rs
+++ b/orchestration/loop/src/webui/api.rs
@@ -71,6 +71,7 @@ fn class_label(t: &Todo) -> &'static str {
         TaskClass::UserAction => "user_action",
         TaskClass::Monitor => "monitor",
         TaskClass::Blocker => "blocker",
+        TaskClass::Coordination => "coordination",
     }
 }
 

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -169,6 +169,28 @@ fn todo_add_class_matrix() {
         "--monitor-policy",
         "exists",
     ]);
+    // Coordination class: orchestration bookkeeping, never agent work.
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--class",
+        "coordination",
+        "--text",
+        "final validation",
+    ]);
+    // Owner assignment on a shared advancement todo.
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--owner",
+        "worker-a",
+        "--text",
+        "worker-a only",
+    ]);
     // Unknown class is rejected fail-closed (was: silently fell back to
     // advancement and polluted the ledger).
     assert!(cli_err(&[
@@ -191,6 +213,17 @@ fn todo_add_class_matrix() {
     assert!(m.resume_when.is_some(), "cadence sets the first due time");
     assert_eq!(m.monitor_target.as_deref(), Some("file:x"));
     assert_eq!(m.monitor_policy.as_deref(), Some("exists"));
+    let coord = g
+        .todos
+        .iter()
+        .find(|t| t.text == "final validation")
+        .unwrap();
+    assert!(
+        coord.class == future_loop::state::TaskClass::Coordination,
+        "coordination class must be preserved"
+    );
+    let owned = g.todos.iter().find(|t| t.text == "worker-a only").unwrap();
+    assert_eq!(owned.owner.as_deref(), Some("worker-a"));
     assert_eq!(m.monitor_cadence.as_deref(), Some("15m"));
 }
 
@@ -881,6 +914,8 @@ fn todo_archive_supersede_update() {
         "45",
         "--blocks",
         "x,y",
+        "--owner",
+        "worker-a",
     ]);
     {
         let store = open_store(&cr);
@@ -891,10 +926,28 @@ fn todo_archive_supersede_update() {
         assert_eq!(t.note.as_deref(), Some("n"));
         assert_eq!(t.priority, future_loop::state::Priority::P0);
         assert_eq!(t.blocked_by_gate.as_deref(), Some("x,y"));
+        assert_eq!(t.owner.as_deref(), Some("worker-a"));
         assert!(
             t.resume_when.is_some(),
             "numeric resume-when sets a real deadline"
         );
+    }
+    // Clear owner assignment via empty --owner.
+    cli_ok(&[
+        "todo",
+        "update",
+        "--goal",
+        &gid,
+        "--todo-id",
+        &u,
+        "--owner",
+        "",
+    ]);
+    {
+        let store = open_store(&cr);
+        let g = store.replay(&gid).unwrap().unwrap();
+        let t = g.todos.iter().find(|t| t.id == u).unwrap();
+        assert_eq!(t.owner, None, "empty --owner clears the assignment");
     }
     // Clear blocks, textual resume-when, unknown status ignored.
     cli_ok(&[

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -582,6 +582,7 @@ fn store_projection_gap_and_guard_arms() {
                 resume_when: None,
                 blocks: None,
                 acceptance: None,
+                owner: None,
                 ts: now_epoch(),
             })
             .unwrap();

--- a/orchestration/loop/tests/productized_features_contract.rs
+++ b/orchestration/loop/tests/productized_features_contract.rs
@@ -65,6 +65,7 @@ fn todo_update_event_applies_field_edits() {
             resume_when: None,
             blocks: None,
             acceptance: None,
+            owner: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -102,6 +103,7 @@ fn todo_update_status_done_is_rejected_by_apply() {
             resume_when: None,
             blocks: None,
             acceptance: None,
+            owner: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/state_drive.rs
+++ b/orchestration/loop/tests/state_drive.rs
@@ -192,6 +192,70 @@ fn goal_query_and_mutation_arms() {
     assert_eq!(anon, vec!["t3".to_string()]);
 }
 
+#[test]
+fn owner_scope_limits_the_frontier_and_survives_lease_expiry() {
+    let now = now_for_test();
+    // A coordination todo is NOT advancement — it never enters the runnable
+    // advancement frontier regardless of owner.
+    let mut g = Goal::new("g", "obj", "/tmp");
+    g.add(Todo::coordination("summary", "final validation"));
+    g.add(Todo::advancement("shared", "shared work"));
+    g.add(Todo::advancement("alice-work", "for alice").owned_by("alice"));
+    let mut expired = Todo::advancement("expired", "leased then lapsed");
+    // Simulate a claim that has since lapsed: claimed_by is stale but the
+    // lease expiry is in the past.
+    expired.claim("alice", 1, now.saturating_sub(2));
+    g.add(expired);
+
+    // Alice sees shared + her owned todo + the lapsed-lease todo (lease
+    // lapsed, owner is None so it's back in the shared pool).
+    let alice: Vec<_> = g
+        .runnable_advancement_for(Some("alice"))
+        .map(|t| t.id.clone())
+        .collect();
+    assert!(alice.contains(&"shared".to_string()));
+    assert!(alice.contains(&"alice-work".to_string()));
+    assert!(alice.contains(&"expired".to_string()));
+    assert!(
+        !alice.contains(&"summary".to_string()),
+        "coordination never runnable"
+    );
+
+    // Bob does NOT see alice's owner-scoped todo, even though it has no live
+    // lease — the owner assignment survives the absence of a lease.
+    let bob: Vec<_> = g
+        .runnable_advancement_for(Some("bob"))
+        .map(|t| t.id.clone())
+        .collect();
+    assert!(bob.contains(&"shared".to_string()));
+    assert!(
+        !bob.contains(&"alice-work".to_string()),
+        "owner scope must hold"
+    );
+    assert!(
+        bob.contains(&"expired".to_string()),
+        "no-owner lapsed lease returns to pool"
+    );
+}
+
+#[test]
+fn owner_scope_blocks_other_agents_even_with_a_live_lease_elsewhere() {
+    // The owner filter is independent of the lease filter: a todo owned by
+    // alice is invisible to bob whether or not someone holds a live lease.
+    let now = now_for_test();
+    let mut g = Goal::new("g", "obj", "/tmp");
+    let mut owned = Todo::advancement("owned", "for alice").owned_by("alice");
+    owned.claim("alice", 3600, now);
+    g.add(owned);
+
+    // Alice (owner + lease holder) sees it.
+    assert_eq!(g.runnable_advancement_for(Some("alice")).count(), 1);
+    // Bob sees nothing: owner scope hides it even though the lease is alice's.
+    assert_eq!(g.runnable_advancement_for(Some("bob")).count(), 0);
+    // Anonymous (no agent id) only sees shared-pool (owner None) todos.
+    assert_eq!(g.runnable_advancement().count(), 0);
+}
+
 fn now_for_test() -> u64 {
     future_loop::state::now_epoch()
 }

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -121,6 +121,7 @@ fn try_claim_ignores_non_lease_events_and_p9_normalizes_to_p1() {
             resume_when: None,
             blocks: None,
             acceptance: None,
+            owner: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -555,6 +556,7 @@ fn apply_renew_and_priority_arms() {
             resume_when: None,
             blocks: None,
             acceptance: None,
+            owner: None,
             ts: now_epoch(),
         })
         .unwrap();
@@ -597,6 +599,7 @@ fn apply_matrix() {
                 resume_when: None,
                 blocks: None,
                 acceptance: None,
+                owner: None,
                 ts: now_epoch(),
             })
             .unwrap();
@@ -613,6 +616,7 @@ fn apply_matrix() {
             resume_when: Some("defer:5".into()),
             blocks: Some(vec!["a".into()]),
             acceptance: None,
+            owner: None,
             ts: now_epoch(),
         })
         .unwrap();

--- a/orchestration/loop/tests/todo_update_blocks_contract.rs
+++ b/orchestration/loop/tests/todo_update_blocks_contract.rs
@@ -96,6 +96,7 @@ fn update_blocks_sets_blocking_set() {
             resume_when: None,
             blocks: Some(vec!["t3".into()]),
             acceptance: None,
+            owner: None,
             ts,
         })
         .unwrap();
@@ -120,6 +121,7 @@ fn update_blocks_replaces_existing_set() {
             resume_when: None,
             blocks: Some(vec!["t3".into(), "t2".into()]),
             acceptance: None,
+            owner: None,
             ts,
         })
         .unwrap();
@@ -144,6 +146,7 @@ fn update_blocks_empty_clears() {
             resume_when: None,
             blocks: Some(vec![]),
             acceptance: None,
+            owner: None,
             ts,
         })
         .unwrap();
@@ -168,6 +171,7 @@ fn update_without_blocks_leaves_set_untouched() {
             resume_when: None,
             blocks: None,
             acceptance: None,
+            owner: None,
             ts,
         })
         .unwrap();
@@ -244,6 +248,7 @@ fn replay_rebuilds_updated_blocks() {
             resume_when: None,
             blocks: Some(vec!["t2".into(), "t3".into()]),
             acceptance: None,
+            owner: None,
             ts,
         })
         .unwrap();


### PR DESCRIPTION
## 根因

loop 没有「todo 归属」概念，只有「谁此刻持 live lease」。orchestrator 手动 claim 的协调 todo（1h lease）过期后重新进入共享 frontier，任何 worker 的 `run` 按先到先得把它抢走。coverage goal 里这浪费了 ~$37（8 个无效 turn 中的 7 个）。

## 修复（两个正交改动）

### 1. `TaskClass::Coordination`

编排簿记 todo（goal parent / summary / 终验）现在是独立 class，**不再是 Advancement**，因此永不进入 worker 的 runnable frontier。orchestrator 直接 complete 它。堵住「worker 抢 goal 自己的 summary todo」。

### 2. `Todo::owner`（可持久归属）

`owner` = 「谁该做」（durable assignment），与 `claimed_by`/lease = 「谁此刻在做」（live lock）正交。owner-scoped todo 只对该 agent runnable，**即使 lease 过期**（lease 释放锁，永不释放归属）；`None` = 共享池（行为不变）。

- `todo add --owner X` / `todo update --owner X`（`--owner ""` 清除）
- `Todo::owned_by()` / `Todo::coordination()` 工厂

## 兼容性

- 无 owner + 无 coordination = frontier 行为完全不变
- `owner` 用 `#[serde(default)]`，老 ledger 无此字段反序列化为 `None`
- 全部 loop 测试绿、fmt/clippy 净

## 不做（避免过度设计）

- 不复活 capability gate（产品决策已删除）
- 不强制「一个 todo 只能一个 agent」（破坏 backup 接管/负载均衡这个特性）

## 验证

- `cargo test -p future-loop` 全绿
- `cargo fmt --check` + `cargo clippy -p future-loop --all-targets -- -D warnings` 净