### PR TITLE
fix(history): harden typed session recovery across clients

### DIFF
--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -487,231 +487,277 @@ pub(crate) fn cmd_get_session_entries(
         let sess = session.read();
         (sess.session_manager.clone(), sess.session_id.clone())
     };
-    let entries: Vec<serde_json::Value> = session_manager
-        .load(&session_id)
-        .map(|s| {
-            // The authoritative metadata is the last session_info snapshot
-            // (the append-only commit path appends a fresh one per run). Surface
-            // it in the first session_info slot — where clients (CLI info, fork)
-            // look — and drop the stale earlier ones so callers see exactly one.
-            let authoritative_info = s
-                .entries
-                .iter()
-                .rev()
-                .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
-                .and_then(|e| e.content.clone());
-            let mut emitted_session_info = false;
-            // Per-run output tokens + wall-clock duration live only in the
-            // `run_terminal` marker's content JSON (the assistant entry's content
-            // is a block array, so it can't carry them). Bind each marker to the
-            // assistant entry that precedes it — the run's final reply — so the
-            // GUI/mobile footer ("time · N tokens") survives a reload. Positional
-            // binding (not run_id) because the on-disk assistant entry's meta may
-            // lack run_id on the append-only fast path. Clearing the pointer after
-            // a marker keeps a terminal of a reply-less run (cancel/error before
-            // any assistant entry) from overwriting the previous run's stats.
-            let mut last_assistant_id: Option<String> = None;
-            let mut run_stats: std::collections::HashMap<String, (i64, i64, i64, i64)> =
-                std::collections::HashMap::new();
-            // Per-run usage deltas from the cumulative session_info snapshots
-            // (tokens_in / tokens_cache_r): the snapshot written just before a
-            // run_terminal marker is the post-run state, and the one captured at
-            // the previous run_terminal (or session start) is the pre-run state,
-            // so consecutive-snapshot deltas are exactly this run's billed usage.
-            let mut prev_snapshot: (i64, i64) = (0, 0);
-            let mut current_snapshot: (i64, i64) = (0, 0);
-            for marker in &s.entries {
-                if marker.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
-                    last_assistant_id = Some(marker.id.clone());
-                } else if marker.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                    if let Some(content) = marker.content.as_ref() {
-                        current_snapshot = (
-                            content
-                                .get("tokens_in")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(current_snapshot.0),
-                            content
-                                .get("tokens_cache_r")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(current_snapshot.1),
-                        );
-                    }
-                } else if marker.entry_type == crate::session::ENTRY_TYPE_RUN_TERMINAL {
-                    if let (Some(aid), Some(content)) =
-                        (last_assistant_id.as_deref(), marker.content.as_ref())
-                    {
-                        let tokens = content
-                            .get("run_tokens")
+    let session_path = session_manager.session_path(&session_id);
+    if !session_path.exists() {
+        return RpcResponse::ok(
+            id,
+            "get_session_entries",
+            serde_json::json!({"entries": []}),
+        );
+    }
+    let loaded = match session_manager.load(&session_id) {
+        Ok(session) => session,
+        Err(error) => {
+            return RpcResponse::build_fail_code(
+                id,
+                "get_session_entries",
+                "session_history_unreadable",
+                &format!("Unable to load session history: {error}"),
+                serde_json::json!({"sessionId": session_id}),
+            );
+        }
+    };
+    let entries: Vec<serde_json::Value> = {
+        let s = loaded;
+        // The authoritative metadata is the last session_info snapshot
+        // (the append-only commit path appends a fresh one per run). Surface
+        // it in the first session_info slot — where clients (CLI info, fork)
+        // look — and drop the stale earlier ones so callers see exactly one.
+        let authoritative_info = s
+            .entries
+            .iter()
+            .rev()
+            .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
+            .and_then(|e| e.content.clone());
+        let mut emitted_session_info = false;
+        // Per-run output tokens + wall-clock duration live only in the
+        // `run_terminal` marker's content JSON (the assistant entry's content
+        // is a block array, so it can't carry them). Bind each marker to the
+        // assistant entry that precedes it — the run's final reply — so the
+        // GUI/mobile footer ("time · N tokens") survives a reload. Positional
+        // binding (not run_id) because the on-disk assistant entry's meta may
+        // lack run_id on the append-only fast path. Clearing the pointer after
+        // a marker keeps a terminal of a reply-less run (cancel/error before
+        // any assistant entry) from overwriting the previous run's stats.
+        let mut last_assistant_id: Option<String> = None;
+        let mut run_stats: std::collections::HashMap<String, (i64, i64, i64, i64)> =
+            std::collections::HashMap::new();
+        // Per-run usage deltas from the cumulative session_info snapshots
+        // (tokens_in / tokens_cache_r): the snapshot written just before a
+        // run_terminal marker is the post-run state, and the one captured at
+        // the previous run_terminal (or session start) is the pre-run state,
+        // so consecutive-snapshot deltas are exactly this run's billed usage.
+        let mut prev_snapshot: (i64, i64) = (0, 0);
+        let mut current_snapshot: (i64, i64) = (0, 0);
+        for marker in &s.entries {
+            if marker.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
+                last_assistant_id = Some(marker.id.clone());
+            } else if marker.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                if let Some(content) = marker.content.as_ref() {
+                    current_snapshot = (
+                        content
+                            .get("tokens_in")
                             .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-                        let duration = content
-                            .get("run_duration_ms")
+                            .unwrap_or(current_snapshot.0),
+                        content
+                            .get("tokens_cache_r")
                             .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-                        let delta_in = (current_snapshot.0 - prev_snapshot.0).max(0);
-                        let delta_cache = (current_snapshot.1 - prev_snapshot.1).max(0);
-                        run_stats
-                            .insert(aid.to_string(), (tokens, duration, delta_in, delta_cache));
-                    }
-                    last_assistant_id = None;
-                    prev_snapshot = current_snapshot;
+                            .unwrap_or(current_snapshot.1),
+                    );
                 }
+            } else if marker.entry_type == crate::session::ENTRY_TYPE_RUN_TERMINAL {
+                if let (Some(aid), Some(content)) =
+                    (last_assistant_id.as_deref(), marker.content.as_ref())
+                {
+                    let tokens = content
+                        .get("run_tokens")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let duration = content
+                        .get("run_duration_ms")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let delta_in = (current_snapshot.0 - prev_snapshot.0).max(0);
+                    let delta_cache = (current_snapshot.1 - prev_snapshot.1).max(0);
+                    run_stats.insert(aid.to_string(), (tokens, duration, delta_in, delta_cache));
+                }
+                last_assistant_id = None;
+                prev_snapshot = current_snapshot;
             }
-            s.entries
-                .iter()
-                .filter(|e| {
-                    if !matches!(
-                        e.entry_type.as_str(),
-                        "user" | "assistant" | "tool" | "session_info" | "compaction"
-                    ) {
+        }
+        s.entries
+            .iter()
+            .filter(|e| {
+                if !matches!(
+                    e.entry_type.as_str(),
+                    "user" | "assistant" | "tool" | "session_info" | "compaction"
+                ) {
+                    return false;
+                }
+                // Keep only the first session_info slot; its content is
+                // replaced with the authoritative (last) snapshot below, and
+                // the stale later snapshots are dropped.
+                if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                    if emitted_session_info {
                         return false;
                     }
-                    // Keep only the first session_info slot; its content is
-                    // replaced with the authoritative (last) snapshot below, and
-                    // the stale later snapshots are dropped.
-                    if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                        if emitted_session_info {
-                            return false;
-                        }
-                        emitted_session_info = true;
-                    }
-                    true
-                })
-                .map(|e| {
-                    let content_text = e
-                        .content
-                        .as_ref()
-                        .map(|c| {
-                            if let Some(arr) = c.as_array() {
-                                let texts = arr.iter().filter_map(|block| {
-                                    (block.get("type").and_then(|value| value.as_str())
-                                        == Some("text"))
+                    emitted_session_info = true;
+                }
+                true
+            })
+            .map(|e| {
+                let content_text = e
+                    .content
+                    .as_ref()
+                    .map(|c| {
+                        if let Some(arr) = c.as_array() {
+                            let texts = arr.iter().filter_map(|block| {
+                                (block.get("type").and_then(|value| value.as_str()) == Some("text"))
                                     .then(|| block.get("text").and_then(|text| text.as_str()))
                                     .flatten()
-                                });
-                                if e.role == "user" {
-                                    // A user entry's visible text is only their typed
-                                    // message (the first text block). Any later text
-                                    // block is agent-injected attachment context
-                                    // (file paths), which must not leak into the bubble.
-                                    texts.take(1).collect::<Vec<_>>().join(" ")
-                                } else {
-                                    texts.collect::<Vec<_>>().join(" ")
-                                }
+                            });
+                            if e.role == "user" {
+                                // A user entry's visible text is only their typed
+                                // message (the first text block). Any later text
+                                // block is agent-injected attachment context
+                                // (file paths), which must not leak into the bubble.
+                                texts.take(1).collect::<Vec<_>>().join(" ")
                             } else {
-                                c.as_str().unwrap_or("").to_string()
+                                texts.collect::<Vec<_>>().join(" ")
                             }
-                        })
-                        .unwrap_or_default();
-                    // Build the display content for this entry. Only include the
-                    // actual visible text — no thinking or tool formatting.
-                    // The forked session's messages should look identical to
-                    // original GUI messages (which store thinking/tools in
-                    // run events, not in the message content).
-                    let full_content = if e.entry_type == "tool" {
-                        // Tool entries: show the result text, or a placeholder.
-                        e.content
-                            .as_ref()
-                            .and_then(serde_json::Value::as_array)
-                            .and_then(|blocks| {
-                                blocks.iter().find_map(|block| {
-                                    (block.get("type").and_then(serde_json::Value::as_str)
-                                        == Some("tool_result"))
-                                    .then(|| {
-                                        block.get("content").and_then(serde_json::Value::as_str)
-                                    })
-                                    .flatten()
-                                })
+                        } else {
+                            c.as_str().unwrap_or("").to_string()
+                        }
+                    })
+                    .unwrap_or_default();
+                // Build the display content for this entry. Only include the
+                // actual visible text — no thinking or tool formatting.
+                // The forked session's messages should look identical to
+                // original GUI messages (which store thinking/tools in
+                // run events, not in the message content).
+                let full_content = if e.entry_type == "tool" {
+                    // Tool entries: show the result text, or a placeholder.
+                    e.content
+                        .as_ref()
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|blocks| {
+                            blocks.iter().find_map(|block| {
+                                (block.get("type").and_then(serde_json::Value::as_str)
+                                    == Some("tool_result"))
+                                .then(|| block.get("content").and_then(serde_json::Value::as_str))
+                                .flatten()
                             })
-                            .map(str::to_owned)
-                            .unwrap_or(content_text)
-                    } else {
-                        // User and assistant entries: just the text content.
-                        content_text
-                    };
+                        })
+                        .map(str::to_owned)
+                        .unwrap_or(content_text)
+                } else {
+                    // User and assistant entries: just the text content.
+                    content_text
+                };
 
-                    // Typed payload (audit item 1): SessionEntryPayload mirrors
-                    // the on-disk entry schema (snake_case keys).
-                    let mut payload = crate::rpc::payloads::SessionEntryPayload {
-                        id: e.id.clone(),
-                        entry_type: Some(e.entry_type.clone()),
-                        role: e.role.clone(),
-                        content: serde_json::Value::String(full_content),
-                        name: e.name.clone(),
-                        tool_args: e.tool_args.clone(),
-                        timestamp: e.timestamp.to_rfc3339(),
-                        thinking: None,
-                        meta: None,
-                        tool_calls: None,
-                        output_tokens: None,
-                        duration_ms: None,
-                        input_tokens: None,
-                        cache_read_tokens: None,
-                        checkpoint: None,
-                    };
-                    if e.entry_type == crate::session::ENTRY_TYPE_COMPACTION {
-                        payload.content = serde_json::Value::String(String::new());
-                        payload.checkpoint = e.content.clone();
-                    }
-                    // Include thinking and tool_calls for the new agent-based
-                    // message display (entryProjection.ts).
-                    if !e.thinking.is_empty() {
-                        payload.thinking = Some(e.thinking.clone());
-                    }
-                    // Structured per-entry metadata (e.g. user attachments with
-                    // their cached thumbnails) so the GUI can rebuild attachment
-                    // chips after reload — the JSONL is the only message source.
-                    if let Some(ref meta) = e.meta {
-                        payload.meta = Some(meta.clone());
-                    }
-                    if !e.tool_calls.is_empty() {
-                        payload.tool_calls = serde_json::to_value(&e.tool_calls).ok();
-                    }
-                    // Surface this reply's output tokens + duration on the final
-                    // assistant entry of each run (bound from the run_terminal
-                    // marker above) so the footer can show "time · N tokens" after
-                    // a reload — entriesToMessages / the mobile reducer read these
-                    // top-level fields.
-                    if e.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
-                        if let Some((tokens, duration, delta_in, delta_cache)) =
-                            run_stats.get(&e.id)
-                        {
-                            if *tokens > 0 {
-                                payload.output_tokens = Some(*tokens);
-                            }
-                            if *duration > 0 {
-                                payload.duration_ms = Some(*duration);
-                            }
-                            if *delta_in > 0 {
-                                payload.input_tokens = Some(*delta_in);
-                            }
-                            if *delta_cache > 0 {
-                                payload.cache_read_tokens = Some(*delta_cache);
-                            }
+                // Typed payload (audit item 1): SessionEntryPayload mirrors
+                // the on-disk entry schema (snake_case keys).
+                let mut payload = crate::rpc::payloads::SessionEntryPayload {
+                    id: e.id.clone(),
+                    entry_type: Some(e.entry_type.clone()),
+                    role: e.role.clone(),
+                    content: serde_json::Value::String(full_content),
+                    name: e.name.clone(),
+                    tool_args: e.tool_args.clone(),
+                    timestamp: e.timestamp.to_rfc3339(),
+                    thinking: None,
+                    meta: None,
+                    tool_calls: None,
+                    output_tokens: None,
+                    duration_ms: None,
+                    input_tokens: None,
+                    cache_read_tokens: None,
+                    checkpoint: None,
+                    tool_call_id: None,
+                    tool_result_is_error: None,
+                };
+                if e.entry_type == crate::session::ENTRY_TYPE_COMPACTION {
+                    payload.content = serde_json::Value::String(String::new());
+                    payload.checkpoint = e.content.clone();
+                }
+                // Include thinking and tool_calls for the new agent-based
+                // message display (entryProjection.ts).
+                if !e.thinking.is_empty() {
+                    payload.thinking = Some(e.thinking.clone());
+                }
+                // Structured per-entry metadata (e.g. user attachments with
+                // their cached thumbnails) so the GUI can rebuild attachment
+                // chips after reload — the JSONL is the only message source.
+                if let Some(ref meta) = e.meta {
+                    payload.meta = Some(meta.clone());
+                }
+                if !e.tool_calls.is_empty() {
+                    payload.tool_calls = serde_json::to_value(&e.tool_calls).ok();
+                }
+                if !e.tool_call_id.is_empty() {
+                    payload.tool_call_id = Some(e.tool_call_id.clone());
+                }
+                if e.entry_type == crate::session::ENTRY_TYPE_TOOL {
+                    payload.tool_result_is_error = e
+                        .content
+                        .as_ref()
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|blocks| {
+                            blocks.iter().find(|block| {
+                                block.get("type").and_then(serde_json::Value::as_str)
+                                    == Some("tool_result")
+                            })
+                        })
+                        .map(|block| {
+                            block
+                                .get("is_error")
+                                .and_then(serde_json::Value::as_bool)
+                                .unwrap_or(false)
+                        });
+                }
+                // Surface this reply's output tokens + duration on the final
+                // assistant entry of each run (bound from the run_terminal
+                // marker above) so the footer can show "time · N tokens" after
+                // a reload — entriesToMessages / the mobile reducer read these
+                // top-level fields.
+                if e.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
+                    if let Some((tokens, duration, delta_in, delta_cache)) = run_stats.get(&e.id) {
+                        if *tokens > 0 {
+                            payload.output_tokens = Some(*tokens);
+                        }
+                        if *duration > 0 {
+                            payload.duration_ms = Some(*duration);
+                        }
+                        if *delta_in > 0 {
+                            payload.input_tokens = Some(*delta_in);
+                        }
+                        if *delta_cache > 0 {
+                            payload.cache_read_tokens = Some(*delta_cache);
                         }
                     }
-                    // For session_info entries, include the original content
-                    // JSON (session_name, cwd, parent_session_id, …) so callers can
-                    // read fork metadata without a second RPC.
-                    if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                        // Use the authoritative (last) snapshot's content so the
-                        // single emitted session_info reflects current metadata,
-                        // not the stale values from session creation.
-                        if let Some(ref content) = authoritative_info {
-                            payload.content = content.clone();
-                        }
+                }
+                // For session_info entries, include the original content
+                // JSON (session_name, cwd, parent_session_id, …) so callers can
+                // read fork metadata without a second RPC.
+                if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                    // Use the authoritative (last) snapshot's content so the
+                    // single emitted session_info reflects current metadata,
+                    // not the stale values from session creation.
+                    if let Some(ref content) = authoritative_info {
+                        payload.content = content.clone();
                     }
-                    serde_json::to_value(&payload).unwrap_or_default()
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+                }
+                serde_json::to_value(&payload).unwrap_or_default()
+            })
+            .collect()
+    };
     if let Some(raw_offset) = cmd.offset {
+        const PAGE_BYTES: usize = 8 * 1024 * 1024;
         let offset = raw_offset.max(0) as usize;
         let limit = cmd.limit.unwrap_or(250).clamp(1, 1_000) as usize;
-        let end = offset.saturating_add(limit).min(entries.len());
+        let start = offset.min(entries.len());
+        let mut end = start;
+        let mut bytes = 0usize;
+        for entry in entries.iter().skip(start).take(limit) {
+            let entry_bytes = serde_json::to_vec(entry).map_or(0, |value| value.len());
+            if end > start && bytes.saturating_add(entry_bytes) > PAGE_BYTES {
+                break;
+            }
+            bytes = bytes.saturating_add(entry_bytes);
+            end += 1;
+        }
         let page = entries
-            .get(offset..end)
+            .get(start..end)
             .map(<[serde_json::Value]>::to_vec)
             .unwrap_or_default();
         let has_more = end < entries.len();

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -535,7 +535,13 @@ fn get_session_entries_renders_roles_and_run_stats() {
         vec![],
     );
     assistant.thinking = "deep thought".to_string();
-    let tool = crate::session::SessionEntry::new_tool("call-1", "tool output");
+    let mut tool = crate::session::SessionEntry::new_tool("call-1", "tool output");
+    tool.content = Some(serde_json::json!([{
+        "type": "tool_result",
+        "tool_call_id": "call-1",
+        "content": "tool output",
+        "is_error": false
+    }]));
     let terminal = crate::session::SessionEntry::run_terminal(
         "run-1",
         crate::session::RUN_STATE_COMPLETED,
@@ -574,6 +580,36 @@ fn get_session_entries_renders_roles_and_run_stats() {
     assert_eq!(assistant_entry["duration_ms"], 1500);
     let tool_entry = &entries[3];
     assert_eq!(tool_entry["content"], "tool output");
+    assert_eq!(tool_entry["tool_call_id"], "call-1");
+    assert_eq!(tool_entry["tool_result_is_error"], false);
+}
+
+#[test]
+fn get_session_entries_reports_a_corrupt_persisted_history() {
+    let state = make_app_state();
+    save_via(
+        &state,
+        "default",
+        "mock",
+        vec![crate::session::SessionEntry::new_user(
+            "user",
+            serde_json::json!("question"),
+        )],
+    );
+    let path = state.session_manager.session_path("default");
+    let raw = std::fs::read_to_string(&path).expect("read session");
+    let first = raw.lines().next().expect("session row");
+    std::fs::write(&path, format!("{first}\n{{not-json}}\n{first}\n")).expect("corrupt middle row");
+
+    let response = parse_response(&handle_command_internal(
+        &state,
+        make_cmd("get_session_entries"),
+    ));
+    assert_eq!(response["success"], false);
+    assert_eq!(response["error_code"], "session_history_unreadable");
+    assert!(response["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("Unable to load session history")));
 }
 
 #[test]

--- a/desktop/src-tauri/src/agent_bridge/client.rs
+++ b/desktop/src-tauri/src/agent_bridge/client.rs
@@ -251,8 +251,12 @@ pub fn list_streaming_sessions_command() -> RpcCommand {
     base_command("list_streaming_sessions", String::new())
 }
 
-pub fn get_session_entries_command(session_id: String) -> RpcCommand {
-    base_command("get_session_entries", session_id)
+pub fn get_session_entries_page_command(session_id: String, offset: i64, limit: i64) -> RpcCommand {
+    RpcCommand {
+        offset: Some(offset),
+        limit: Some(limit),
+        ..base_command("get_session_entries", session_id)
+    }
 }
 
 pub fn new_session_command(
@@ -640,10 +644,10 @@ mod tests {
             list_streaming_sessions_command().r#type,
             "list_streaming_sessions"
         );
-        assert_eq!(
-            get_session_entries_command("sess".to_string()).r#type,
-            "get_session_entries"
-        );
+        let command = get_session_entries_page_command("sess".to_string(), 25, 50);
+        assert_eq!(command.r#type, "get_session_entries");
+        assert_eq!(command.offset, Some(25));
+        assert_eq!(command.limit, Some(50));
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent_bridge/import.rs
+++ b/desktop/src-tauri/src/agent_bridge/import.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 use super::client::{
-    connect_agent, get_session_entries_command, get_state_command, list_session_ids_command,
-    list_sessions_command, map_rpc_error, set_session_name_command, RpcResponseExt,
+    connect_agent, get_state_command, list_session_ids_command, list_sessions_command,
+    map_rpc_error, set_session_name_command, RpcResponseExt,
 };
 use crate::store;
 
@@ -112,27 +112,19 @@ pub(crate) async fn list_agent_session_ids(
     Ok(ids)
 }
 
-/// Fetch the full entry list for a session. Returns empty on any failure.
-async fn fetch_session_entries(session_id: &str) -> Vec<serde_json::Value> {
-    let mut client = match connect_agent().await {
-        Ok(c) => c,
-        Err(_) => return vec![],
-    };
-    let resp = match client
-        .execute_command(get_session_entries_command(session_id.to_string()))
-        .await
-    {
-        Ok(r) => r.into_inner(),
-        Err(_) => return vec![],
-    };
-    if !resp.success {
-        return vec![];
-    }
-    future_rpc::decode::decode_session_entries(&resp)
+/// Fetch the full entry list for a session. An unreadable journal is a real
+/// import failure, not an empty conversation.
+async fn fetch_session_entries(
+    session_id: &str,
+) -> Result<Vec<serde_json::Value>, crate::AppError> {
+    let data = super::get_session_entries(session_id.to_string()).await?;
+    Ok(data
+        .get("entries")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|entry| serde_json::to_value(entry).ok())
-        .collect()
+        .collect())
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -379,6 +371,9 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
         return Ok(0);
     }
 
+    // Validate/read the history before creating any local rows. A corrupt
+    // journal must not leave behind a thread that looks like an empty session.
+    let entries = fetch_session_entries(&summary.id).await?;
     let title = best_title;
     let (mode, workspace_id, workspace_path, workspace_name) = thread_mode(summary, &title);
 
@@ -422,13 +417,9 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
         });
     }
 
-    // Fetch entries to count assistant replies and synthesize run events.
-    let entries = fetch_session_entries(&summary.id).await;
-    let assistant_count = entries
-        .iter()
-        .filter(|e| e.get("role").and_then(|r| r.as_str()) == Some("assistant"))
-        .count();
-    let run_count = assistant_count.max(1);
+    // Count real exchanges and synthesize run events from the fetched history.
+    let entry_groups = super::session::group_session_entries(&entries);
+    let run_count = entry_groups.len().max(1);
 
     let mut run_ids: Vec<String> = Vec::with_capacity(run_count);
     for _ in 0..run_count {
@@ -438,7 +429,7 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
 
     // Write synthetic run events from the imported session's tool calls
     // so the right panel (Runs tab) is populated immediately.
-    super::session::synthesize_run_events_from_entries(&entries, &run_ids);
+    super::session::synthesize_run_events_from_entries(&entries, &entry_groups, &run_ids);
 
     Ok(run_count)
 }
@@ -711,19 +702,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_session_entries_returns_empty_on_failures() {
+    async fn fetch_session_entries_reports_failures() {
         let mock = super::super::test_support::mock_agent();
 
         mock.push(
             "get_session_entries",
             super::super::test_support::Reply::Reject("no".into()),
         );
-        assert!(fetch_session_entries("s").await.is_empty());
+        assert!(fetch_session_entries("s").await.is_err());
         mock.push(
             "get_session_entries",
             super::super::test_support::Reply::Data("not json".into()),
         );
-        assert!(fetch_session_entries("s").await.is_empty());
+        assert!(fetch_session_entries("s").await.is_err());
     }
 
     #[tokio::test]
@@ -741,7 +732,9 @@ mod tests {
             }]}),
         );
 
-        let entries = fetch_session_entries("typed-session").await;
+        let entries = fetch_session_entries("typed-session")
+            .await
+            .expect("entries");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["content"], "hello");
     }
@@ -824,7 +817,7 @@ mod tests {
         let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
         std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
         assert!(list_agent_sessions().await.is_empty());
-        assert!(fetch_session_entries("s").await.is_empty());
+        assert!(fetch_session_entries("s").await.is_err());
         std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
     }
 
@@ -835,7 +828,7 @@ mod tests {
             "get_session_entries",
             super::super::test_support::Reply::Status(tonic::Code::Internal, "down"),
         );
-        assert!(fetch_session_entries("s").await.is_empty());
+        assert!(fetch_session_entries("s").await.is_err());
     }
 
     #[test]
@@ -1072,11 +1065,14 @@ mod tests {
         let s = summary("sess-heal-down", &workspace.path);
         assert_eq!(import_one(&s).await.expect("heal"), 0);
 
-        // A brand-new chat import also spawns a title-sync task; its connect
-        // fails under the same unreachable endpoint.
+        // A brand-new import validates history first; an unreachable agent is
+        // reported without leaving a partial empty thread behind.
         _mock.push_data("get_session_entries", serde_json::json!({"entries": []}));
         let s2 = summary("sess-new-down", "");
-        import_one(&s2).await.expect("new");
+        assert!(import_one(&s2).await.is_err());
+        assert!(crate::store::find_thread_by_agent_session("sess-new-down")
+            .expect("find")
+            .is_none());
 
         settle_spawns().await;
         std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
@@ -1126,13 +1122,13 @@ mod tests {
         );
         let s = summary("sess-new", "");
         let runs = import_one(&s).await.expect("import");
-        assert_eq!(runs, 2, "one run per assistant reply");
+        assert_eq!(runs, 1, "consecutive assistants belong to one exchange");
         settle_spawns().await;
         let thread = crate::store::find_thread_by_agent_session("sess-new")
             .expect("find")
             .expect("some");
         assert_eq!(thread.mode, "chat");
-        assert_eq!(crate::store::list_runs(&thread.id).expect("runs").len(), 2);
+        assert_eq!(crate::store::list_runs(&thread.id).expect("runs").len(), 1);
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -15,12 +15,14 @@ mod skills;
 mod stream;
 #[cfg(test)]
 mod test_support;
+#[cfg(test)]
+pub(crate) use self::test_support::get_state_payload;
 
 pub use self::approval::{decide_approval, inject_session_rule, reconcile_pending_approvals};
 pub(crate) use self::client::raw_agent_addr;
 pub use self::client::{
     compact_command, connect_agent, delete_session_command, get_available_models_command,
-    get_run_state_command, get_session_entries_command, get_state_command,
+    get_run_state_command, get_session_entries_page_command, get_state_command,
     list_streaming_sessions_command, map_rpc_error, set_default_model_command, set_model_command,
     set_session_name_command, set_thinking_level_command, RpcResponseExt,
 };
@@ -309,15 +311,43 @@ pub async fn get_session_messages(
 /// with cached thumbnails), which is how the GUI rebuilds attachment chips.
 pub async fn get_session_entries(session_id: String) -> Result<serde_json::Value, crate::AppError> {
     let mut client = connect_agent().await?;
-    let response = client
-        .execute_command(get_session_entries_command(session_id))
-        .await
-        .map_err(|status| format!("get_session_entries failed: {status}"))?
-        .into_inner()
-        .ok_or_rpc_error("get_session_entries returned an error")?;
-    let entries = future_rpc::decode::decode_session_entries(&response)
-        .ok_or_else(|| "get_session_entries typed payload is missing or invalid".to_string())?;
+    let entries = fetch_all_session_entries_with_client(&mut client, &session_id).await?;
     Ok(serde_json::json!({ "entries": entries }))
+}
+
+pub(super) async fn fetch_all_session_entries_with_client(
+    client: &mut crate::agent_proto::FutureAgentClient<tonic::transport::Channel>,
+    session_id: &str,
+) -> Result<Vec<future_rpc::payloads::SessionEntryPayload>, crate::AppError> {
+    const PAGE_SIZE: i64 = 250;
+    let mut offset = 0_i64;
+    let mut entries = Vec::new();
+    loop {
+        let response = client
+            .execute_command(get_session_entries_page_command(
+                session_id.to_string(),
+                offset,
+                PAGE_SIZE,
+            ))
+            .await
+            .map_err(|status| format!("get_session_entries failed: {status}"))?
+            .into_inner()
+            .ok_or_rpc_error("get_session_entries returned an error")?;
+        let page = future_rpc::decode::decode_session_entries_page(&response)
+            .ok_or_else(|| "get_session_entries typed page is missing or invalid".to_string())?;
+        entries.extend(page.entries);
+        if !page.has_more {
+            return Ok(entries);
+        }
+        if page.next_offset <= offset {
+            return Err(format!(
+                "get_session_entries returned a non-advancing offset: {} after {offset}",
+                page.next_offset
+            )
+            .into());
+        }
+        offset = page.next_offset;
+    }
 }
 
 /// Fetch the session's current state (model, thinkingLevel, isStreaming, etc.)
@@ -331,11 +361,12 @@ pub async fn get_session_state(session_id: String) -> Result<serde_json::Value, 
         .map_err(|status| format!("get_state failed: {status}"))?
         .into_inner()
         .ok_or_rpc_error("get_state returned an error")?;
-    if response.data.is_empty() {
-        Ok(serde_json::json!({}))
+    let value = future_rpc::decode::response_data(&response);
+    Ok(if value.is_null() {
+        serde_json::json!({})
     } else {
-        Ok(future_rpc::decode::response_data(&response))
-    }
+        value
+    })
 }
 
 /// Fetch the available model list from the agent (for the web client's model selector).
@@ -347,11 +378,12 @@ pub async fn get_available_models() -> Result<serde_json::Value, crate::AppError
         .map_err(|status| format!("get_available_models failed: {status}"))?
         .into_inner()
         .ok_or_rpc_error("get_available_models returned an error")?;
-    if response.data.is_empty() {
-        Ok(serde_json::json!({ "models": [] }))
+    let value = future_rpc::decode::response_data(&response);
+    Ok(if value.is_null() {
+        serde_json::json!({ "models": [] })
     } else {
-        Ok(future_rpc::decode::response_data(&response))
-    }
+        value
+    })
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -1694,8 +1726,8 @@ mod wire_decode_tests {
 #[cfg(test)]
 mod bridge_tests {
     use super::test_support::{
-        break_home, mock_agent, restore_home, seed_run, seed_thread, seed_workspace, Reply,
-        TestHome,
+        break_home, get_state_payload, mock_agent, restore_home, seed_run, seed_thread,
+        seed_workspace, Reply, TestHome,
     };
     use super::*;
 
@@ -1733,6 +1765,33 @@ mod bridge_tests {
             .expect("typed entries");
         assert_eq!(value["entries"][0]["id"], "e1");
 
+        mock.push_typed_data(
+            "get_session_entries",
+            serde_json::json!({
+                "entries": [{
+                    "id": "e2", "role": "user", "content": "next", "name": "",
+                    "tool_args": "", "timestamp": "2026-08-27T10:00:02Z"
+                }],
+                "hasMore": true,
+                "nextOffset": 1
+            }),
+        );
+        mock.push_typed_data(
+            "get_session_entries",
+            serde_json::json!({"entries": [{
+                "id": "e3", "role": "assistant", "content": "done", "name": "",
+                "tool_args": "", "timestamp": "2026-08-27T10:00:03Z"
+            }]}),
+        );
+        let value = get_session_entries("sess-1".to_string())
+            .await
+            .expect("paged entries");
+        assert_eq!(value["entries"].as_array().expect("entries").len(), 2);
+        let requests = mock.requests_of("get_session_entries");
+        let last_two = &requests[requests.len() - 2..];
+        assert_eq!(last_two[0].offset, Some(0));
+        assert_eq!(last_two[1].offset, Some(1));
+
         mock.push("get_session_entries", Reply::Data(String::new()));
         assert!(get_session_entries("sess-1".to_string()).await.is_err());
 
@@ -1741,6 +1800,12 @@ mod bridge_tests {
             .await
             .expect("state");
         assert_eq!(value["isStreaming"], true);
+        mock.push_typed_data("get_state", get_state_payload("sess-1", true));
+        let value = get_session_state("sess-1".to_string())
+            .await
+            .expect("typed state");
+        assert_eq!(value["sessionId"], "sess-1");
+        assert_eq!(value["thinkingLevel"], "medium");
         mock.push("get_state", Reply::Data(String::new()));
         let value = get_session_state("sess-1".to_string())
             .await
@@ -1750,6 +1815,22 @@ mod bridge_tests {
         mock.push_data("list_models", serde_json::json!({"models": [{"id": "m"}]}));
         let value = get_available_models().await.expect("models");
         assert_eq!(value["models"][0]["id"], "m");
+        mock.push_typed_data(
+            "list_models",
+            serde_json::json!({
+                "models": [{
+                    "id": "typed-model", "label": "Typed", "provider": "future",
+                    "supportsImages": false, "thinkingLevel": "medium",
+                    "contextWindow": 1000, "isDefault": true, "description": null,
+                    "descriptionEn": null, "recommended": true
+                }],
+                "defaultModel": "future/typed-model",
+                "isScoped": false,
+                "builtinProviders": {}
+            }),
+        );
+        let value = get_available_models().await.expect("typed models");
+        assert_eq!(value["models"][0]["id"], "typed-model");
         mock.push("list_models", Reply::Data(String::new()));
         let value = get_available_models().await.expect("models");
         assert_eq!(value, serde_json::json!({"models": []}));

--- a/desktop/src-tauri/src/agent_bridge/run_control.rs
+++ b/desktop/src-tauri/src/agent_bridge/run_control.rs
@@ -157,10 +157,9 @@ pub(crate) async fn wait_for_agent_idle(session_id: &str) {
             .await
         {
             Ok(response) => {
-                let data = response.into_inner().data;
-                let streaming = serde_json::from_str::<serde_json::Value>(&data)
-                    .ok()
-                    .and_then(|value| value.get("isStreaming").and_then(|s| s.as_bool()))
+                let response = response.into_inner();
+                let streaming = future_rpc::decode::decode_get_state(&response)
+                    .map(|state| state.is_streaming)
                     .unwrap_or(false);
                 if !streaming {
                     return;
@@ -181,7 +180,7 @@ fn is_agent_unavailable_error(error: &crate::AppError) -> bool {
 mod tests {
     use super::super::replica::AGENT_REPLICAS;
     use super::super::test_support::{
-        mock_agent, seed_run, seed_thread, seed_workspace, Reply, TestHome,
+        get_state_payload, mock_agent, seed_run, seed_thread, seed_workspace, Reply, TestHome,
     };
     use super::*;
 
@@ -421,9 +420,9 @@ mod tests {
         assert_eq!(mock.requests_of("get_state").len(), 1);
 
         // Streaming twice, then idle: polls until the agent confirms quiet.
-        mock.push_data("get_state", serde_json::json!({"isStreaming": true}));
-        mock.push_data("get_state", serde_json::json!({"isStreaming": true}));
-        mock.push_data("get_state", serde_json::json!({"isStreaming": false}));
+        mock.push_typed_data("get_state", get_state_payload("sess-1", true));
+        mock.push_typed_data("get_state", get_state_payload("sess-1", true));
+        mock.push_typed_data("get_state", get_state_payload("sess-1", false));
         wait_for_agent_idle("sess-1").await;
         assert_eq!(mock.requests_of("get_state").len(), 4);
 

--- a/desktop/src-tauri/src/agent_bridge/session.rs
+++ b/desktop/src-tauri/src/agent_bridge/session.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use tonic::transport::Channel;
 
 use super::client::{
-    fork_command, get_session_entries_command, get_state_command, new_session_command,
-    set_cwd_command, set_permission_level_command, set_sandbox_policy_command, RpcResponseExt,
+    fork_command, get_state_command, new_session_command, set_cwd_command,
+    set_permission_level_command, set_sandbox_policy_command, RpcResponseExt,
 };
 use crate::{agent_proto::FutureAgentClient, store};
 
@@ -186,18 +186,13 @@ pub async fn fork_agent_session(
 
     // ── find the fork point ────────────────────────────────────────────
 
-    let response = client
-        .execute_command(get_session_entries_command(session_id.clone()))
-        .await
-        .map_err(|error| format!("Unable to list session entries: {error}"))?
-        .into_inner()
-        .ok_or_rpc_error("Future Agent rejected the session-entries request.")?;
-
-    let entries: Vec<serde_json::Value> = future_rpc::decode::response_data(&response)
-        .get("entries")
-        .cloned()
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default();
+    let entries: Vec<serde_json::Value> =
+        super::fetch_all_session_entries_with_client(&mut client, &session_id)
+            .await
+            .map_err(|error| format!("Unable to list session entries: {error}"))?
+            .into_iter()
+            .filter_map(|entry| serde_json::to_value(entry).ok())
+            .collect();
 
     let is_user = |e: &serde_json::Value| e.get("role").and_then(|r| r.as_str()) == Some("user");
 
@@ -262,19 +257,13 @@ pub async fn fork_agent_session(
 
     // ── read forked entries for metadata ───────────────────────────────
 
-    let entries_response = client
-        .execute_command(get_session_entries_command(new_session_id.clone()))
-        .await
-        .map_err(|error| format!("Unable to list fork session entries: {error}"))?
-        .into_inner()
-        .ok_or_rpc_error("Future Agent rejected the fork-session entries request.")?;
-
     let fork_entries: Vec<serde_json::Value> =
-        serde_json::from_str::<serde_json::Value>(&entries_response.data)
-            .ok()
-            .and_then(|v| v.get("entries").cloned())
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default();
+        super::fetch_all_session_entries_with_client(&mut client, &new_session_id)
+            .await
+            .map_err(|error| format!("Unable to list fork session entries: {error}"))?
+            .into_iter()
+            .filter_map(|entry| serde_json::to_value(entry).ok())
+            .collect();
 
     // The agent's fork_session writes metadata into a session_info entry
     // (role = "system"); find it — get_session_entries now includes it.
@@ -295,16 +284,26 @@ pub async fn fork_agent_session(
         };
         format!("{parent_title} (fork)")
     });
-    let session_model = session_info
-        .and_then(|e| e.get("model"))
-        .and_then(|m| m.as_str())
-        .unwrap_or("")
-        .to_string();
+    // Session-entry payloads intentionally contain conversation data only;
+    // the selected model lives in the forked session's state. Read it from
+    // the canonical typed response so a payload-only agent does not create
+    // model-less historical runs after a fork.
+    let session_model = match client
+        .execute_command(get_state_command(new_session_id.clone()))
+        .await
+    {
+        Ok(response) => future_rpc::decode::response_data(&response.into_inner())
+            .get("model")
+            .and_then(|model| model.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        Err(error) => {
+            eprintln!("FutureOS: fork get_state failed: {error}");
+            String::new()
+        }
+    };
 
-    let assistant_count = fork_entries
-        .iter()
-        .filter(|e| e.get("role").and_then(|r| r.as_str()) == Some("assistant"))
-        .count();
+    let entry_groups = group_session_entries(&fork_entries);
 
     // ── create workspace + thread ──────────────────────────────────────
 
@@ -335,7 +334,7 @@ pub async fn fork_agent_session(
     }
 
     let (provider, model_id) = split_model(&session_model);
-    let run_count = assistant_count.max(1);
+    let run_count = entry_groups.len().max(1);
     let mut run_ids: Vec<String> = Vec::with_capacity(run_count);
     for _ in 0..run_count {
         let run = store::create_run(store::CreateRunInput {
@@ -356,7 +355,7 @@ pub async fn fork_agent_session(
 
     // Write synthetic run events so the right panel (Runs tab) shows tool calls
     // from the forked history immediately — no live stream exists for these runs.
-    synthesize_run_events_from_entries(&fork_entries, &run_ids);
+    synthesize_run_events_from_entries(&fork_entries, &entry_groups, &run_ids);
 
     Ok(new_thread.id)
 }
@@ -368,101 +367,140 @@ pub async fn fork_agent_session(
 /// forked history to serve it). Panel state is in-memory, so it lasts for
 /// this process lifetime.
 ///
-/// The Nth assistant entry maps to the Nth run_id. Tool result entries
-/// (role = "tool") are matched by `tool_call_id`.
+/// Entries are grouped by canonical `meta.run_id`, with a positional
+/// user-to-next-user fallback for legacy journals. Tool result entries are
+/// matched by `tool_call_id` inside their group.
 pub(super) fn synthesize_run_events_from_entries(
     entries: &[serde_json::Value],
+    groups: &[Vec<usize>],
     run_ids: &[String],
 ) {
-    // Index tool result entries by tool_call_id.
-    let tool_results: HashMap<&str, &serde_json::Value> = entries
-        .iter()
-        .filter(|e| e.get("role").and_then(|r| r.as_str()) == Some("tool"))
-        .filter_map(|e| {
-            let id = e.get("tool_call_id").and_then(|v| v.as_str())?;
-            if id.is_empty() {
-                None
-            } else {
-                Some((id, e))
-            }
-        })
-        .collect();
+    for (group, run_id) in groups.iter().zip(run_ids) {
+        let tool_results: HashMap<&str, &serde_json::Value> = group
+            .iter()
+            .filter_map(|index| entries.get(*index))
+            .filter(|entry| entry.get("role").and_then(|role| role.as_str()) == Some("tool"))
+            .filter_map(|entry| {
+                let id = entry.get("tool_call_id").and_then(|value| value.as_str())?;
+                (!id.is_empty()).then_some((id, entry))
+            })
+            .collect();
+        let mut seq: i64 = 0;
 
-    let mut run_idx: usize = 0;
-    let mut seq: i64 = 0;
-
-    for entry in entries {
-        if entry.get("role").and_then(|r| r.as_str()) != Some("assistant") {
-            continue;
-        }
-        if run_idx >= run_ids.len() {
-            break;
-        }
-        let run_id = &run_ids[run_idx];
-        run_idx += 1;
-
-        let Some(tool_calls) = entry.get("tool_calls").and_then(|v| v.as_array()) else {
-            continue;
-        };
-
-        for tc in tool_calls {
-            let tc_id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            if tc_id.is_empty() {
+        for entry in group.iter().filter_map(|index| entries.get(*index)) {
+            if entry.get("role").and_then(|role| role.as_str()) != Some("assistant") {
                 continue;
             }
-            let name = tc
-                .get("function")
-                .and_then(|f| f.get("name"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let args = tc
-                .get("function")
-                .and_then(|f| f.get("arguments"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let Some(tool_calls) = entry.get("tool_calls").and_then(|value| value.as_array())
+            else {
+                continue;
+            };
 
-            let start_payload = serde_json::json!({
-                "tool_id": tc_id,
-                "tool_name": name,
-                "tool_args": args,
-            });
-            // Imported history is represented by the Agent transcript. Keep
-            // only the GUI's derived tool projection; never recreate a GUI
-            // raw-event JSONL from it.
-            super::persist::persist_run_event(
-                Some(run_id),
-                "tool_start",
-                &start_payload.to_string(),
-                seq,
-            );
-            seq += 1;
+            for tc in tool_calls {
+                let tc_id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                if tc_id.is_empty() {
+                    continue;
+                }
+                let name = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let args = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
 
-            // tool_end from the matching result entry, if one exists.
-            if let Some(result) = tool_results.get(tc_id) {
-                let content = result.get("content").and_then(|v| v.as_str()).unwrap_or("");
-                let is_error = content.starts_with("Error:");
-                let end_payload = if is_error {
-                    serde_json::json!({
-                        "tool_id": tc_id,
-                        "text": content,
-                        "error": content,
-                    })
-                } else {
-                    serde_json::json!({
-                        "tool_id": tc_id,
-                        "text": content,
-                    })
-                };
+                let start_payload = serde_json::json!({
+                    "tool_id": tc_id,
+                    "tool_name": name,
+                    "tool_args": args,
+                });
+                // Imported history is represented by the Agent transcript. Keep
+                // only the GUI's derived tool projection; never recreate a GUI
+                // raw-event JSONL from it.
                 super::persist::persist_run_event(
                     Some(run_id),
-                    "tool_end",
-                    &end_payload.to_string(),
+                    "tool_start",
+                    &start_payload.to_string(),
                     seq,
                 );
                 seq += 1;
+
+                // tool_end from the matching result entry, if one exists.
+                if let Some(result) = tool_results.get(tc_id) {
+                    let content = result.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                    let is_error = result
+                        .get("tool_result_is_error")
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or_else(|| content.starts_with("Error:"));
+                    let end_payload = if is_error {
+                        serde_json::json!({
+                            "tool_id": tc_id,
+                            "text": content,
+                            "error": content,
+                        })
+                    } else {
+                        serde_json::json!({
+                            "tool_id": tc_id,
+                            "text": content,
+                        })
+                    };
+                    super::persist::persist_run_event(
+                        Some(run_id),
+                        "tool_end",
+                        &end_payload.to_string(),
+                        seq,
+                    );
+                    seq += 1;
+                }
             }
         }
     }
+}
+
+/// Group display entries into real agent runs. Canonical run IDs win; entries
+/// from older journals are grouped into user-led exchanges.
+pub(super) fn group_session_entries(entries: &[serde_json::Value]) -> Vec<Vec<usize>> {
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    let mut canonical: HashMap<String, usize> = HashMap::new();
+    let mut current: Option<usize> = None;
+
+    for (entry_index, entry) in entries.iter().enumerate() {
+        let role = entry
+            .get("role")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if !matches!(role, "user" | "assistant" | "tool") {
+            continue;
+        }
+        if let Some(run_id) = entry
+            .pointer("/meta/run_id")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+        {
+            let group_index = *canonical.entry(run_id.to_string()).or_insert_with(|| {
+                groups.push(Vec::new());
+                groups.len() - 1
+            });
+            groups[group_index].push(entry_index);
+            current = Some(group_index);
+            continue;
+        }
+
+        let group_index = match (role, current) {
+            ("user", _) | (_, None) => {
+                groups.push(Vec::new());
+                let index = groups.len() - 1;
+                current = Some(index);
+                index
+            }
+            (_, Some(index)) => index,
+        };
+        groups[group_index].push(entry_index);
+    }
+    groups
 }
 
 pub(super) fn split_model(model: &str) -> (Option<String>, Option<String>) {
@@ -479,8 +517,8 @@ pub(super) fn split_model(model: &str) -> (Option<String>, Option<String>) {
 #[cfg(test)]
 mod tests {
     use super::super::test_support::{
-        break_home, mock_agent, restore_home, seed_run, seed_thread, seed_workspace, Reply,
-        TestHome,
+        break_home, get_state_payload, mock_agent, restore_home, seed_run, seed_thread,
+        seed_workspace, Reply, TestHome,
     };
     use super::*;
 
@@ -777,6 +815,20 @@ mod tests {
     // ── fork_agent_session ──────────────────────────────────────────────
 
     fn entries_payload(entries: serde_json::Value) -> serde_json::Value {
+        let mut entries = entries.as_array().cloned().unwrap_or_default();
+        for entry in &mut entries {
+            if let Some(object) = entry.as_object_mut() {
+                object
+                    .entry("name")
+                    .or_insert_with(|| serde_json::json!(""));
+                object
+                    .entry("tool_args")
+                    .or_insert_with(|| serde_json::json!(""));
+                object
+                    .entry("timestamp")
+                    .or_insert_with(|| serde_json::json!("2026-08-27T00:00:00Z"));
+            }
+        }
         serde_json::json!({"entries": entries})
     }
 
@@ -792,12 +844,12 @@ mod tests {
 
     fn forked_entries() -> serde_json::Value {
         serde_json::json!([
-            {"id": "f0", "role": "system", "content": {"session_name": "Forked Chat"}, "model": "future/k3"},
-            {"id": "f1", "role": "user", "content": "first question"},
-            {"id": "f2", "role": "assistant", "content": "first answer", "tool_calls": [
+            {"id": "f0", "role": "system", "content": {"session_name": "Forked Chat"}, "name": "", "tool_args": "", "timestamp": "2026-08-27T00:00:00Z", "model": "future/k3"},
+            {"id": "f1", "role": "user", "content": "first question", "name": "", "tool_args": "", "timestamp": "2026-08-27T00:00:01Z"},
+            {"id": "f2", "role": "assistant", "content": "first answer", "name": "", "tool_args": "", "timestamp": "2026-08-27T00:00:02Z", "tool_calls": [
                 {"id": "tc-1", "function": {"name": "shell", "arguments": "{\"command\":\"ls\"}"}}
             ]},
-            {"id": "f3", "role": "tool", "tool_call_id": "tc-1", "content": "file.txt"}
+            {"id": "f3", "role": "tool", "content": "file.txt", "name": "", "tool_args": "", "timestamp": "2026-08-27T00:00:03Z", "tool_call_id": "tc-1", "tool_result_is_error": false}
         ])
     }
 
@@ -813,7 +865,10 @@ mod tests {
             entries_payload(conversation_entries()),
         );
         mock.push_data("fork", serde_json::json!({"sessionId": "sess-fork"}));
-        mock.push_data("get_session_entries", entries_payload(forked_entries()));
+        mock.push_typed_data("get_session_entries", entries_payload(forked_entries()));
+        let mut fork_state = get_state_payload("sess-fork", false);
+        fork_state["model"] = serde_json::json!("future/k3");
+        mock.push_state_for_session("sess-fork", Reply::TypedData(fork_state));
         mock.push("set_cwd", Reply::Data("{}".to_string()));
 
         let new_thread_id = fork_agent_session(&thread.id, "ignored", 1)
@@ -946,7 +1001,7 @@ mod tests {
         let error = fork_agent_session(&thread.id, "x", 0)
             .await
             .expect_err("entries reject");
-        assert_eq!(error.to_string(), "bad");
+        assert_eq!(error.to_string(), "Unable to list session entries: bad");
 
         // No matching user message.
         mock.push_data(
@@ -1024,7 +1079,10 @@ mod tests {
         let error = fork_agent_session(&thread.id, "x", 0)
             .await
             .expect_err("fork entries reject");
-        assert_eq!(error.to_string(), "bad");
+        assert_eq!(
+            error.to_string(),
+            "Unable to list fork session entries: bad"
+        );
     }
 
     #[tokio::test]
@@ -1169,7 +1227,7 @@ mod tests {
 
         let entries = serde_json::json!([
             {"role": "assistant", "tool_calls": [
-                {"id": "tc-1", "function": {"name": "shell", "arguments": "{\"command\":\"ls\"}"}},
+                {"id": "tc-1", "function": {"name": "shell", "arguments": {"command": "ls"}}},
                 {"id": "", "function": {"name": "write", "arguments": "{}"}},
                 {"id": "tc-2"},
                 {"id": "tc-err", "function": {"name": "read", "arguments": "{}"}}
@@ -1183,6 +1241,7 @@ mod tests {
         ]);
         synthesize_run_events_from_entries(
             &entries.as_array().expect("array").to_vec(),
+            &[vec![0, 1, 2, 3], vec![4, 5, 6]],
             &[run_a.id.clone(), run_b.id.clone()],
         );
 
@@ -1200,6 +1259,39 @@ mod tests {
                 .expect("input")
                 .is_none(),
             "each assistant binds its own run"
+        );
+    }
+
+    #[test]
+    fn groups_multiple_assistant_entries_into_their_canonical_run() {
+        let entries = serde_json::json!([
+            {"role": "system", "content": {}},
+            {"role": "user", "meta": {"run_id": "r1"}},
+            {"role": "assistant", "meta": {"run_id": "r1"}},
+            {"role": "assistant", "meta": {"run_id": "r1"}},
+            {"role": "tool", "meta": {"run_id": "r1"}},
+            {"role": "user", "meta": {"run_id": "r2"}},
+            {"role": "assistant", "meta": {"run_id": "r2"}}
+        ]);
+        assert_eq!(
+            group_session_entries(entries.as_array().expect("entries")),
+            vec![vec![1, 2, 3, 4], vec![5, 6]]
+        );
+    }
+
+    #[test]
+    fn groups_legacy_entries_by_user_exchange() {
+        let entries = serde_json::json!([
+            {"role": "user"},
+            {"role": "assistant"},
+            {"role": "assistant"},
+            {"role": "tool"},
+            {"role": "user"},
+            {"role": "assistant"}
+        ]);
+        assert_eq!(
+            group_session_entries(entries.as_array().expect("entries")),
+            vec![vec![0, 1, 2, 3], vec![4, 5]]
         );
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/test_support.rs
+++ b/desktop/src-tauri/src/agent_bridge/test_support.rs
@@ -38,6 +38,48 @@ pub(crate) enum Reply {
     Status(tonic::Code, &'static str),
 }
 
+/// Production-shaped JSON source for a typed-only `get_state` response.
+pub(crate) fn get_state_payload(session_id: &str, is_streaming: bool) -> serde_json::Value {
+    serde_json::json!({
+        "agentInstanceId": "agent-test",
+        "model": "future/test",
+        "imageSupport": false,
+        "thinkingLevel": "medium",
+        "isStreaming": is_streaming,
+        "isCompacting": false,
+        "sessionFile": "",
+        "sessionId": session_id,
+        "sessionName": "Typed Session",
+        "explicitSession": true,
+        "autoCompactionEnabled": true,
+        "queryCount": 1,
+        "version": "test",
+        "cwd": "/tmp",
+        "skills": [],
+        "contextFiles": [],
+        "extensions": [],
+        "contextWindow": 1000,
+        "contextTokens": 10,
+        "contextPercent": 1.0,
+        "tokensIn": 1,
+        "tokensOut": 2,
+        "tokensCacheR": 0,
+        "tokensCacheW": 0,
+        "totalCost": 0.0,
+        "permissionLevel": "default",
+        "parentSessionId": null,
+        "createdBy": "desktop",
+        "sourceMeta": null,
+        "activeRun": null,
+        "queuedRuns": [],
+        "recentTerminalAcks": [],
+        "queuedCount": 0,
+        "interruptedRun": null,
+        "requestedRun": null,
+        "pendingApprovals": []
+    })
+}
+
 /// One scripted `stream_events` outcome.
 pub(crate) enum StreamScript {
     /// The attach itself fails with this status.

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -250,7 +250,7 @@ fn empty_agent_state(session_name: &str) -> serde_json::Value {
     serde_json::json!({
         "model": null,
         "thinkingLevel": null,
-        "session_name": session_name,
+        "sessionName": session_name,
         "sessionId": null,
         "cwd": null,
         "parentSessionId": null,
@@ -298,8 +298,12 @@ pub async fn get_thread_agent_state(
         }
         return Err(format!("get_state rejected: {}", resp.error).into());
     }
-    let value = serde_json::from_str::<serde_json::Value>(&resp.data)
-        .map_err(|e| format!("get_state parse error: {e}"))?;
+    let value = future_rpc::decode::response_data(&resp);
+    if value.is_null() {
+        return Err("get_state typed payload is missing or invalid"
+            .to_string()
+            .into());
+    }
     // Converge the DB title toward the agent's session_name — the name shared
     // with every client (TUI `/name`, CLI, channels), whose renames never
     // reach the GUI DB. The sidebar treats the agent name as authoritative
@@ -307,7 +311,8 @@ pub async fn get_thread_agent_state(
     // a stale DB title surfaces as "the rename didn't survive a restart".
     // Best-effort; sync_thread_title never bumps updated_at (sidebar order).
     if let Some(name) = value
-        .get("session_name")
+        .get("sessionName")
+        .or_else(|| value.get("session_name"))
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|n| !n.is_empty())
@@ -343,11 +348,12 @@ pub async fn compact_thread_context(
         .map_err(|error| format!("compact RPC failed: {error}"))?
         .into_inner()
         .ok_or_rpc_error("compact returned an error")?;
-    if response.data.is_empty() {
-        return Ok(serde_json::json!({}));
-    }
-    serde_json::from_str(&response.data)
-        .map_err(|error| format!("compact response parse error: {error}").into())
+    let value = future_rpc::decode::response_data(&response);
+    Ok(if value.is_null() {
+        serde_json::json!({})
+    } else {
+        value
+    })
 }
 
 /// Fetch session entries from the agent (user, assistant, tool messages).
@@ -373,29 +379,18 @@ pub async fn get_session_entries(thread_id: String) -> Result<serde_json::Value,
         return Ok(serde_json::json!({ "entries": [] }));
     };
 
-    let mut client = crate::agent_bridge::connect_agent()
-        .await
-        .map_err(|e| format!("Agent unavailable: {e}"))?;
-    let cmd = crate::agent_bridge::get_session_entries_command(session_id.to_string());
-    let resp = client
-        .execute_command(cmd)
-        .await
-        .map_err(|e| format!("get_session_entries failed: {e}"))?
-        .into_inner();
-    if !resp.success {
+    let result = crate::agent_bridge::get_session_entries(session_id.to_string()).await;
+    if let Err(error) = &result {
         // A session the agent no longer knows (e.g. lost after an environment
         // switch restarts the agent) is benign for reads: report empty history,
         // matching a thread with no session. The prompt path recreates it on the
         // next send. Other rejections stay real errors.
-        if resp.error.contains("session not found") {
+        if error.to_string().contains("session not found") {
             return Ok(serde_json::json!({ "entries": [] }));
         }
-        return Err(resp.error.into());
+        return Err(error.to_string().into());
     }
-    let entries = future_rpc::decode::decode_session_entries(&resp).ok_or_else(|| {
-        "Parse error: typed session entries payload is missing or invalid".to_string()
-    })?;
-    Ok(serde_json::json!({ "entries": entries }))
+    result
 }
 
 #[tauri::command]
@@ -668,7 +663,7 @@ mod tests {
             .expect("state");
         assert_eq!(value["model"], serde_json::Value::Null);
         assert_eq!(value["sessionId"], serde_json::Value::Null);
-        assert_eq!(value["session_name"], serde_json::json!(thread.title));
+        assert_eq!(value["sessionName"], serde_json::json!(thread.title));
     }
 
     #[tokio::test]
@@ -983,18 +978,15 @@ mod tests {
         let _lock = mock_agent_lock();
         let _home = init("cmd_agent_state_ok");
         let thread = make_thread(&_home, Some("sess_state"));
-        crate::commands::agent_mock::ensure_mock_agent();
-        script_mock_agent(MockScript {
-            data: HashMap::from([(
-                "get_state".to_string(),
-                "{\"session_name\":\"Agent Name\",\"model\":\"m\"}".to_string(),
-            )]),
-            ..Default::default()
-        });
+        let agent = crate::commands::agent_mock::ensure_mock_agent();
+        script_mock_agent(MockScript::default());
+        let mut payload = crate::agent_bridge::get_state_payload("sess_state", false);
+        payload["sessionName"] = serde_json::json!("Agent Name");
+        agent.script_typed_for("get_state", "sess_state", payload);
         let value = get_thread_agent_state(thread.id.clone())
             .await
             .expect("state");
-        assert_eq!(value["session_name"], serde_json::json!("Agent Name"));
+        assert_eq!(value["sessionName"], serde_json::json!("Agent Name"));
         // Title converged toward the agent name.
         let reloaded = crate::store::get_thread(&thread.id)
             .expect("get")

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -693,6 +693,10 @@ async fn handle_command(
                     return;
                 }
             }
+            if let Err(error) = validate_continue_source(&cmd.session_id, &cmd.run_id) {
+                reply(client, &msg, false, Value::Null, Some(&error.to_string())).await;
+                return;
+            }
             // Resume a failed run: synthesize a continue prompt from the run's
             // recent terminal events and push it through the normal prompt
             // pipeline (model/thinking default to the session's current values).
@@ -1189,6 +1193,37 @@ fn build_continue_prompt(run_id: &str) -> String {
     lines.join("\n")
 }
 
+/// A continuation is not a free-form prompt alias: it may only resume the
+/// failed run that belongs to the addressed session. This keeps a stale mobile
+/// outbox entry (including one from a previous pairing) from creating or
+/// steering an unrelated conversation.
+fn validate_continue_source(session_id: &str, run_id: &str) -> Result<(), crate::AppError> {
+    if session_id.trim().is_empty() || run_id.trim().is_empty() {
+        return Err("A continuation requires a session and source run."
+            .to_string()
+            .into());
+    }
+    let run = crate::store::get_run(run_id)?
+        .ok_or_else(|| "The source run no longer exists.".to_string())?;
+    if run.status != "failed" {
+        return Err("Only a failed run can be continued.".to_string().into());
+    }
+    let thread = crate::store::get_thread(&run.thread_id)?
+        .ok_or_else(|| "The source run's conversation no longer exists.".to_string())?;
+    let run_session_id = thread
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&thread.id);
+    if run_session_id != session_id {
+        return Err("The source run does not belong to this session."
+            .to_string()
+            .into());
+    }
+    Ok(())
+}
+
 fn remote_prompt_receipt(command_id: &str) -> Result<Option<Value>, crate::AppError> {
     let Some(run) = crate::store::find_run_by_trigger_message_id(command_id)? else {
         return Ok(None);
@@ -1422,7 +1457,7 @@ fn paginate_messages(messages: Vec<Value>, offset: usize, limit: usize) -> Value
 /// client uses to fetch the remainder.
 fn paginate_items(mut items: Vec<Value>, offset: usize, limit: usize, key: &str) -> Value {
     for item in items.iter_mut() {
-        truncate_message_content(item, MESSAGE_CONTENT_CAP_BYTES);
+        cap_remote_item(item, MESSAGE_CONTENT_CAP_BYTES);
     }
     let total = items.len();
     let start = offset.min(total);
@@ -1485,6 +1520,8 @@ fn truncate_message_content(message: &mut Value, cap: usize) {
         .map(|bytes| bytes.len() > cap)
         .unwrap_or(false);
     if !oversized {
+        // Other fields may still be oversized; the caller's final item cap
+        // handles those after this content-specific pass.
         return;
     }
     // Replay events carry their payload in `data` (a JSON string), not
@@ -1541,6 +1578,81 @@ fn truncate_message_content(message: &mut Value, cap: usize) {
         }
         _ => {}
     }
+}
+
+/// Bound the complete serialized item, including structured tool arguments and
+/// metadata that are outside `content`.
+fn cap_remote_item(item: &mut Value, cap: usize) {
+    truncate_message_content(item, cap.saturating_sub(16 * 1024));
+    if serialized_len(item) <= cap {
+        return;
+    }
+
+    if let Some(tool_calls) = item.get_mut("tool_calls").and_then(Value::as_array_mut) {
+        for call in tool_calls {
+            let Some(arguments) = call.pointer_mut("/function/arguments") else {
+                continue;
+            };
+            let bytes = serialized_len(arguments);
+            if bytes > 8 * 1024 {
+                *arguments = json!({
+                    "_truncated": true,
+                    "bytes": bytes,
+                    "note": "tool arguments exceeded the relay item limit",
+                });
+            }
+        }
+    }
+    if serialized_len(item) <= cap {
+        return;
+    }
+
+    if let Some(object) = item.as_object_mut() {
+        if let Some(meta) = object.get("meta") {
+            let run_id = meta.get("run_id").cloned();
+            let original_bytes = serialized_len(meta);
+            object.insert(
+                "meta".to_string(),
+                json!({
+                    "run_id": run_id,
+                    "_truncated": true,
+                    "bytes": original_bytes,
+                }),
+            );
+        }
+    }
+    if serialized_len(item) <= cap {
+        return;
+    }
+
+    let original_bytes = serialized_len(item);
+    let mut replacement = serde_json::Map::new();
+    if let Some(object) = item.as_object() {
+        for key in [
+            "id",
+            "role",
+            "entry_type",
+            "type",
+            "run_id",
+            "idx",
+            "timestamp",
+        ] {
+            if let Some(value) = object.get(key) {
+                replacement.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    replacement.insert("_truncated".to_string(), Value::Bool(true));
+    replacement.insert("originalBytes".to_string(), Value::from(original_bytes));
+    replacement.insert(
+        "content".to_string(),
+        Value::String("[…远程条目过大，已截断；完整内容见本机会话…]".to_string()),
+    );
+    *item = Value::Object(replacement);
+}
+
+fn serialized_len(value: &Value) -> usize {
+    serde_json::to_vec(value).map_or(0, |bytes| bytes.len())
 }
 
 /// Return a byte index at a char boundary, not exceeding `max_bytes`, and
@@ -1602,8 +1714,13 @@ async fn publish_reply_payload(
     let Some(reply_subject) = msg.reply.clone() else {
         return;
     };
-    let _ = client.publish(reply_subject, payload.into()).await;
-    let _ = client.flush().await;
+    if let Err(error) = client.publish(reply_subject, payload.into()).await {
+        eprintln!("FutureOS: failed to publish remote command reply: {error}");
+        return;
+    }
+    if let Err(error) = client.flush().await {
+        eprintln!("FutureOS: failed to flush remote command reply: {error}");
+    }
 }
 
 #[cfg(test)]
@@ -1722,6 +1839,31 @@ mod tests {
         assert!(content.len() <= MESSAGE_CONTENT_CAP_BYTES + 128);
         let size = serde_json::to_vec(&page).map(|b| b.len()).unwrap();
         assert!(size < 1024 * 1024, "page too large: {size}");
+    }
+
+    #[test]
+    fn paginate_caps_structured_tool_arguments_and_metadata() {
+        let entries = vec![json!({
+            "id": "a1",
+            "role": "assistant",
+            "content": "done",
+            "tool_calls": [{
+                "id": "tc-1",
+                "function": {
+                    "name": "write",
+                    "arguments": {"path": "/tmp/x", "content": "x".repeat(700_000)},
+                }
+            }],
+            "meta": {"run_id": "r1", "blob": "y".repeat(700_000)},
+        })];
+        let page = paginate_items(entries, 0, 100, "entries");
+        let size = serde_json::to_vec(&page).expect("serialize page").len();
+        assert!(size < 1024 * 1024, "page too large: {size}");
+        assert_eq!(
+            page.pointer("/entries/0/tool_calls/0/function/arguments/_truncated"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(page.pointer("/entries/0/meta/run_id"), Some(&json!("r1")));
     }
 
     #[test]
@@ -3075,8 +3217,23 @@ mod bridge_tests {
             agent_session_id: Some(session.clone()),
         })
         .unwrap();
-        // An active run on the session → the busy guard fires before anything
-        // is persisted or spawned.
+        let source = crate::store::create_run(crate::store::CreateRunInput {
+            id: Some("run-failed-source".to_string()),
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        crate::store::update_run_status_if_active(crate::store::UpdateRunStatusInput {
+            run_id: source.id.clone(),
+            status: "failed".to_string(),
+            error_message: Some("boom".to_string()),
+            error_type: Some("model_failed".to_string()),
+        })
+        .unwrap();
+        // A separate active run on the session → the busy guard fires before
+        // anything is persisted or spawned.
         crate::store::create_run(crate::store::CreateRunInput {
             id: Some("run-active".to_string()),
             thread_id: thread.id.clone(),
@@ -3087,10 +3244,82 @@ mod bridge_tests {
         .unwrap();
 
         let reply = bridge
-            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": "run-active" }))
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": source.id }))
             .await;
         assert_eq!(reply["success"], json!(false));
         assert!(reply["error"].as_str().unwrap().contains("still running"));
+
+        bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn continue_run_rejects_missing_wrong_session_and_nonfailed_sources() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("cmd-continue-source-guards").await;
+        let session = unique("sess");
+        let thread = crate::store::create_thread(crate::store::CreateThreadInput {
+            mode: "chat".to_string(),
+            title: Some("Guarded continuation".to_string()),
+            workspace_id: None,
+            workspace_path: None,
+            workspace_name: None,
+            agent_session_id: Some(session.clone()),
+        })
+        .unwrap();
+        let completed = crate::store::create_run(crate::store::CreateRunInput {
+            id: Some(unique("run-completed")),
+            thread_id: thread.id.clone(),
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        crate::store::update_run_status_if_active(crate::store::UpdateRunStatusInput {
+            run_id: completed.id.clone(),
+            status: "completed".to_string(),
+            error_message: None,
+            error_type: None,
+        })
+        .unwrap();
+
+        let missing = bridge
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": "missing-run" }))
+            .await;
+        assert_eq!(missing["success"], json!(false));
+        assert!(missing["error"]
+            .as_str()
+            .unwrap()
+            .contains("no longer exists"));
+
+        let nonfailed = bridge
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": session, "runId": completed.id }))
+            .await;
+        assert_eq!(nonfailed["success"], json!(false));
+        assert!(nonfailed["error"].as_str().unwrap().contains("failed run"));
+
+        let failed = crate::store::create_run(crate::store::CreateRunInput {
+            id: Some(unique("run-failed")),
+            thread_id: thread.id,
+            trigger_message_id: None,
+            model_provider: None,
+            model_id: None,
+        })
+        .unwrap();
+        crate::store::update_run_status_if_active(crate::store::UpdateRunStatusInput {
+            run_id: failed.id.clone(),
+            status: "failed".to_string(),
+            error_message: Some("boom".to_string()),
+            error_type: Some("model_failed".to_string()),
+        })
+        .unwrap();
+        let wrong_session = bridge
+            .call(json!({ "id": unique("cmd"), "type": "continue_run", "sessionId": "another-session", "runId": failed.id }))
+            .await;
+        assert_eq!(wrong_session["success"], json!(false));
+        assert!(wrong_session["error"]
+            .as_str()
+            .unwrap()
+            .contains("does not belong"));
 
         bridge.stop();
     }

--- a/desktop/src/integrations/agent/agentStateCache.test.ts
+++ b/desktop/src/integrations/agent/agentStateCache.test.ts
@@ -21,16 +21,16 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
-type Listener = (event: { payload: Record<string, unknown> | undefined }) => void;
+type Listener = (event: {
+  payload: Record<string, unknown> | undefined;
+}) => void;
 let agentEventListener: Listener | null = null;
 let providerConfigListener: Listener | null = null;
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: (name: string, handler: Listener) => {
-    if (name === "agent-event")
-      agentEventListener = handler;
-    if (name === "provider-config-changed")
-      providerConfigListener = handler;
+    if (name === "agent-event") agentEventListener = handler;
+    if (name === "provider-config-changed") providerConfigListener = handler;
     return Promise.resolve(() => {});
   },
 }));
@@ -43,7 +43,7 @@ function statePayload(overrides: Record<string, unknown> = {}) {
   return {
     model: "m1",
     thinkingLevel: "high",
-    session_name: "Session",
+    sessionName: "Session",
     sessionId: "s1",
     cwd: "/w",
     parentSessionId: null,
@@ -89,9 +89,11 @@ describe("agentStateCache fetch/cache", () => {
   });
 
   it("fetches and parses session state including activeRun variants", async () => {
-    invokeMock.mockResolvedValue(statePayload({
-      activeRun: { runId: "r1", state: "running", epoch: 2, lastEventIdx: 7 },
-    }));
+    invokeMock.mockResolvedValue(
+      statePayload({
+        activeRun: { runId: "r1", state: "running", epoch: 2, lastEventIdx: 7 },
+      }),
+    );
     const state = await getAgentState("t-fetch");
     expect(state).toMatchObject({
       model: "m1",
@@ -106,14 +108,23 @@ describe("agentStateCache fetch/cache", () => {
     expect((await getAgentState("t-run-str")).activeRun).toBeNull();
     invokeMock.mockResolvedValue(statePayload({ activeRun: { runId: 1 } }));
     expect((await getAgentState("t-run-bad")).activeRun).toBeNull();
-    invokeMock.mockResolvedValue(statePayload({ activeRun: { runId: "r", state: "queued" } }));
-    expect((await getAgentState("t-run-min")).activeRun).toMatchObject({ epoch: 0, lastEventIdx: -1 });
+    invokeMock.mockResolvedValue(
+      statePayload({ activeRun: { runId: "r", state: "queued" } }),
+    );
+    expect((await getAgentState("t-run-min")).activeRun).toMatchObject({
+      epoch: 0,
+      lastEventIdx: -1,
+    });
   });
 
   it("parses missing fields as null", async () => {
     invokeMock.mockResolvedValue({});
     const state = await getAgentState("t-empty");
-    expect(state).toMatchObject({ model: null, thinkingLevel: null, sessionName: null });
+    expect(state).toMatchObject({
+      model: null,
+      thinkingLevel: null,
+      sessionName: null,
+    });
   });
 
   it("serves fresh entries from cache and dedupes in-flight requests", async () => {
@@ -130,9 +141,12 @@ describe("agentStateCache fetch/cache", () => {
 
     // In-flight dedupe.
     let resolveInvoke!: (v: unknown) => void;
-    invokeMock.mockImplementation(() => new Promise((resolve) => {
-      resolveInvoke = resolve;
-    }));
+    invokeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInvoke = resolve;
+        }),
+    );
     const a = getAgentState("t-flight", { force: true });
     const b = getAgentState("t-flight", { force: true });
     resolveInvoke(statePayload());
@@ -148,7 +162,10 @@ describe("agentStateCache fetch/cache", () => {
     invokeMock.mockResolvedValue(statePayload());
     await getAgentState("t-patch");
     updateCachedAgentState("t-patch", { model: "m2" });
-    expect(getCachedAgentState("t-patch")).toMatchObject({ model: "m2", thinkingLevel: "high" });
+    expect(getCachedAgentState("t-patch")).toMatchObject({
+      model: "m2",
+      thinkingLevel: "high",
+    });
 
     updateCachedAgentState("t-fresh", { model: "m3" } as never);
     expect(getCachedAgentState("t-fresh")).toMatchObject({ model: "m3" });
@@ -176,16 +193,21 @@ describe("agentStateCache fetch/cache", () => {
 
   it("keeps the optimistic update when a slower fetch resolves behind it", async () => {
     let resolveInvoke!: (v: unknown) => void;
-    invokeMock.mockImplementation(() => new Promise((resolve) => {
-      resolveInvoke = resolve;
-    }));
+    invokeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInvoke = resolve;
+        }),
+    );
     const pending = getAgentState("t-race");
     // The user changes the model while the fetch is in flight.
     updateCachedAgentState("t-race", { model: "m-optimistic" } as never);
     resolveInvoke(statePayload({ model: "m-stale" }));
     const state = await pending;
     expect(state.model).toBe("m-optimistic");
-    expect(getCachedAgentState("t-race")).toMatchObject({ model: "m-optimistic" });
+    expect(getCachedAgentState("t-race")).toMatchObject({
+      model: "m-optimistic",
+    });
   });
 
   it("prunes past the 100-entry cap", () => {
@@ -228,11 +250,23 @@ describe("agentStateCache event listener", () => {
     emit({ _eventType: "model_changed", sessionId: "s1", model: "m-new" });
     expect(getCachedAgentState("t-set")).toMatchObject({ model: "m-new" });
 
-    emit({ _eventType: "thinking_level_changed", sessionId: "s1", level: "low" });
-    expect(getCachedAgentState("t-set")).toMatchObject({ thinkingLevel: "low" });
+    emit({
+      _eventType: "thinking_level_changed",
+      sessionId: "s1",
+      level: "low",
+    });
+    expect(getCachedAgentState("t-set")).toMatchObject({
+      thinkingLevel: "low",
+    });
 
-    emit({ _eventType: "session_name_changed", sessionId: "s1", name: "Renamed" });
-    expect(getCachedAgentState("t-set")).toMatchObject({ sessionName: "Renamed" });
+    emit({
+      _eventType: "session_name_changed",
+      sessionId: "s1",
+      name: "Renamed",
+    });
+    expect(getCachedAgentState("t-set")).toMatchObject({
+      sessionName: "Renamed",
+    });
 
     // Non-string values leave the entry unchanged.
     emit({ _eventType: "model_changed", sessionId: "s1", model: 42 });
@@ -248,10 +282,13 @@ describe("agentStateCache event listener", () => {
     await getAgentState("t-cwd");
     invokeMock.mockResolvedValue(undefined);
     const cwdEvents: Event[] = [];
-    window.addEventListener("future:cwd-changed", e => cwdEvents.push(e));
+    window.addEventListener("future:cwd-changed", (e) => cwdEvents.push(e));
     emit({ _eventType: "cwd_changed", sessionId: "s1", cwd: "/new" });
     await flushAsync();
-    expect(invokeMock).toHaveBeenCalledWith("reconcile_thread_workspace", { sessionId: "s1", cwd: "/new" });
+    expect(invokeMock).toHaveBeenCalledWith("reconcile_thread_workspace", {
+      sessionId: "s1",
+      cwd: "/new",
+    });
     expect(cwdEvents).toHaveLength(1);
     expect(getCachedAgentState("t-cwd")).toMatchObject({ cwd: "/new" });
   });
@@ -259,7 +296,9 @@ describe("agentStateCache event listener", () => {
   it("toasts when the workspace reconcile fails", async () => {
     invokeMock.mockRejectedValue(new Error("no access"));
     const toasts: CustomEvent[] = [];
-    window.addEventListener("futureos:toast", e => toasts.push(e as CustomEvent));
+    window.addEventListener("futureos:toast", (e) =>
+      toasts.push(e as CustomEvent),
+    );
     emit({ _eventType: "cwd_changed", sessionId: "s1", cwd: "/bad" });
     await flushAsync();
     await flushAsync();
@@ -274,13 +313,22 @@ describe("agentStateCache event listener", () => {
     emit({ _eventType: "config_reloaded", sessionId: "s1" });
     await flushAsync();
     await flushAsync();
-    expect(getCachedAgentState("t-conf")).toMatchObject({ model: "m-reloaded" });
+    expect(getCachedAgentState("t-conf")).toMatchObject({
+      model: "m-reloaded",
+    });
   });
 
   it("forwards content events as window CustomEvents", () => {
     const received: CustomEvent[] = [];
-    window.addEventListener("future:agent-event", e => received.push(e as CustomEvent));
-    emit({ _eventType: "user_message", sessionId: "s1", threadId: "t1", text: "hi" });
+    window.addEventListener("future:agent-event", (e) =>
+      received.push(e as CustomEvent),
+    );
+    emit({
+      _eventType: "user_message",
+      sessionId: "s1",
+      threadId: "t1",
+      text: "hi",
+    });
     emit({
       _eventType: "compaction_started",
       sessionId: "s1",
@@ -304,7 +352,10 @@ describe("agentStateCache event listener", () => {
       error: "provider unavailable",
     });
     expect(received).toHaveLength(4);
-    expect(received[0]?.detail).toMatchObject({ threadId: "t1", eventType: "user_message" });
+    expect(received[0]?.detail).toMatchObject({
+      threadId: "t1",
+      eventType: "user_message",
+    });
     expect(received[1]?.detail).toMatchObject({
       threadId: "t1",
       eventType: "compaction_started",

--- a/desktop/src/integrations/agent/agentStateCache.test.ts
+++ b/desktop/src/integrations/agent/agentStateCache.test.ts
@@ -29,8 +29,10 @@ let providerConfigListener: Listener | null = null;
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: (name: string, handler: Listener) => {
-    if (name === "agent-event") agentEventListener = handler;
-    if (name === "provider-config-changed") providerConfigListener = handler;
+    if (name === "agent-event")
+      agentEventListener = handler;
+    if (name === "provider-config-changed")
+      providerConfigListener = handler;
     return Promise.resolve(() => {});
   },
 }));
@@ -282,7 +284,7 @@ describe("agentStateCache event listener", () => {
     await getAgentState("t-cwd");
     invokeMock.mockResolvedValue(undefined);
     const cwdEvents: Event[] = [];
-    window.addEventListener("future:cwd-changed", (e) => cwdEvents.push(e));
+    window.addEventListener("future:cwd-changed", e => cwdEvents.push(e));
     emit({ _eventType: "cwd_changed", sessionId: "s1", cwd: "/new" });
     await flushAsync();
     expect(invokeMock).toHaveBeenCalledWith("reconcile_thread_workspace", {
@@ -296,9 +298,8 @@ describe("agentStateCache event listener", () => {
   it("toasts when the workspace reconcile fails", async () => {
     invokeMock.mockRejectedValue(new Error("no access"));
     const toasts: CustomEvent[] = [];
-    window.addEventListener("futureos:toast", (e) =>
-      toasts.push(e as CustomEvent),
-    );
+    window.addEventListener("futureos:toast", e =>
+      toasts.push(e as CustomEvent));
     emit({ _eventType: "cwd_changed", sessionId: "s1", cwd: "/bad" });
     await flushAsync();
     await flushAsync();
@@ -320,9 +321,8 @@ describe("agentStateCache event listener", () => {
 
   it("forwards content events as window CustomEvents", () => {
     const received: CustomEvent[] = [];
-    window.addEventListener("future:agent-event", (e) =>
-      received.push(e as CustomEvent),
-    );
+    window.addEventListener("future:agent-event", e =>
+      received.push(e as CustomEvent));
     emit({
       _eventType: "user_message",
       sessionId: "s1",

--- a/desktop/src/integrations/agent/agentStateCache.ts
+++ b/desktop/src/integrations/agent/agentStateCache.ts
@@ -20,7 +20,12 @@ export interface AgentSessionState {
   activeRun?: {
     runId: string;
     epoch: number;
-    state: "starting" | "running" | "cancelling" | "cancellation_stuck" | "finalizing";
+    state:
+      | "starting"
+      | "running"
+      | "cancelling"
+      | "cancellation_stuck"
+      | "finalizing";
     lastEventIdx: number;
   } | null;
 }
@@ -53,8 +58,7 @@ const versions = new Map<string, number>();
 const listeners = new Set<() => void>();
 
 function notify() {
-  for (const listener of listeners)
-    listener();
+  for (const listener of listeners) listener();
 }
 
 // Module-scoped so the reference stays stable across renders — otherwise
@@ -85,20 +89,30 @@ export async function getAgentState(
   }
 
   const pending = inFlight.get(threadId);
-  if (pending)
-    return pending;
+  if (pending) return pending;
 
   const requestVersion = versions.get(threadId) ?? 0;
-  const request = invokeCommand<Record<string, unknown>>("get_thread_agent_state", { threadId })
+  const request = invokeCommand<Record<string, unknown>>(
+    "get_thread_agent_state",
+    { threadId },
+  )
     .then((raw) => {
       const state: AgentSessionState = {
         model: typeof raw.model === "string" ? raw.model : null,
-        thinkingLevel: typeof raw.thinkingLevel === "string" ? raw.thinkingLevel : null,
-        sessionName: typeof raw.session_name === "string" ? raw.session_name : null,
+        thinkingLevel:
+          typeof raw.thinkingLevel === "string" ? raw.thinkingLevel : null,
+        sessionName:
+          typeof raw.sessionName === "string"
+            ? raw.sessionName
+            : typeof raw.session_name === "string"
+              ? raw.session_name
+              : null,
         sessionId: typeof raw.sessionId === "string" ? raw.sessionId : null,
         cwd: typeof raw.cwd === "string" ? raw.cwd : null,
-        parentSessionId: typeof raw.parentSessionId === "string" ? raw.parentSessionId : null,
-        isStreaming: typeof raw.isStreaming === "boolean" ? raw.isStreaming : undefined,
+        parentSessionId:
+          typeof raw.parentSessionId === "string" ? raw.parentSessionId : null,
+        isStreaming:
+          typeof raw.isStreaming === "boolean" ? raw.isStreaming : undefined,
         activeRun: parseActiveRun(raw.activeRun),
       };
       if ((versions.get(threadId) ?? 0) === requestVersion) {
@@ -110,16 +124,14 @@ export async function getAgentState(
       return cache.get(threadId)?.state ?? state;
     })
     .finally(() => {
-      if (inFlight.get(threadId) === request)
-        inFlight.delete(threadId);
+      if (inFlight.get(threadId) === request) inFlight.delete(threadId);
     });
   inFlight.set(threadId, request);
   return request;
 }
 
 function parseActiveRun(value: unknown): AgentSessionState["activeRun"] {
-  if (!value || typeof value !== "object")
-    return null;
+  if (!value || typeof value !== "object") return null;
   const run = value as Record<string, unknown>;
   if (typeof run.runId !== "string" || typeof run.state !== "string")
     return null;
@@ -136,12 +148,17 @@ function parseActiveRun(value: unknown): AgentSessionState["activeRun"] {
  * state object (rather than mutating in place) so useSyncExternalStore's
  * Object.is snapshot comparison detects the change and re-renders subscribers.
  */
-export function updateCachedAgentState(threadId: string, patch: Partial<AgentSessionState>) {
+export function updateCachedAgentState(
+  threadId: string,
+  patch: Partial<AgentSessionState>,
+) {
   versions.set(threadId, (versions.get(threadId) ?? 0) + 1);
   inFlight.delete(threadId);
   const cached = cache.get(threadId);
   cache.set(threadId, {
-    state: cached ? { ...cached.state, ...patch } : (patch as AgentSessionState),
+    state: cached
+      ? { ...cached.state, ...patch }
+      : (patch as AgentSessionState),
     // Always use the current time — an optimistic update from the user's
     // explicit action must not inherit a stale fetchedAt that would make
     // getCachedAgentState treat it as expired immediately.
@@ -159,9 +176,10 @@ export function updateCachedAgentState(threadId: string, patch: Partial<AgentSes
  * Freshness is the writer's job — getAgentState still refetches once an entry
  * is older than CACHE_TTL_MS.
  */
-export function getCachedAgentState(threadId: string | undefined | null): AgentSessionState | undefined {
-  if (!threadId)
-    return undefined;
+export function getCachedAgentState(
+  threadId: string | undefined | null,
+): AgentSessionState | undefined {
+  if (!threadId) return undefined;
   return cache.get(threadId)?.state;
 }
 
@@ -169,8 +187,7 @@ export function getCachedAgentState(threadId: string | undefined | null): AgentS
 export function invalidateAgentState(threadId: string) {
   versions.set(threadId, (versions.get(threadId) ?? 0) + 1);
   inFlight.delete(threadId);
-  if (cache.delete(threadId))
-    notify();
+  if (cache.delete(threadId)) notify();
 }
 
 function touchCache(threadId: string, entry: CacheEntry) {
@@ -190,8 +207,7 @@ function pruneCache() {
 
 /** Pre-fetch agent state for a thread in the background. */
 export function prefetchAgentState(threadId: string | undefined | null) {
-  if (!threadId)
-    return;
+  if (!threadId) return;
   // Fire-and-forget: the agent may be offline or the thread may have no session
   // yet, so swallow the rejection here — awaiting callers still see it.
   void getAgentState(threadId).catch(() => {});
@@ -206,8 +222,7 @@ export function prefetchAgentState(threadId: string | undefined | null) {
  * available to synchronous readers until the fresh one lands.
  */
 export function revalidateAgentState(threadId: string | undefined | null) {
-  if (!threadId)
-    return;
+  if (!threadId) return;
   void getAgentState(threadId, { force: true }).catch(() => {});
 }
 
@@ -218,7 +233,9 @@ export function revalidateAgentState(threadId: string | undefined | null) {
  * Returns the same object reference until the entry changes, keeping
  * useSyncExternalStore's snapshot stable.
  */
-export function useCachedAgentState(threadId: string | undefined | null): AgentSessionState | undefined {
+export function useCachedAgentState(
+  threadId: string | undefined | null,
+): AgentSessionState | undefined {
   return useSyncExternalStore(subscribe, () => getCachedAgentState(threadId));
 }
 
@@ -231,8 +248,7 @@ let eventListenerInstalled = false;
  * latency as the TUI — no polling, no synthetic run delay.
  */
 export function installAgentEventListener() {
-  if (eventListenerInstalled)
-    return;
+  if (eventListenerInstalled) return;
   eventListenerInstalled = true;
 
   void listen<Record<string, unknown>>("provider-config-changed", (event) => {
@@ -248,14 +264,12 @@ export function installAgentEventListener() {
 
   void listen<Record<string, unknown>>("agent-event", (event) => {
     const p = event.payload;
-    if (!p)
-      return;
+    if (!p) return;
 
     const threadId = typeof p.threadId === "string" ? p.threadId : null;
     const sessionId = typeof p.sessionId === "string" ? p.sessionId : null;
     const eventType = typeof p._eventType === "string" ? p._eventType : null;
-    if (!sessionId || !eventType)
-      return;
+    if (!sessionId || !eventType) return;
 
     switch (eventType) {
       // ── Settings-change events: update cache ──
@@ -281,11 +295,12 @@ export function installAgentEventListener() {
       case "compaction_started":
       case "compaction_committed":
       case "compaction_failed":
-        if (!threadId)
-          return;
-        window.dispatchEvent(new CustomEvent("future:agent-event", {
-          detail: { threadId, sessionId, eventType, payload: p },
-        }));
+        if (!threadId) return;
+        window.dispatchEvent(
+          new CustomEvent("future:agent-event", {
+            detail: { threadId, sessionId, eventType, payload: p },
+          }),
+        );
         break;
     }
   });
@@ -305,20 +320,23 @@ function applySettingsEvent(
     invokeCommand("reconcile_thread_workspace", {
       sessionId,
       cwd: p.cwd,
-    }).then(() => {
-      window.dispatchEvent(new CustomEvent("future:cwd-changed"));
-    }).catch((error: unknown) => {
-      emitFutureEvent("toast", {
-        message: i18n.t("agent:thread.workspaceAccessError", { message: String(error) }),
-        tone: "error",
+    })
+      .then(() => {
+        window.dispatchEvent(new CustomEvent("future:cwd-changed"));
+      })
+      .catch((error: unknown) => {
+        emitFutureEvent("toast", {
+          message: i18n.t("agent:thread.workspaceAccessError", {
+            message: String(error),
+          }),
+          tone: "error",
+        });
       });
-    });
   }
 
   const revalidate: string[] = [];
   for (const [threadId, entry] of cache) {
-    if (entry.state.sessionId !== sessionId)
-      continue;
+    if (entry.state.sessionId !== sessionId) continue;
 
     if (eventType === "config_reloaded") {
       // The agent rebuilt this session's settings: drop the snapshot and
@@ -385,8 +403,7 @@ export async function listStreamingThreadIds(): Promise<string[]> {
   try {
     const raw = await invokeCommand<string[]>("list_streaming_thread_ids");
     return Array.isArray(raw) ? raw : [];
-  }
-  catch {
+  } catch {
     // Agent unreachable: report "nothing streaming" — the next tick retries.
     return [];
   }

--- a/desktop/src/integrations/agent/agentStateCache.ts
+++ b/desktop/src/integrations/agent/agentStateCache.ts
@@ -89,7 +89,8 @@ export async function getAgentState(
   }
 
   const pending = inFlight.get(threadId);
-  if (pending) return pending;
+  if (pending)
+    return pending;
 
   const requestVersion = versions.get(threadId) ?? 0;
   const request = invokeCommand<Record<string, unknown>>(
@@ -124,14 +125,16 @@ export async function getAgentState(
       return cache.get(threadId)?.state ?? state;
     })
     .finally(() => {
-      if (inFlight.get(threadId) === request) inFlight.delete(threadId);
+      if (inFlight.get(threadId) === request)
+        inFlight.delete(threadId);
     });
   inFlight.set(threadId, request);
   return request;
 }
 
 function parseActiveRun(value: unknown): AgentSessionState["activeRun"] {
-  if (!value || typeof value !== "object") return null;
+  if (!value || typeof value !== "object")
+    return null;
   const run = value as Record<string, unknown>;
   if (typeof run.runId !== "string" || typeof run.state !== "string")
     return null;
@@ -179,7 +182,8 @@ export function updateCachedAgentState(
 export function getCachedAgentState(
   threadId: string | undefined | null,
 ): AgentSessionState | undefined {
-  if (!threadId) return undefined;
+  if (!threadId)
+    return undefined;
   return cache.get(threadId)?.state;
 }
 
@@ -187,7 +191,8 @@ export function getCachedAgentState(
 export function invalidateAgentState(threadId: string) {
   versions.set(threadId, (versions.get(threadId) ?? 0) + 1);
   inFlight.delete(threadId);
-  if (cache.delete(threadId)) notify();
+  if (cache.delete(threadId))
+    notify();
 }
 
 function touchCache(threadId: string, entry: CacheEntry) {
@@ -207,7 +212,8 @@ function pruneCache() {
 
 /** Pre-fetch agent state for a thread in the background. */
 export function prefetchAgentState(threadId: string | undefined | null) {
-  if (!threadId) return;
+  if (!threadId)
+    return;
   // Fire-and-forget: the agent may be offline or the thread may have no session
   // yet, so swallow the rejection here — awaiting callers still see it.
   void getAgentState(threadId).catch(() => {});
@@ -222,7 +228,8 @@ export function prefetchAgentState(threadId: string | undefined | null) {
  * available to synchronous readers until the fresh one lands.
  */
 export function revalidateAgentState(threadId: string | undefined | null) {
-  if (!threadId) return;
+  if (!threadId)
+    return;
   void getAgentState(threadId, { force: true }).catch(() => {});
 }
 
@@ -248,7 +255,8 @@ let eventListenerInstalled = false;
  * latency as the TUI — no polling, no synthetic run delay.
  */
 export function installAgentEventListener() {
-  if (eventListenerInstalled) return;
+  if (eventListenerInstalled)
+    return;
   eventListenerInstalled = true;
 
   void listen<Record<string, unknown>>("provider-config-changed", (event) => {
@@ -264,12 +272,14 @@ export function installAgentEventListener() {
 
   void listen<Record<string, unknown>>("agent-event", (event) => {
     const p = event.payload;
-    if (!p) return;
+    if (!p)
+      return;
 
     const threadId = typeof p.threadId === "string" ? p.threadId : null;
     const sessionId = typeof p.sessionId === "string" ? p.sessionId : null;
     const eventType = typeof p._eventType === "string" ? p._eventType : null;
-    if (!sessionId || !eventType) return;
+    if (!sessionId || !eventType)
+      return;
 
     switch (eventType) {
       // ── Settings-change events: update cache ──
@@ -295,7 +305,8 @@ export function installAgentEventListener() {
       case "compaction_started":
       case "compaction_committed":
       case "compaction_failed":
-        if (!threadId) return;
+        if (!threadId)
+          return;
         window.dispatchEvent(
           new CustomEvent("future:agent-event", {
             detail: { threadId, sessionId, eventType, payload: p },
@@ -336,7 +347,8 @@ function applySettingsEvent(
 
   const revalidate: string[] = [];
   for (const [threadId, entry] of cache) {
-    if (entry.state.sessionId !== sessionId) continue;
+    if (entry.state.sessionId !== sessionId)
+      continue;
 
     if (eventType === "config_reloaded") {
       // The agent rebuilt this session's settings: drop the snapshot and
@@ -403,7 +415,8 @@ export async function listStreamingThreadIds(): Promise<string[]> {
   try {
     const raw = await invokeCommand<string[]>("list_streaming_thread_ids");
     return Array.isArray(raw) ? raw : [];
-  } catch {
+  }
+  catch {
     // Agent unreachable: report "nothing streaming" — the next tick retries.
     return [];
   }

--- a/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
@@ -1,5 +1,6 @@
 import {
   clearPendingContinuation,
+  discardPendingContinuation,
   loadPendingContinuation,
   savePendingContinuation,
   type PendingContinuation,
@@ -18,8 +19,10 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 }));
 
 const pending: PendingContinuation = {
-  version: 1,
+  version: 2,
   commandId: "continue-1",
+  pairId: "pair-1",
+  expectedDesktopId: "desktop-1",
   sessionId: "session-1",
   sourceRunId: "run-1",
   createdAt: 123,
@@ -36,6 +39,22 @@ describe("pending continuation storage", () => {
   it("ignores malformed records", async () => {
     mockData.set("futureos.remote.pending-continuation.v1", JSON.stringify({ version: 1 }));
     await expect(loadPendingContinuation()).resolves.toBeNull();
+  });
+
+  it("does not recover legacy records without a pairing identity", async () => {
+    mockData.set(
+      "futureos.remote.pending-continuation.v1",
+      JSON.stringify({
+        version: 1,
+        commandId: "legacy",
+        sessionId: "session-1",
+        sourceRunId: "run-1",
+        createdAt: 1,
+      }),
+    );
+    await expect(loadPendingContinuation()).resolves.toBeNull();
+    await discardPendingContinuation();
+    expect(mockData.has("futureos.remote.pending-continuation.v1")).toBe(false);
   });
 
   it("ignores corrupt JSON", async () => {

--- a/mobile/src/remote/__tests__/timeline.test.ts
+++ b/mobile/src/remote/__tests__/timeline.test.ts
@@ -201,6 +201,8 @@ describe("entry reducer", () => {
         meta: { run_id: "run-9" },
         output_tokens: 12,
         duration_ms: 3400,
+        input_tokens: 34,
+        cache_read_tokens: 21,
       },
       { id: "u2", role: "user", content: "thanks" },
     ]);
@@ -213,6 +215,8 @@ describe("entry reducer", () => {
       runId: "run-9",
       durationMs: 3400,
       outputTokens: 12,
+      inputTokens: 34,
+      cacheReadTokens: 21,
     });
     expect(reply.segments).toEqual([
       { id: expect.any(String), kind: "thinking", text: "reasoning…" },
@@ -322,6 +326,42 @@ describe("user message mirror", () => {
         runId: "run-1",
         text: "check this",
       }),
+    ]);
+  });
+
+  test("pairs persisted tool results by id and trusts explicit error status", () => {
+    const timeline = timelineFromEntries([
+      { id: "u1", role: "user", content: "run tools" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "done",
+        tool_calls: [
+          { id: "call-read", function: { name: "read", arguments: { path: "/tmp/x" } } },
+          { id: "call-shell", function: { name: "shell", arguments: { command: "true" } } },
+        ],
+      },
+      {
+        id: "t2",
+        role: "tool",
+        content: "ok",
+        tool_call_id: "call-shell",
+        tool_result_is_error: true,
+      },
+      {
+        id: "t1",
+        role: "tool",
+        content: "Error: legacy-looking text",
+        tool_call_id: "call-read",
+        tool_result_is_error: false,
+      },
+    ]);
+    const reply = timeline.items.find(item => item.kind === "message" && item.role === "assistant");
+    if (!reply || reply.kind !== "message") throw new Error("reply bubble missing");
+    const tools = reply.segments?.filter(segment => segment.kind === "tool") ?? [];
+    expect(tools.map(segment => (segment.kind === "tool" ? segment.tool.status : null))).toEqual([
+      "completed",
+      "failed",
     ]);
   });
 

--- a/mobile/src/remote/__tests__/usePromptOutbox.test.ts
+++ b/mobile/src/remote/__tests__/usePromptOutbox.test.ts
@@ -71,9 +71,11 @@ function deferred<T = unknown>(): {
 
 function fakeEngine(): SyncEngine {
   return {
-    mutate: jest.fn((_sessionId: string, apply: (timeline: ReturnType<typeof emptyTimeline>) => unknown) => {
-      apply(emptyTimeline());
-    }),
+    mutate: jest.fn(
+      (_sessionId: string, apply: (timeline: ReturnType<typeof emptyTimeline>) => unknown) => {
+        apply(emptyTimeline());
+      },
+    ),
   } as unknown as SyncEngine;
 }
 
@@ -179,8 +181,10 @@ describe("usePromptOutbox recovery", () => {
 
   it("automatically reconciles a durable continuation after reconnect", async () => {
     await savePendingContinuation({
-      version: 1,
+      version: 2,
       commandId: "continue-1",
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       sessionId: "session-2",
       sourceRunId: "failed-run",
       createdAt: 2,
@@ -530,7 +534,12 @@ describe("usePromptOutbox continueRun", () => {
       await h.result.continueRun("session-1", "run-1");
     });
     expect(requestRetry).toHaveBeenCalledWith(
-      { id: expect.stringMatching(/^continue_/), type: "continue_run", sessionId: "session-1", runId: "run-1" },
+      {
+        id: expect.stringMatching(/^continue_/),
+        type: "continue_run",
+        sessionId: "session-1",
+        runId: "run-1",
+      },
       "session-1",
     );
     await expect(loadPendingContinuation()).resolves.toBeNull();
@@ -571,8 +580,10 @@ describe("usePromptOutbox continueRun", () => {
 
   it("clears a stale continuation that targets a different run", async () => {
     await savePendingContinuation({
-      version: 1,
+      version: 2,
       commandId: "continue-old",
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       sessionId: "other-session",
       sourceRunId: "other-run",
       createdAt: 2,
@@ -595,6 +606,28 @@ describe("usePromptOutbox continueRun", () => {
     });
     const h = await mountContinue(requestRetry);
     await expect(h.result.continueRun("session-1", "run-1")).rejects.toThrow("boom");
+    await expect(loadPendingContinuation()).resolves.toBeNull();
+  });
+
+  it("discards a continuation from a different pairing without sending it", async () => {
+    await savePendingContinuation({
+      version: 2,
+      commandId: "continue-foreign",
+      pairId: "another-pair",
+      expectedDesktopId: "another-desktop",
+      sessionId: "session-2",
+      sourceRunId: "run-2",
+      createdAt: 2,
+    });
+    const requestRetry = jest.fn(async () => ({ data: ack() }));
+    const h = await mountContinue(requestRetry);
+    await act(async () => {
+      await h.result.continueRun("session-1", "run-1");
+    });
+    expect(requestRetry).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "continue-foreign" }),
+      expect.anything(),
+    );
     await expect(loadPendingContinuation()).resolves.toBeNull();
   });
 });
@@ -684,8 +717,10 @@ describe("usePromptOutbox recovery error handling", () => {
 
   it("clears and records a non-transient continuation recovery failure", async () => {
     await savePendingContinuation({
-      version: 1,
+      version: 2,
       commandId: "continue-err",
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       sessionId: "session-2",
       sourceRunId: "failed-run",
       createdAt: 2,

--- a/mobile/src/remote/__tests__/useRemoteConnection.test.ts
+++ b/mobile/src/remote/__tests__/useRemoteConnection.test.ts
@@ -4,6 +4,7 @@ import * as Network from "expo-network";
 import { AppState } from "react-native";
 import type { ConnectionState } from "../connectionState";
 import { attemptPendingRevoke, claimPairingCode, serverRevoke } from "../pairing";
+import { discardPendingContinuation } from "../pendingContinuationStorage";
 import { clearPendingPrompt, loadPendingPrompt } from "../pendingPromptStorage";
 import {
   clearCredentials,
@@ -44,6 +45,11 @@ jest.mock("../pendingPromptStorage", () => ({
   __esModule: true,
   clearPendingPrompt: jest.fn(async () => {}),
   loadPendingPrompt: jest.fn(async () => null),
+}));
+
+jest.mock("../pendingContinuationStorage", () => ({
+  __esModule: true,
+  discardPendingContinuation: jest.fn(async () => {}),
 }));
 
 jest.mock("../client", () => {
@@ -332,6 +338,7 @@ describe("useRemoteConnection", () => {
       const c = client();
       act(() => c.callbacks.onPresence({ ...presence, unpaired: true }));
       expect(clearCredentials).toHaveBeenCalled();
+      expect(discardPendingContinuation).toHaveBeenCalled();
       expect(options.resetCatalog).toHaveBeenCalled();
       expect(options.resetConversation).toHaveBeenCalled();
       expect(options.resetTimeline).toHaveBeenCalled();

--- a/mobile/src/remote/pendingContinuationStorage.ts
+++ b/mobile/src/remote/pendingContinuationStorage.ts
@@ -1,8 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export interface PendingContinuation {
-  version: 1;
+  version: 2;
   commandId: string;
+  pairId: string;
+  expectedDesktopId: string;
   sessionId: string;
   sourceRunId: string;
   createdAt: number;
@@ -16,9 +18,13 @@ export async function loadPendingContinuation(): Promise<PendingContinuation | n
     if (!raw) return null;
     const value = JSON.parse(raw) as Partial<PendingContinuation>;
     if (
-      value.version !== 1 ||
+      value.version !== 2 ||
       typeof value.commandId !== "string" ||
       !value.commandId ||
+      typeof value.pairId !== "string" ||
+      !value.pairId ||
+      typeof value.expectedDesktopId !== "string" ||
+      !value.expectedDesktopId ||
       typeof value.sessionId !== "string" ||
       !value.sessionId ||
       typeof value.sourceRunId !== "string" ||
@@ -41,4 +47,9 @@ export async function savePendingContinuation(continuation: PendingContinuation)
 export async function clearPendingContinuation(commandId: string): Promise<void> {
   const current = await loadPendingContinuation();
   if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+}
+
+/** Drop any continuation, including legacy/malformed records that cannot be decoded safely. */
+export async function discardPendingContinuation(): Promise<void> {
+  await AsyncStorage.removeItem(KEY);
 }

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -143,6 +143,10 @@ function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
       ...(entry.checkpoint ? { checkpoint: entry.checkpoint } : {}),
       ...(entry.thinking != null ? { thinking: entry.thinking } : {}),
       ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      ...(entry.tool_call_id != null ? { tool_call_id: entry.tool_call_id } : {}),
+      ...(entry.tool_result_is_error != null
+        ? { tool_result_is_error: entry.tool_result_is_error }
+        : {}),
       ...(entry.meta
         ? {
             meta: {
@@ -160,6 +164,8 @@ function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
       ...(entry.timestamp ? { timestamp: entry.timestamp } : {}),
       ...(entry.output_tokens != null ? { output_tokens: entry.output_tokens } : {}),
       ...(entry.duration_ms != null ? { duration_ms: entry.duration_ms } : {}),
+      ...(entry.input_tokens != null ? { input_tokens: entry.input_tokens } : {}),
+      ...(entry.cache_read_tokens != null ? { cache_read_tokens: entry.cache_read_tokens } : {}),
     };
   });
 }

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -173,6 +173,10 @@ export interface HistoryEntry {
   thinking?: string | null;
   /** Tool calls an assistant entry introduced — rendered as activity rows. */
   tool_calls?: { id?: string; function?: { name?: string; arguments?: unknown } }[] | null;
+  /** Correlates a tool result with the originating assistant tool call. */
+  tool_call_id?: string | null;
+  /** Authoritative tool-result status when persisted by the agent. */
+  tool_result_is_error?: boolean | null;
   meta?: {
     /** Canonical Agent run identity (present on new entries). */
     run_id?: string;
@@ -182,6 +186,10 @@ export interface HistoryEntry {
   output_tokens?: number;
   /** Reply wall-clock duration in ms — paired with `output_tokens`. */
   duration_ms?: number;
+  /** Prompt tokens billed for this run. */
+  input_tokens?: number;
+  /** Cache-read subset of input tokens. */
+  cache_read_tokens?: number;
   /** Desktop-store run outcome, added by the remote bridge for recovery parity. */
   run_status?: "completed" | "failed" | "cancelled" | string;
   /** Raw run error for `run_status: "failed"` — the bridge pairs it with the

--- a/mobile/src/remote/usePromptOutbox.ts
+++ b/mobile/src/remote/usePromptOutbox.ts
@@ -6,6 +6,7 @@ import { clearSessionDraftIfMatches } from "./draftStorage";
 import { uploadAttachments } from "./files";
 import {
   clearPendingContinuation,
+  discardPendingContinuation,
   loadPendingContinuation,
   savePendingContinuation,
   type PendingContinuation,
@@ -113,6 +114,16 @@ async function deliverPendingContinuation(
       pending.sessionId,
     )
   ).data;
+}
+
+function continuationMatchesCredentials(
+  pending: PendingContinuation,
+  credentials: RemoteCredentials,
+): boolean {
+  return (
+    pending.pairId === credentials.pairId &&
+    pending.expectedDesktopId === credentials.expectedDesktopId
+  );
 }
 
 interface PromptOutboxOptions {
@@ -352,8 +363,13 @@ export function usePromptOutbox({
 
       const operation = (async () => {
         const client = clientRef.current;
-        if (!client) throw new Error("not_connected");
+        const credentials = credentialsRef.current;
+        if (!client || !credentials) throw new Error("not_connected");
         let pending = await loadPendingContinuation();
+        if (pending && !continuationMatchesCredentials(pending, credentials)) {
+          await discardPendingContinuation();
+          pending = null;
+        }
         let checkReceipt = pending !== null;
         if (pending && (pending.sessionId !== sessionId || pending.sourceRunId !== runId)) {
           if (promptReceiptSupported) await pendingPromptReceipt(client, pending.commandId);
@@ -363,8 +379,10 @@ export function usePromptOutbox({
         }
         if (!pending) {
           pending = {
-            version: 1,
+            version: 2,
             commandId: randomId("continue"),
+            pairId: credentials.pairId,
+            expectedDesktopId: credentials.expectedDesktopId,
             sessionId,
             sourceRunId: runId,
             createdAt: Date.now(),
@@ -395,14 +413,19 @@ export function usePromptOutbox({
         }
       }
     },
-    [clientRef, promptReceiptSupported],
+    [clientRef, credentialsRef, promptReceiptSupported],
   );
 
   const recoverPendingContinuation = useCallback(async () => {
     const client = clientRef.current;
-    if (!client || !credentialsRef.current || continuationInFlightRef.current) return;
+    const credentials = credentialsRef.current;
+    if (!client || !credentials || continuationInFlightRef.current) return;
     const pending = await loadPendingContinuation();
     if (!pending || continuationInFlightRef.current) return;
+    if (!continuationMatchesCredentials(pending, credentials)) {
+      await discardPendingContinuation();
+      return;
+    }
 
     const operation = (async () => {
       try {

--- a/mobile/src/remote/useRemoteConnection.ts
+++ b/mobile/src/remote/useRemoteConnection.ts
@@ -7,6 +7,7 @@ import type { ConnectionState } from "./connectionState";
 import { classifyError } from "./connectionState";
 import { attemptPendingRevoke, claimPairingCode, serverRevoke } from "./pairing";
 import { clearPendingPrompt, loadPendingPrompt } from "./pendingPromptStorage";
+import { discardPendingContinuation } from "./pendingContinuationStorage";
 import {
   INITIAL_PRESENCE_STATE,
   isDesktopOnline,
@@ -132,6 +133,7 @@ export function useRemoteConnection({
             void clientRef.current?.close("Unpair");
             clientRef.current = null;
             void clearCredentials();
+            void discardPendingContinuation();
             setCredentials(null);
             setPresence(null);
             resetCatalog();
@@ -405,6 +407,7 @@ export function useRemoteConnection({
     await clearCredentials();
     const pendingPrompt = await loadPendingPrompt();
     if (pendingPrompt) await clearPendingPrompt(pendingPrompt.commandId);
+    await discardPendingContinuation();
     setCredentials(null);
     setPresence(null);
     resetCatalog();

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -1035,6 +1035,11 @@ message SessionEntry {
   optional string entry_type = 15;
   // Structured v2/legacy checkpoint payload serialized as JSON.
   optional string checkpoint = 16;
+  // Correlates a persisted tool result with its originating tool call.
+  optional string tool_call_id = 17;
+  // Authoritative tool-result status. Absent for legacy entries that did not
+  // persist an explicit status.
+  optional bool tool_result_is_error = 18;
 }
 
 // One event as replayed by get_events_since. Field names mirror the

--- a/packages/rpc/src/decode.rs
+++ b/packages/rpc/src/decode.rs
@@ -6,7 +6,7 @@
 //! payload is absent (an untyped command, or a pre-typed-RPC agent).
 
 use crate::payloads::{
-    EventsSincePayload, GetStatePayload, ProjectionPayload, ReplayEventPayload,
+    EventsSincePayload, GetStatePayload, ProjectionPayload, ReplayEventPayload, SessionEntriesPage,
     SessionEntryPayload, SessionSummaryPayload,
 };
 use crate::proto;
@@ -132,24 +132,43 @@ pub fn decode_list_sessions(resp: &proto::RpcResponse) -> Option<Vec<SessionSumm
 
 /// get_session_entries rows, decoded from the typed wire form when present.
 pub fn decode_session_entries(resp: &proto::RpcResponse) -> Option<Vec<SessionEntryPayload>> {
+    decode_session_entries_page(resp).map(|page| page.entries)
+}
+
+/// A complete `get_session_entries` page, including continuation metadata.
+pub fn decode_session_entries_page(resp: &proto::RpcResponse) -> Option<SessionEntriesPage> {
     if let Some(Kind::GetSessionEntries(response)) =
         resp.payload.as_ref().and_then(|p| p.kind.as_ref())
     {
-        return Some(
-            response
+        return Some(SessionEntriesPage {
+            entries: response
                 .entries
                 .iter()
                 .map(session_entry_from_proto)
                 .collect(),
-        );
+            has_more: response.has_more,
+            next_offset: response.next_offset,
+        });
     }
     fallback_value(resp).and_then(|value| {
-        let rows = value.get("entries")?.as_array()?.clone();
-        let mut out = Vec::with_capacity(rows.len());
+        let rows = value.get("entries")?.as_array()?;
+        let mut entries = Vec::with_capacity(rows.len());
         for row in rows {
-            out.push(serde_json::from_value(row).ok()?);
+            entries.push(serde_json::from_value(row.clone()).ok()?);
         }
-        Some(out)
+        Some(SessionEntriesPage {
+            entries,
+            has_more: value
+                .get("hasMore")
+                .or_else(|| value.get("has_more"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            next_offset: value
+                .get("nextOffset")
+                .or_else(|| value.get("next_offset"))
+                .and_then(Value::as_i64)
+                .unwrap_or_default(),
+        })
     })
 }
 
@@ -463,6 +482,8 @@ pub(crate) fn session_entry_from_proto(entry: &proto::SessionEntry) -> SessionEn
         input_tokens: entry.input_tokens,
         cache_read_tokens: entry.cache_read_tokens,
         checkpoint: entry.checkpoint.as_ref().map(|raw| inflate_json_value(raw)),
+        tool_call_id: entry.tool_call_id.clone(),
+        tool_result_is_error: entry.tool_result_is_error,
     }
 }
 
@@ -1020,13 +1041,21 @@ mod tests {
                 tool_calls: Some("[]".to_string()),
                 output_tokens: Some(9),
                 duration_ms: Some(11),
+                tool_call_id: Some("call-1".to_string()),
+                tool_result_is_error: Some(true),
                 ..Default::default()
             }],
-            ..Default::default()
+            has_more: true,
+            next_offset: 7,
         }));
+        let page = decode_session_entries_page(&resp).unwrap();
+        assert!(page.has_more);
+        assert_eq!(page.next_offset, 7);
         let entries = decode_session_entries(&resp).unwrap();
         assert_eq!(entries[0].content, json!({"schema": 1}));
         assert_eq!(entries[0].meta, Some(json!({"m": 2})));
+        assert_eq!(entries[0].tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(entries[0].tool_result_is_error, Some(true));
         assert_eq!(entries[0].output_tokens, Some(9));
         assert_eq!(entries[0].duration_ms, Some(11));
 

--- a/packages/rpc/src/encode.rs
+++ b/packages/rpc/src/encode.rs
@@ -299,6 +299,8 @@ pub(crate) fn session_entry_to_proto(entry: &SessionEntryPayload) -> proto::Sess
             .checkpoint
             .as_ref()
             .map(|value| serde_json::to_string(value).unwrap_or_default()),
+        tool_call_id: entry.tool_call_id.clone(),
+        tool_result_is_error: entry.tool_result_is_error,
     }
 }
 

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -1116,6 +1116,13 @@ pub struct SessionEntry {
     /// Structured v2/legacy checkpoint payload serialized as JSON.
     #[prost(string, optional, tag = "16")]
     pub checkpoint: ::core::option::Option<::prost::alloc::string::String>,
+    /// Correlates a persisted tool result with its originating tool call.
+    #[prost(string, optional, tag = "17")]
+    pub tool_call_id: ::core::option::Option<::prost::alloc::string::String>,
+    /// Authoritative tool-result status. Absent for legacy entries that did not
+    /// persist an explicit status.
+    #[prost(bool, optional, tag = "18")]
+    pub tool_result_is_error: ::core::option::Option<bool>,
 }
 /// One event as replayed by get_events_since. Field names mirror the
 /// StreamEvent envelope.

--- a/packages/rpc/src/payloads.rs
+++ b/packages/rpc/src/payloads.rs
@@ -158,6 +158,20 @@ pub struct SessionEntryPayload {
     pub cache_read_tokens: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_result_is_error: Option<bool>,
+}
+
+/// One page returned by `get_session_entries`.
+#[derive(Serialize, Deserialize)]
+pub struct SessionEntriesPage {
+    pub entries: Vec<SessionEntryPayload>,
+    #[serde(default, rename = "hasMore", alias = "has_more")]
+    pub has_more: bool,
+    #[serde(default, rename = "nextOffset", alias = "next_offset")]
+    pub next_offset: i64,
 }
 
 /// One replayed event (get_events_since; proto `ReplayEvent`). Keys mirror
@@ -318,6 +332,8 @@ mod tests {
             input_tokens: None,
             cache_read_tokens: None,
             checkpoint: None,
+            tool_call_id: None,
+            tool_result_is_error: None,
         };
         let value = serde_json::to_value(&payload).unwrap();
         assert_eq!(value["content"], json!("hi"));
@@ -329,6 +345,8 @@ mod tests {
             "duration_ms",
             "input_tokens",
             "cache_read_tokens",
+            "tool_call_id",
+            "tool_result_is_error",
         ] {
             assert!(value.get(key).is_none(), "{key} must be omitted");
         }

--- a/packages/thread-projection/src/events.ts
+++ b/packages/thread-projection/src/events.ts
@@ -23,8 +23,15 @@ export interface SessionEntry {
   content: string;
   name?: string;
   tool_args?: string;
+  /** ID of the originating call for a persisted tool-result entry. */
+  tool_call_id?: string;
+  /** Explicit tool-result status; absent in legacy histories. */
+  tool_result_is_error?: boolean;
   thinking?: string;
-  tool_calls?: Array<{ id: string; function: { name: string; arguments: unknown } }>;
+  tool_calls?: Array<{
+    id: string;
+    function: { name: string; arguments: unknown };
+  }>;
   /** RFC3339 entry time; preserved across re-saves so history keeps real times. */
   timestamp?: string;
   /** Output tokens for the reply — only the final assistant entry of a run. */

--- a/packages/thread-projection/src/projection.ts
+++ b/packages/thread-projection/src/projection.ts
@@ -1,4 +1,9 @@
-import type { AgentActivityItem, AgentMessage, MessageAttachment, MessageSegment } from "./model";
+import type {
+  AgentActivityItem,
+  AgentMessage,
+  MessageAttachment,
+  MessageSegment,
+} from "./model";
 import type { ToolKind } from "./group";
 import type { SessionEntry } from "./events";
 import { isSoftExit, nonZeroExitCode } from "./liveApply";
@@ -12,11 +17,12 @@ import {
 } from "./group";
 
 /** Rebuild the message's attachment chips from a user entry's meta. */
-function attachmentsFromMeta(entry: SessionEntry): MessageAttachment[] | undefined {
+function attachmentsFromMeta(
+  entry: SessionEntry,
+): MessageAttachment[] | undefined {
   const items = entry.meta?.attachments;
-  if (!Array.isArray(items) || items.length === 0)
-    return undefined;
-  return items.map(item => ({
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+  return items.map((item) => ({
     path: item.path,
     name: item.name,
     kind: item.kind ?? "file",
@@ -52,14 +58,14 @@ interface ExchangeAcc {
  * error with "Error: ", and a shell non-zero exit puts an "[exit: N]" footer at the end of the
  * output (with the bare grep/diff/test exit-1 soft-fail exemption).
  */
-function toolResultFailed(content: string, command: string | undefined): boolean {
-  if (!content)
-    return false;
-  if (content.startsWith("Error:"))
-    return true;
+function toolResultFailed(
+  content: string,
+  command: string | undefined,
+): boolean {
+  if (!content) return false;
+  if (content.startsWith("Error:")) return true;
   const code = nonZeroExitCode(content);
-  if (code === null)
-    return false;
+  if (code === null) return false;
   return !isSoftExit(code, command);
 }
 
@@ -68,12 +74,17 @@ function toolResultFailed(content: string, command: string | undefined): boolean
  * one summary row ("编辑了 N 个文件"), matching the live/store path. A text or
  * thinking segment — or a failed tool — breaks the run.
  */
-function collapseActivitySegments(segments: MessageSegment[]): MessageSegment[] {
+function collapseActivitySegments(
+  segments: MessageSegment[],
+): MessageSegment[] {
   const out: MessageSegment[] = [];
-  const runs = foldCollapsibleRuns(segments, seg =>
-    seg.kind === "activity" && seg.item.status === "completed" && COLLAPSIBLE_KINDS.has(seg.item.kind as ToolKind)
+  const runs = foldCollapsibleRuns(segments, (seg) =>
+    seg.kind === "activity" &&
+    seg.item.status === "completed" &&
+    COLLAPSIBLE_KINDS.has(seg.item.kind as ToolKind)
       ? (seg.item.kind as ToolKind)
-      : null);
+      : null,
+  );
 
   for (const run of runs) {
     if (!run.collapsed) {
@@ -81,8 +92,11 @@ function collapseActivitySegments(segments: MessageSegment[]): MessageSegment[] 
       continue;
     }
     const items = run.group
-      .filter((seg): seg is Extract<MessageSegment, { kind: "activity" }> => seg.kind === "activity")
-      .map(seg => seg.item);
+      .filter(
+        (seg): seg is Extract<MessageSegment, { kind: "activity" }> =>
+          seg.kind === "activity",
+      )
+      .map((seg) => seg.item);
     const children = run.kind === "shell" ? items : dedupeByTarget(items);
     // Seed both ids from the first child tool-call id (stable across reloads)
     // so a re-projection reuses the collapsed row instead of remounting it.
@@ -90,7 +104,13 @@ function collapseActivitySegments(segments: MessageSegment[]): MessageSegment[] 
     out.push({
       id: `seg_${base}`,
       kind: "activity",
-      item: { id: `collapsed_${base}`, kind: run.kind, status: "completed", count: children.length, children },
+      item: {
+        id: `collapsed_${base}`,
+        kind: run.kind,
+        status: "completed",
+        count: children.length,
+        children,
+      },
     });
   }
 
@@ -118,16 +138,20 @@ function entryKey(entry: SessionEntry): string {
  * "[Context compaction: …]" (compaction/mod.rs).
  */
 function isCompactionDivider(entry: SessionEntry): boolean {
-  return entry.entry_type === "compaction"
-    || (entry.role === "user" && entry.content.startsWith("[Context compaction:"));
+  return (
+    entry.entry_type === "compaction" ||
+    (entry.role === "user" && entry.content.startsWith("[Context compaction:"))
+  );
 }
 
 /** Render a compaction marker as a divider, not as a user bubble / new exchange. */
 function dividerMessage(entry: SessionEntry, now: string): AgentMessage {
   const key = entry.checkpoint?.checkpoint_id || entryKey(entry);
-  const tokensBefore = typeof entry.checkpoint?.tokens_before === "number" && entry.checkpoint.tokens_before > 0
-    ? entry.checkpoint.tokens_before
-    : undefined;
+  const tokensBefore =
+    typeof entry.checkpoint?.tokens_before === "number" &&
+    entry.checkpoint.tokens_before > 0
+      ? entry.checkpoint.tokens_before
+      : undefined;
   return {
     id: `m_${key}`,
     role: "assistant",
@@ -135,12 +159,16 @@ function dividerMessage(entry: SessionEntry, now: string): AgentMessage {
     content: "",
     status: "complete",
     createdAt: entry.timestamp ?? now,
-    segments: [{
-      id: `seg_${key}_compaction`,
-      kind: "compaction",
-      ...(tokensBefore ? { tokensBefore } : {}),
-      ...(entry.checkpoint?.trigger ? { trigger: entry.checkpoint.trigger } : {}),
-    }],
+    segments: [
+      {
+        id: `seg_${key}_compaction`,
+        kind: "compaction",
+        ...(tokensBefore ? { tokensBefore } : {}),
+        ...(entry.checkpoint?.trigger
+          ? { trigger: entry.checkpoint.trigger }
+          : {}),
+      },
+    ],
   };
 }
 
@@ -170,27 +198,33 @@ function foldAssistantEntry(acc: ExchangeAcc, entry: SessionEntry) {
   // Last assistant entry of the exchange carries the reply's time + usage,
   // and seeds the assistant message's stable id.
   acc.assistantEntryId = key;
-  if (entry.timestamp)
-    acc.assistantCreatedAt = entry.timestamp;
+  if (entry.timestamp) acc.assistantCreatedAt = entry.timestamp;
   if (typeof entry.output_tokens === "number")
     acc.outputTokens = entry.output_tokens;
   if (typeof entry.input_tokens === "number")
     acc.inputTokens = entry.input_tokens;
   if (typeof entry.cache_read_tokens === "number")
     acc.cacheReadTokens = entry.cache_read_tokens;
-  if (typeof entry.duration_ms === "number")
-    acc.durationMs = entry.duration_ms;
+  if (typeof entry.duration_ms === "number") acc.durationMs = entry.duration_ms;
   if (typeof entry.meta?.run_id === "string" && entry.meta.run_id)
     acc.runId = entry.meta.run_id;
   if (entry.thinking) {
-    acc.segments.push({ id: `seg_${key}_thinking`, kind: "thinking", text: entry.thinking });
+    acc.segments.push({
+      id: `seg_${key}_thinking`,
+      kind: "thinking",
+      text: entry.thinking,
+    });
   }
   // Text (any preamble) comes before the tool calls it introduces — that's
   // the order the model emits within a message, and the order the live path
   // shows. Pushing tools first put "Read config.toml" above "Let me check
   // the config".
   if (entry.content?.trim()) {
-    acc.segments.push({ id: `seg_${key}_text`, kind: "text", text: entry.content });
+    acc.segments.push({
+      id: `seg_${key}_text`,
+      kind: "text",
+      text: entry.content,
+    });
     acc.finalText = entry.content;
   }
   if (entry.tool_calls) {
@@ -208,7 +242,11 @@ function foldAssistantEntry(acc: ExchangeAcc, entry: SessionEntry) {
         // keeps a write's hover from being its entire file content.
         detail: target,
       };
-      acc.segments.push({ id: `seg_${key}_${tc.id || index}`, kind: "activity", item });
+      acc.segments.push({
+        id: `seg_${key}_${tc.id || index}`,
+        kind: "activity",
+        item,
+      });
       acc.pendingTools.push(item);
     }
   }
@@ -221,20 +259,34 @@ function foldAssistantEntry(acc: ExchangeAcc, entry: SessionEntry) {
  * tool_calls in order (the agent executes and appends results in order).
  */
 function foldToolEntry(acc: ExchangeAcc | null, entry: SessionEntry) {
-  const item = acc?.pendingTools.shift();
+  if (!acc) return;
+  const matchingIndex = entry.tool_call_id
+    ? acc.pendingTools.findIndex((item) => item.id === entry.tool_call_id)
+    : -1;
+  const item =
+    matchingIndex >= 0
+      ? acc.pendingTools.splice(matchingIndex, 1)[0]
+      : acc.pendingTools.shift();
   if (item) {
     const command = item.kind === "shell" ? item.target : undefined;
-    if (toolResultFailed(entry.content, command))
+    if (
+      entry.tool_result_is_error === true ||
+      (entry.tool_result_is_error === undefined &&
+        toolResultFailed(entry.content, command))
+    )
       item.status = "failed";
   }
 }
 
 /** Emit a completed exchange as 1 user message + (when non-empty) 1 assistant. */
 function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
-  if (!acc.userMessage)
-    return;
+  if (!acc.userMessage) return;
   messages.push(acc.userMessage);
-  const textSegments = acc.segments.filter(s => s.kind === "text") as { kind: "text"; id: string; text: string }[];
+  const textSegments = acc.segments.filter((s) => s.kind === "text") as {
+    kind: "text";
+    id: string;
+    text: string;
+  }[];
   // Collapse same-kind tool bursts only after statuses are final (a failing
   // tool result, processed later, must break the group).
   const segments = collapseActivitySegments(acc.segments);
@@ -243,17 +295,18 @@ function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
   // yet (the agent is still streaming). An empty completed bubble would steal
   // the runId in applyRunMetadata and block upsertStreamingPreview from
   // inserting the live preview when the user returns to this thread.
-  const hasContent = acc.finalText
-    || textSegments.length > 0
-    || segments.length > 0
-    || acc.outputTokens !== undefined
-    || acc.durationMs !== undefined;
+  const hasContent =
+    acc.finalText ||
+    textSegments.length > 0 ||
+    segments.length > 0 ||
+    acc.outputTokens !== undefined ||
+    acc.durationMs !== undefined;
   if (hasContent) {
     messages.push({
       id: acc.assistantEntryId ? `m_${acc.assistantEntryId}` : segId(),
       role: "assistant",
       authorKey: "author.researchCopilot",
-      content: acc.finalText || textSegments.map(s => s.text).join("\n"),
+      content: acc.finalText || textSegments.map((s) => s.text).join("\n"),
       segments: segments.length > 0 ? segments : undefined,
       status: "complete",
       // An aborted exchange has no assistant entry, so no recorded reply time —
@@ -298,17 +351,13 @@ export function entriesToMessages(entries: SessionEntry[]): AgentMessage[] {
       }
       acc = newExchangeAcc();
       acc.userMessage = userMessageFromEntry(entry, now);
-    }
-    else if (entry.role === "assistant") {
-      if (!acc)
-        acc = newExchangeAcc();
+    } else if (entry.role === "assistant") {
+      if (!acc) acc = newExchangeAcc();
       foldAssistantEntry(acc, entry);
-    }
-    else if (entry.role === "tool") {
+    } else if (entry.role === "tool") {
       foldToolEntry(acc, entry);
     }
   }
-  if (acc)
-    flushAcc(messages, acc);
+  if (acc) flushAcc(messages, acc);
   return messages;
 }


### PR DESCRIPTION
## Summary

- preserve typed session tool correlation and explicit tool-result status across RPC, desktop, and mobile projections
- page complete session history, surface corrupt journals, and group fork/import history by canonical runs with legacy exchange fallback
- restore mobile usage fields and bound complete NATS history items, including structured tool arguments and metadata
- retain typed RPC consumer and continuation pairing fixes from the preceding review

## Validation

- future-rpc: 105 unit tests and 5 wire tests passed
- mobile: 32 suites, 532 tests passed; TypeScript typecheck passed
- desktop frontend: 62 files, 657 tests passed; TypeScript typecheck passed
- desktop Rust: clippy with all targets and warnings denied passed; 1090 full-suite tests passed, then the one updated error-message assertion passed on focused rerun
- agent: 7 focused session-history tests passed; agent and RPC clippy passed with warnings denied
- Rust formatting, Prettier, and git diff checks passed

## Not run

- physical iOS or Android device validation
- live external NATS end-to-end validation