### PR TITLE
fix(tui): stop footer spinner from re-asserting after agent_end

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -3347,7 +3347,22 @@ impl<T: TerminalIo> App<T> {
         }
         self.state.model = s.model.clone().unwrap_or_else(|| "(no model)".to_string());
         self.state.thinking = s.thinking_level.clone();
-        self.state.streaming = s.is_streaming;
+        // Guard against a stale `get_state` snapshot racing `agent_end`: the
+        // agent broadcasts `agent_end` from inside the run task but only
+        // clears `is_streaming` later, when the completion monitor calls
+        // `RunControl::finish`. A refresh answered inside that window returns
+        // `isStreaming: true` + an `activeRun` in "finalizing". If our local
+        // event bookkeeping already marked that exact run terminal, the event
+        // stream is fresher — don't let the stale snapshot re-assert the
+        // spinner (there is no later refresh to correct it).
+        let stale_finalizing = match &s.active_run {
+            Some(active) if s.is_streaming && active.state == "finalizing" => self
+                .chat
+                .run_state(&active.run_id)
+                .is_some_and(|rs| rs != RunState::Running && rs != RunState::Queued),
+            _ => false,
+        };
+        self.state.streaming = s.is_streaming && !stale_finalizing;
         if !self.state.streaming {
             self.state.active_tool_count = 0;
             self.state.tool_start_time = None;
@@ -4856,6 +4871,131 @@ mod tests {
         app.state.model = "deepseek-v4-pro".into();
         app.handle_cmd(UiCmd::Refreshed(Err("transport error".into())));
         assert_eq!(app.state.model, "deepseek-v4-pro");
+    }
+
+    /// Regression test for the "spinner keeps spinning after the reply
+    /// finishes" bug.
+    ///
+    /// The agent broadcasts `agent_end` from inside the run task, but only
+    /// clears `is_streaming` in the completion monitor that runs *after* the
+    /// task returns (`RunControl::finish`). A `get_state` that lands in that
+    /// window returns the stale `is_streaming: true` + `activeRun` in
+    /// "finalizing", and `apply_refresh_state` must not let it overwrite the
+    /// `streaming = false` the `agent_end` handler just set — with no later
+    /// refresh to correct it, the footer spinner would stay up forever.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stale_get_state_after_agent_end_must_not_reassert_streaming() {
+        let stale = r#"{
+            "sessionId":"s1",
+            "model":"openai/gpt-4o",
+            "thinkingLevel":"high",
+            "isStreaming":true,
+            "activeRun":{"runId":"run-1","epoch":1,"state":"finalizing","lastEventIdx":9}
+        }"#
+        .to_string();
+        let mock = AppMockAgent {
+            state_script: Some(std::sync::Arc::new(std::sync::Mutex::new(vec![stale]))),
+            ..Default::default()
+        };
+        let (addr, _seen) = spawn_app_mock_with(mock).await;
+        let (mut app, mut rx) = make_app_at(&addr, &CliOptions::default());
+        app.client.set_current_session_id("s1");
+
+        // A run is streaming.
+        app.handle_agent_event(&make_event("agent_start", "{}"));
+        assert!(app.state.streaming);
+
+        // agent_end arrives; local run bookkeeping already marks it terminal,
+        // so the handler correctly clears streaming.
+        app.handle_agent_event(&make_event_with_run("agent_end", "{}", "run-1"));
+        assert!(!app.state.streaming, "agent_end must clear streaming");
+
+        // The handler's spawn_refresh races the agent's finish(): the mock
+        // answers get_state with the stale in-flight snapshot. The run is
+        // already terminal in local bookkeeping, so apply_refresh_state must
+        // ignore the stale streaming re-assertion.
+        for _ in 0..300 {
+            while let Ok(cmd) = rx.try_recv() {
+                app.handle_cmd(cmd);
+            }
+            if !_seen.lock().unwrap().is_empty() {
+                // get_state was served; give the Refreshed cmd one more tick
+                // to be processed before concluding.
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                while let Ok(cmd) = rx.try_recv() {
+                    app.handle_cmd(cmd);
+                }
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            !app.state.streaming,
+            "stale finalizing snapshot must not re-assert streaming (spinner stuck)"
+        );
+    }
+
+    /// Same race as above, but for a run this client never saw end (a foreign
+    /// run owned by another client on the same session): local bookkeeping
+    /// has no terminal record, so the snapshot's streaming must be trusted.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn finalizing_snapshot_for_unknown_run_keeps_streaming() {
+        let state = r#"{
+            "sessionId":"s1",
+            "model":"openai/gpt-4o",
+            "thinkingLevel":"high",
+            "isStreaming":true,
+            "activeRun":{"runId":"foreign-run","epoch":1,"state":"finalizing","lastEventIdx":9}
+        }"#
+        .to_string();
+        let mock = AppMockAgent {
+            state_script: Some(std::sync::Arc::new(std::sync::Mutex::new(vec![state]))),
+            ..Default::default()
+        };
+        let (addr, _seen) = spawn_app_mock_with(mock).await;
+        let (op_tx, mut rx) = mpsc::unbounded_channel();
+        let (client, mut events, _conn) = GrpcClient::new(&addr);
+        let mut app = App::new(
+            FakeTerminal {
+                writes: Rc::new(RefCell::new(Vec::new())),
+                cols: 100,
+                rows: 30,
+                on_input: None,
+                on_resize: None,
+            },
+            Arc::new(client),
+            op_tx,
+            &CliOptions::default(),
+            std::env::temp_dir().join(format!("tui-test-settings-{}.json", random_id())),
+        );
+        app.client.set_current_session_id("s1");
+
+        // A foreign run streams: agent_start arrives over the event stream,
+        // but this client has no message bound to the run.
+        app.handle_agent_event(&make_event_with_run("agent_start", "{}", "foreign-run"));
+        assert!(app.state.streaming);
+
+        // The agent_end event is missed (raced past the subscription), and
+        // the periodic refresh is what tells the TUI the run is still live.
+        app.state.streaming = false;
+        app.spawn_refresh();
+        for _ in 0..300 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            while let Ok(cmd) = rx.try_recv() {
+                app.handle_cmd(cmd);
+            }
+            // Keep the client's event receiver drained so the stream manager
+            // never sees a full channel.
+            while events.try_recv().is_ok() {}
+            let got_state = _seen.lock().unwrap().iter().any(|(t, _)| t == "get_state");
+            if got_state && rx.is_empty() {
+                break;
+            }
+        }
+        assert!(
+            app.state.streaming,
+            "finalizing snapshot for an unknown (foreign) run must keep streaming"
+        );
     }
 
     #[tokio::test]

--- a/tui/src/components/chat_area.rs
+++ b/tui/src/components/chat_area.rs
@@ -364,6 +364,15 @@ impl ChatArea {
         self.rerender_message(index);
     }
 
+    /// Current lifecycle state tracked for `run_id` (None when the run is
+    /// unknown to this chat).
+    pub fn run_state(&self, run_id: &str) -> Option<RunState> {
+        self.messages
+            .iter()
+            .find(|m| m.run_id.as_deref() == Some(run_id))
+            .and_then(|m| m.run_state)
+    }
+
     /// True when this chat owns a message bound to `run_id` — i.e. the run
     /// was submitted by this client (foreign runs from other clients on the
     /// same session never get a `bind_user_run`).


### PR DESCRIPTION
## Problem

After an AI reply finishes, the footer spinner keeps spinning even though the answer is complete. Submitting a new prompt still works.

## Root cause

A race between the event stream and a refresh RPC:

- The agent broadcasts `agent_end` from *inside* the run task, but only clears `is_streaming` later — when the completion monitor runs `RunControl::finish` after the task returns.
- The TUI's `agent_end` handler sets `streaming = false` and immediately fires `spawn_refresh()` (to update token/cost totals).
- If that `get_state` lands while the agent's run is still in the "finalizing" window, the snapshot returns `isStreaming: true` + `activeRun.state = "finalizing"`. `apply_refresh_state` blindly overwrote `streaming` back to `true`, and no later refresh corrects it — the spinner stays up forever.

The race predates the Rust TUI (it's a 1:1 port of the TS code), but became far more likely after the durable run-lifecycle refactor (#65/#66) widened the finalizing window to include the synchronous disk commit.

## Fix

Guard `apply_refresh_state`: when a snapshot shows `isStreaming: true` with an `activeRun` in "finalizing", only honor it if local run bookkeeping has **not** already marked that exact run terminal. That means:

- Our own run (locally terminal via `agent_end`) → stale snapshot is ignored, spinner stops.
- A foreign run (another client on the same session, or one we attached to mid-run) → no local record, so the snapshot is trusted and streaming still shows.

## Tests

- `stale_get_state_after_agent_end_must_not_reassert_streaming` — reproduces the exact race (mock `get_state` returns the stale in-flight snapshot) and asserts the spinner is not re-asserted.
- `finalizing_snapshot_for_unknown_run_keeps_streaming` — guards the foreign-run path so the fix doesn't over-correct.

All 827 `future-tui` lib tests pass; fmt + clippy clean.