### PR TITLE
docs: document full .future/loop/ directory tree in directory-layout

### DIFF
--- a/docs/directory-layout.md
+++ b/docs/directory-layout.md
@@ -111,10 +111,31 @@ elsewhere and are never touched by reclamation of this directory.
 ## Loop control plane — project-local, not under `~/.future/`
 
 The `future-loop` state is **project-local**: run it from the project
-directory and goals live under `<cwd>/.future/loop/` (`registry.json`,
-`goals/<id>/events.jsonl`, `goals/<id>/ACTIVE_GOAL_STATE.md`, `runs/`).
-`FUTURE_LOOP_ROOT` overrides the root for special setups; `~/.future/loop/`
-is not used — see [loop-control-plane.md](loop-control-plane.md).
+directory and everything lives under `<cwd>/.future/loop/`
+(`FUTURE_LOOP_ROOT` overrides the root for special setups; `~/.future/loop/`
+is not used). See [loop-control-plane.md](loop-control-plane.md).
+
+```text
+<cwd>/.future/loop/
+├── registry.json                  # goal registry (one entry per goal)
+├── goals/<goal_id>/
+│   ├── events.jsonl               # event-sourced ledger (the authoritative state)
+│   ├── runs.jsonl                 # authoritative spend/run ledger
+│   ├── next_action.txt            # kernel should-run decision snapshot
+│   ├── schema.json                # event-store schema version stamp
+│   ├── ACTIVE_GOAL_STATE.md       # human-readable active-state projection
+│   ├── status-cache.json          # status projection cache
+│   ├── read_diagnostics.json      # ledger-read diagnostics (unknown event kinds)
+│   ├── scheduler-state/           # scheduler state (backed up with the goal)
+│   └── runs/                      # run-history (compaction/retention, LoopX-style)
+│       └── index.jsonl            # append-only run index
+├── runs/
+│   └── <run_id>.live.jsonl        # live in-flight worker run logs
+├── inbox/
+│   └── *.json                     # operator inbox (liveness alerts, …)
+└── backups/
+    └── <ts>-<goal_id>/            # per-goal backup (ledger + scheduler-state + registry entry)
+```
 
 ## `~/.future/bin/` — CLI links
 

--- a/docs/directory-layout.zh-CN.md
+++ b/docs/directory-layout.zh-CN.md
@@ -100,11 +100,32 @@ GUI 的每线程聊天工作区，每个子目录以 agent 会话 id（已知时
 
 ## loop 控制面 — 项目本地，不在 `~/.future/` 下
 
-`future-loop` 的状态是**项目本地**的：在项目目录运行它，目标状态存放在
-`<cwd>/.future/loop/` 下（`registry.json`、`goals/<id>/events.jsonl`、
-`goals/<id>/ACTIVE_GOAL_STATE.md`、`runs/`）。`FUTURE_LOOP_ROOT` 可为特殊
-场景覆盖状态根；`~/.future/loop/` 不会被使用——见
+`future-loop` 的状态是**项目本地**的：在项目目录运行它，全部状态存放在
+`<cwd>/.future/loop/` 下（`FUTURE_LOOP_ROOT` 可为特殊场景覆盖状态根；
+`~/.future/loop/` 不会被使用）。见
 [loop-control-plane.zh-CN.md](loop-control-plane.zh-CN.md)。
+
+```text
+<cwd>/.future/loop/
+├── registry.json                  # 目标注册表（每个目标一条）
+├── goals/<goal_id>/
+│   ├── events.jsonl               # 事件源账本（权威状态）
+│   ├── runs.jsonl                 # 权威花费/运行账本
+│   ├── next_action.txt            # 内核 should-run 决策快照
+│   ├── schema.json                # 事件 store schema 版本戳
+│   ├── ACTIVE_GOAL_STATE.md       # 人可读的活跃状态投影
+│   ├── status-cache.json          # status 投影缓存
+│   ├── read_diagnostics.json      # 账本读取诊断（未知事件类型）
+│   ├── scheduler-state/           # 调度器状态（随目标一起备份）
+│   └── runs/                      # run-history（compaction/retention，LoopX 风格）
+│       └── index.jsonl            # 追加式 run 索引
+├── runs/
+│   └── <run_id>.live.jsonl        # live 进行中 worker run 日志
+├── inbox/
+│   └── *.json                     # operator inbox（活性告警等）
+└── backups/
+    └── <ts>-<goal_id>/            # 每目标备份（账本 + scheduler-state + 注册表项）
+```
 
 ## `~/.future/bin/` — CLI 链接
 


### PR DESCRIPTION
## 问题

`docs/directory-layout.md` / `docs/directory-layout.zh-CN.md` 的 loop 章节只列了 4 个文件（`registry.json`、`goals/<id>/events.jsonl`、`goals/<id>/ACTIVE_GOAL_STATE.md`、`runs/`），缺少 loop 状态根的完整目录结构。

## 改动

对照 `orchestration/loop/src/` 代码，补全 `<cwd>/.future/loop/` 的完整目录树：

| 目录/文件 | 用途 | 代码出处 |
|---|---|---|
| `goals/<id>/events.jsonl` | 事件源账本（权威状态） | `store.rs` EVENTS_FILE |
| `goals/<id>/runs.jsonl` | 权威花费/运行账本 | `store.rs` RUNS_FILE |
| `goals/<id>/next_action.txt` | 内核 should-run 决策快照 | `store.rs` NEXT_ACTION_FILE |
| `goals/<id>/schema.json` | 事件 store schema 版本戳 | `store.rs` SCHEMA_FILE |
| `goals/<id>/ACTIVE_GOAL_STATE.md` | 人可读活跃状态投影 | `migration.rs:414` |
| `goals/<id>/status-cache.json` | status 投影缓存 | `projection/status_cache.rs` |
| `goals/<id>/read_diagnostics.json` | 账本读取诊断 | `store.rs` READ_DIAGNOSTICS_FILE |
| `goals/<id>/scheduler-state/` | 调度器状态（随目标备份） | `store.rs:1038` |
| `goals/<id>/runs/` + `index.jsonl` | run-history（compaction/retention） | `runtime/mod.rs` |
| `runs/<run_id>.live.jsonl` | live 进行中 run 日志 | `console.rs:4037`、`webui/api.rs:631` |
| `inbox/*.json` | operator inbox（活性告警等） | `console.rs:3251`、`operator_inbox.rs` |
| `backups/<ts>-<goal_id>/` | 每目标备份 | `store.rs:1030` |

纯文档改动，无代码变更。