### PR TITLE
Fix Desktop thinking and response streaming

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -165,41 +165,33 @@ const EVENTS_PAGE_SIZE: i64 = 50_000;
 /// paging from `next`, `None` when the tail is complete. Terminates on a
 /// malformed has_more page (no advancing idx) instead of re-requesting the
 /// same cursor forever.
-fn next_events_cursor(page: &serde_json::Value, cursor: i64) -> Option<i64> {
-    let has_more = page
-        .get("hasMore")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    if !has_more {
+fn next_events_cursor(page: &future_rpc::payloads::EventsSincePayload, cursor: i64) -> Option<i64> {
+    if !page.has_more {
         return None;
     }
-    let last_idx = page
-        .get("events")
-        .and_then(|value| value.as_array())
-        .and_then(|events| events.last())
-        .and_then(|event| event.get("idx"))
-        .and_then(|value| value.as_i64());
-    last_idx.filter(|idx| *idx > cursor)
+    page.events
+        .last()
+        .map(|event| event.idx)
+        .filter(|idx| *idx > cursor)
 }
 
 /// Fetch the agent's buffered events for a session's current run (P1c backfill).
 /// `since_idx = -1` returns the requested run's retained prefix. A stale or
 /// unknown `run_id` is an explicit error and never realigns to another run.
-/// Returns the parsed `data`
-/// JSON — shape `{ runId, events: [{ type, data, runId, idx }] }`. Lets a phone /
-/// web client that joined an in-flight run mid-stream reconstruct the prefix it
-/// missed, keyed by the same `runId`/`idx` the live events carry (so it dedupes).
+/// Returns the canonical typed replay payload. Typed protobuf and legacy JSON
+/// responses are normalized once in `future-rpc`; callers never inspect raw
+/// response JSON or oneof fields themselves.
 ///
 /// Paged under the hood (`max_events`): the returned envelope holds the
 /// complete tail regardless of journal size.
-pub async fn get_events_since(
+pub async fn get_events_since_payload(
     session_id: String,
     run_id: String,
     since_idx: i64,
-) -> Result<serde_json::Value, crate::AppError> {
+) -> Result<future_rpc::payloads::EventsSincePayload, crate::AppError> {
     let mut client = connect_agent().await?;
     let mut cursor = since_idx;
-    let mut merged: Option<serde_json::Value> = None;
+    let mut merged: Option<future_rpc::payloads::EventsSincePayload> = None;
     loop {
         let command = crate::agent_proto::RpcCommand {
             run_id: run_id.clone(),
@@ -229,23 +221,34 @@ pub async fn get_events_since(
             })?
             .into_inner()
             .ok_or_rpc_error("get_events_since returned an error")?;
-        let page = if response.data.is_empty() {
-            serde_json::json!({ "events": [] })
-        } else {
-            future_rpc::decode::response_data(&response)
-        };
+        let mut page = future_rpc::decode::decode_events_since(&response).unwrap_or_else(|| {
+            future_rpc::payloads::EventsSincePayload {
+                run_id: run_id.clone(),
+                events: Vec::new(),
+                truncated: false,
+                projection: None,
+                has_more: false,
+            }
+        });
+        if !page.run_id.is_empty() && page.run_id != run_id {
+            return Err(format!(
+                "get_events_since returned run {}, expected {run_id}",
+                page.run_id
+            )
+            .into());
+        }
+        if page.run_id.is_empty() {
+            page.run_id.clone_from(&run_id);
+        }
         let next = next_events_cursor(&page, cursor);
         match &mut merged {
             None => merged = Some(page),
             Some(total) => {
-                if let (Some(total_events), Some(page_events)) = (
-                    total
-                        .get_mut("events")
-                        .and_then(|value| value.as_array_mut()),
-                    page.get("events").and_then(|value| value.as_array()),
-                ) {
-                    total_events.extend(page_events.iter().cloned());
+                total.truncated |= page.truncated;
+                if total.projection.is_none() {
+                    total.projection = page.projection.take();
                 }
+                total.events.append(&mut page.events);
             }
         }
         match next {
@@ -253,12 +256,28 @@ pub async fn get_events_since(
             None => break,
         }
     }
-    let mut result = merged.unwrap_or_else(|| serde_json::json!({ "events": [] }));
+    let mut result = merged.unwrap_or(future_rpc::payloads::EventsSincePayload {
+        run_id,
+        events: Vec::new(),
+        truncated: false,
+        projection: None,
+        has_more: false,
+    });
     // The merged envelope describes the complete tail, not one page.
-    if let Some(object) = result.as_object_mut() {
-        object.remove("hasMore");
-    }
+    result.has_more = false;
     Ok(result)
+}
+
+/// JSON compatibility wrapper for remote/web consumers. Native Desktop code
+/// uses [`get_events_since_payload`] directly and therefore stays strongly
+/// typed across the RPC boundary.
+pub async fn get_events_since(
+    session_id: String,
+    run_id: String,
+    since_idx: i64,
+) -> Result<serde_json::Value, crate::AppError> {
+    serde_json::to_value(get_events_since_payload(session_id, run_id, since_idx).await?)
+        .map_err(|error| format!("Could not serialize get_events_since response: {error}").into())
 }
 
 /// Fetch a session's full message history from the agent (LLM Message shape:
@@ -1546,20 +1565,25 @@ mod watchdog_tests {
 #[cfg(test)]
 mod events_paging_tests {
     use super::next_events_cursor;
+    use future_rpc::payloads::EventsSincePayload;
     use serde_json::json;
+
+    fn replay_page(value: serde_json::Value) -> EventsSincePayload {
+        serde_json::from_value(value).expect("replay page")
+    }
 
     #[test]
     fn stops_when_the_page_reports_no_tail() {
         // hasMore absent (legacy server) or false ends the loop.
-        let page = json!({"events": [{"idx": 3}]});
+        let page = replay_page(json!({"events": [{"idx": 3}]}));
         assert_eq!(next_events_cursor(&page, -1), None);
-        let page = json!({"events": [{"idx": 3}], "hasMore": false});
+        let page = replay_page(json!({"events": [{"idx": 3}], "hasMore": false}));
         assert_eq!(next_events_cursor(&page, -1), None);
     }
 
     #[test]
     fn advances_to_the_last_event_idx_while_has_more() {
-        let page = json!({"events": [{"idx": 3}, {"idx": 7}], "hasMore": true});
+        let page = replay_page(json!({"events": [{"idx": 3}, {"idx": 7}], "hasMore": true}));
         assert_eq!(next_events_cursor(&page, -1), Some(7));
         assert_eq!(next_events_cursor(&page, 7), None); // idx must advance
     }
@@ -1568,13 +1592,19 @@ mod events_paging_tests {
     fn malformed_has_more_pages_terminate_instead_of_looping() {
         // No events, no idx, or a non-advancing idx would re-request the same
         // cursor forever — the loop must bail.
-        assert_eq!(next_events_cursor(&json!({"hasMore": true}), -1), None);
         assert_eq!(
-            next_events_cursor(&json!({"events": [], "hasMore": true}), -1),
+            next_events_cursor(&replay_page(json!({"hasMore": true})), -1),
             None
         );
         assert_eq!(
-            next_events_cursor(&json!({"events": [{"idx": 5}], "hasMore": true}), 5),
+            next_events_cursor(&replay_page(json!({"events": [], "hasMore": true})), -1),
+            None
+        );
+        assert_eq!(
+            next_events_cursor(
+                &replay_page(json!({"events": [{"idx": 5}], "hasMore": true})),
+                5,
+            ),
             None
         );
     }
@@ -1991,6 +2021,66 @@ mod bridge_tests {
     }
 
     #[tokio::test]
+    async fn events_since_payload_decodes_typed_pages_without_json_reparse() {
+        let mock = mock_agent();
+        mock.push_typed_data(
+            "get_events_since",
+            serde_json::json!({
+                "runId": "run-typed",
+                "events": [
+                    {
+                        "type": "thinking_delta",
+                        "data": "{\"text\":\"reason\"}",
+                        "runId": "run-typed",
+                        "idx": 0
+                    },
+                    {
+                        "type": "text_chunk",
+                        "data": "{\"text\":\"answer\"}",
+                        "runId": "run-typed",
+                        "idx": 1
+                    }
+                ],
+                "truncated": false,
+                "hasMore": false
+            }),
+        );
+
+        let replay =
+            get_events_since_payload("session-typed".to_string(), "run-typed".to_string(), -1)
+                .await
+                .expect("typed replay");
+
+        assert_eq!(replay.run_id, "run-typed");
+        assert_eq!(replay.events.len(), 2);
+        assert_eq!(replay.events[0].event_type, "thinking_delta");
+        assert_eq!(replay.events[0].data, r#"{"text":"reason"}"#);
+        assert_eq!(replay.events[1].event_type, "text_chunk");
+        assert_eq!(replay.events[1].data, r#"{"text":"answer"}"#);
+        assert!(!replay.has_more);
+    }
+
+    #[tokio::test]
+    async fn events_since_payload_rejects_cross_run_response() {
+        let mock = mock_agent();
+        mock.push_typed_data(
+            "get_events_since",
+            serde_json::json!({
+                "runId": "wrong-run",
+                "events": [],
+                "truncated": false
+            }),
+        );
+
+        let error =
+            get_events_since_payload("session-typed".to_string(), "expected-run".to_string(), -1)
+                .await
+                .expect_err("cross-run replay must fail");
+        assert!(error.to_string().contains("wrong-run"), "{error}");
+        assert!(error.to_string().contains("expected-run"), "{error}");
+    }
+
+    #[tokio::test]
     async fn events_since_empty_and_terminating_pages() {
         let mock = mock_agent();
 
@@ -1999,7 +2089,10 @@ mod bridge_tests {
         let merged = get_events_since("s".to_string(), "r".to_string(), 0)
             .await
             .expect("empty");
-        assert_eq!(merged, serde_json::json!({"events": []}));
+        assert_eq!(
+            merged,
+            serde_json::json!({"runId": "r", "events": [], "truncated": false})
+        );
 
         // A hasMore page whose idx does not advance terminates the loop.
         mock.push_data(

--- a/desktop/src-tauri/src/commands/runs.rs
+++ b/desktop/src-tauri/src/commands/runs.rs
@@ -114,36 +114,23 @@ async fn agent_events(
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .unwrap_or_else(|| run.thread_id.clone());
-    let agent_json =
-        agent_bridge::get_events_since(sid, run_id.to_string(), since_sequence).await?;
-    let Some(events) = agent_json.get("events").and_then(|v| v.as_array()) else {
-        return Ok(Vec::new());
-    };
-    let records: Vec<store::RunEventRecord> = events
-        .iter()
+    let replay =
+        agent_bridge::get_events_since_payload(sid, run_id.to_string(), since_sequence).await?;
+    let records: Vec<store::RunEventRecord> = replay
+        .events
+        .into_iter()
         .enumerate()
         .map(|(i, e)| store::RunEventRecord {
-            id: e
-                .get("eventId")
-                .and_then(|v| v.as_str())
-                .filter(|id| !id.is_empty())
-                .map(str::to_string)
-                .unwrap_or_else(|| format!("agent_{run_id}_{i}")),
+            id: if e.event_id.is_empty() {
+                format!("agent_{run_id}_{i}")
+            } else {
+                e.event_id
+            },
             run_id: run_id.to_string(),
-            event_type: e
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            payload: e
-                .get("data")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-            sequence: e.get("idx").and_then(|v| v.as_i64()).unwrap_or(i as i64),
-            created_at: e
-                .get("timestamp")
-                .and_then(|value| value.as_str())
-                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+            event_type: e.event_type,
+            payload: (!e.data.is_empty()).then_some(e.data),
+            sequence: e.idx,
+            created_at: chrono::DateTime::parse_from_rfc3339(&e.timestamp)
                 .map(|value| value.timestamp_millis())
                 .unwrap_or(0),
         })

--- a/desktop/src/features/agent/threadRunProjection.async.test.ts
+++ b/desktop/src/features/agent/threadRunProjection.async.test.ts
@@ -111,6 +111,40 @@ describe("upsertStreamingPreview", () => {
     expect(listRunEventsSince).toHaveBeenLastCalledWith("r-up3", 0);
   });
 
+  it("renders reasoning-only deltas immediately and appends answer text on the next push", async () => {
+    listRunEventsSince.mockResolvedValue(runEvents("r-stream", [
+      ["thinking_start", {}],
+      ["thinking_delta", { text: "live reasoning" }],
+    ]));
+    const { setMessages, state } = collect([userMessage("u1")]);
+
+    await upsertStreamingPreview("r-stream", 1000, setMessages);
+    let bubble = state().find(m => m.id === "stream_r-stream");
+    expect(bubble).toMatchObject({
+      content: "",
+      status: "streaming",
+      thinkingActive: true,
+      segments: [{ kind: "thinking", text: "live reasoning" }],
+    });
+
+    listRunEventsSince.mockResolvedValue(runEvents("r-stream", [
+      ["thinking_end", {}],
+      ["text_chunk", { text: "live answer" }],
+    ], 2));
+    await upsertStreamingPreview("r-stream", 1000, setMessages);
+
+    bubble = state().find(m => m.id === "stream_r-stream");
+    expect(bubble).toMatchObject({
+      content: "live answer",
+      thinkingActive: false,
+      segments: [
+        { kind: "thinking", text: "live reasoning" },
+        { kind: "text", text: "live answer" },
+      ],
+    });
+    expect(listRunEventsSince).toHaveBeenLastCalledWith("r-stream", 1);
+  });
+
   it("rebuilds from the full log when the event sequence regresses", async () => {
     listRunEventsSince.mockResolvedValue(textEvents("r-up4", "one"));
     const { setMessages } = collect([userMessage("u1")]);

--- a/packages/rpc/src/decode.rs
+++ b/packages/rpc/src/decode.rs
@@ -159,7 +159,91 @@ pub fn decode_events_since(resp: &proto::RpcResponse) -> Option<EventsSincePaylo
     {
         return Some(events_since_from_proto(events));
     }
-    fallback_value(resp).and_then(|value| serde_json::from_value(value).ok())
+    fallback_value(resp).and_then(events_since_from_value)
+}
+
+/// Decode the released JSON replay envelope without making one malformed row
+/// poison the whole page. Older clients treated every field independently and
+/// supplied safe defaults; keep that compatibility at the protocol boundary
+/// while all native callers consume one typed shape.
+fn events_since_from_value(value: Value) -> Option<EventsSincePayload> {
+    let object = value.as_object()?;
+    let events = object.get("events")?.as_array()?;
+    Some(EventsSincePayload {
+        run_id: object
+            .get("runId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        events: events
+            .iter()
+            .enumerate()
+            .map(|(index, event)| replay_event_from_value(event, index as i64))
+            .collect(),
+        truncated: object
+            .get("truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        projection: object.get("projection").and_then(projection_from_value),
+        has_more: object
+            .get("hasMore")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    })
+}
+
+fn projection_from_value(value: &Value) -> Option<ProjectionPayload> {
+    let object = value.as_object()?;
+    let events = object.get("events")?.as_array()?;
+    Some(ProjectionPayload {
+        run_id: object
+            .get("runId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        cursor: object.get("cursor").and_then(Value::as_i64).unwrap_or(-1),
+        events: events
+            .iter()
+            .enumerate()
+            .map(|(index, event)| replay_event_from_value(event, index as i64))
+            .collect(),
+    })
+}
+
+fn replay_event_from_value(value: &Value, fallback_idx: i64) -> ReplayEventPayload {
+    let field = |name: &str| value.get(name);
+    ReplayEventPayload {
+        event_type: field("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        data: field("data")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        run_id: field("runId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        idx: field("idx").and_then(Value::as_i64).unwrap_or(fallback_idx),
+        session_id: field("sessionId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        epoch: field("epoch").and_then(Value::as_i64).unwrap_or_default(),
+        event_id: field("eventId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        timestamp: field("timestamp")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        session_idx: field("sessionIdx").and_then(Value::as_i64).unwrap_or(-1),
+        run_sequence: field("runSequence")
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+    }
 }
 
 fn fallback_value(resp: &proto::RpcResponse) -> Option<Value> {
@@ -407,7 +491,11 @@ fn projection_from_proto(projection: &proto::ProjectionSnapshot) -> ProjectionPa
 fn replay_event_from_proto(event: &proto::ReplayEvent) -> ReplayEventPayload {
     ReplayEventPayload {
         event_type: event.r#type.clone(),
-        data: event.data.clone(),
+        // A typed replay event may omit the legacy `data` string. Reconstruct
+        // it from the typed payload so downstream JSON consumers still receive
+        // text/thinking deltas; preserve byte-identical legacy data when it is
+        // present.
+        data: replay_event_data_json(event),
         run_id: event.run_id.clone(),
         idx: event.idx,
         session_id: event.session_id.clone(),
@@ -959,11 +1047,25 @@ mod tests {
             run_id: "r1".to_string(),
             events: vec![proto::ReplayEvent {
                 r#type: "text_chunk".to_string(),
-                data: "{}".to_string(),
+                payload: typed_text_chunk("streamed answer"),
                 ..Default::default()
             }],
             truncated: true,
-            projection: None,
+            projection: Some(proto::ProjectionSnapshot {
+                run_id: "r1".to_string(),
+                cursor: 9,
+                events: vec![proto::ReplayEvent {
+                    r#type: "thinking_delta".to_string(),
+                    payload: Some(proto::EventPayload {
+                        kind: Some(proto::event_payload::Kind::ThinkingDelta(
+                            proto::ThinkingDelta {
+                                text: "streamed thought".to_string(),
+                            },
+                        )),
+                    }),
+                    ..Default::default()
+                }],
+            }),
             has_more: true,
         }));
         let payload = decode_events_since(&resp).unwrap();
@@ -971,9 +1073,31 @@ mod tests {
         assert!(payload.truncated);
         assert!(payload.has_more);
         assert_eq!(payload.events.len(), 1);
+        assert_eq!(payload.events[0].data, r#"{"text":"streamed answer"}"#);
+        assert_eq!(
+            payload.projection.unwrap().events[0].data,
+            r#"{"text":"streamed thought"}"#,
+        );
 
         let resp = resp_with_data(r#"{"runId":"r2","events":[],"truncated":false}"#);
         assert_eq!(decode_events_since(&resp).unwrap().run_id, "r2");
+
+        // Released JSON agents are decoded row-by-row: malformed optional
+        // fields retain the event and receive the same safe defaults Desktop
+        // historically applied after parsing the raw envelope.
+        let resp = resp_with_data(
+            r#"{"events":[
+                {"type":"text_chunk","data":"{\"text\":\"legacy\"}","idx":7},
+                {"type":null,"data":123,"idx":null}
+            ]}"#,
+        );
+        let legacy = decode_events_since(&resp).unwrap();
+        assert_eq!(legacy.events.len(), 2);
+        assert_eq!(legacy.events[0].idx, 7);
+        assert_eq!(legacy.events[0].data, r#"{"text":"legacy"}"#);
+        assert_eq!(legacy.events[1].event_type, "");
+        assert_eq!(legacy.events[1].data, "");
+        assert_eq!(legacy.events[1].idx, 1);
 
         // No typed payload and no data → None.
         assert!(decode_events_since(&proto::RpcResponse::default()).is_none());

--- a/packages/rpc/src/payloads.rs
+++ b/packages/rpc/src/payloads.rs
@@ -162,30 +162,43 @@ pub struct SessionEntryPayload {
 
 /// One replayed event (get_events_since; proto `ReplayEvent`). Keys mirror
 /// the StreamEvent envelope.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplayEventPayload {
     #[serde(rename = "type")]
+    #[serde(default)]
     pub event_type: String,
+    #[serde(default)]
     pub data: String,
+    #[serde(default)]
     pub run_id: String,
+    #[serde(default)]
     pub idx: i64,
+    #[serde(default)]
     pub session_id: String,
+    #[serde(default)]
     pub epoch: i64,
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub session_idx: i64,
+    #[serde(default)]
     pub run_sequence: i64,
 }
 
 /// get_events_since payload (proto `EventsSince`).
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventsSincePayload {
+    #[serde(default)]
     pub run_id: String,
+    #[serde(default)]
     pub events: Vec<ReplayEventPayload>,
+    #[serde(default)]
     pub truncated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub projection: Option<ProjectionPayload>,
     /// True when the page was cut short (request `max_events` / server size
     /// budget) and more events follow. Absent on the wire when false so
@@ -199,11 +212,14 @@ fn is_false(value: &bool) -> bool {
 }
 
 /// A compressed projection snapshot (proto `ProjectionSnapshot`).
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectionPayload {
+    #[serde(default)]
     pub run_id: String,
+    #[serde(default)]
     pub cursor: i64,
+    #[serde(default)]
     pub events: Vec<ReplayEventPayload>,
 }
 


### PR DESCRIPTION
## Summary

- decode get_events_since typed protobuf responses at the shared RPC boundary, with tolerant legacy JSON fallback
- keep Desktop replay pagination and Run event projection strongly typed while preserving the remote/web JSON compatibility wrapper
- reconstruct legacy event data from typed payloads and add regression coverage for reasoning-first incremental rendering

## Root cause

After the typed RPC migration, successful get_events_since responses carry events in the typed payload while the legacy outer data string can be empty. Desktop treated an empty outer data string as an empty replay page, so thinking and text deltas were discarded and only the final prompt response appeared.

## Validation

- cargo test -p future-rpc --lib: 105 passed
- cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib: 1086 passed
- Desktop Vitest full suite: 60 files, 651 passed
- npm --prefix desktop run typecheck
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- cargo fmt --check --manifest-path packages/rpc/Cargo.toml
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- git diff --check

## Not run

- rebuilt Desktop manual GUI interaction test