### PR TITLE
fix(tui): keep thinking streaming after a queued message

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -4844,6 +4844,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn thinking_deltas_continue_after_queued_message() {
+        // Regression: a user message queued mid-stream (enqueue_if_busy) is
+        // pushed after the streaming assistant. Thinking deltas must keep
+        // landing on that assistant, not silently drop or target the queued
+        // user message.
+        let (mut app, _rx) = make_app(100, 30);
+        app.handle_agent_event(&make_event("agent_start", "{}"));
+        app.handle_agent_event(&make_event("thinking_start", "{}"));
+        app.handle_agent_event(&make_event("thinking_delta", "{\"text\":\"reason one\"}"));
+
+        // Queue a message while thinking is streaming.
+        app.handle_agent_event(&make_event(
+            "user_message",
+            "{\"text\":\"queued while streaming\"}",
+        ));
+
+        app.handle_agent_event(&make_event("thinking_delta", "{\"text\":\" reason two\"}"));
+        app.handle_agent_event(&make_event("thinking_end", "{}"));
+
+        assert_eq!(
+            app.chat.last_assistant_thinking(),
+            Some("reason one reason two")
+        );
+        // The queued user message is still the literal last message.
+        assert_eq!(app.chat.last_message().unwrap().role, ChatRole::User);
+    }
+
+    #[tokio::test]
     async fn terminal_acks_map_to_run_states() {
         let (mut app, _rx) = make_app(100, 30);
         app.chat

--- a/tui/src/components/chat_area.rs
+++ b/tui/src/components/chat_area.rs
@@ -557,27 +557,28 @@ impl ChatArea {
     }
 
     pub fn append_thinking_delta(&mut self, text: &str) {
-        if self.messages.is_empty() {
+        // Target the last assistant message, not the literal last message: a
+        // user message queued mid-stream (enqueue_if_busy) is pushed after the
+        // streaming assistant, and the thinking deltas still belong to that
+        // assistant turn. Using `find_assistant_index` mirrors
+        // `append_to_last_message`, which already survives a trailing queued
+        // user message.
+        let Some(idx) = self.find_assistant_index() else {
             return;
-        }
-        let last_idx = self.messages.len() - 1;
-        let last = &mut self.messages[last_idx];
-        if last.role == ChatRole::Assistant {
-            if let Some(thinking) = last.thinking.as_mut() {
-                thinking.push_str(text);
-                self.mark_message_dirty(last_idx);
-            }
+        };
+        let msg = &mut self.messages[idx];
+        if let Some(thinking) = msg.thinking.as_mut() {
+            thinking.push_str(text);
+            self.mark_message_dirty(idx);
         }
     }
 
     pub fn end_thinking(&mut self) {
-        if self.messages.is_empty() {
+        let Some(idx) = self.find_assistant_index() else {
             return;
-        }
-        let last_idx = self.messages.len() - 1;
-        let last = &self.messages[last_idx];
-        if last.role == ChatRole::Assistant && last.thinking.is_some() {
-            self.rerender_message(last_idx);
+        };
+        if self.messages[idx].thinking.is_some() {
+            self.rerender_message(idx);
         }
     }
 
@@ -835,6 +836,16 @@ impl ChatArea {
             .iter()
             .map(|m| (m.role, crate::utils::strip_ansi_codes(&m.content)))
             .collect()
+    }
+
+    /// Test-only view: the last assistant message's thinking text.
+    #[cfg(test)]
+    pub(crate) fn last_assistant_thinking(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| m.role == ChatRole::Assistant)
+            .and_then(|m| m.thinking.as_deref())
     }
 
     fn find_tool_index(&self, tool_id: &str) -> Option<usize> {
@@ -2400,9 +2411,12 @@ mod tests {
         assert_eq!(chat.messages[1].thinking.as_deref(), Some("think"));
         chat.end_thinking();
 
-        // A thinking delta on a non-assistant last message is dropped.
+        // A thinking delta with a user message queued after the streaming
+        // assistant still lands on that assistant (not dropped, not on the
+        // trailing user message).
         chat.add_message(ChatMessage::new("u2".into(), ChatRole::User, "q2"));
         chat.append_thinking_delta("dropped");
+        assert_eq!(chat.messages[1].thinking.as_deref(), Some("thinkdropped"));
         assert!(chat.messages.last().unwrap().thinking.is_none());
 
         // start_thinking on an assistant without thinking adds the section.


### PR DESCRIPTION
## Problem

While the agent is streaming, submitting another message queues it (`enqueue_if_busy`) and pushes a user message bubble after the streaming assistant. From that moment the in-flight thinking deltas stopped rendering — the screen froze until the next tool call produced output.

## Root cause

`ChatArea::append_thinking_delta` and `end_thinking` targeted the **literal last** message. With a queued user message appended after the streaming assistant, the last message is `User`, so every subsequent `thinking_delta` was silently dropped. Text chunks were unaffected because `append_to_last_message` already targets the last **assistant** message via `find_assistant_index`.

## Fix

Target the last assistant message in `append_thinking_delta` / `end_thinking` (mirroring `append_to_last_message`), so thinking keeps streaming to the in-flight turn with a queued message behind it.

## Tests

- New app-level regression test `thinking_deltas_continue_after_queued_message` reproducing the exact event sequence (agent_start → thinking_start → thinking_delta → queued user_message → thinking_delta → thinking_end). Verified it **fails against the old code** and passes with the fix.
- Updated `thinking_lifecycle_edge_cases` which had encoded the old drop behavior.
- `cargo test -p future-tui` → 819 + 5 passed; `make lint-rust` clean.
- Full Rust suites (agent 1584, cli 703, channels 341, rpc/loop, desktop backend 1084) all pass locally.