### PR TITLE
Fix typed session history loading

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/import.rs
+++ b/desktop/src-tauri/src/agent_bridge/import.rs
@@ -3,7 +3,6 @@
 //! records + per-reply run records so they appear in the thread list and right
 //! panel immediately.
 
-use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
@@ -15,32 +14,17 @@ use crate::store;
 
 // ─── agent RPC types ────────────────────────────────────────────────────────
 
-/// Lightweight session summary from the agent's `list_sessions` RPC.
-///
-/// Field casing (audit item 1): the canonical wire keys are camelCase. The
-/// agent also emits snake_case legacy aliases alongside them during the
-/// migration window — the struct reads only the canonical camelCase keys, and
-/// the legacy keys are ignored (declaring an `alias` here would make serde see
-/// both spellings of the same field as a duplicate and reject the entry).
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// Desktop import shape derived from the typed `list_sessions` response.
+#[derive(Debug)]
 pub struct AgentSessionSummary {
     pub id: String,
-    #[serde(default, rename = "sessionName")]
     pub name: Option<String>,
-    // Tolerate a missing/null cwd (e.g. channel sessions) — an empty cwd is
-    // routed to a chat workspace by `thread_mode`, not dropped.
-    #[serde(default)]
     pub cwd: String,
-    #[serde(default)]
     pub model: String,
-    #[serde(default)]
     pub first_message: Option<String>,
-    #[serde(default)]
     #[allow(dead_code)]
     pub parent_session_id: String,
     /// Whether the agent is currently streaming a response for this session.
-    #[serde(default)]
     #[allow(dead_code)]
     pub is_streaming: bool,
 }
@@ -76,30 +60,22 @@ async fn list_agent_sessions() -> Vec<AgentSessionSummary> {
         return vec![];
     }
 
-    // Parse per-session rather than all-or-nothing: a single malformed entry
-    // must not drop every other importable session.
-    let value: serde_json::Value = match serde_json::from_str(&inner.data) {
-        Ok(value) => value,
-        Err(error) => {
-            eprintln!("FutureOS: session import parse failed: {error}");
-            return vec![];
-        }
+    let Some(sessions) = future_rpc::decode::decode_list_sessions(&inner) else {
+        eprintln!("FutureOS: session import parse failed: typed payload is missing or invalid");
+        return vec![];
     };
-    let raw_sessions = value
-        .get("sessions")
-        .and_then(|s| s.as_array())
-        .cloned()
-        .unwrap_or_default();
-    let mut sessions = Vec::with_capacity(raw_sessions.len());
-    for raw in raw_sessions {
-        match serde_json::from_value::<AgentSessionSummary>(raw) {
-            Ok(summary) => sessions.push(summary),
-            Err(error) => {
-                eprintln!("FutureOS: skipping malformed session in import list: {error}");
-            }
-        }
-    }
     sessions
+        .into_iter()
+        .map(|summary| AgentSessionSummary {
+            id: summary.id,
+            name: summary.session_name,
+            cwd: summary.cwd,
+            model: summary.model,
+            first_message: summary.first_message,
+            parent_session_id: summary.parent_session_id,
+            is_streaming: summary.is_streaming,
+        })
+        .collect()
 }
 
 /// The set of session ids the agent currently knows about, with transport
@@ -152,11 +128,11 @@ async fn fetch_session_entries(session_id: &str) -> Vec<serde_json::Value> {
     if !resp.success {
         return vec![];
     }
-    serde_json::from_str::<serde_json::Value>(&resp.data)
-        .ok()
-        .and_then(|v| v.get("entries").cloned())
-        .and_then(|v| serde_json::from_value(v).ok())
+    future_rpc::decode::decode_session_entries(&resp)
         .unwrap_or_default()
+        .into_iter()
+        .filter_map(|entry| serde_json::to_value(entry).ok())
+        .collect()
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -582,46 +558,6 @@ pub async fn import_missing_sessions() {
 mod tests {
     use super::*;
 
-    /// Audit item 1: the canonical casing of list_sessions rows is camelCase;
-    /// the struct must parse it directly. The agent also emits snake_case
-    /// legacy aliases alongside the canonical keys during the migration window,
-    /// so the struct reads ONLY the camelCase spellings — declaring aliases for
-    /// the legacy keys would make serde treat the two spellings of one field as
-    /// a duplicate and reject the whole entry.
-    #[test]
-    fn agent_session_summary_parses_list_sessions_json() {
-        let raw = serde_json::json!({
-            "id": "abc123",
-            "sessionName": "fix the login bug",
-            "model": "deepseek-v4-pro",
-            "cwd": "/Users/test/my-project",
-            "updatedAt": "2026-07-21 10:00:00",
-            "parentSessionId": "parent-1",
-            "firstMessage": "please fix the login bug on the homepage",
-            "queryCount": 5,
-            "isStreaming": true,
-            // Legacy snake_case aliases the agent still emits alongside the
-            // canonical keys — must be ignored, not treated as duplicates.
-            "session_name": "fix the login bug",
-            "first_message": "please fix the login bug on the homepage",
-            "parent_session_id": "parent-1",
-            "is_streaming": true,
-        });
-
-        let summary: AgentSessionSummary =
-            serde_json::from_value(raw).expect("should parse list_sessions JSON");
-
-        assert_eq!(summary.id, "abc123");
-        assert_eq!(summary.name.as_deref(), Some("fix the login bug"));
-        assert_eq!(
-            summary.first_message.as_deref(),
-            Some("please fix the login bug on the homepage")
-        );
-        assert_eq!(summary.cwd, "/Users/test/my-project");
-        assert_eq!(summary.model, "deepseek-v4-pro");
-        assert!(summary.is_streaming);
-    }
-
     /// session_title prefers first_message over name and cwd_basename.
     #[test]
     fn session_title_prefers_first_message() {
@@ -697,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_agent_sessions_skips_malformed_entries_and_survives_errors() {
+    async fn list_agent_sessions_survives_rpc_and_payload_errors() {
         let mock = super::super::test_support::mock_agent();
 
         // Reject → empty.
@@ -706,7 +642,6 @@ mod tests {
             super::super::test_support::Reply::Reject("nope".into()),
         );
         assert!(list_agent_sessions().await.is_empty());
-
         // Transport error → empty.
         mock.push(
             "list_sessions",
@@ -720,18 +655,30 @@ mod tests {
             super::super::test_support::Reply::Data("not json".into()),
         );
         assert!(list_agent_sessions().await.is_empty());
+    }
 
-        // One valid + one malformed entry → only the valid one survives.
-        mock.push_data(
+    #[tokio::test]
+    async fn list_agent_sessions_decodes_typed_only_response() {
+        let mock = super::super::test_support::mock_agent();
+        mock.push_typed_data(
             "list_sessions",
-            serde_json::json!({"sessions": [
-                {"id": "s1", "sessionName": "ok", "cwd": "/ws/a", "model": "m", "firstMessage": "hi"},
-                42
-            ]}),
+            serde_json::json!({"sessions": [{
+                "id": "typed-session",
+                "sessionName": "Typed history",
+                "model": "future/k3",
+                "cwd": "/ws/typed",
+                "updatedAt": "2026-08-27 10:00:00",
+                "parentSessionId": "",
+                "firstMessage": "hello",
+                "queryCount": 1,
+                "isStreaming": false
+            }]}),
         );
+
         let sessions = list_agent_sessions().await;
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].id, "s1");
+        assert_eq!(sessions[0].id, "typed-session");
+        assert_eq!(sessions[0].first_message.as_deref(), Some("hello"));
     }
 
     #[tokio::test]
@@ -772,18 +719,31 @@ mod tests {
             super::super::test_support::Reply::Reject("no".into()),
         );
         assert!(fetch_session_entries("s").await.is_empty());
-
         mock.push(
             "get_session_entries",
             super::super::test_support::Reply::Data("not json".into()),
         );
         assert!(fetch_session_entries("s").await.is_empty());
+    }
 
-        mock.push_data(
+    #[tokio::test]
+    async fn fetch_session_entries_decodes_typed_only_response() {
+        let mock = super::super::test_support::mock_agent();
+        mock.push_typed_data(
             "get_session_entries",
-            serde_json::json!({"entries": [{"role": "assistant"}, {"role": "user"}]}),
+            serde_json::json!({"entries": [{
+                "id": "entry-1",
+                "role": "user",
+                "content": "hello",
+                "name": "",
+                "tool_args": "",
+                "timestamp": "2026-08-27T10:00:00Z"
+            }]}),
         );
-        assert_eq!(fetch_session_entries("s").await.len(), 2);
+
+        let entries = fetch_session_entries("typed-session").await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["content"], "hello");
     }
 
     // ── thread_mode / is_desktop_chat_cwd ──────────────────────────────
@@ -1157,11 +1117,11 @@ mod tests {
     async fn import_one_creates_a_new_chat_thread_and_runs() {
         let _home = super::super::test_support::TestHome::new("import-new");
         let mock = super::super::test_support::mock_agent();
-        mock.push_data(
+        mock.push_typed_data(
             "get_session_entries",
             serde_json::json!({"entries": [
-                {"role": "assistant", "content": "a1"},
-                {"role": "assistant", "content": "a2"}
+                {"id": "a1", "role": "assistant", "content": "a1", "name": "", "tool_args": "", "timestamp": "2026-08-27T10:00:00Z"},
+                {"id": "a2", "role": "assistant", "content": "a2", "name": "", "tool_args": "", "timestamp": "2026-08-27T10:00:01Z"}
             ]}),
         );
         let s = summary("sess-new", "");
@@ -1235,21 +1195,24 @@ mod tests {
         let mock = super::super::test_support::mock_agent();
 
         // Empty list → silent Ok.
-        mock.push_data("list_sessions", serde_json::json!({}));
+        mock.push_typed_data("list_sessions", serde_json::json!({"sessions": []}));
         import_missing_sessions().await;
 
         // Two sessions, each with one assistant reply.
-        mock.push_data(
+        mock.push_typed_data(
             "list_sessions",
             serde_json::json!({"sessions": [
-                {"id": "sess-m1", "cwd": "", "model": "future/k3", "firstMessage": "one"},
-                {"id": "sess-m2", "cwd": "", "model": "future/k3", "firstMessage": "two"}
+                {"id": "sess-m1", "sessionName": null, "cwd": "", "model": "future/k3", "updatedAt": "2026-08-27 10:00:00", "parentSessionId": "", "firstMessage": "one", "queryCount": 1, "isStreaming": false},
+                {"id": "sess-m2", "sessionName": null, "cwd": "", "model": "future/k3", "updatedAt": "2026-08-27 10:00:00", "parentSessionId": "", "firstMessage": "two", "queryCount": 1, "isStreaming": false}
             ]}),
         );
-        for _ in 0..2 {
-            mock.push_data(
+        for index in 0..2 {
+            mock.push_typed_data(
                 "get_session_entries",
-                serde_json::json!({"entries": [{"role": "assistant"}]}),
+                serde_json::json!({"entries": [{
+                    "id": format!("reply-{index}"), "role": "assistant", "content": "ok",
+                    "name": "", "tool_args": "", "timestamp": "2026-08-27T10:00:01Z"
+                }]}),
             );
         }
         import_missing_sessions().await;

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -296,11 +296,9 @@ pub async fn get_session_entries(session_id: String) -> Result<serde_json::Value
         .map_err(|status| format!("get_session_entries failed: {status}"))?
         .into_inner()
         .ok_or_rpc_error("get_session_entries returned an error")?;
-    if response.data.is_empty() {
-        Ok(serde_json::json!({ "entries": [] }))
-    } else {
-        Ok(future_rpc::decode::response_data(&response))
-    }
+    let entries = future_rpc::decode::decode_session_entries(&response)
+        .ok_or_else(|| "get_session_entries typed payload is missing or invalid".to_string())?;
+    Ok(serde_json::json!({ "entries": entries }))
 }
 
 /// Fetch the session's current state (model, thinkingLevel, isStreaming, etc.)
@@ -1693,19 +1691,20 @@ mod bridge_tests {
             .expect("messages");
         assert_eq!(value, serde_json::json!({"messages": []}));
 
-        mock.push_data(
+        mock.push_typed_data(
             "get_session_entries",
-            serde_json::json!({"entries": [{"id": "e1"}]}),
+            serde_json::json!({"entries": [{
+                "id": "e1", "role": "assistant", "content": "world", "name": "",
+                "tool_args": "", "timestamp": "2026-08-27T10:00:01Z"
+            }]}),
         );
         let value = get_session_entries("sess-1".to_string())
             .await
-            .expect("entries");
+            .expect("typed entries");
         assert_eq!(value["entries"][0]["id"], "e1");
+
         mock.push("get_session_entries", Reply::Data(String::new()));
-        let value = get_session_entries("sess-1".to_string())
-            .await
-            .expect("entries");
-        assert_eq!(value, serde_json::json!({"entries": []}));
+        assert!(get_session_entries("sess-1".to_string()).await.is_err());
 
         mock.push_data("get_state", serde_json::json!({"isStreaming": true}));
         let value = get_session_state("sess-1".to_string())

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -30,6 +30,8 @@ use crate::agent_proto::{RpcCommand, RpcResponse, StreamEvent, StreamRequest};
 pub(crate) enum Reply {
     /// `success = true` with the given JSON `data` string.
     Data(String),
+    /// `success = true` with the production typed payload and empty `data`.
+    TypedData(serde_json::Value),
     /// `success = false` with this error message.
     Reject(String),
     /// Transport-level failure (tonic status).
@@ -127,6 +129,13 @@ impl FutureAgent for MockAgent {
                 data,
                 String::new(),
             ))),
+            Reply::TypedData(data) => {
+                let payload = future_rpc::encode::response_payload(&cmd.r#type, &data)
+                    .expect("scripted typed payload must match its command");
+                let mut response = rpc_response(&cmd, true, String::new(), String::new());
+                response.payload = Some(payload);
+                Ok(tonic::Response::new(response))
+            }
             Reply::Reject(error) => Ok(tonic::Response::new(rpc_response(
                 &cmd,
                 false,
@@ -299,6 +308,11 @@ impl MockAgentGuard {
     /// Queue a successful reply whose `data` is the JSON rendering of `value`.
     pub(crate) fn push_data(&self, command_type: &str, value: serde_json::Value) {
         self.push(command_type, Reply::Data(value.to_string()));
+    }
+
+    /// Queue a production-shaped typed-only response (`data` stays empty).
+    pub(crate) fn push_typed_data(&self, command_type: &str, value: serde_json::Value) {
+        self.push(command_type, Reply::TypedData(value));
     }
 
     /// Queue a `get_run_state` reply (get_state carrying a run id) for one

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -392,7 +392,10 @@ pub async fn get_session_entries(thread_id: String) -> Result<serde_json::Value,
         }
         return Err(resp.error.into());
     }
-    serde_json::from_str(&resp.data).map_err(|e| format!("Parse error: {e}").into())
+    let entries = future_rpc::decode::decode_session_entries(&resp).ok_or_else(|| {
+        "Parse error: typed session entries payload is missing or invalid".to_string()
+    })?;
+    Ok(serde_json::json!({ "entries": entries }))
 }
 
 #[tauri::command]
@@ -1017,6 +1020,33 @@ mod tests {
             .await
             .expect("entries");
         assert_eq!(value["entries"], serde_json::json!([]));
+        script_mock_agent(MockScript::default());
+    }
+
+    #[tokio::test]
+    async fn get_session_entries_reads_typed_only_agent_history() {
+        let _lock = mock_agent_lock();
+        let _home = init("cmd_entries_typed");
+        let thread = make_thread(&_home, Some("sess_entries_typed"));
+        script_mock_agent(MockScript::default());
+        let agent = crate::commands::agent_mock::ensure_mock_agent();
+        agent.script_typed_for(
+            "get_session_entries",
+            "sess_entries_typed",
+            serde_json::json!({"entries": [{
+                "id": "entry-typed",
+                "role": "user",
+                "content": "still here",
+                "name": "",
+                "tool_args": "",
+                "timestamp": "2026-08-27T10:00:00Z"
+            }]}),
+        );
+
+        let value = get_session_entries(thread.id.clone())
+            .await
+            .expect("typed entries");
+        assert_eq!(value["entries"][0]["content"], "still here");
         script_mock_agent(MockScript::default());
     }
 

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -2467,8 +2467,13 @@ mod bridge_tests {
         agent.set_session_entries(
             &session,
             json!({ "entries": [{
-                "entryType": "assistant",
+                "id": "persisted-assistant",
+                "entry_type": "assistant",
+                "role": "assistant",
                 "content": "partial",
+                "name": "",
+                "tool_args": "",
+                "timestamp": "2026-08-27T10:00:00Z",
                 "meta": { "run_id": history_run.id }
             }] }),
         );
@@ -2488,6 +2493,32 @@ mod bridge_tests {
             .await;
         assert_eq!(reply["success"], json!(true));
         assert_eq!(reply["data"]["entries"].as_array().unwrap().len(), 1);
+
+        // Production sidecar responses carry typed payload only (`data` is
+        // empty); mobile history must still flow through the remote bridge.
+        agent.script_typed_for(
+            "get_session_entries",
+            &session,
+            json!({"entries": [{
+                "id": "typed-mobile-entry",
+                "role": "assistant",
+                "content": "typed mobile history",
+                "name": "",
+                "tool_args": "",
+                "timestamp": "2026-08-27T10:00:00Z"
+            }]}),
+        );
+        let reply = bridge
+            .call(
+                json!({ "id": unique("cmd"), "type": "get_session_entries", "sessionId": session }),
+            )
+            .await;
+        assert_eq!(reply["success"], json!(true));
+        assert_eq!(
+            reply["data"]["entries"][0]["content"],
+            json!("typed mobile history")
+        );
+
         agent.script_for("get_session_entries", &session, false, json!(null), "nope");
         let reply = bridge
             .call(

--- a/desktop/src-tauri/src/remote/test_support.rs
+++ b/desktop/src-tauri/src/remote/test_support.rs
@@ -87,6 +87,7 @@ struct ScriptedResponse {
     success: bool,
     data: String,
     error: String,
+    typed: bool,
 }
 
 #[derive(Default)]
@@ -126,6 +127,23 @@ impl MockAgent {
         self.script_for(command, "", success, data, error);
     }
 
+    /// Enqueue a typed-only response addressed to one session.
+    pub(crate) fn script_typed_for(&self, command: &str, session_id: &str, data: Value) {
+        let key = format!("{command}:{session_id}");
+        self.state
+            .lock()
+            .unwrap()
+            .scripts
+            .entry(key)
+            .or_default()
+            .push_back(ScriptedResponse {
+                success: true,
+                data: data.to_string(),
+                error: String::new(),
+                typed: true,
+            });
+    }
+
     /// Enqueue a one-shot response for `command` addressed to `session_id`.
     pub(crate) fn script_for(
         &self,
@@ -146,11 +164,43 @@ impl MockAgent {
                 success,
                 data: data.to_string(),
                 error: error.to_string(),
+                typed: false,
             });
     }
 
     /// Set the `get_session_entries` payload for one session.
-    pub(crate) fn set_session_entries(&self, session_id: &str, entries: Value) {
+    pub(crate) fn set_session_entries(&self, session_id: &str, mut entries: Value) {
+        // Keep convenient attachment-focused fixtures wire-valid now that the
+        // desktop consumes the typed SessionEntry contract.
+        for (index, entry) in entries
+            .get_mut("entries")
+            .and_then(Value::as_array_mut)
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let Some(object) = entry.as_object_mut() else {
+                continue;
+            };
+            object
+                .entry("id")
+                .or_insert_with(|| Value::String(format!("mock-entry-{index}")));
+            object
+                .entry("role")
+                .or_insert_with(|| Value::String("user".to_string()));
+            object
+                .entry("content")
+                .or_insert_with(|| Value::String(String::new()));
+            object
+                .entry("name")
+                .or_insert_with(|| Value::String(String::new()));
+            object
+                .entry("tool_args")
+                .or_insert_with(|| Value::String(String::new()));
+            object
+                .entry("timestamp")
+                .or_insert_with(|| Value::String("2026-08-27T00:00:00Z".to_string()));
+        }
         self.state
             .lock()
             .unwrap()
@@ -202,7 +252,7 @@ struct AgentService {
 
 impl AgentService {
     fn answer(&self, cmd: crate::agent_proto::RpcCommand) -> crate::agent_proto::RpcResponse {
-        let (success, data, error) = {
+        let (success, data, error, typed) = {
             let mut state = self.state.lock().unwrap();
             state
                 .requests
@@ -219,19 +269,33 @@ impl AgentService {
                         .and_then(VecDeque::pop_front)
                 });
             match scripted {
-                Some(response) => (response.success, response.data, response.error),
+                Some(response) => (
+                    response.success,
+                    response.data,
+                    response.error,
+                    response.typed,
+                ),
                 // The persistent facade (commands tests) — one-shot scripts
                 // take precedence over it.
                 None => {
                     if let Some(error) = state.persistent_errors.get(cmd.r#type.as_str()) {
-                        (false, String::new(), error.clone())
+                        (false, String::new(), error.clone(), false)
                     } else if let Some(data) = state.persistent_data.get(cmd.r#type.as_str()) {
-                        (true, data.clone(), String::new())
+                        (true, data.clone(), String::new(), false)
                     } else {
-                        default_answer(&cmd, &mut state)
+                        let (success, data, error) = default_answer(&cmd, &mut state);
+                        (success, data, error, false)
                     }
                 }
             }
+        };
+        let (data, payload) = if typed {
+            let value = serde_json::from_str(&data).expect("scripted typed response JSON");
+            let payload = future_rpc::encode::response_payload(&cmd.r#type, &value)
+                .expect("scripted typed payload must match its command");
+            (String::new(), Some(payload))
+        } else {
+            (data, None)
         };
         crate::agent_proto::RpcResponse {
             id: cmd.id.clone(),
@@ -240,6 +304,7 @@ impl AgentService {
             success,
             data,
             error,
+            payload,
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary
- decode typed-only list_sessions and get_session_entries responses in the desktop importer and thread reader
- route mobile history through the same typed session-entry decoder
- add typed-only regression coverage for desktop, import, remote bridge, and attachment fixtures

## Validation
- cargo test --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo test -p future-cli --quiet (one MCP network flake passed on isolated rerun)
- cargo test -p future-agent list_sessions -- --nocapture
- cargo test -p future-agent get_session_entries -- --nocapture