### PR TITLE
fix(agent): resolve provider config at request time

### DIFF
--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -60,6 +60,10 @@ pub struct StreamContext {
 
 pub struct Loop {
     pub provider: Arc<dyn LLMProvider>,
+    /// Canonical `provider/model` reference. Provider/model configuration is
+    /// resolved from the Agent Registry at each LLM request; this field is an
+    /// identity only and never carries a configuration snapshot.
+    pub model_ref: String,
     pub model: String,
     pub system_prompt: String,
     pub tools: Vec<AgentTool>,
@@ -103,6 +107,7 @@ impl Loop {
     pub fn new(provider: Arc<dyn LLMProvider>, model: &str) -> Self {
         Self {
             provider,
+            model_ref: model.to_string(),
             model: model.to_string(),
             system_prompt: String::new(),
             tools: vec![],
@@ -158,6 +163,7 @@ impl Loop {
             .with_system_prompt(&self.system_prompt)
             .with_config(self.config.clone());
         copy.verbose = self.verbose;
+        copy.model_ref = self.model_ref.clone();
         copy.parallel_tools = self.parallel_tools;
         copy.model_registry = self.model_registry.clone();
         copy.preflight_context_check = self.preflight_context_check;

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -45,6 +45,7 @@ impl Loop {
             message.ensure_journal_entry_id();
         }
         let mut active_checkpoint = self.active_checkpoint.lock().clone();
+        let mut context_manager = self.context_manager.clone();
         // Validate: last message must not be from assistant
         if let Some(last) = messages.last() {
             if last.role == "assistant" {
@@ -106,11 +107,36 @@ impl Loop {
 
             // Emit turn_start
 
+            // Model limits are provider authority, not run/session state. A
+            // catalog edit can change context limits while a multi-turn agent
+            // run is active, so refresh the compaction budget from the same
+            // shared Registry before every actual LLM turn. The dynamic LLM
+            // client independently resolves protocol, route, headers,
+            // modalities and max-output tokens for the request itself.
+            if let (Some(registry), Some(manager)) =
+                (&self.model_registry, context_manager.as_mut())
+            {
+                let model_ref = if self.model_ref.is_empty() {
+                    ctx.model.as_str()
+                } else {
+                    self.model_ref.as_str()
+                };
+                if let Some((_identity, model, _api_key)) =
+                    registry.read().resolve_request_target(model_ref)
+                {
+                    manager.context_window = model.context_window.max(1);
+                    let (reserve_tokens, keep_recent_tokens) =
+                        crate::compaction::context_token_budgets(manager.context_window);
+                    manager.reserve_tokens = reserve_tokens;
+                    manager.keep_recent_tokens = keep_recent_tokens;
+                    manager.model = model.id;
+                }
+            }
+
             // Build a model-only projection from the immutable journal view.
             // A committed checkpoint changes this request's prompt but never
             // replaces `messages`, which remains the complete transcript.
-            let context_window = self
-                .context_manager
+            let context_window = context_manager
                 .as_ref()
                 .map(|manager| manager.context_window.max(1) as u64)
                 .unwrap_or(1_000_000);
@@ -151,7 +177,7 @@ impl Loop {
                     phase: automatic_phase,
                 });
             };
-            let prepared = if let Some(manager) = &self.context_manager {
+            let prepared = if let Some(manager) = &context_manager {
                 if provider_limit_checkpoint_id.is_some() {
                     // The retry below must use exactly the checkpoint produced
                     // for this failed model step. A second automatic checkpoint
@@ -305,7 +331,7 @@ impl Loop {
                             };
                             let provider_limit_operation_id =
                                 format!("cmp_{}", crate::utils::generate_entry_id());
-                            let Some(manager) = &self.context_manager else {
+                            let Some(manager) = &context_manager else {
                                 let error = anyhow!(
                                     "context compaction is unavailable for provider-limit recovery"
                                 );

--- a/agent/src/auth/mod.rs
+++ b/agent/src/auth/mod.rs
@@ -9,13 +9,14 @@ use std::collections::HashMap;
 pub struct AuthEntry {
     #[serde(rename = "type")]
     pub entry_type: String,
+    #[serde(default)]
     pub key: String,
-    #[serde(rename = "baseUrl", default)]
+    #[serde(rename = "base_url", alias = "baseUrl", default)]
     pub base_url: Option<String>,
 }
 
 /// Auth store holding all provider credentials
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AuthStore {
     entries: HashMap<String, AuthEntry>,
 }
@@ -45,7 +46,7 @@ impl AuthStore {
     }
 
     /// Parse auth from JSON string
-    fn from_json(data: &str) -> Result<Self, String> {
+    pub(crate) fn from_json(data: &str) -> Result<Self, String> {
         let raw: HashMap<String, serde_json::Value> =
             serde_json::from_str(data).map_err(|e| e.to_string())?;
 
@@ -59,17 +60,12 @@ impl AuthStore {
         Ok(Self { entries })
     }
 
-    /// Get API key for a provider (case-insensitive, prefix match).
+    /// Get the API key for exactly one provider.
     ///
-    /// Resolution order:
-    /// 1. Exact key match in the HashMap ("deepseek-v4-pro").
-    /// 2. Case-insensitive exact match.
-    /// 3. Prefix match — prefers the **longest** matching entry name
-    ///    (most specific).  If two entries match and have the same
-    ///    length, alphabetical order breaks the tie.  This avoids
-    ///    non-deterministic resolution when multiple entries share a
-    ///    prefix (e.g. "deepseek-v4-flash" and "deepseek-v4-pro" both
-    ///    match query "deepseek").
+    /// Credentials are provider-owned authority. Model ids, provider-name
+    /// prefixes, and an account-wide "default" must never borrow another
+    /// provider's secret. Case-insensitive equality is retained only for
+    /// legacy auth files written before provider ids were normalized.
     pub fn get(&self, provider: &str) -> Option<String> {
         let provider_lower = provider.to_lowercase();
 
@@ -87,55 +83,20 @@ impl AuthStore {
             }
         }
 
-        // Prefix match: pick the **longest** matching entry name
-        // (most specific), with alphabetical tie-break.
-        let mut best: Option<(&String, &AuthEntry)> = None;
-        for (name, entry) in &self.entries {
-            if entry.key.is_empty() {
-                continue;
-            }
-            let name_lower = name.to_lowercase();
-            if name_lower.starts_with(&provider_lower) || provider_lower.starts_with(&name_lower) {
-                match best {
-                    None => best = Some((name, entry)),
-                    Some((best_name, _)) => {
-                        if name.len() > best_name.len()
-                            || (name.len() == best_name.len() && name.as_str() < best_name.as_str())
-                        {
-                            best = Some((name, entry));
-                        }
-                    }
-                }
-            }
-        }
-        if let Some((_, entry)) = best {
-            return Some(entry.key.clone());
-        }
-
         None
     }
 
-    /// Get base URL for a provider (case-insensitive, prefix match).
+    /// Get the base URL for exactly one provider.
     pub fn base_url(&self, provider: &str) -> Option<String> {
         let provider_lower = provider.to_lowercase();
         for (name, entry) in &self.entries {
             let name_lower = name.to_lowercase();
-            if name_lower == provider_lower || provider_lower.starts_with(&name_lower) {
+            if name_lower == provider_lower {
                 if let Some(ref url) = entry.base_url {
                     if !url.is_empty() {
                         return Some(url.trim_end_matches('/').to_string());
                     }
                 }
-            }
-        }
-        None
-    }
-
-    /// Get the first available API key as default
-    pub fn default_key(&self) -> Option<String> {
-        for entry in self.entries.values() {
-            if !entry.key.is_empty() {
-                return Some(entry.key.clone());
             }
         }
         None
@@ -151,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn prefix_match_is_deterministic_preferring_longer_name() {
+    fn provider_lookup_never_uses_prefix_matches() {
         let store2 = make_store(
             r#"{
                 "deepseek":       {"type": "api_key", "key": "short-key"},
@@ -159,44 +120,21 @@ mod tests {
             }"#,
         );
 
-        // Query "deepseek" → exact match for "deepseek" wins, get "short-key"
         assert_eq!(store2.get("deepseek"), Some("short-key".to_string()));
-
-        // Query "deepseek-" → no exact match, both prefix-match.
-        // "deepseek-v4-pro" (16 chars) is longer than "deepseek" (8 chars).
-        assert_eq!(store2.get("deepseek-"), Some("long-key".to_string()));
+        assert_eq!(store2.get("deepseek-"), None);
     }
 
     #[test]
-    fn prefix_match_prefers_longer_name_over_shorter() {
-        // Simulate the ambiguous case: multiple entries sharing a prefix.
-        // Run many iterations to catch any HashMap-ordering non-determinism.
-        for _ in 0..100 {
-            let store = make_store(
-                r#"{
-                    "openai":      {"type": "api_key", "key": "generic"},
-                    "openai-gpt-5": {"type": "api_key", "key": "specific"}
-                }"#,
-            );
-            // "openai" → exact match for "openai" wins
-            assert_eq!(store.get("openai"), Some("generic".to_string()));
-            // "openai-" → prefix: "openai-gpt-5" (12) > "openai" (6), so "specific"
-            assert_eq!(store.get("openai-"), Some("specific".to_string()));
-        }
-    }
-
-    #[test]
-    fn exact_match_takes_priority_over_prefix() {
+    fn exact_match_is_case_insensitive_only() {
         let store = make_store(
             r#"{
                 "deepseek":       {"type": "api_key", "key": "generic"},
                 "deepseek-v4":    {"type": "api_key", "key": "specific"}
             }"#,
         );
-        // Exact key match
         assert_eq!(store.get("deepseek"), Some("generic".to_string()));
-        // Exact case-insensitive: "DeepSeek" vs "deepseek"
         assert_eq!(store.get("DeepSeek"), Some("generic".to_string()));
+        assert_eq!(store.get("deepseek-v4-pro"), None);
     }
 
     #[test]
@@ -230,17 +168,15 @@ mod tests {
     }
 
     #[test]
-    fn prefix_match_prefers_longer_name_when_query_is_shorter() {
+    fn similar_provider_names_remain_isolated() {
         let store = make_store(
             r#"{
                 "deepseek-v4-pro": {"type": "api_key", "key": "pro-key"},
                 "deepseek": {"type": "api_key", "key": "base-key"}
             }"#,
         );
-        // "deepseek" exact match → base-key
         assert_eq!(store.get("deepseek"), Some("base-key".to_string()));
-        // "deepseek-" no exact, both prefix match → prefer longer "deepseek-v4-pro"
-        assert_eq!(store.get("deepseek-"), Some("pro-key".to_string()));
+        assert_eq!(store.get("deepseek-"), None);
     }
 
     #[test]
@@ -257,14 +193,28 @@ mod tests {
     }
 
     #[test]
-    fn base_url_case_insensitive_prefix() {
+    fn base_url_reads_the_current_snake_case_storage_field() {
+        let store = make_store(
+            r#"{
+                "future": {"type": "api_key", "key": "k", "base_url": "https://future.example/api"}
+            }"#,
+        );
+        assert_eq!(
+            store.base_url("future"),
+            Some("https://future.example/api".to_string())
+        );
+    }
+
+    #[test]
+    fn base_url_does_not_use_prefix_matches() {
         let store = make_store(
             r#"{
                 "azure-openai": {"type": "api_key", "key": "key", "baseUrl": "https://my.openai.azure.com/"}
             }"#,
         );
+        assert_eq!(store.base_url("Azure-OpenAI-eus"), None);
         assert_eq!(
-            store.base_url("Azure-OpenAI-eus"),
+            store.base_url("Azure-OpenAI"),
             Some("https://my.openai.azure.com".to_string())
         );
     }
@@ -290,24 +240,6 @@ mod tests {
     }
 
     #[test]
-    fn default_key_returns_first_non_empty() {
-        let store = make_store(
-            r#"{
-                "a": {"type": "api_key", "key": ""},
-                "b": {"type": "api_key", "key": "valid-key"}
-            }"#,
-        );
-        assert!(store.default_key().is_some());
-        assert_ne!(store.default_key().as_deref(), Some(""));
-    }
-
-    #[test]
-    fn default_key_empty_store_returns_none() {
-        let store = make_store(r#"{}"#);
-        assert_eq!(store.default_key(), None);
-    }
-
-    #[test]
     fn base_url_matching_entry_without_url_returns_none() {
         // Name matches but the entry carries no baseUrl → falls through to None.
         let store = make_store(
@@ -326,7 +258,7 @@ mod tests {
         let auth_path = home.auth_path();
         std::fs::create_dir_all(&auth_path).unwrap();
         let store = AuthStore::load();
-        assert!(store.default_key().is_none());
+        assert!(store.get("future").is_none());
     }
 
     #[test]
@@ -338,13 +270,6 @@ mod tests {
         std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
         std::fs::write(&auth_path, "not json").unwrap();
         let store = AuthStore::load();
-        assert!(store.default_key().is_none());
-    }
-
-    #[test]
-    fn default_key_skips_empty_key_entries() {
-        // Only empty-key entries → the loop skips every return and ends at None.
-        let store = make_store(r#"{"a": {"type": "api_key", "key": ""}}"#);
-        assert_eq!(store.default_key(), None);
+        assert!(store.get("future").is_none());
     }
 }

--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -590,7 +590,6 @@ async fn async_main(
         .as_ref()
         .filter(|m| !m.base_url.is_empty())
         .map(|m| m.base_url.clone())
-        .or_else(|| auth_store.base_url(&resolved_model))
         .or_else(|| {
             model_config
                 .as_ref()
@@ -604,20 +603,15 @@ async fn async_main(
     };
 
     // Resolve API key from auth.json > model config
-    let api_key = auth_store
-        .get(&resolved_model)
-        .or_else(|| {
-            model_config
-                .as_ref()
-                .and_then(|m| auth_store.get(&m.provider))
-        })
+    let api_key = model_config
+        .as_ref()
+        .and_then(|m| auth_store.get(&m.provider))
         .or_else(|| {
             model_config
                 .as_ref()
                 .filter(|m| !m.api_key.is_empty())
                 .map(|m| m.api_key.clone())
         })
-        .or_else(|| auth_store.default_key())
         .unwrap_or_default();
 
     // Default thinking level (clients override per-session).

--- a/agent/src/engine/mod.rs
+++ b/agent/src/engine/mod.rs
@@ -97,7 +97,7 @@ impl Engine {
             api_key: api_key.to_string(),
             config,
             tools: vec![],
-            session: crate::session::Session::new(&cwd, model, ""),
+            session: crate::session::Session::new(&cwd, model),
             session_manager: Arc::new(Manager::default_for(&cwd)),
             settings: Arc::new(Settings::default()),
             agent_loop,

--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -46,8 +46,18 @@ fn llm_timeout_secs() -> u64 {
 
 pub struct Client {
     http: HttpClient,
-    target: RwLock<schema::ResolvedModelTarget>,
+    /// Static targets are used by standalone/test clients. Session clients set
+    /// this to `None`: they retain only a provider/model identity plus
+    /// session-local generation choices, never a copied provider/model config.
+    target: RwLock<Option<schema::ResolvedModelTarget>>,
+    generation: RwLock<schema::GenerationConfig>,
+    live_model: Option<LiveModelSource>,
     adapters: AdapterRegistry,
+}
+
+struct LiveModelSource {
+    canonical_model: String,
+    registry: std::sync::Arc<parking_lot::RwLock<crate::models::Registry>>,
 }
 
 impl Client {
@@ -68,36 +78,102 @@ impl Client {
             .unwrap_or_else(|_| HttpClient::new());
         Self {
             http,
-            target: RwLock::new(target),
+            generation: RwLock::new(target.generation.clone()),
+            target: RwLock::new(Some(target)),
+            live_model: None,
             adapters,
         }
     }
 
+    /// Build a session client that owns no provider or model configuration.
+    /// Every `stream_model` call re-resolves the canonical reference from the
+    /// Agent's authoritative Registry snapshot. Even an unresolved historical
+    /// identity gets this client, so it can never fall back to a stale template
+    /// provider while waiting for a configured replacement.
+    pub fn from_live_model(
+        canonical_model: String,
+        registry: std::sync::Arc<parking_lot::RwLock<crate::models::Registry>>,
+    ) -> Self {
+        let http = HttpClient::builder()
+            .timeout(std::time::Duration::from_secs(llm_timeout_secs()))
+            .build()
+            .unwrap_or_else(|_| HttpClient::new());
+        Self {
+            http,
+            target: RwLock::new(None),
+            generation: RwLock::new(schema::GenerationConfig::default()),
+            live_model: Some(LiveModelSource {
+                canonical_model,
+                registry,
+            }),
+            adapters: AdapterRegistry::default(),
+        }
+    }
+
+    fn target_for_request(&self) -> Result<schema::ResolvedModelTarget> {
+        let Some(source) = &self.live_model else {
+            let mut target = self
+                .target
+                .read()
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("static model target is unavailable"))?;
+            target.generation = self.generation.read().clone();
+            return Ok(target);
+        };
+
+        // One Registry read produces one coherent provider/model snapshot. A
+        // concurrent config commit swaps the whole Registry before publishing
+        // its revision, so this request sees either the complete old revision
+        // or the complete new one, never mixed key/base-url/model metadata.
+        let (_resolved_identity, model, api_key) = source
+            .registry
+            .read()
+            .resolve_request_target(&source.canonical_model)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "model `{}` is no longer available and no configured replacement exists",
+                    source.canonical_model
+                )
+            })?;
+        let generation = self.generation.read().clone();
+        let mut target = schema::ResolvedModelTarget::from_model(
+            &model,
+            api_key,
+            generation.temperature,
+            Some(crate::models::effective_max_tokens(&model)),
+        )?;
+        target.generation.thinking_level = generation.thinking_level;
+        target.generation.thinking_budget = generation.thinking_budget;
+        Ok(target)
+    }
+
     pub fn with_thinking_level(self, level: &str) -> Self {
-        self.target.write().generation.thinking_level = level.to_string();
+        self.generation.write().thinking_level = level.to_string();
         self
     }
 
     pub fn with_thinking_budget(self, budget: i32) -> Self {
-        self.target.write().generation.thinking_budget = budget;
+        self.generation.write().thinking_budget = budget;
         self
     }
 
     pub fn with_thinking_level_map(self, map: HashMap<String, String>) -> Self {
-        self.target.write().capabilities.reasoning.levels = map
-            .iter()
-            .map(|(key, value)| (key.clone(), serde_json::Value::String(value.clone())))
-            .collect();
+        if let Some(target) = self.target.write().as_mut() {
+            target.capabilities.reasoning.levels = map
+                .iter()
+                .map(|(key, value)| (key.clone(), serde_json::Value::String(value.clone())))
+                .collect();
+        }
         self
     }
 
     pub fn with_temperature(self, temperature: f32) -> Self {
-        self.target.write().generation.temperature = Some(temperature);
+        self.generation.write().temperature = Some(temperature);
         self
     }
 
     pub fn with_max_tokens(self, max_tokens: i32) -> Self {
-        self.target.write().generation.max_output_tokens = Some(max_tokens);
+        self.generation.write().max_output_tokens = Some(max_tokens);
         self
     }
 }
@@ -106,9 +182,54 @@ impl Client {
 impl crate::types::LLMProvider for Client {
     async fn stream_model(
         &self,
-        request: schema::ModelRequest,
+        mut request: schema::ModelRequest,
     ) -> Result<ReceiverStream<schema::ModelStreamEvent>> {
-        let target = self.target.read().clone();
+        let target = self.target_for_request()?;
+        // The session stores a canonical provider/model reference, while the
+        // upstream request always uses the latest resolved provider model id.
+        request.model = target.model_id.clone();
+        // Modality changes are also request-time provider state. Never mutate
+        // the durable conversation when a model temporarily loses image input;
+        // adapt only this outbound projection.
+        if target.capabilities.supports_image_input {
+            for message in &mut request.messages {
+                let already_has_image = message
+                    .content
+                    .iter()
+                    .any(|block| matches!(block, crate::types::ContentBlock::Image { .. }));
+                if already_has_image {
+                    continue;
+                }
+                let image_paths = message
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("attachments"))
+                    .and_then(serde_json::Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter(|attachment| {
+                        attachment.get("kind").and_then(serde_json::Value::as_str) == Some("image")
+                    })
+                    .filter_map(|attachment| {
+                        attachment
+                            .get("path")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_owned)
+                    })
+                    .collect::<Vec<_>>();
+                for path in image_paths {
+                    if let Some(url) = crate::utils::image_data_url_for_model(&path) {
+                        message.content.push(crate::types::ContentBlock::image(url));
+                    }
+                }
+            }
+        } else {
+            for message in &mut request.messages {
+                message
+                    .content
+                    .retain(|block| !matches!(block, crate::types::ContentBlock::Image { .. }));
+            }
+        }
         let adapter = self.adapters.get(target.protocol.protocol())?;
         let body = adapter.build_body(&target, &request)?;
         let url = format!(
@@ -275,18 +396,10 @@ impl crate::types::LLMProvider for Client {
         Ok(ReceiverStream::new(rx))
     }
 
-    fn set_api_key(&self, api_key: &str) {
-        self.target.write().route.api_key = api_key.to_string();
-    }
-
-    fn set_base_url(&self, base_url: &str) {
-        self.target.write().route.base_url = base_url.to_string();
-    }
-
     fn update_thinking(&self, level: &str, budget: i32) {
-        let mut target = self.target.write();
-        target.generation.thinking_level = level.to_string();
-        target.generation.thinking_budget = budget;
+        let mut generation = self.generation.write();
+        generation.thinking_level = level.to_string();
+        generation.thinking_budget = budget;
     }
 }
 
@@ -353,7 +466,7 @@ mod tests {
             Some(0.7),
             Some(4096),
         ));
-        let target = client.target.read();
+        let target = client.target_for_request().unwrap();
         assert_eq!(target.route.base_url, "https://api.openai.com");
         assert_eq!(target.route.api_key, "sk-test");
         assert_eq!(target.generation.temperature, Some(0.7));
@@ -374,7 +487,7 @@ mod tests {
             .with_thinking_level_map(levels)
             .with_temperature(0.3)
             .with_max_tokens(2048);
-        let target = client.target.read();
+        let target = client.target_for_request().unwrap();
         assert_eq!(target.generation.thinking_level, "medium");
         assert_eq!(target.generation.thinking_budget, 8000);
         assert_eq!(target.generation.temperature, Some(0.3));
@@ -386,16 +499,154 @@ mod tests {
     }
 
     #[test]
-    fn runtime_setters_update_the_resolved_target() {
+    fn runtime_thinking_setter_updates_generation_controls() {
         let client = Client::from_target(chat_target("https://api.test", "old-key", None, None));
-        crate::types::LLMProvider::set_api_key(&client, "new-key");
-        crate::types::LLMProvider::set_base_url(&client, "https://new.test");
         crate::types::LLMProvider::update_thinking(&client, "high", 16000);
-        let target = client.target.read();
-        assert_eq!(target.route.api_key, "new-key");
-        assert_eq!(target.route.base_url, "https://new.test");
+        let target = client.target_for_request().unwrap();
+        assert_eq!(target.route.api_key, "old-key");
+        assert_eq!(target.route.base_url, "https://api.test");
         assert_eq!(target.generation.thinking_level, "high");
         assert_eq!(target.generation.thinking_budget, 16000);
+    }
+
+    #[test]
+    fn live_client_resolves_the_latest_complete_provider_model_snapshot_per_request() {
+        fn model(base_url: &str, context_window: i32, max_tokens: i32) -> crate::models::Model {
+            crate::models::Model {
+                id: "m".into(),
+                name: "M".into(),
+                provider: "provider-a".into(),
+                api: "chat".into(),
+                base_url: base_url.into(),
+                input: vec!["text".into()],
+                output: vec!["text".into()],
+                context_window,
+                max_tokens,
+                ..Default::default()
+            }
+        }
+
+        let first_model = model("https://old.example", 8_000, 1_000);
+        let first_registry = crate::models::Registry::from_models_and_auth(
+            vec![first_model.clone()],
+            r#"{"provider-a":{"type":"api_key","key":"old-key","base_url":"https://old-auth.example"}}"#,
+        );
+        let registry = std::sync::Arc::new(parking_lot::RwLock::new(first_registry));
+        let client = Client::from_live_model("provider-a/m".into(), registry.clone());
+        assert!(
+            client.target.read().is_none(),
+            "session client caches no target"
+        );
+
+        let first = client.target_for_request().unwrap();
+        assert_eq!(first.route.api_key, "old-key");
+        assert_eq!(first.route.base_url, "https://old-auth.example");
+        assert_eq!(first.capabilities.context_window, 8_000);
+        assert_eq!(first.generation.max_output_tokens, Some(1_000));
+
+        let mut changed = model("https://new.example", 32_000, 4_000);
+        changed.input.push("image".into());
+        *registry.write() = crate::models::Registry::from_models_and_auth(
+            vec![changed],
+            r#"{"provider-a":{"type":"api_key","key":"new-key","base_url":"https://new-auth.example"}}"#,
+        );
+
+        let latest = client.target_for_request().unwrap();
+        assert_eq!(latest.route.api_key, "new-key");
+        assert_eq!(latest.route.base_url, "https://new-auth.example");
+        assert_eq!(latest.capabilities.context_window, 32_000);
+        assert!(latest.capabilities.supports_image_input);
+        assert_eq!(latest.generation.max_output_tokens, Some(4_000));
+    }
+
+    #[test]
+    fn live_client_never_borrows_another_providers_key() {
+        let model = crate::models::Model {
+            id: "m".into(),
+            name: "M".into(),
+            provider: "deepseek".into(),
+            api: "chat".into(),
+            base_url: "https://api.deepseek.com".into(),
+            input: vec!["text".into()],
+            output: vec!["text".into()],
+            context_window: 8_000,
+            max_tokens: 1_000,
+            ..Default::default()
+        };
+        let registry = std::sync::Arc::new(parking_lot::RwLock::new(
+            crate::models::Registry::from_models_and_auth(
+                vec![model.clone()],
+                r#"{"future":{"type":"api_key","key":"future-key"}}"#,
+            ),
+        ));
+        let client = Client::from_live_model("deepseek/m".into(), registry);
+        let error = client.target_for_request().unwrap_err();
+        assert!(error.to_string().contains("no longer available"));
+        assert!(!error.to_string().contains("future-key"));
+    }
+
+    #[test]
+    fn live_client_replaces_a_removed_historical_model_at_request_time() {
+        let old = crate::models::Model {
+            id: "old".into(),
+            name: "Old".into(),
+            provider: "provider-a".into(),
+            api: "chat".into(),
+            base_url: "https://api.example".into(),
+            input: vec!["text".into()],
+            output: vec!["text".into()],
+            context_window: 8_000,
+            max_tokens: 1_000,
+            ..Default::default()
+        };
+        let registry = std::sync::Arc::new(parking_lot::RwLock::new(
+            crate::models::Registry::from_models_and_auth(
+                vec![old.clone()],
+                r#"{"provider-a":{"type":"api_key","key":"old-key"}}"#,
+            ),
+        ));
+        let client = Client::from_live_model("provider-a/old".into(), registry.clone());
+
+        let mut replacement = old;
+        replacement.id = "new".into();
+        replacement.name = "New".into();
+        replacement.context_window = 64_000;
+        *registry.write() = crate::models::Registry::from_models_and_auth(
+            vec![replacement],
+            r#"{"provider-a":{"type":"api_key","key":"new-key"}}"#,
+        );
+
+        let target = client.target_for_request().unwrap();
+        assert_eq!(target.model_id, "new");
+        assert_eq!(target.route.api_key, "new-key");
+        assert_eq!(target.capabilities.context_window, 64_000);
+    }
+
+    #[test]
+    fn future_platform_api_root_does_not_override_the_model_v1_route() {
+        let model = crate::models::Model {
+            id: "deepseek-v4-pro".into(),
+            name: "DeepSeek V4 Pro".into(),
+            provider: "future".into(),
+            api: "openai-completions".into(),
+            base_url: "https://test.future-os.cn/api/v1".into(),
+            input: vec!["text".into()],
+            output: vec!["text".into()],
+            context_window: 128_000,
+            max_tokens: 16_384,
+            ..Default::default()
+        };
+        let registry = std::sync::Arc::new(parking_lot::RwLock::new(
+            crate::models::Registry::from_models_and_auth(
+                vec![model],
+                r#"{"future":{"type":"api_key","key":"future-key","base_url":"https://test.future-os.cn/api"}}"#,
+            ),
+        ));
+        let client = Client::from_live_model("future/deepseek-v4-pro".into(), registry);
+
+        let target = client.target_for_request().unwrap();
+        assert_eq!(target.route.base_url, "https://test.future-os.cn/api/v1");
+        assert_eq!(target.route.api_key, "future-key");
     }
 
     #[test]

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -241,7 +241,7 @@ pub fn get_default_model() -> Option<String> {
 /// Like `get_default_model` but reuses an existing registry to avoid
 /// re-deserialising the model catalog on every GUI poll.
 pub fn get_default_model_with(registry: &Registry) -> Option<String> {
-    let auth = crate::AuthStore::load();
+    let auth = &registry.auth_store;
     let all = registry.all_models();
 
     // A user-chosen global default (set by the onboarding model-picker) wins over
@@ -666,6 +666,11 @@ pub struct Registry {
     builtin: std::sync::Arc<Vec<Model>>,
     user: Vec<Model>,
     provider_overrides: HashMap<String, ProviderOverride>,
+    /// Credentials captured in the same immutable provider snapshot as the
+    /// model catalog and route overrides. Provider mutations replace the whole
+    /// Registry under one write lock; request paths therefore cannot observe a
+    /// new key with an old base URL, protocol, modality, or token limit.
+    auth_store: crate::AuthStore,
 }
 
 impl Registry {
@@ -717,7 +722,110 @@ impl Registry {
             builtin,
             user: user_models,
             provider_overrides: final_overrides,
+            auth_store,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_models_and_auth(models: Vec<Model>, auth_json: &str) -> Self {
+        Self {
+            builtin: std::sync::Arc::new(models),
+            user: Vec::new(),
+            provider_overrides: HashMap::new(),
+            auth_store: crate::AuthStore::from_json(auth_json).expect("valid test auth"),
+        }
+    }
+
+    /// Resolve the complete authoritative configuration for one LLM request.
+    ///
+    /// Sessions persist only the canonical `provider/model` reference. Every
+    /// request resolves that reference against the latest Registry snapshot so
+    /// provider key/base URL/headers and model protocol/modalities/context/token
+    /// limits never become session-owned cached state. Credential lookup is
+    /// exact by provider; no model-id or account-wide fallback is permitted.
+    pub fn resolve_for_request(&self, id: &str) -> Option<(Model, String)> {
+        let mut model = self.resolve(id)?;
+        // Future auth stores the platform API root (`{platform}/api`), not an
+        // OpenAI-compatible model route. Registry construction has already
+        // derived `{platform}/api/v1`; do not collapse it back to `/api` here.
+        // Other providers store their request base URL directly in auth.json.
+        if model.provider != "future" {
+            if let Some(base_url) = self.auth_store.base_url(&model.provider) {
+                model.base_url = base_url;
+            }
+        }
+        let api_key = self
+            .auth_store
+            .get(&model.provider)
+            .or_else(|| (!model.api_key.is_empty()).then(|| model.api_key.clone()))
+            .unwrap_or_default();
+        // Explicit user providers may intentionally be keyless (for example a
+        // local Ollama-compatible endpoint). Built-in providers are callable
+        // only with their own exact credential or embedded provider key.
+        if api_key.is_empty() && !self.is_user_defined(&model) {
+            return None;
+        }
+        Some((model, api_key))
+    }
+
+    /// Resolve the selected identity for an actual request, falling back to
+    /// the current replacement policy if the historical model disappeared or
+    /// its provider is no longer configured. This closes the narrow race where
+    /// a run was accepted just before an authoritative Registry swap.
+    pub fn resolve_request_target(&self, id: &str) -> Option<(String, Model, String)> {
+        if let Some((model, api_key)) = self.resolve_for_request(id) {
+            return Some((format!("{}/{}", model.provider, model.id), model, api_key));
+        }
+        let replacement = self.replacement_model(id)?;
+        let (model, api_key) = self.resolve_for_request(&replacement)?;
+        Some((replacement, model, api_key))
+    }
+
+    pub fn is_model_available(&self, id: &str) -> bool {
+        self.resolve_for_request(id).is_some()
+    }
+
+    pub fn request_model_accepts_images(&self, id: &str) -> bool {
+        self.resolve_request_target(id)
+            .is_some_and(|(_, model, _)| model.input.iter().any(|kind| kind == "image"))
+    }
+
+    /// Choose a deterministic replacement for an empty/removed/unconfigured
+    /// session model. Preserve the selected provider whenever it still has a
+    /// callable model; only cross providers when that provider itself is no
+    /// longer usable. The user-selected global default wins within the same
+    /// provider, followed by provider-recommended models and stable id order.
+    pub fn replacement_model(&self, current: &str) -> Option<String> {
+        let current_provider = current.split_once('/').map(|(provider, _)| provider);
+        let global_default = get_default_model_with(self);
+        if let (Some(provider), Some(default)) = (current_provider, global_default.as_deref()) {
+            if default.split_once('/').map(|(p, _)| p) == Some(provider) {
+                return Some(default.to_string());
+            }
+        }
+
+        if let Some(provider) = current_provider {
+            let mut same_provider = self
+                .all_models()
+                .into_iter()
+                .filter(|model| model.provider == provider)
+                .filter(|model| model.output.iter().any(|kind| kind == "text"))
+                .filter(|model| {
+                    self.is_model_available(&format!("{}/{}", model.provider, model.id))
+                })
+                .collect::<Vec<_>>();
+            same_provider.sort_by(|left, right| {
+                right
+                    .recommended
+                    .cmp(&left.recommended)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            if let Some(model) = same_provider.first() {
+                return Some(format!("{}/{}", model.provider, model.id));
+            }
+        }
+
+        global_default
     }
 
     fn apply_override(&self, model: &mut Model) {
@@ -1851,6 +1959,7 @@ mod tests {
             builtin: std::sync::Arc::new(vec![]),
             user: vec![],
             provider_overrides: overrides,
+            auth_store: crate::AuthStore::default(),
         };
         let mut model = Model {
             provider: "testprov".to_string(),
@@ -1872,6 +1981,7 @@ mod tests {
             builtin: std::sync::Arc::new(vec![builtin]),
             user: vec![user],
             provider_overrides: HashMap::new(),
+            auth_store: crate::AuthStore::default(),
         };
         let models = reg.all_models();
         assert_eq!(models.len(), 1);
@@ -1886,6 +1996,7 @@ mod tests {
             builtin: std::sync::Arc::new(vec![builtin]),
             user: vec![user],
             provider_overrides: HashMap::new(),
+            auth_store: crate::AuthStore::default(),
         };
         let models = reg.all_models();
         assert_eq!(models.len(), 2);
@@ -1914,6 +2025,7 @@ mod tests {
             ]),
             user: vec![],
             provider_overrides: HashMap::new(),
+            auth_store: crate::AuthStore::default(),
         };
         let summaries = reg.builtin_provider_summaries();
         assert_eq!(summaries.len(), 1);

--- a/agent/src/rpc/commands/providers.rs
+++ b/agent/src/rpc/commands/providers.rs
@@ -16,7 +16,7 @@ pub(crate) fn handle_reload_auth(state: &AppState, id: &str) -> String {
     // removed providers and models.json edits become visible to every
     // session — set_model now resolves against this cache instead of
     // constructing a fresh Registry per call.
-    refresh_registry_and_credentials(state);
+    refresh_authoritative_provider_state(state);
     let revision = crate::rpc::publish_provider_config_changed("*", "reload", true, true);
     RpcResponse::ok(
         id,
@@ -26,19 +26,23 @@ pub(crate) fn handle_reload_auth(state: &AppState, id: &str) -> String {
 }
 
 pub(crate) fn handle_sync_future_models(state: &AppState, id: &str) -> String {
+    let _provider_guard = PROVIDER_COMMAND_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     // Dedicated post-login initialization: synchronously fetch the Future
     // provider's models (warming the cache), then rebuild the registry against
     // that warm cache so the very next `list_models` returns a complete list.
     // Unlike `reload_auth`, this blocks on the network fetch — it is only ever
     // called once by the GUI's onboarding init flow, never on a hot path.
     let synced = crate::models::sync_future_models_cache();
-    *state.model_registry.write() = crate::models::Registry::new();
-    state.reload_all_credentials();
+    refresh_authoritative_provider_state(state);
     let model_count = state.model_registry.read().all_models().len();
+    let revision =
+        crate::rpc::publish_provider_config_changed("future", "models_synced", false, true);
     RpcResponse::ok(
         id,
         "sync_future_models",
-        serde_json::json!({ "synced": synced, "modelCount": model_count }),
+        serde_json::json!({ "synced": synced, "modelCount": model_count, "revision": revision }),
     )
 }
 
@@ -110,8 +114,6 @@ pub(crate) fn list_models_response(
     registry: &crate::models::Registry,
     include_builtin_providers: bool,
 ) -> String {
-    let auth = crate::AuthStore::load();
-
     // Always return all available models.  Scoping / defaults are client-side.
     // Builtin catalog models are only listed when they are credential-reachable
     // (an API key inline or in auth.json) — otherwise the picker would drown
@@ -123,8 +125,7 @@ pub(crate) fn list_models_response(
         .into_iter()
         .filter(|model| {
             registry.is_user_defined(model)
-                || !model.api_key.is_empty()
-                || auth.get(&model.provider).is_some()
+                || registry.is_model_available(&format!("{}/{}", model.provider, model.id))
         })
         .filter(|model| model.output.iter().any(|o| o == "text"))
         .collect();
@@ -304,12 +305,15 @@ fn provider_view(state: &AppState) -> Result<serde_json::Value, String> {
 }
 
 /// Rebuild the shared model registry so provider/models.json changes become
-/// visible to every session, then refresh each live session's cached
-/// credentials. Shared by `reload_auth` and the config-write commands, which
-/// apply it inline so clients need no follow-up refresh round-trip.
-fn refresh_registry_and_credentials(state: &AppState) {
+/// visible to every request, then reconcile only invalid session model
+/// references. Provider settings themselves are request-time authority and are
+/// never copied into sessions. Shared by `reload_auth` and config-write commands.
+/// Callers hold `PROVIDER_COMMAND_LOCK` and invoke this only after the durable
+/// mutation succeeds; they publish `provider_config_changed` only after this
+/// complete Registry revision is installed.
+fn refresh_authoritative_provider_state(state: &AppState) {
     *state.model_registry.write() = crate::models::Registry::new();
-    state.reload_all_credentials();
+    state.reconcile_provider_references();
 }
 
 /// Apply one auth.json mutation and refresh live state (see dispatch comment).
@@ -335,7 +339,7 @@ pub(crate) fn cmd_set_auth(state: &AppState, id: &str, cmd: &RpcCommand) -> Stri
     if let Err(error) = crate::config::providers::mutate_auth(mutation) {
         return RpcResponse::build_fail(id, "set_auth", &error);
     }
-    refresh_registry_and_credentials(state);
+    refresh_authoritative_provider_state(state);
     let revision = crate::rpc::publish_provider_config_changed(
         &mutation.provider,
         "auth_updated",
@@ -401,7 +405,7 @@ pub(crate) fn cmd_upsert_provider(state: &AppState, id: &str, cmd: &RpcCommand) 
     if let Err(error) = crate::config::providers::upsert_provider(spec) {
         return RpcResponse::build_fail(id, "upsert_provider", &error);
     }
-    refresh_registry_and_credentials(state);
+    refresh_authoritative_provider_state(state);
     let revision = crate::rpc::publish_provider_config_changed(
         &spec.id,
         if spec.create_only {
@@ -456,7 +460,7 @@ pub(crate) fn cmd_delete_provider(state: &AppState, id: &str, cmd: &RpcCommand) 
     if let Err(error) = crate::config::providers::delete_provider(provider_id) {
         return RpcResponse::build_fail(id, "delete_provider", &error);
     }
-    refresh_registry_and_credentials(state);
+    refresh_authoritative_provider_state(state);
     let revision = crate::rpc::publish_provider_config_changed(provider_id, "deleted", true, true);
     RpcResponse::ok(
         id,

--- a/agent/src/rpc/commands/providers_tests.rs
+++ b/agent/src/rpc/commands/providers_tests.rs
@@ -353,6 +353,9 @@ fn list_models_sorts_and_includes_builtin_providers() {
     let auth_path = home.auth_path();
     std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
     std::fs::write(&auth_path, serde_json::to_string_pretty(&auth).unwrap()).unwrap();
+    // This test writes behind the Agent command boundary, so explicitly mimic
+    // the atomic Registry swap that a real provider mutation performs.
+    *state.model_registry.write() = crate::models::Registry::new();
 
     let mut cmd = make_cmd("list_models");
     cmd.include_builtin_providers = true;

--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -368,10 +368,10 @@ pub(crate) fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> S
     // which overrides this below.
     let default_model = crate::models::get_default_model_with(&state.model_registry.read())
         .unwrap_or_else(|| inherit_model.clone());
-    // Apply via set_model: it sets the canonical model AND rebuilds the
-    // loop's provider client for that model's endpoint/key/compat.  A bare
-    // `loop_.model = bare_id` leaves the provider on the template's startup
-    // model, which breaks whenever the current default differs.
+    // Apply via set_model: it records the canonical identity and installs an
+    // identity-only client that resolves the authoritative provider/model
+    // snapshot for each request. A bare `loop_.model = bare_id` would retain
+    // the template's static startup client.
     if let Err(e) = new_sess.set_model(&default_model.clone()) {
         tracing::warn!("[new_session] could not sync model to fresh loop: {e}");
     }
@@ -452,10 +452,10 @@ pub(crate) fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> S
         } else {
             disk_model.clone()
         };
-        let supports_images = crate::models::model_accepts_images_with(
-            &state.model_registry.read(),
-            &effective_model,
-        );
+        let supports_images = state
+            .model_registry
+            .read()
+            .request_model_accepts_images(&effective_model);
         let mut msgs = new_sess.messages.write();
         *msgs = crate::session::entries_to_agent_messages(&entries, supports_images);
         if !disk_model.is_empty() {
@@ -857,8 +857,10 @@ pub(crate) fn cmd_fork(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
-    let supports_images =
-        crate::models::model_accepts_images_with(&state.model_registry.read(), &forked.model);
+    let supports_images = state
+        .model_registry
+        .read()
+        .request_model_accepts_images(&forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {
@@ -961,8 +963,10 @@ pub(crate) fn cmd_clone(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
-    let supports_images =
-        crate::models::model_accepts_images_with(&state.model_registry.read(), &forked.model);
+    let supports_images = state
+        .model_registry
+        .read()
+        .request_model_accepts_images(&forked.model);
     let msgs = crate::session::entries_to_agent_messages(&forked.entries, supports_images);
     *new_sess.messages.write() = msgs;
     if !forked.model.is_empty() {

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -164,7 +164,7 @@ fn list_sessions_returns_array() {
 fn list_session_ids_reports_all_files_including_corrupt() {
     let state = make_app_state();
     // Persist one real session.
-    let mut session = crate::session::Session::new("/tmp", "mock", "");
+    let mut session = crate::session::Session::new("/tmp", "mock");
     session
         .entries
         .push(crate::session::SessionEntry::session_info(
@@ -208,7 +208,7 @@ fn list_sessions_emits_canonical_keys() {
     let state = make_app_state();
     // list_sessions reads persisted session summaries, so persist one —
     // the summary fields come from the session_info entry.
-    let mut session = crate::session::Session::new("/tmp", "mock", "");
+    let mut session = crate::session::Session::new("/tmp", "mock");
     session.name = "My session".to_string();
     session
         .entries

--- a/agent/src/rpc/commands/settings.rs
+++ b/agent/src/rpc/commands/settings.rs
@@ -87,15 +87,14 @@ pub(crate) fn handle_cycle_model(
     // Use the cached registry — Registry::new() re-parses the 1.9 MB
     // catalog AND may do blocking network I/O (future provider
     // refresh) on every call.
-    let auth = crate::AuthStore::load();
-    let models: Vec<String> = state
-        .model_registry
-        .read()
+    let registry = state.model_registry.read();
+    let models: Vec<String> = registry
         .all_models()
         .into_iter()
-        .filter(|m| !m.api_key.is_empty() || auth.get(&m.provider).is_some())
+        .filter(|m| registry.is_model_available(&format!("{}/{}", m.provider, m.id)))
         .map(|m| format!("{}/{}", m.provider, m.id))
         .collect();
+    drop(registry);
 
     if models.is_empty() {
         return RpcResponse::ok(

--- a/agent/src/rpc/commands/settings_tests.rs
+++ b/agent/src/rpc/commands/settings_tests.rs
@@ -314,6 +314,7 @@ fn cycle_model_advances_to_next_credentialled_model() {
     let auth_path = home.auth_path();
     std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
     std::fs::write(&auth_path, serde_json::to_string_pretty(&auth).unwrap()).unwrap();
+    *state.model_registry.write() = crate::models::Registry::new();
 
     let resp = parse_response(&handle_command_internal(&state, make_cmd("cycle_model")));
     assert_eq!(resp["success"], true);
@@ -448,6 +449,7 @@ fn cycle_model_fails_while_loop_is_locked() {
     let auth_path = home.auth_path();
     std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
     std::fs::write(&auth_path, serde_json::to_string_pretty(&auth).unwrap()).unwrap();
+    *state.model_registry.write() = crate::models::Registry::new();
 
     let session = state.get_session("default").unwrap();
     let agent_loop = session.read().agent_loop.clone();

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -164,18 +164,34 @@ impl AppState {
         if new_sess.switch_session(session_id).is_err() {
             return None;
         }
-        // If the session file had no model saved, fall back to the default
-        // — via set_model, which also rebuilds the loop's provider client.
-        // A bare `new_sess.model = ...` would leave the loop pointing at the
-        // template's startup model/endpoint.
-        if new_sess.model.is_empty() {
-            let default_model = crate::models::get_default_model_with(&self.model_registry.read())
-                .unwrap_or_else(|| self.loop_template.model.clone());
-            // Match form: the plain if-block's closing brace collected a
-            // phantom zero-count gap region even with both edges hot.
-            match default_model.is_empty() {
-                true => (),
-                false => {
+        // Cold history is reconciled on hydration as well as during a live
+        // provider-config commit. A removed persisted model must not survive
+        // merely because this session was not resident when the catalog
+        // changed. `set_model` appends the authoritative session_info without
+        // rewriting any historical messages.
+        let model_needs_replacement = new_sess.model.is_empty()
+            || !self
+                .model_registry
+                .read()
+                .is_model_available(&new_sess.model);
+        if model_needs_replacement {
+            let default_model = self
+                .model_registry
+                .read()
+                .replacement_model(&new_sess.model);
+            match default_model {
+                None => {
+                    // Even with no usable provider, replace the template's
+                    // static client with an identity-only live client. The next
+                    // request must fail cleanly instead of reusing a startup key.
+                    let unresolved = new_sess.model.clone();
+                    let _ = new_sess.set_model(&unresolved).inspect_err(|e| {
+                        tracing::warn!(
+                            "[session] could not install unresolved live model identity: {e}"
+                        );
+                    });
+                }
+                Some(default_model) => {
                     // set_model persists via update_session_info, which fails
                     // for legacy session files lacking a session_info entry —
                     // log and defer to an explicit /model instead of failing
@@ -237,24 +253,25 @@ impl AppState {
         id
     }
 
-    /// Refresh the in-memory API key of every live session from auth.json.
-    /// Invoked by the `reload_auth` command and, since audit item 2, inline by
-    /// the config-write commands (`set_auth` / `upsert_provider` /
-    /// `delete_provider`) after the agent writes its own auth.json/models.json
-    /// — FutureGene login/logout, custom-provider key edits — so no running
-    /// session keeps using a stale key. Active runs own independent snapshots;
-    /// the short shared control-plane lock is waited out rather than skipped.
+    /// Reconcile live sessions after the Agent atomically replaces its
+    /// authoritative provider/model Registry.
     ///
-    /// Sessions that were created before any credentials existed (model is empty)
-    /// get a default model resolved and applied, so the user can prompt immediately
-    /// after login without switching threads.
-    pub fn reload_all_credentials(&self) {
+    /// Sessions own only a canonical `provider/model` reference. They never own
+    /// credentials, base URLs, protocol settings, modalities, context windows,
+    /// or token limits; the LLM request path resolves all of those from the
+    /// latest Registry snapshot. Consequently provider edits require no
+    /// per-session credential refresh. This pass exists only to replace an empty
+    /// or removed model reference and persist that new selection.
+    pub fn reconcile_provider_references(&self) {
         let sessions = self.sessions.read().values().cloned().collect::<Vec<_>>();
         for sess in &sessions {
             let model_needs_reselection = {
                 let session = sess.read();
                 session.model.is_empty()
-                    || self.model_registry.read().resolve(&session.model).is_none()
+                    || !self
+                        .model_registry
+                        .read()
+                        .is_model_available(&session.model)
             };
             if model_needs_reselection {
                 // Session created before login — resolve and apply default model.
@@ -275,12 +292,22 @@ impl AppState {
                         }
                     }
                     let still_needs_reselection = session.model.is_empty()
-                        || self.model_registry.read().resolve(&session.model).is_none();
+                        || !self
+                            .model_registry
+                            .read()
+                            .is_model_available(&session.model);
                     if still_needs_reselection {
                         let registry = self.model_registry.read();
-                        let default_model =
-                            crate::models::get_default_model_with(&registry).unwrap_or_default();
+                        let default_model = registry.replacement_model(&session.model);
                         drop(registry);
+                        let Some(default_model) = default_model else {
+                            tracing::warn!(
+                                session_id = %session.session_id,
+                                model = %session.model,
+                                "provider update left no configured replacement model"
+                            );
+                            continue;
+                        };
                         loop {
                             match session.set_model(&default_model) {
                                 Ok(()) => break,
@@ -306,41 +333,12 @@ impl AppState {
                                 }
                             }
                         }
-                        if default_model.is_empty() {
-                            reload_credentials_wait(&session);
-                        }
                         session.broadcaster.broadcast(SseEvent::new(
                             "model_changed",
                             serde_json::json!({"model": session.model}),
                         ));
-                    } else {
-                        // Model was set concurrently — just refresh credentials
-                        reload_credentials_wait(&session);
                     }
                 }
-            } else {
-                reload_credentials_wait(&sess.read());
-            }
-        }
-    }
-}
-
-/// Provider config commits are synchronization barriers: unlike an ordinary
-/// prompt (which reports a transient busy error), they wait until every live
-/// session has installed the authoritative credential revision.
-fn reload_credentials_wait(session: &ServerSession) {
-    loop {
-        match session.reload_credentials() {
-            Ok(()) => return,
-            Err(error) if error.to_string().contains("configuration is busy") => {
-                std::thread::yield_now();
-            }
-            Err(error) => {
-                tracing::error!(
-                    session_id = %session.session_id,
-                    "failed to refresh live session credentials: {error:#}"
-                );
-                return;
             }
         }
     }
@@ -355,7 +353,7 @@ static GET_SESSION_PRE_INSERT_HOOK: parking_lot::Mutex<
     Option<(String, Box<dyn Fn(&AppState) + Send>)>,
 > = parking_lot::Mutex::new(None);
 
-/// Test-only hook fired by `reload_all_credentials` inside the write lock,
+/// Test-only hook fired by `reconcile_provider_references` inside the write lock,
 /// before the model-emptiness re-check, so tests can deterministically win
 /// the TOCTOU race and exercise the "model was set concurrently" arm. The
 /// hook receives the already-held write guard (never re-locks) and only
@@ -366,10 +364,10 @@ static RELOAD_RACE_HOOK: parking_lot::Mutex<
     Option<(String, Box<dyn Fn(&mut ServerSession) + Send>)>,
 > = parking_lot::Mutex::new(None);
 
-/// Serializes the reload-credentials tests: they mutate the process-global
+/// Serializes provider-reconciliation tests: they mutate the process-global
 /// model registry and RELOAD_RACE_HOOK, which races when the suite runs the
 /// tests in parallel (observed: repeated CI failures of
-/// reload_all_credentials_reselects_invalid_model_installed_mid_check).
+/// reconcile_provider_references_reselects_invalid_model_installed_mid_check).
 #[cfg(test)]
 static TEST_RELOAD_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
@@ -877,6 +875,20 @@ mod tests {
                 .finish(),
         );
         let (_dir, state) = bare_app_state();
+        let model = crate::models::Model {
+            id: "replacement".to_string(),
+            name: "Replacement".to_string(),
+            provider: "provider-a".to_string(),
+            api: "chat".to_string(),
+            base_url: "https://api.example".to_string(),
+            input: vec!["text".to_string()],
+            output: vec!["text".to_string()],
+            ..Default::default()
+        };
+        *state.model_registry.write() = crate::models::Registry::from_models_and_auth(
+            vec![model],
+            r#"{"provider-a":{"type":"api_key","key":"key"}}"#,
+        );
         // A persisted session with no model info anywhere → the hydrate path
         // applies the registry/loop default model.
         let snapshot = crate::session::Session::snapshot(
@@ -928,7 +940,7 @@ mod tests {
     }
 
     #[test]
-    fn reload_all_credentials_waits_for_write_locked_session() {
+    fn provider_reconcile_waits_only_when_a_model_reference_needs_replacement() {
         let _reload_lock = TEST_RELOAD_LOCK.lock();
 
         let (_dir, state) = bare_app_state();
@@ -948,13 +960,14 @@ mod tests {
         state.create_session(session);
         let state = std::sync::Arc::new(state);
         let session = state.get_session("locked").unwrap();
-        // A held read guard temporarily prevents reconciliation, but the
-        // refresh must wait rather than acknowledge with stale session state.
+        // A model-less session requires a persisted default selection, so the
+        // model-reconciliation pass waits for its session write lock. Ordinary
+        // key/base-url/metadata changes never visit valid sessions at all.
         let guard = session.read();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
         let reload_state = state.clone();
         let worker = std::thread::spawn(move || {
-            reload_state.reload_all_credentials();
+            reload_state.reconcile_provider_references();
             done_tx.send(()).unwrap();
         });
         assert!(done_rx
@@ -1067,7 +1080,7 @@ mod tests {
     }
 
     #[test]
-    fn reload_all_credentials_reselects_invalid_model_installed_mid_check() {
+    fn reconcile_provider_references_reselects_invalid_model_installed_mid_check() {
         let _reload_lock = TEST_RELOAD_LOCK.lock();
 
         // Self-contained credentials: reload rebuilds the registry from the
@@ -1108,7 +1121,7 @@ mod tests {
                 sess.model = "concurrent-model".to_string();
             }),
         ));
-        state.reload_all_credentials();
+        state.reconcile_provider_references();
         assert!(RELOAD_RACE_HOOK.lock().is_none());
         let session = state.get_session("modeless").unwrap();
         let selected = session.read().model.clone();
@@ -1218,6 +1231,24 @@ mod tests {
     #[test]
     fn get_state_reports_active_run_and_estimates_cost() {
         let (_dir, state) = bare_app_state();
+        let priced_model = crate::models::Model {
+            id: "deepseek-chat".to_string(),
+            name: "DeepSeek Chat".to_string(),
+            provider: "deepseek".to_string(),
+            api: "chat".to_string(),
+            base_url: "https://api.deepseek.com".to_string(),
+            input: vec!["text".to_string()],
+            output: vec!["text".to_string()],
+            cost: crate::models::Cost {
+                input: 1.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        *state.model_registry.write() = crate::models::Registry::from_models_and_auth(
+            vec![priced_model],
+            r#"{"deepseek":{"type":"api_key","key":"key"}}"#,
+        );
         let snapshot = crate::session::Session::snapshot(
             "s-run".to_string(),
             "/tmp".to_string(),
@@ -1315,7 +1346,7 @@ mod tests {
     }
 
     #[test]
-    fn reload_all_credentials_applies_default_to_model_less_sessions() {
+    fn reconcile_provider_references_applies_default_to_model_less_sessions() {
         let _reload_lock = TEST_RELOAD_LOCK.lock();
 
         let _home = crate::test_support::TestHome::new();
@@ -1344,11 +1375,11 @@ mod tests {
         );
         state.create_session(session);
 
-        state.reload_all_credentials();
+        state.reconcile_provider_references();
         let session = state.get_session("bare").unwrap();
         assert!(
             !session.read().model.is_empty(),
-            "model-less session got the credentialled default"
+            "model-less session got the authoritative default model identity"
         );
     }
 

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -115,10 +115,9 @@ pub struct ServerSession {
     /// Runtime "allow in this workspace/chat" rules for the current run. Shared
     /// into the live sandbox at prompt start; cleared each new run.
     pub session_rules: crate::sandbox::rules::SessionRules,
-    /// Process-wide cached model registry (shared from `AppState`).  Used by
-    /// `set_model`/`reload_credentials` so hydrating N sessions costs zero
-    /// registry rebuilds; refreshed in place by the `reload_auth` command
-    /// after provider/auth changes on disk.
+    /// Process-wide authoritative provider/model Registry shared by every
+    /// session. Provider commands replace it atomically after durable writes;
+    /// actual LLM requests resolve all provider/model settings from it.
     pub model_registry: Arc<parking_lot::RwLock<crate::models::Registry>>,
 }
 
@@ -130,22 +129,6 @@ pub fn default_workspace() -> String {
         .join("workspace")
         .to_string_lossy()
         .to_string()
-}
-
-/// Resolve the API key for a model, in priority order: an entry keyed by the
-/// exact model id, then by its provider, then the model's own configured key
-/// (when non-empty), then the account-wide default. Empty string when none match.
-fn resolve_api_key(
-    auth: &crate::AuthStore,
-    model: &str,
-    provider: &str,
-    model_key: &str,
-) -> String {
-    auth.get(model)
-        .or_else(|| auth.get(provider))
-        .or_else(|| (!model_key.is_empty()).then(|| model_key.to_string()))
-        .or_else(|| auth.default_key())
-        .unwrap_or_default()
 }
 
 impl ServerSession {
@@ -396,8 +379,8 @@ impl ServerSession {
     }
 
     pub fn set_model(&mut self, model: &str) -> Result<()> {
-        // Resolve against the shared cached registry — never rebuilds it.
-        // The cache is refreshed by `reload_auth` when models.json changes.
+        // Resolve identity against the shared authoritative Registry. The
+        // resulting live client retains this identity, not these settings.
         let resolved = self.model_registry.read().resolve(model);
         // Store full provider/id as the canonical model identifier for display
         // and session persistence. Resolve bare ID to provider/id when possible.
@@ -411,36 +394,37 @@ impl ServerSession {
         // fit is deliberately NOT checked here: a selector click must not write
         // a checkpoint. The run loop checks immediately before its first LLM
         // request, using this newly selected provider and model window.
-        let new_provider = if let Some(model_config) = resolved.as_ref() {
+        if let Some(model_config) = resolved.as_ref() {
             let max_tokens = Some(crate::models::effective_max_tokens(model_config));
-            let auth = crate::AuthStore::load();
-            let api_key =
-                resolve_api_key(&auth, model, &model_config.provider, &model_config.api_key);
-            let target = crate::llm::schema::ResolvedModelTarget::from_model(
+            // Validate a known model's current protocol shape before publishing
+            // the identity. The resulting target is deliberately discarded.
+            crate::llm::schema::ResolvedModelTarget::from_model(
                 model_config,
-                api_key,
+                String::new(),
                 None,
                 max_tokens,
             )?;
-            let mut client = crate::llm::Client::from_target(target);
-            if !self.thinking_level.is_empty() {
-                client = client.with_thinking_level(&self.thinking_level);
-            }
-            let thinking_budget = self
-                .agent_loop
-                .try_read()
-                .map_err(|_| anyhow::anyhow!("session configuration is busy; retry /model"))?
-                .config
-                .thinking_budget;
-            if thinking_budget > 0 {
-                client = client.with_thinking_budget(thinking_budget);
-            }
-            Some(std::sync::Arc::new(client) as std::sync::Arc<dyn crate::types::LLMProvider>)
-        } else {
-            None
-        };
+        }
+        let mut client = crate::llm::Client::from_live_model(
+            canonical_model.clone(),
+            self.model_registry.clone(),
+        );
+        if !self.thinking_level.is_empty() {
+            client = client.with_thinking_level(&self.thinking_level);
+        }
+        let thinking_budget = self
+            .agent_loop
+            .try_read()
+            .map_err(|_| anyhow::anyhow!("session configuration is busy; retry /model"))?
+            .config
+            .thinking_budget;
+        if thinking_budget > 0 {
+            client = client.with_thinking_budget(thinking_budget);
+        }
+        let new_provider =
+            std::sync::Arc::new(client) as std::sync::Arc<dyn crate::types::LLMProvider>;
 
-        // Update the agent loop in one shot — both model name and provider endpoint.
+        // Update the agent loop in one shot — model identity and its dynamic client.
         // Fail explicitly when the loop is busy so the caller knows to retry
         // rather than silently continuing with the old model. Active runs use
         // snapshots and do not hold this control-plane lock.
@@ -449,6 +433,7 @@ impl ServerSession {
             .try_write()
             .map_err(|_| anyhow::anyhow!("session configuration is busy; retry /model"))?;
         self.model = canonical_model;
+        loop_.model_ref = self.model.clone();
         // Set agent loop model to bare canonical ID for LLM API calls.
         // The session-level self.model already holds the full provider/id.
         if let Some(ref mc) = resolved {
@@ -457,18 +442,10 @@ impl ServerSession {
             loop_.model = model.to_string();
         }
 
-        if let Some(model_config) = resolved {
-            if !model_config.input.iter().any(|input| input == "image") {
-                self.strip_image_content_from_messages();
-            }
-
-            // The fresh provider was built and validated before publishing the
-            // selection, so the next-run control plane cannot expose a
-            // half-built client.
-            if let Some(provider) = new_provider {
-                loop_.provider = provider;
-            }
-        }
+        // Always replace the provider client, including for an unresolved
+        // historical identity. It owns no target and therefore must resolve or
+        // replace that identity from the Registry at request time.
+        loop_.provider = new_provider;
         drop(loop_);
 
         // Persist through the same ordered queue as run appends/finalization.
@@ -482,86 +459,22 @@ impl ServerSession {
         Ok(())
     }
 
-    /// Re-resolve the API key for this session's current model from disk
-    /// (auth.json) and push it into the live provider. Called when credentials
-    /// change out-of-band — FutureGene login/logout, custom-provider key edits —
-    /// so the session doesn't keep serving prompts with the stale in-memory key
-    /// until the next `set_model` (the prompt path never re-reads auth.json).
-    ///
-    /// Unlike `set_model` this stays correct even when the model no longer
-    /// resolves: after logout the Future models drop out of the registry, so a
-    /// `resolve` miss must NOT leave the old key in place. We derive the provider
-    /// from the canonical `provider/id` model id and, resolving no key, clear the
-    /// credential so the stale one can't keep being used. The key-resolution
-    /// order mirrors `set_model` for parity.
-    ///
-    /// Active runs use a provider snapshot, so updating this control plane
-    /// affects the next request without mutating headers already sent by an
-    /// in-flight request.
-    ///
-    /// Also heals the `set_model` fallback: while the registry could not
-    /// resolve this model (catalog unavailable during a logout/broken-auth
-    /// window), `set_model` froze the full `provider/id` literal into the
-    /// loop, and upstream rejects that name ("Model 'provider/id' is not
-    /// configured"). Once the registry resolves the model again, restore the
-    /// bare id so the next request carries a name the server knows.
-    pub fn reload_credentials(&self) -> Result<()> {
-        if self.model.is_empty() {
-            let loop_ = self
-                .agent_loop
-                .try_read()
-                .map_err(|_| anyhow::anyhow!("run configuration is busy; retry prompt"))?;
-            loop_.provider.set_api_key("");
+    /// Reconcile only the persisted provider/model identity after a provider
+    /// commit or cold-history hydration. Provider configuration itself is never
+    /// copied here; request-time resolution also applies this replacement rule
+    /// to close the commit/request race.
+    pub fn reconcile_model_reference(&mut self) -> Result<()> {
+        let needs_replacement =
+            self.model.is_empty() || !self.model_registry.read().is_model_available(&self.model);
+        if !needs_replacement {
             return Ok(());
         }
-        let registry_resolved = self.model_registry.read().resolve(&self.model);
-        let provider = registry_resolved
-            .as_ref()
-            .map(|m| m.provider.clone())
-            .unwrap_or_else(|| self.model.split('/').next().unwrap_or("").to_string());
-
-        let auth = crate::AuthStore::load();
-        let model_key = registry_resolved
-            .as_ref()
-            .map(|m| m.api_key.clone())
-            .unwrap_or_default();
-        let base_url = registry_resolved
-            .as_ref()
-            .map(|m| m.base_url.clone())
-            .unwrap_or_default();
-        let api_key = resolve_api_key(&auth, &self.model, &provider, &model_key);
-
-        // The shared loop is a short-lived control plane; active runs own
-        // independent snapshots. Wait until the latest credential revision is
-        // installed so config commands cannot acknowledge while a session is
-        // still on the old key. A write lock is needed (not just for the
-        // interior-mutable provider) because the fallback heal below mutates
-        // `loop_.model`.
-        let mut loop_ = self
-            .agent_loop
-            .try_write()
-            .map_err(|_| anyhow::anyhow!("run configuration is busy; retry prompt"))?;
-        loop_.provider.set_api_key(&api_key);
-        if !base_url.is_empty() {
-            loop_.provider.set_base_url(&base_url);
-        }
-        // Fallback heal: `set_model` only ever stores the bare resolved id
-        // here, so any divergence means the loop still carries the unresolved
-        // literal from a resolve-miss window.
-        if let Some(mc) = registry_resolved.as_ref() {
-            if loop_.model != mc.id {
-                loop_.model = mc.id.clone();
-            }
-        }
-        Ok(())
-    }
-
-    fn strip_image_content_from_messages(&self) {
-        for message in self.messages.write().iter_mut() {
-            message
-                .content
-                .retain(|block| !matches!(block, crate::types::ContentBlock::Image { .. }));
-        }
+        let replacement = self
+            .model_registry
+            .read()
+            .replacement_model(&self.model)
+            .ok_or_else(|| anyhow::anyhow!("no configured provider has an available model"))?;
+        self.set_model(&replacement)
     }
 
     pub fn set_thinking_level(&mut self, level: &str) {
@@ -626,10 +539,10 @@ impl ServerSession {
         let mut messages = self.messages.read().clone();
         if messages.is_empty() {
             if let Ok(session) = self.session_manager.load(&self.session_id) {
-                let supports_images = crate::models::model_accepts_images_with(
-                    &self.model_registry.read(),
-                    &self.model,
-                );
+                let supports_images = self
+                    .model_registry
+                    .read()
+                    .request_model_accepts_images(&self.model);
                 messages =
                     crate::session::entries_to_agent_messages(&session.entries, supports_images);
                 if !messages.is_empty() {
@@ -936,7 +849,10 @@ impl ServerSession {
             } else {
                 session.model.clone()
             };
-            let supports_images = crate::models::model_accepts_images(&effective_model);
+            let supports_images = self
+                .model_registry
+                .read()
+                .request_model_accepts_images(&effective_model);
             let msgs = crate::session::entries_to_agent_messages(&session.entries, supports_images);
             if !session.model.is_empty() {
                 self.model = session.model.clone();
@@ -946,9 +862,9 @@ impl ServerSession {
                     id,
                 );
 
-                // Sync the agent loop's model + provider endpoint so the next
-                // prompt uses the saved model, not a stale leftover from the
-                // previous session. set_model persists via update_session_info,
+                // Sync the agent loop's model identity + dynamic client so the
+                // next prompt uses the saved model, not a stale leftover from
+                // the previous session. set_model persists via update_session_info,
                 // which fails for legacy session files lacking a session_info
                 // entry — log and defer to an explicit /model.
                 let _ = self.set_model(&self.model.clone()).inspect_err(|e| {
@@ -1100,23 +1016,6 @@ mod tests {
         }
     }
 
-    struct KeyRecordingProvider(Arc<parking_lot::Mutex<String>>);
-
-    #[async_trait::async_trait]
-    impl LLMProvider for KeyRecordingProvider {
-        async fn stream_model(
-            &self,
-            _request: ModelRequest,
-        ) -> anyhow::Result<ReceiverStream<ModelStreamEvent>> {
-            let (_tx, rx) = mpsc::channel(1);
-            Ok(ReceiverStream::new(rx))
-        }
-
-        fn set_api_key(&self, api_key: &str) {
-            *self.0.lock() = api_key.to_string();
-        }
-    }
-
     struct FailingProvider;
 
     #[async_trait::async_trait]
@@ -1231,23 +1130,6 @@ mod tests {
             ApprovalGate::default(),
             Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
         )
-    }
-
-    // ─── resolve_api_key ────────────────────────────────────────────────────
-
-    #[test]
-    fn resolve_api_key_prefers_model_id() {
-        let auth = crate::AuthStore::load();
-        // With an empty auth store, should fall back to model_key or empty
-        let key = resolve_api_key(&auth, "unknown/model", "unknown", "model_key_123");
-        assert!(key == "model_key_123" || key.is_empty());
-    }
-
-    #[test]
-    fn resolve_api_key_empty_model_key() {
-        let auth = crate::AuthStore::load();
-        let key = resolve_api_key(&auth, "unknown/model", "unknown", "");
-        assert!(key.is_empty() || !key.is_empty()); // just verify no panic
     }
 
     // ─── default_workspace ──────────────────────────────────────────────────
@@ -1476,32 +1358,6 @@ mod tests {
         }
         session.new_session().unwrap();
         assert!(session.get_messages().is_empty());
-    }
-
-    // ─── strip_image_content_from_messages ──────────────────────────────────
-
-    #[test]
-    fn strip_images_removes_image_blocks() {
-        let session = make_test_session("s1");
-        {
-            let mut msgs = session.messages.write();
-            msgs.push(crate::types::AgentMessage {
-                role: "user".to_string(),
-                content: vec![
-                    crate::types::ContentBlock::text("look"),
-                    crate::types::ContentBlock::image("data:image/png;base64,abc"),
-                ],
-                ..Default::default()
-            });
-        }
-        session.strip_image_content_from_messages();
-        let msgs = session.messages.read();
-        assert_eq!(msgs[0].content.len(), 1);
-        let is_expected_text = matches!(
-            &msgs[0].content[0],
-            crate::types::ContentBlock::Text { text } if text == "look"
-        );
-        assert!(is_expected_text, "expected a Text block holding 'look'");
     }
 
     // ─── coverage batch 16: scheduler/set_model/switch residuals ──────────
@@ -2466,23 +2322,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn key_recording_provider_streams_empty() {
-        use tokio_stream::StreamExt;
-        let observed = Arc::new(parking_lot::Mutex::new(String::new()));
-        let provider = KeyRecordingProvider(observed.clone());
-        let mut stream = provider
-            .stream_model(ModelRequest {
-                model: "mock".into(),
-                system_prompt: String::new(),
-                messages: vec![],
-                tools: vec![],
-            })
-            .await
-            .unwrap();
-        assert!(stream.next().await.is_none());
-    }
-
     // ─── add_session_rule ───────────────────────────────────────────────────
 
     #[test]
@@ -2581,116 +2420,6 @@ mod tests {
         let mut session = make_test_session("s1");
         session.disable_builtin_tools();
         // Should not panic
-    }
-
-    #[test]
-    fn strip_images_removes_image_blocks_v2() {
-        let session = make_test_session("s1");
-        session.messages.write().push(crate::types::AgentMessage {
-            role: "user".to_string(),
-            content: vec![
-                crate::types::ContentBlock::text("hello"),
-                crate::types::ContentBlock::image("data:image/png;base64,abc"),
-            ],
-            ..Default::default()
-        });
-        session.strip_image_content_from_messages();
-        let msgs = session.messages.read();
-        assert_eq!(msgs[0].content.len(), 1);
-    }
-
-    #[test]
-    fn reload_credentials_no_panic() {
-        let session = make_test_session("s1");
-        let _ = session.reload_credentials();
-    }
-
-    #[test]
-    fn reload_credentials_applies_authoritative_provider_key() {
-        let _home = crate::test_support::TestHome::new();
-        let auth_path = crate::config::providers::auth_json_path();
-        std::fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
-        std::fs::write(
-            auth_path,
-            r#"{"custom":{"type":"api_key","key":"new-key"}}"#,
-        )
-        .unwrap();
-
-        let observed = Arc::new(parking_lot::Mutex::new("old-key".to_string()));
-        let cwd = test_workspace();
-        let mut session = ServerSession::new(
-            "key-refresh".to_string(),
-            Arc::new(tokio::sync::RwLock::new(Loop::new(
-                Arc::new(KeyRecordingProvider(observed.clone())),
-                "model",
-            ))),
-            Arc::new(Manager::new(test_session_dir())),
-            &cwd,
-            Arc::new(SseBroadcaster::new()),
-            ApprovalGate::default(),
-            Arc::new(parking_lot::RwLock::new(crate::models::Registry::new())),
-        );
-        session.model = "custom/model".to_string();
-
-        session.reload_credentials().unwrap();
-        assert_eq!(&*observed.lock(), "new-key");
-    }
-
-    #[test]
-    fn reload_credentials_heals_fallback_model_literal() {
-        let mut session = make_test_session("fallback-heal");
-        session.set_model("gpt-4o").unwrap();
-        let bare = session.agent_loop.try_read().unwrap().model.clone();
-        assert!(!bare.contains('/'), "resolved set_model stores the bare id");
-        // Simulate the resolve-miss window: set_model's fallback froze the
-        // full provider/id literal into the loop.
-        let canonical = session.model.clone();
-        assert!(canonical.contains('/'));
-        session.agent_loop.try_write().unwrap().model = canonical;
-
-        session.reload_credentials().unwrap();
-        assert_eq!(session.agent_loop.try_read().unwrap().model, bare);
-    }
-
-    #[test]
-    fn reload_credentials_keeps_consistent_model_id() {
-        let mut session = make_test_session("consistent-model");
-        session.set_model("gpt-4o").unwrap();
-        let before = session.agent_loop.try_read().unwrap().model.clone();
-
-        session.reload_credentials().unwrap();
-        assert_eq!(session.agent_loop.try_read().unwrap().model, before);
-    }
-
-    #[test]
-    fn reload_credentials_leaves_unresolved_model_literal() {
-        let mut session = make_test_session("unresolved-model");
-        // Resolve miss: the fallback stores the literal, and reload must not
-        // rewrite it while the registry still cannot resolve the model.
-        session.set_model("unknown-provider/unknown-model").unwrap();
-        assert_eq!(
-            session.agent_loop.try_read().unwrap().model,
-            "unknown-provider/unknown-model"
-        );
-
-        session.reload_credentials().unwrap();
-        assert_eq!(
-            session.agent_loop.try_read().unwrap().model,
-            "unknown-provider/unknown-model"
-        );
-    }
-
-    #[test]
-    fn reload_credentials_reports_busy_when_loop_is_read_locked() {
-        let mut session = make_test_session("busy-loop");
-        session.set_model("gpt-4o").unwrap();
-        // A held read guard makes the credential install's try_write fail.
-        let _read_guard = session.agent_loop.try_read().unwrap();
-        let error = session.reload_credentials().unwrap_err();
-        assert!(
-            error.to_string().contains("configuration is busy"),
-            "unexpected error: {error:#}"
-        );
     }
 
     #[test]

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -157,11 +157,12 @@ impl ServerSession {
         client_request_id: &str,
         busy_policy: crate::runtime::BusyPolicy,
     ) -> Result<crate::runtime::RunAck> {
-        // auth.json is authoritative. Refresh immediately before freezing the
-        // run snapshot so a UI/catalog view and the actual request can never
-        // disagree about which key is in use. Failure rejects admission rather
-        // than silently running with stale credentials.
-        self.reload_credentials()?;
+        // Provider and model configuration is deliberately NOT copied into the
+        // session or scheduled payload. The accepted run freezes user/session
+        // choices, while every actual LLM request resolves the selected
+        // provider/model reference from the Agent's latest authoritative
+        // Registry snapshot (key, base URL, protocol, headers, modalities,
+        // context window, and token limits).
         if self.deleting {
             return Err(crate::runtime::RunQueueError::Deleting.into());
         }
@@ -497,8 +498,10 @@ impl ServerSession {
         // Whether the active model accepts image input (catalog modalities).
         // Uses the cached registry from ServerSession to avoid ~15% CPU overhead
         // from re-deserialising the full model catalog on every prompt.
-        let model_supports_images =
-            crate::models::model_accepts_images_with(&self.model_registry.read(), &run_model);
+        let model_supports_images = self
+            .model_registry
+            .read()
+            .request_model_accepts_images(&run_model);
         // Images are read + (down)encoded to base64 here, on the agent, from the
         // local path the GUI sent — the base64 never crosses the wire.
         let mut user_message = build_user_message_with_model_context(

--- a/agent/src/session/fork.rs
+++ b/agent/src/session/fork.rs
@@ -145,7 +145,6 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
         version: CURRENT_SESSION_VERSION,
         cwd: parent.cwd.clone(),
         model: parent_model.clone(),
-        base_url: parent.base_url.clone(),
         name: fork_name,
         parent_session_id: parent.id.clone(),
         leaf_id: String::new(),
@@ -190,7 +189,7 @@ mod tests {
 
     #[test]
     fn fork_session_bad_entry_id_clones_all() {
-        let mut parent = Session::new("/tmp", "model", "");
+        let mut parent = Session::new("/tmp", "model");
         parent
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -201,7 +200,7 @@ mod tests {
 
     #[test]
     fn fork_session_preserves_model() {
-        let mut parent = Session::new("/tmp", "my-model", "");
+        let mut parent = Session::new("/tmp", "my-model");
         parent
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -211,7 +210,7 @@ mod tests {
 
     #[test]
     fn fork_session_generates_new_ids() {
-        let mut parent = Session::new("/tmp", "model", "");
+        let mut parent = Session::new("/tmp", "model");
         parent
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -228,7 +227,7 @@ mod tests {
 
     #[test]
     fn fork_session_name_suffix() {
-        let mut parent = Session::new("/tmp", "model", "");
+        let mut parent = Session::new("/tmp", "model");
         parent.set_session_name("Original Chat");
         parent
             .entries
@@ -308,7 +307,7 @@ mod tests {
 
     #[test]
     fn fork_session_copies_entries_up_to_fork_point() {
-        let mut parent = Session::new("/tmp/test", "test-model", "");
+        let mut parent = Session::new("/tmp/test", "test-model");
         let u1 = make_entry("u1", ENTRY_TYPE_USER, "user", "hello");
         let a1 = make_entry("a1", ENTRY_TYPE_ASSISTANT, "assistant", "hi there");
         let u2 = make_entry("u2", ENTRY_TYPE_USER, "user", "help me");
@@ -328,7 +327,7 @@ mod tests {
     fn entries_to_messages_roundtrip_preserves_history_count() {
         // Simulate: a forked session with history is created, but
         // messages is empty → first prompt save would truncate disk.
-        let mut parent = Session::new("/tmp/test", "test-model", "");
+        let mut parent = Session::new("/tmp/test", "test-model");
         let u1 = make_entry("u1", ENTRY_TYPE_USER, "user", "hello");
         let a1 = make_entry("a1", ENTRY_TYPE_ASSISTANT, "assistant", "hi");
         let a1_id = a1.id.clone();
@@ -384,7 +383,7 @@ mod tests {
 
     #[test]
     fn fork_remaps_v2_checkpoint_range_to_child_entry_ids() {
-        let mut parent = Session::new("/tmp/test", "test-model", "");
+        let mut parent = Session::new("/tmp/test", "test-model");
         let first = make_entry("u1", ENTRY_TYPE_USER, "user", "old");
         let cutoff = make_entry("a1", ENTRY_TYPE_ASSISTANT, "assistant", "answer");
         let checkpoint = ContextCheckpoint {
@@ -420,7 +419,7 @@ mod tests {
 
     #[test]
     fn fork_keeps_compaction_entry_with_non_object_content() {
-        let mut parent = Session::new("/tmp/test", "m", "");
+        let mut parent = Session::new("/tmp/test", "m");
         let user = make_entry("u1", ENTRY_TYPE_USER, "user", "hi");
         let cp = make_entry("cp", ENTRY_TYPE_COMPACTION, "system", "not-an-object");
         let a1 = make_entry("a1", ENTRY_TYPE_ASSISTANT, "assistant", "answer");
@@ -439,7 +438,7 @@ mod tests {
 
     #[test]
     fn fork_keeps_compaction_entry_with_legacy_schema_version() {
-        let mut parent = Session::new("/tmp/test", "m", "");
+        let mut parent = Session::new("/tmp/test", "m");
         let user = make_entry("u1", ENTRY_TYPE_USER, "user", "hi");
         let mut cp = make_entry("cp", ENTRY_TYPE_COMPACTION, "system", "x");
         cp.content = Some(serde_json::json!({ "schema_version": 1 }));
@@ -459,7 +458,7 @@ mod tests {
 
     #[test]
     fn fork_drops_v2_compaction_missing_range_key() {
-        let mut parent = Session::new("/tmp/test", "m", "");
+        let mut parent = Session::new("/tmp/test", "m");
         let user = make_entry("u1", ENTRY_TYPE_USER, "user", "hi");
         let mut cp = make_entry("cp", ENTRY_TYPE_COMPACTION, "system", "x");
         cp.content = Some(serde_json::json!({ "schema_version": 2, "cutoff_entry_id": "u1" }));
@@ -479,7 +478,7 @@ mod tests {
 
     #[test]
     fn fork_drops_v2_compaction_referencing_out_of_fork_id() {
-        let mut parent = Session::new("/tmp/test", "m", "");
+        let mut parent = Session::new("/tmp/test", "m");
         let user = make_entry("u1", ENTRY_TYPE_USER, "user", "hi");
         let mut cp = make_entry("cp", ENTRY_TYPE_COMPACTION, "system", "x");
         cp.content = Some(serde_json::json!({

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -623,7 +623,6 @@ impl Manager {
             version: crate::session::CURRENT_SESSION_VERSION,
             cwd,
             model,
-            base_url: String::new(),
             name,
             parent_session_id,
             leaf_id: String::new(),
@@ -702,7 +701,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         // Add session_info entry (model/thinking_level are in content JSON)
         session.entries.push(SessionEntry::session_info(
             serde_json::json!({"session_name": "test", "cwd": "/tmp/test", "model": "gpt-4o", "thinking_level": "high"}),
@@ -743,7 +742,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let mut session = Session::new("/tmp/test", "claude", "");
+        let mut session = Session::new("/tmp/test", "claude");
         session.entries.push(agent_message_to_entry(&message));
         manager.save(&session).unwrap();
 
@@ -788,7 +787,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -858,7 +857,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -912,7 +911,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));
@@ -962,7 +961,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session.entries.push(SessionEntry::session_info(
             serde_json::json!({"model": "gpt-4o"}),
             "gpt-4o".to_string(),
@@ -1336,7 +1335,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let session = Session::new("/tmp/test", "model", "");
+        let session = Session::new("/tmp/test", "model");
         manager.save(&session).unwrap();
         let run_data_path = manager.run_data_path(&session.id);
         std::fs::create_dir_all(&run_data_path).unwrap();
@@ -1368,7 +1367,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session
             .entries
             .push(SessionEntry::new_user("user", serde_json::json!("hello")));

--- a/agent/src/session/model.rs
+++ b/agent/src/session/model.rs
@@ -13,8 +13,6 @@ pub struct Session {
     pub version: i32,
     pub cwd: String,
     pub model: String,
-    #[serde(rename = "base_url")]
-    pub base_url: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
     #[serde(
@@ -55,14 +53,13 @@ pub struct SessionSummary {
 }
 
 impl Session {
-    pub fn new(cwd: &str, model: &str, base_url: &str) -> Self {
+    pub fn new(cwd: &str, model: &str) -> Self {
         let now = Local::now();
         Self {
             id: generate_id(),
             version: CURRENT_SESSION_VERSION,
             cwd: cwd.to_string(),
             model: model.to_string(),
-            base_url: base_url.to_string(),
             name: String::new(),
             parent_session_id: String::new(),
             leaf_id: String::new(),
@@ -89,7 +86,6 @@ impl Session {
             version: CURRENT_SESSION_VERSION,
             cwd,
             model,
-            base_url: String::new(),
             name,
             parent_session_id,
             leaf_id: String::new(),
@@ -105,14 +101,6 @@ impl Session {
 
     pub fn set_session_name(&mut self, name: &str) {
         self.name = name.trim().to_string();
-    }
-
-    pub fn get_base_url(&self) -> &str {
-        &self.base_url
-    }
-
-    pub fn set_base_url(&mut self, url: &str) {
-        self.base_url = url.to_string();
     }
 
     pub fn get_session_info(&self) -> Option<&serde_json::Value> {
@@ -133,28 +121,19 @@ mod tests {
 
     #[test]
     fn session_new_fields() {
-        let s = Session::new("/tmp/test", "gpt-4o", "https://api.openai.com");
+        let s = Session::new("/tmp/test", "gpt-4o");
         assert_eq!(s.cwd, "/tmp/test");
         assert_eq!(s.model, "gpt-4o");
-        assert_eq!(s.base_url, "https://api.openai.com");
         assert!(s.entries.is_empty());
         assert!(s.parent_session_id.is_empty());
     }
 
     #[test]
     fn session_name_get_set() {
-        let mut s = Session::new("/tmp", "model", "");
+        let mut s = Session::new("/tmp", "model");
         assert_eq!(s.get_session_name(), "");
         s.set_session_name("My Chat");
         assert_eq!(s.get_session_name(), "My Chat");
-    }
-
-    #[test]
-    fn session_base_url_get_set() {
-        let mut s = Session::new("/tmp", "model", "https://old.com");
-        assert_eq!(s.get_base_url(), "https://old.com");
-        s.set_base_url("https://new.com");
-        assert_eq!(s.get_base_url(), "https://new.com");
     }
 
     #[test]
@@ -178,7 +157,7 @@ mod tests {
 
     #[test]
     fn get_session_info_extracts_from_entries() {
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session.entries.push(SessionEntry::session_info(
             serde_json::json!({"model": "gpt-4o", "thinking_level": "high"}),
             "gpt-4o".to_string(),
@@ -193,7 +172,18 @@ mod tests {
         assert_eq!(info["thinking_level"], "high");
 
         // Session without session_info entry
-        let empty = Session::new("/tmp/test", "gpt-4o", "");
+        let empty = Session::new("/tmp/test", "gpt-4o");
         assert!(empty.get_session_info().is_none());
+    }
+
+    #[test]
+    fn legacy_base_url_is_readable_but_never_re_persisted() {
+        let session = Session::new("/tmp/test", "openai/gpt-4o");
+        let mut value = serde_json::to_value(&session).unwrap();
+        value["base_url"] = serde_json::json!("https://stale.example/v1");
+
+        let loaded: Session = serde_json::from_value(value).unwrap();
+        let persisted = serde_json::to_value(loaded).unwrap();
+        assert!(persisted.get("base_url").is_none());
     }
 }

--- a/agent/src/session/summary.rs
+++ b/agent/src/session/summary.rs
@@ -349,7 +349,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         session.entries.push(SessionEntry::session_info(
             serde_json::json!({"session_name": "named-session", "cwd": "/tmp/test", "model": "gpt-4o", "thinking_level": "high"}),
             "gpt-4o".to_string(),
@@ -411,7 +411,7 @@ mod tests {
                 .as_nanos()
         ));
         let manager = Manager::new(dir.clone());
-        let mut session = Session::new("/tmp/test", "gpt-4o", "");
+        let mut session = Session::new("/tmp/test", "gpt-4o");
         // No session_info entry — legacy/corrupt layout.
         session
             .entries

--- a/agent/src/types/mod.rs
+++ b/agent/src/types/mod.rs
@@ -957,17 +957,6 @@ pub trait LLMProvider: Send + Sync {
         request: crate::llm::schema::ModelRequest,
     ) -> anyhow::Result<tokio_stream::wrappers::ReceiverStream<crate::llm::schema::ModelStreamEvent>>;
 
-    /// Refresh only the API key at runtime, after an out-of-band credential
-    /// change (FutureGene login/logout, custom-provider key edits). This leaves
-    /// the base_url untouched — a login/logout changes the key, not the model's
-    /// endpoint.
-    fn set_api_key(&self, _api_key: &str) {}
-
-    /// Refresh the provider endpoint in the same shared runtime client. Run
-    /// snapshots clone the provider Arc, so this also keeps already-accepted
-    /// queued work aligned with a committed provider edit.
-    fn set_base_url(&self, _base_url: &str) {}
-
     /// Update thinking level and budget at runtime (after set_thinking_level / cycle_thinking_level).
     fn update_thinking(&self, _level: &str, _budget: i32) {}
 }
@@ -1979,7 +1968,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn provider_default_key_and_thinking_setters_are_noops() {
+    async fn provider_default_thinking_setter_is_a_noop() {
         struct MinimalProvider;
         #[async_trait::async_trait]
         impl LLMProvider for MinimalProvider {
@@ -1994,8 +1983,6 @@ mod tests {
             }
         }
         let provider = MinimalProvider;
-        provider.set_api_key("ignored");
-        provider.set_base_url("https://x.test");
         provider.update_thinking("high", 1234);
         // The canonical model stream implementation is callable too.
         let mut stream = provider


### PR DESCRIPTION
## Summary

- keep only canonical provider/model identity in sessions and resolve the complete provider snapshot for every LLM request
- enforce exact provider credential lookup and atomically publish provider configuration revisions
- replace removed historical models deterministically and preserve legacy JSONL readability
- retain the derived Future /api/v1 model route when auth stores the platform /api root, preventing historical conversations from receiving 405

## Validation

- make lint-rust
- cargo test --manifest-path agent/Cargo.toml --lib: 1575 passed, 0 failed
- focused request-time provider, model replacement, Future route, cold hydration, and legacy JSONL regression tests