### PR TITLE
docs: sync directory-layout with current ~/.future/ tree

### DIFF
--- a/docs/directory-layout.md
+++ b/docs/directory-layout.md
@@ -13,20 +13,27 @@ Windows layout is identical with `%USERPROFILE%\.future\` as the root.
 │   ├── auth.json              # credentials, keyed by model id or provider
 │   ├── sessions/              # flat JSONL session store (one file per session)
 │   ├── skills/                # installed user skills (APP_SKILLS_DIR)
+│   ├── browser/               # CLI browser-tool state (config.json, profile/, artifacts/)
+│   ├── images/                # CLI image-tool output directory
 │   └── logs/agent.log         # agent log (when logging is enabled)
+├── agent-app/                 # legacy credential dir (auth.json) read for back-compat
 ├── channels/
-│   └── config.json            # Feishu / DingTalk bridge config (see channels-config.md)
+│   ├── config.json            # Feishu / DingTalk bridge config (see channels-config.md)
+│   └── feishu/                # Feishu bridge data (session file, received files)
 ├── tui/                       # the terminal UI (future-tui)
 │   ├── settings.json          # defaultModel, defaultThinkingLevel, … (see tui.md)
 │   ├── keybindings.json       # optional keybinding overrides
 │   ├── debug.log              # TUI runtime log
-│   └── write.log              # raw screen-write log (PI_TUI_WRITE_LOG=1 only)
+│   ├── write.log              # raw screen-write log (PI_TUI_WRITE_LOG=1 only)
+│   └── crash.log              # panic backtrace appended on crash
 ├── app/                       # the desktop GUI (FutureOS app)
 │   ├── app.db                 # SQLite database (threads, runs, approvals, …)
 │   ├── images/                # per-thread image tree (thumb/ + origin/)
-│   └── review/                # per-workspace shadow git review repos
+│   ├── review/                # per-workspace shadow git review repos
+│   └── run_events/            # per-run event logs (JSONL)
 ├── workspaces/
 │   └── chat/                  # per-thread chat workspaces (agent session / thread id)
+├── remote_pairing.json        # desktop remote-bridge identity (nkey_seed + user_jwt)
 └── bin/                       # CLI / agent links: `future`, `future-agent` (see below)
 ```
 
@@ -47,7 +54,18 @@ vars:
 - `skills/` — one of the two skill discovery directories
   (`APP_SKILLS_DIR`); the other is `~/.agents/skills/` (`AGENTS_SKILLS_DIR`).
   Skills are plain directories with a `SKILL.md` + YAML frontmatter.
+- `browser/` — CLI browser-tool state (`config.json`, `profile/` for the
+  Chromium profile, `artifacts/` for screenshots). Honors `FUTURE_HOME`.
+- `images/` — output directory for the CLI image generation/editing tools
+  (`future tools call image …`).
 - `logs/agent.log` — written when logging is enabled.
+
+## `~/.future/agent-app/` — legacy credential directory
+
+The agent resolves `auth.json` from `~/.future/agent-app/auth.json` before
+`~/.future/agent/auth.json` (back-compat with credentials written by older
+GUI builds); both `agent/` and `agent-app/` are treated as credential
+locations by the GUI's file-access guard. New writes go to `~/.future/agent/`.
 
 ## `~/.future/channels/` — channel bridges
 
@@ -55,7 +73,8 @@ Owned by `future-channel` (the Feishu / DingTalk bridge). `config.json`
 holds the `agent`, `feishu` and `dingtalk` blocks — see
 [channels-config.md](channels-config.md) for the full schema and defaults.
 If the file is missing, the bridge writes a default template and exits,
-asking you to edit it and restart.
+asking you to edit it and restart. `feishu/` is the Feishu bridge's data
+directory (session file and received files/images).
 
 ## `~/.future/tui/` — terminal UI
 
@@ -63,7 +82,8 @@ Owned by `future-tui`. `settings.json` persists client-side settings
 (`defaultModel`, `defaultThinkingLevel`, `defaultPermissionLevel`,
 `enabledModelIds`); optional keybinding overrides go in `keybindings.json`;
 `debug.log` is written when `PI_DEBUG_REDRAW=1`, and `write.log` records raw
-screen writes when `PI_TUI_WRITE_LOG=1`. See [tui.md](tui.md).
+screen writes when `PI_TUI_WRITE_LOG=1`; `crash.log` receives the panic
+backtrace when the TUI crashes. See [tui.md](tui.md).
 
 ## `~/.future/app/` — desktop GUI
 
@@ -75,6 +95,12 @@ Owned by the Tauri desktop app (see `desktop/`):
   rather than the OS cache dir because macOS may purge the cache.
 - `review/` — shadow git repositories used for the review feature, one
   `<workspace_id>` subdir per workspace's runs.
+- `run_events/` — per-run event logs (JSONL), derived from the agent's JSONL
+  sessions.
+
+The desktop remote bridge keeps its pairing identity (`nkey_seed` +
+`user_jwt` + NATS addresses) in `~/.future/remote_pairing.json` (at the
+`~/.future` root, not under `app/`).
 
 ## `~/.future/workspaces/chat/` — chat workspaces
 

--- a/docs/directory-layout.zh-CN.md
+++ b/docs/directory-layout.zh-CN.md
@@ -12,20 +12,27 @@ FutureOS 的所有用户状态都存放在 `~/.future/` 下（Windows 为
 │   ├── auth.json              # 凭据，按模型 id 或 provider 键控
 │   ├── sessions/              # 扁平 JSONL 会话存储（每个会话一个文件）
 │   ├── skills/                # 已安装的用户技能（APP_SKILLS_DIR）
+│   ├── browser/               # CLI 浏览器工具状态（config.json、profile/、artifacts/）
+│   ├── images/                # CLI 图片工具输出目录
 │   └── logs/agent.log         # agent 日志（启用日志时）
+├── agent-app/                 # 遗留凭据目录（auth.json），向后兼容读取
 ├── channels/
-│   └── config.json            # 飞书 / 钉钉桥配置（见 channels-config.zh-CN.md）
+│   ├── config.json            # 飞书 / 钉钉桥配置（见 channels-config.zh-CN.md）
+│   └── feishu/                # 飞书桥数据（会话文件、接收的文件）
 ├── tui/                       # 终端界面（future-tui）
 │   ├── settings.json          # defaultModel、defaultThinkingLevel 等（见 tui.zh-CN.md）
 │   ├── keybindings.json       # 可选按键绑定覆盖
 │   ├── debug.log              # 调试重绘日志（仅 PI_DEBUG_REDRAW=1）
-│   └── write.log              # 原始屏幕写入日志（仅 PI_TUI_WRITE_LOG=1）
+│   ├── write.log              # 原始屏幕写入日志（仅 PI_TUI_WRITE_LOG=1）
+│   └── crash.log              # 崩溃时的 panic 回溯
 ├── app/                       # 桌面 GUI（FutureOS App）
 │   ├── app.db                 # SQLite 数据库（会话线程、run、审批等）
 │   ├── images/                # 每线程图片树（thumb/ + origin/）
-│   └── review/                # 每个 workspace 的影子 git 评审仓库
+│   ├── review/                # 每个 workspace 的影子 git 评审仓库
+│   └── run_events/            # 每个 run 的事件日志（JSONL）
 ├── workspaces/
 │   └── chat/                  # 每线程聊天工作区（agent 会话 / 线程 id）
+├── remote_pairing.json        # 桌面远程桥身份（nkey_seed + user_jwt）
 └── bin/                       # CLI / agent 链接：`future`、`future-agent`（见下）
 ```
 
@@ -44,20 +51,30 @@ FutureOS 的所有用户状态都存放在 `~/.future/` 下（Windows 为
 - `skills/` — 两个技能发现目录之一（`APP_SKILLS_DIR`）；另一个是
   `~/.agents/skills/`（`AGENTS_SKILLS_DIR`）。技能是含 `SKILL.md` +
   YAML frontmatter 的普通目录。
+- `browser/` — CLI 浏览器工具状态（`config.json`、Chromium 的 `profile/`、
+  截图的 `artifacts/`）。遵循 `FUTURE_HOME`。
+- `images/` — CLI 图片生成/编辑工具（`future tools call image …`）的输出目录。
 - `logs/agent.log` — 启用日志时写入。
+
+## `~/.future/agent-app/` — 遗留凭据目录
+
+agent 解析 `auth.json` 时会先读 `~/.future/agent-app/auth.json`，再读
+`~/.future/agent/auth.json`（向后兼容旧版 GUI 写入的凭据）；GUI 的文件访问
+守卫把 `agent/` 与 `agent-app/` 都视为凭据位置。新的写入都落到 `~/.future/agent/`。
 
 ## `~/.future/channels/` — 渠道桥
 
 归 `future-channel`（飞书 / 钉钉桥）所有。`config.json` 包含 `agent`、
 `feishu`、`dingtalk` 三个块——完整 schema 与默认值见
 [channels-config.zh-CN.md](channels-config.zh-CN.md)。若文件不存在，桥会
-写入默认模板并退出，提示编辑后重启。
+写入默认模板并退出，提示编辑后重启。`feishu/` 是飞书桥的数据目录（会话文件
+与接收的文件/图片）。
 
 ## `~/.future/tui/` — 终端界面
 
 归 `future-tui` 所有。`settings.json` 持久化客户端侧设置（`defaultModel`、
 `defaultThinkingLevel`、`defaultPermissionLevel`、`enabledModelIds`）；
-可选的按键绑定覆盖放在 `keybindings.json`；`debug.log` 在设置 `PI_DEBUG_REDRAW=1` 时写入调试重绘日志，设置 `PI_TUI_WRITE_LOG=1` 时 `write.log` 记录原始屏幕写入。
+可选的按键绑定覆盖放在 `keybindings.json`；`debug.log` 在设置 `PI_DEBUG_REDRAW=1` 时写入调试重绘日志，设置 `PI_TUI_WRITE_LOG=1` 时 `write.log` 记录原始屏幕写入；`crash.log` 在 TUI 崩溃时接收 panic 回溯。
 见 [tui.zh-CN.md](tui.zh-CN.md)。
 
 ## `~/.future/app/` — 桌面 GUI
@@ -70,6 +87,10 @@ FutureOS 的所有用户状态都存放在 `~/.future/` 下（Windows 为
   可能清理缓存目录。
 - `review/` — 评审功能使用的影子 git 仓库，每个 workspace 的 run 共享一个
   `<workspace_id>` 子目录。
+- `run_events/` — 每个 run 的事件日志（JSONL），派生自 agent 的 JSONL 会话。
+
+桌面远程桥把配对身份（`nkey_seed` + `user_jwt` + NATS 地址）保存在
+`~/.future/remote_pairing.json`（位于 `~/.future` 根，而非 `app/` 下）。
 
 ## `~/.future/workspaces/chat/` — 聊天工作区
 


### PR DESCRIPTION
## 问题

`docs/directory-layout.md` / `docs/directory-layout.zh-CN.md` 的 `~/.future/` 树形图与分节描述落后于实际代码，漏掉了多个真实存在、由代码写入的目录/文件。

## 核对（代码证据）

| 缺失项 | 实际路径 | 代码出处 |
|---|---|---|
| `agent/browser/` | `~/.future/agent/browser/{config.json,profile/,artifacts/}` | `cli/src/browser/browser_state.rs`（honors `FUTURE_HOME`） |
| `agent/images/` | `~/.future/agent/images/` | `cli/src/commands/tools.rs` |
| `agent-app/` | `~/.future/agent-app/auth.json`（读取优先于 `agent/`） | `agent/src/auth/mod.rs:28` |
| `app/run_events/` | `~/.future/app/run_events/` | `desktop/src-tauri/src/store/runs.rs:535` |
| `channels/feishu/` | `~/.future/channels/feishu/` | `channels/src/feishu/bridge.rs:35` |
| `remote_pairing.json` | `~/.future/remote_pairing.json`（根下） | `desktop/src-tauri/src/remote/pairing.rs:44` |
| `tui/crash.log` | `~/.future/tui/crash.log` | `tui/src/crash.rs` |

已核对无误（无需改动）：`sessions/` 扁平 JSONL、`logs/agent.log`、loop 项目本地 `<cwd>/.future/loop/`、`workspaces/chat/`。

## 改动

- 英中两版树形图补齐 7 个缺失条目。
- 英中两版分节描述对应补充：agent 章节加 `browser/`/`images/`，新增 `agent-app/` 章节，channels/tui/app 章节分别补 `feishu/`、`crash.log`、`run_events/` + `remote_pairing.json` 说明。

纯文档改动，无代码变更。