### PR TITLE
feat(tui,desktop): completion bell when an agent run finishes

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-minimize",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-request-user-attention",
     "dialog:allow-open",
     "dialog:allow-save"
   ]

--- a/desktop/src-tauri/src/agent_bridge/session.rs
+++ b/desktop/src-tauri/src/agent_bridge/session.rs
@@ -654,6 +654,7 @@ mod tests {
             auto_connect_remote: None,
             skill_guide_dismissed: None,
             skill_intro_dismissed: None,
+            bell_on_complete: None,
         })
         .expect("update settings");
         mock.push("set_sandbox_policy", Reply::Data("{}".to_string()));

--- a/desktop/src-tauri/src/commands/settings.rs
+++ b/desktop/src-tauri/src/commands/settings.rs
@@ -40,6 +40,7 @@ mod tests {
             auto_connect_remote: Some(true),
             skill_guide_dismissed: None,
             skill_intro_dismissed: None,
+            bell_on_complete: None,
         })
         .expect("update");
         assert_eq!(updated.approval_tier, "manual");

--- a/desktop/src-tauri/src/store/app_settings.rs
+++ b/desktop/src-tauri/src/store/app_settings.rs
@@ -30,6 +30,9 @@ pub struct AppSettings {
     /// 知道了 / click-outside). Off by default; once set, the bubble and its
     /// blue dot never show again (until app data is wiped).
     pub skill_intro_dismissed: bool,
+    /// Play a completion bell + request window attention when an agent run
+    /// finishes. On by default.
+    pub bell_on_complete: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -42,6 +45,7 @@ pub struct UpdateAppSettingsInput {
     pub auto_connect_remote: Option<bool>,
     pub skill_guide_dismissed: Option<bool>,
     pub skill_intro_dismissed: Option<bool>,
+    pub bell_on_complete: Option<bool>,
 }
 
 const KEY_APPROVAL_TIER: &str = "approval_tier";
@@ -51,6 +55,7 @@ const KEY_AUTO_UPGRADE_SKILLS: &str = "auto_upgrade_skills";
 const KEY_AUTO_CONNECT_REMOTE: &str = "auto_connect_remote";
 const KEY_SKILL_GUIDE_DISMISSED: &str = "skill_guide_dismissed";
 const KEY_SKILL_INTRO_DISMISSED: &str = "skill_intro_dismissed";
+const KEY_BELL_ON_COMPLETE: &str = "bell_on_complete";
 
 pub fn get_app_settings() -> Result<AppSettings, crate::AppError> {
     let conn = connect()?;
@@ -98,6 +103,10 @@ pub fn update_app_settings(input: UpdateAppSettingsInput) -> Result<AppSettings,
         };
         write_value(&tx, KEY_SKILL_INTRO_DISMISSED, value, now)?;
     }
+    if let Some(bell_on_complete) = input.bell_on_complete {
+        let value = if bell_on_complete { "true" } else { "false" };
+        write_value(&tx, KEY_BELL_ON_COMPLETE, value, now)?;
+    }
 
     let settings = read_app_settings(&tx)?;
     tx.commit()?;
@@ -126,6 +135,9 @@ fn read_app_settings(conn: &Connection) -> Result<AppSettings, crate::AppError> 
     let skill_intro_dismissed = read_value(conn, KEY_SKILL_INTRO_DISMISSED)?
         .map(|value| value == "true")
         .unwrap_or(false); // Off by default — the bubble shows once until dismissed.
+    let bell_on_complete = read_value(conn, KEY_BELL_ON_COMPLETE)?
+        .map(|value| value == "true")
+        .unwrap_or(true); // On by default — a finished run should get noticed.
     Ok(AppSettings {
         approval_tier,
         hidden_models,
@@ -134,6 +146,7 @@ fn read_app_settings(conn: &Connection) -> Result<AppSettings, crate::AppError> 
         auto_connect_remote,
         skill_guide_dismissed,
         skill_intro_dismissed,
+        bell_on_complete,
     })
 }
 
@@ -181,6 +194,7 @@ mod tests {
             auto_connect_remote: Some(true),
             skill_guide_dismissed: Some(true),
             skill_intro_dismissed: Some(true),
+            bell_on_complete: None,
         }
     }
 
@@ -228,9 +242,27 @@ mod tests {
             auto_connect_remote: None,
             skill_guide_dismissed: None,
             skill_intro_dismissed: None,
+            bell_on_complete: None,
         })
         .expect("update");
         assert_eq!(updated.approval_tier, "off");
+    }
+
+    #[test]
+    fn bell_on_complete_defaults_on_and_updates_off() {
+        let (_home, conn) = guarded_conn("settings_bell");
+        drop(conn);
+        // Absent → on by default.
+        let default = update_app_settings(UpdateAppSettingsInput::default()).expect("noop");
+        assert!(default.bell_on_complete);
+        // Explicit false → off, and persists across connections.
+        let updated = update_app_settings(UpdateAppSettingsInput {
+            bell_on_complete: Some(false),
+            ..Default::default()
+        })
+        .expect("update");
+        assert!(!updated.bell_on_complete);
+        assert!(!get_app_settings().expect("re-read").bell_on_complete);
     }
 
     #[test]
@@ -244,6 +276,7 @@ mod tests {
         write_value(&conn, KEY_SHOW_THINKING, "yes", 1).expect("write thinking");
         write_value(&conn, KEY_AUTO_UPGRADE_SKILLS, "0", 1).expect("write upgrade");
         write_value(&conn, KEY_AUTO_CONNECT_REMOTE, "true", 1).expect("write remote");
+        write_value(&conn, KEY_BELL_ON_COMPLETE, "yes", 1).expect("write bell");
 
         let settings = read_app_settings(&conn).expect("read");
         assert_eq!(settings.approval_tier, "off");
@@ -251,6 +284,7 @@ mod tests {
         assert!(!settings.show_thinking);
         assert!(!settings.auto_upgrade_skills);
         assert!(settings.auto_connect_remote);
+        assert!(!settings.bell_on_complete);
     }
 
     #[test]
@@ -265,6 +299,7 @@ mod tests {
             auto_connect_remote: None,
             skill_guide_dismissed: None,
             skill_intro_dismissed: None,
+            bell_on_complete: None,
         })
         .expect("noop update");
         assert_eq!(settings.approval_tier, "off", "defaults survive a noop");
@@ -282,6 +317,7 @@ mod tests {
             auto_connect_remote: None,
             skill_guide_dismissed: Some(false),
             skill_intro_dismissed: Some(false),
+            bell_on_complete: None,
         })
         .expect("update");
         assert!(!updated.skill_guide_dismissed);

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -29,6 +29,7 @@ import { ActivityRail } from "./ActivityRail";
 import { AppShellDialogs } from "./AppShellDialogs";
 import { ContextPanel } from "./ContextPanel";
 import { useAgentConnection } from "./hooks/useAgentConnection";
+import { useAgentDoneBell } from "./hooks/useAgentDoneBell";
 import { useApprovals } from "./hooks/useApprovals";
 import { useAppSettings } from "./hooks/useAppSettings";
 import { useAutoUpgradeSkills } from "./hooks/useAutoUpgradeSkills";
@@ -77,6 +78,7 @@ export function AppShell() {
 
   const { appSettings, changeSettings } = useAppSettings();
   useAutoUpgradeSkills(appSettings.autoUpgradeSkills);
+  useAgentDoneBell(appSettings.bellOnComplete);
   const { hasUpdate, cachedStatus, markSeen: markUpdateSeen } = useUpdateChecker();
   // Drives the onboarding gate below. Kept with the other top-level hooks so
   // the early returns further down stay after every hook call (rules of hooks).

--- a/desktop/src/components/layout/hooks/useAgentDoneBell.hook.test.ts
+++ b/desktop/src/components/layout/hooks/useAgentDoneBell.hook.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "../../../test/renderHook";
+import { useAgentDoneBell } from "./useAgentDoneBell";
+
+const playDoneBell = vi.fn();
+vi.mock("../../../lib/doneBell", () => ({
+  playDoneBell: (...args: unknown[]) => playDoneBell(...args),
+}));
+
+const requestUserAttention = vi.fn();
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ requestUserAttention }),
+  UserAttentionType: { Critical: 1, Informational: 2 },
+}));
+
+function emitAgentEnd() {
+  window.dispatchEvent(new CustomEvent("futureos:agent_end", { detail: undefined }));
+}
+
+describe("useAgentDoneBell", () => {
+  beforeEach(() => {
+    playDoneBell.mockReset();
+    requestUserAttention.mockReset();
+  });
+
+  it("bells and requests attention when a run finishes", () => {
+    const { unmount } = renderHook(() => useAgentDoneBell(true));
+    act(() => {
+      emitAgentEnd();
+    });
+    expect(playDoneBell).toHaveBeenCalledTimes(1);
+    // UserAttentionType.Critical compiles to 1.
+    expect(requestUserAttention).toHaveBeenCalledWith(1);
+    unmount();
+  });
+
+  it("stays silent when bellOnComplete is off", () => {
+    const { unmount } = renderHook(() => useAgentDoneBell(false));
+    act(() => {
+      emitAgentEnd();
+    });
+    expect(playDoneBell).not.toHaveBeenCalled();
+    expect(requestUserAttention).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("stops listening after unmount", () => {
+    const { unmount } = renderHook(() => useAgentDoneBell(true));
+    unmount();
+    act(() => {
+      emitAgentEnd();
+    });
+    expect(playDoneBell).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/components/layout/hooks/useAgentDoneBell.ts
+++ b/desktop/src/components/layout/hooks/useAgentDoneBell.ts
@@ -1,0 +1,25 @@
+import { getCurrentWindow, UserAttentionType } from "@tauri-apps/api/window";
+import { useEffect } from "react";
+import { playDoneBell } from "../../../lib/doneBell";
+import { onFutureEvent } from "../../../lib/futureEvents";
+
+/**
+ * Global "agent done" alert: when any conversation's run finishes
+ * (the `agent_end` bus event), play the WebAudio bell and ask the OS to
+ * draw attention to the window (Dock bounce on macOS, taskbar flash on
+ * Windows). Gated by the `bellOnComplete` app setting.
+ *
+ * `agent_end` fires once per finished run regardless of which thread it
+ * belongs to — the hook intentionally lives at the shell level, not inside
+ * a per-thread component.
+ */
+export function useAgentDoneBell(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled)
+      return;
+    return onFutureEvent("agent_end", () => {
+      playDoneBell();
+      void getCurrentWindow().requestUserAttention(UserAttentionType.Critical);
+    });
+  }, [enabled]);
+}

--- a/desktop/src/features/settings/GeneralPage.tsx
+++ b/desktop/src/features/settings/GeneralPage.tsx
@@ -14,6 +14,8 @@ export function GeneralPage({
   onToggleShowThinking,
   autoUpgradeSkills,
   onToggleAutoUpgradeSkills,
+  bellOnComplete,
+  onToggleBellOnComplete,
 }: {
   approvalTier: ApprovalTier;
   onChangeApprovalTier: (value: ApprovalTier) => void;
@@ -21,6 +23,8 @@ export function GeneralPage({
   onToggleShowThinking: (value: boolean) => void;
   autoUpgradeSkills: boolean;
   onToggleAutoUpgradeSkills: (value: boolean) => void;
+  bellOnComplete: boolean;
+  onToggleBellOnComplete: (value: boolean) => void;
 }) {
   const { t } = useTranslation("settings");
   const sandboxAvailability = useSandboxAvailability();
@@ -81,6 +85,12 @@ export function GeneralPage({
           description={t("autoUpgradeSkills.description")}
         >
           <Switch checked={autoUpgradeSkills} label={t("autoUpgradeSkills.title")} onChange={onToggleAutoUpgradeSkills} />
+        </SettingsRow>
+        <SettingsRow
+          title={t("bellOnComplete.title")}
+          description={t("bellOnComplete.description")}
+        >
+          <Switch checked={bellOnComplete} label={t("bellOnComplete.title")} onChange={onToggleBellOnComplete} />
         </SettingsRow>
       </SettingsList>
     </SettingsSection>

--- a/desktop/src/features/settings/SettingsDialog.tsx
+++ b/desktop/src/features/settings/SettingsDialog.tsx
@@ -174,6 +174,8 @@ export function SettingsDialog({
                     onToggleShowThinking={value => onChangeSettings({ showThinking: value })}
                     autoUpgradeSkills={appSettings.autoUpgradeSkills}
                     onToggleAutoUpgradeSkills={value => onChangeSettings({ autoUpgradeSkills: value })}
+                    bellOnComplete={appSettings.bellOnComplete}
+                    onToggleBellOnComplete={value => onChangeSettings({ bellOnComplete: value })}
                   />
                 )
               : null}

--- a/desktop/src/i18n/locales/en/settings.json
+++ b/desktop/src/i18n/locales/en/settings.json
@@ -23,6 +23,10 @@
     "title": "Auto-upgrade skills",
     "description": "Silently upgrade installed skills to their latest version each time the app opens"
   },
+  "bellOnComplete": {
+    "title": "Completion bell",
+    "description": "Play a sound and attract the window's attention when an agent finishes"
+  },
   "remote": {
     "autoConnect": {
       "title": "Auto-connect phone on launch",

--- a/desktop/src/i18n/locales/zh/settings.json
+++ b/desktop/src/i18n/locales/zh/settings.json
@@ -23,6 +23,10 @@
     "title": "自动升级技能",
     "description": "每次打开 App 时静默将已安装技能升级到最新版本"
   },
+  "bellOnComplete": {
+    "title": "完成提示音",
+    "description": "智能体任务完成时播放提示音并吸引窗口注意力"
+  },
   "remote": {
     "autoConnect": {
       "title": "打开软件后自动连接手机",

--- a/desktop/src/integrations/storage/appSettings.ts
+++ b/desktop/src/integrations/storage/appSettings.ts
@@ -30,6 +30,11 @@ export interface AppSettings {
    * never show again (until app data is wiped).
    */
   skillIntroDismissed: boolean;
+  /**
+   * Play a completion bell and request window attention when an agent run
+   * finishes. On by default.
+   */
+  bellOnComplete: boolean;
 }
 
 /** Fallback used before the persisted settings load. */
@@ -41,6 +46,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   autoConnectRemote: false,
   skillGuideDismissed: false,
   skillIntroDismissed: false,
+  bellOnComplete: true,
 };
 
 export async function getAppSettings() {
@@ -55,6 +61,7 @@ export async function updateAppSettings(input: {
   autoConnectRemote?: boolean;
   skillGuideDismissed?: boolean;
   skillIntroDismissed?: boolean;
+  bellOnComplete?: boolean;
 }) {
   return invokeCommand<AppSettings>("update_app_settings", { input });
 }

--- a/desktop/src/lib/doneBell.test.ts
+++ b/desktop/src/lib/doneBell.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Fake AudioContext: records oscillator/gain wiring so tests can assert the
+ * two-note shape without any real audio device.
+ */
+class FakeOscillator {
+  type = "";
+  frequency = { value: 0 };
+  connect = vi.fn().mockReturnThis();
+  start = vi.fn();
+  stop = vi.fn();
+}
+class FakeGain {
+  gain = {
+    value: 0,
+    setValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+  };
+
+  connect = vi.fn().mockReturnThis();
+}
+class FakeAudioContext {
+  currentTime = 0;
+  destination = {};
+  createOscillator = vi.fn(() => new FakeOscillator());
+  createGain = vi.fn(() => new FakeGain());
+}
+
+describe("playDoneBell", () => {
+  let audioContext: FakeAudioContext;
+
+  beforeEach(() => {
+    audioContext = new FakeAudioContext();
+    // A constructible class whose constructor returns the fake instance —
+    // an arrow function can't be `new`-ed by the production code.
+    const StubAudioContext = class {
+      constructor() {
+        return audioContext as unknown as this;
+      }
+    };
+    vi.stubGlobal("AudioContext", StubAudioContext);
+    vi.resetModules();
+  });
+
+  it("synthesizes the two-note ding without any asset", async () => {
+    const { playDoneBell: play } = await import("./doneBell");
+    play();
+    expect(audioContext.createOscillator).toHaveBeenCalledTimes(2);
+    expect(audioContext.createGain).toHaveBeenCalledTimes(2);
+    const first = audioContext.createOscillator.mock.results[0];
+    expect(first?.value.frequency.value).toBe(1318.51); // E6 → C7 ding-dong
+  });
+
+  it("is a silent no-op when AudioContext is unavailable", async () => {
+    vi.stubGlobal("AudioContext", undefined);
+    const { playDoneBell: play } = await import("./doneBell");
+    expect(() => play()).not.toThrow();
+  });
+
+  it("never throws when the audio graph fails mid-way", async () => {
+    audioContext.createOscillator.mockImplementation(() => {
+      throw new Error("no audio device");
+    });
+    const { playDoneBell: play } = await import("./doneBell");
+    expect(() => play()).not.toThrow();
+  });
+});

--- a/desktop/src/lib/doneBell.ts
+++ b/desktop/src/lib/doneBell.ts
@@ -1,0 +1,51 @@
+/**
+ * Completion bell synthesized with the WebAudio API — no audio asset, works
+ * identically on macOS / Windows / Linux. Two sine notes (E6 → C7) give a
+ * short "ding-dong" that is unmistakable but not harsh.
+ *
+ * Deliberately silent-and-safe on failure: jsdom tests, muted systems, or
+ * browsers without an AudioContext must never throw or block the UI thread.
+ */
+
+let ctx: AudioContext | null = null;
+
+const NOTE_E6 = 1318.51;
+const NOTE_C7 = 2093.0;
+
+function bellContext(): AudioContext | null {
+  if (ctx)
+    return ctx;
+  const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor)
+    return null;
+  ctx = new Ctor();
+  return ctx;
+}
+
+function tone(ac: AudioContext, start: number, frequency: number, duration: number, volume: number) {
+  const osc = ac.createOscillator();
+  const gain = ac.createGain();
+  osc.type = "sine";
+  osc.frequency.value = frequency;
+  // Exponential ramps cannot start from 0 — climb from a tiny value.
+  gain.gain.setValueAtTime(0.0001, start);
+  gain.gain.exponentialRampToValueAtTime(volume, start + 0.015);
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  osc.connect(gain).connect(ac.destination);
+  osc.start(start);
+  osc.stop(start + duration + 0.02);
+}
+
+export function playDoneBell() {
+  try {
+    const ac = bellContext();
+    if (!ac)
+      return;
+    const now = ac.currentTime;
+    tone(ac, now, NOTE_E6, 0.16, 0.22);
+    tone(ac, now + 0.14, NOTE_C7, 0.22, 0.16);
+  }
+  catch {
+    // Audio unavailable — the attention request (caller side) still fires.
+  }
+}

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -277,9 +277,15 @@ pub struct TuiSettings {
     pub default_thinking_level: Option<String>,
     pub default_permission_level: Option<String>,
     pub enabled_model_ids: Option<Vec<String>>,
+    /// Terminal bell (BEL) when a run of ours completes or errors. On by default.
+    pub bell_on_complete: Option<bool>,
 }
 
 impl TuiSettings {
+    /// `bellOnComplete` with the default of `true` when absent.
+    pub fn bell_enabled(&self) -> bool {
+        self.bell_on_complete.unwrap_or(true)
+    }
     fn to_json(&self) -> Value {
         // Key order mirrors the TS object literal + late `enabledModelIds`
         // assignment (JSON.stringify preserves insertion order).
@@ -298,6 +304,9 @@ impl TuiSettings {
                 "enabledModelIds".into(),
                 Value::Array(ids.iter().map(|s| Value::String(s.clone())).collect()),
             );
+        }
+        if let Some(bell) = self.bell_on_complete {
+            obj.insert("bellOnComplete".into(), Value::Bool(bell));
         }
         Value::Object(obj)
     }
@@ -322,6 +331,7 @@ impl TuiSettings {
                     .map(String::from)
                     .collect()
             }),
+            bell_on_complete: v.get("bellOnComplete").and_then(Value::as_bool),
         }
     }
 }
@@ -1660,6 +1670,23 @@ impl<T: TerminalIo> App<T> {
             "agent_end" => {
                 if let Some(run_id) = &event.run_id {
                     self.chat.update_run_state(run_id, RunState::Terminal);
+                }
+                // Terminal bell when one of OUR runs finishes cleanly (or
+                // errors out) — the BEL byte goes straight to the terminal
+                // emulator, so it also reaches a user who unfocused the
+                // window. Foreign runs (another client on the same session)
+                // never get a `bind_user_run`, so `has_run` gates them out.
+                let state = event.data.get("state").and_then(Value::as_str);
+                let is_our_run = event
+                    .run_id
+                    .as_deref()
+                    .map(|id| self.chat.has_run(id))
+                    .unwrap_or(false);
+                if self.tui_settings.bell_enabled()
+                    && is_our_run
+                    && matches!(state, Some("completed") | Some("error"))
+                {
+                    self.terminal.write("\x07");
                 }
                 self.state.streaming = self.client.has_running_run();
                 self.state.active_tool_count = 0;
@@ -4759,6 +4786,7 @@ mod tests {
             default_thinking_level: Some("high".into()),
             default_permission_level: None,
             enabled_model_ids: Some(vec!["a".into(), "b".into()]),
+            bell_on_complete: None,
         };
         let json = serde_json::to_string(&settings.to_json()).unwrap();
         let parsed: Value = serde_json::from_str(&json).unwrap();
@@ -4778,6 +4806,7 @@ mod tests {
             default_thinking_level: None,
             default_permission_level: None,
             enabled_model_ids: Some(vec!["x".into()]),
+            bell_on_complete: None,
         };
         let json = serde_json::to_string_pretty(&settings.to_json()).unwrap();
         let model_pos = json.find("defaultModel").unwrap();
@@ -4887,6 +4916,114 @@ mod tests {
             app.chat.last_message().unwrap().run_state,
             Some(RunState::Superseded)
         );
+    }
+
+    // ─── Done bell (agent_end terminal BEL) ────────────────────────────
+
+    fn bind_our_run(app: &mut App<FakeTerminal>, run_id: &str) {
+        app.chat
+            .add_message(ChatMessage::new("m1".into(), ChatRole::User, "hello"));
+        app.chat
+            .bind_user_run("m1", run_id, RunState::Running, None);
+    }
+
+    #[tokio::test]
+    async fn bell_rings_when_our_run_completes() {
+        let (mut app, _rx) = make_app(100, 30);
+        bind_our_run(&mut app, "run-1");
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"completed"}"#,
+            "run-1",
+        ));
+        assert!(
+            terminal_writes(&app).contains('\x07'),
+            "a clean completion of our run must ring the terminal bell, wrote: {:?}",
+            terminal_writes(&app)
+        );
+    }
+
+    #[tokio::test]
+    async fn bell_rings_when_our_run_errors() {
+        let (mut app, _rx) = make_app(100, 30);
+        bind_our_run(&mut app, "run-1");
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"error"}"#,
+            "run-1",
+        ));
+        assert!(
+            terminal_writes(&app).contains('\x07'),
+            "an errored run needs the user's attention too"
+        );
+    }
+
+    #[tokio::test]
+    async fn bell_stays_silent_for_foreign_run() {
+        let (mut app, _rx) = make_app(100, 30);
+        bind_our_run(&mut app, "run-1");
+        // A completed run this client never submitted (another TUI on the
+        // same session) must not ring our bell.
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"completed"}"#,
+            "run-foreign",
+        ));
+        assert!(
+            !terminal_writes(&app).contains('\x07'),
+            "foreign runs must not ring the bell"
+        );
+    }
+
+    #[tokio::test]
+    async fn bell_stays_silent_for_cancelled_and_incomplete_runs() {
+        let (mut app, _rx) = make_app(100, 30);
+        bind_our_run(&mut app, "run-1");
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"cancelled"}"#,
+            "run-1",
+        ));
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"incomplete"}"#,
+            "run-1",
+        ));
+        assert!(
+            !terminal_writes(&app).contains('\x07'),
+            "user-initiated cancels and incomplete streams must not ring"
+        );
+    }
+
+    #[tokio::test]
+    async fn bell_respects_bell_on_complete_setting() {
+        let (mut app, _rx) = make_app(100, 30);
+        bind_our_run(&mut app, "run-1");
+        app.tui_settings.bell_on_complete = Some(false);
+        app.handle_agent_event(&make_event_with_run(
+            "agent_end",
+            r#"{"state":"completed"}"#,
+            "run-1",
+        ));
+        assert!(
+            !terminal_writes(&app).contains('\x07'),
+            "bellOnComplete=false must silence the bell"
+        );
+    }
+
+    #[test]
+    fn tui_settings_bell_on_complete_roundtrip() {
+        // Absent → default on.
+        let v: Value = json_parse(r#"{}"#);
+        assert!(TuiSettings::from_json(&v).bell_enabled());
+        // Explicit false → off.
+        let v: Value = json_parse(r#"{"bellOnComplete":false}"#);
+        assert!(!TuiSettings::from_json(&v).bell_enabled());
+        // Explicit true → on, and serializes back to bellOnComplete.
+        let v: Value = json_parse(r#"{"bellOnComplete":true}"#);
+        let settings = TuiSettings::from_json(&v);
+        assert!(settings.bell_enabled());
+        assert_eq!(settings.to_json()["bellOnComplete"], Value::Bool(true));
     }
 
     #[tokio::test]

--- a/tui/src/components/chat_area.rs
+++ b/tui/src/components/chat_area.rs
@@ -364,6 +364,15 @@ impl ChatArea {
         self.rerender_message(index);
     }
 
+    /// True when this chat owns a message bound to `run_id` — i.e. the run
+    /// was submitted by this client (foreign runs from other clients on the
+    /// same session never get a `bind_user_run`).
+    pub fn has_run(&self, run_id: &str) -> bool {
+        self.messages
+            .iter()
+            .any(|m| m.run_id.as_deref() == Some(run_id))
+    }
+
     pub fn update_queue_position(&mut self, run_id: &str, queue_position: u32) {
         let Some(index) = self
             .messages


### PR DESCRIPTION
## What

Agent 任务结束时「叮」一下 —— TUI 和 GUI 两端都加上，对应 DHH 访谈里 Herdr 的「agent done → ding」体验。

### TUI
- `agent_end` 命中自己提交的 run（`chat.has_run` 门控，同 session 其他客户端的 foreign run 不会响）且状态为 `completed` / `error` 时，向终端写 `\x07`（BEL）——即使窗口失焦，终端模拟器也会响铃。
- 新增 TUI 设置 `bellOnComplete`（`~/.future/tui/settings.json`），缺省开启。

### Desktop
- 新增 `useAgentDoneBell` hook（AppShell 层级）：`agent_end` 总线事件触发 WebAudio 双音 ding（E6→C7，无音频资源）+ `requestUserAttention(Critical)`（macOS Dock 跳动 / Windows 任务栏闪烁）。
- 新增 `bellOnComplete` 应用设置（SQLite，缺省开启），Settings > General 加了开关，i18n en/zh。
- capability 增加 `core:window:allow-request-user-attention`。

## Tests

- TUI：6 个新测试 —— 完成/错误响铃、foreign run 静默、cancelled/incomplete 静默、设置关闭静默、设置 JSON 往返。全量 825 通过。
- Desktop Rust：app_settings 默认值/持久化/损坏修复测试。1087 通过。
- Desktop TS：`doneBell.test.ts`（假 AudioContext 双音形状 + 无音频环境 no-op + 中途异常不抛）+ `useAgentDoneBell.hook.test.ts`（开启/关闭/卸载）。vitest 657 通过。
- `make lint-rust` + `make test`（全量套件）本地通过。