### PR TITLE
fix(loop): decode typed-RPC payload + bind worker session so worker stop can abort orphans

### DIFF
--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -155,6 +155,16 @@ impl AgentClient {
                 .unwrap_or("unknown error");
             return Err(anyhow!("Command '{cmd_type}' failed [{code}]: {msg}"));
         }
+        // Typed-first decode: the agent retired command-response dual-write, so
+        // typed commands (e.g. `prompt`) carry their payload in the typed
+        // `payload` oneof with an EMPTY `data` string. Reading `data` directly
+        // returned Null for every typed command, which surfaced downstream as
+        // "prompt response missing run_id: null". Decode the typed payload first;
+        // keep the strict JSON parse for untyped commands so a malformed `data`
+        // string still surfaces as an error instead of silently becoming Null.
+        if response.payload.is_some() {
+            return Ok(future_rpc::decode::response_data(&response));
+        }
         if response.data.is_empty() {
             return Ok(Value::Null);
         }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3634,6 +3634,21 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         }
         None => client.new_session(&goal0.cwd, &session_title).await?,
     };
+    // Bind agent-id → session-id in the ledger BEFORE any prompt. This is the
+    // authoritative mapping `worker stop`/`worker list` use to locate this
+    // worker's backing agent session — recorded first so a prompt/parse
+    // failure (or a client kill) that leaves the turn orphaned can still be
+    // discovered and aborted (the `.live.jsonl` run_header is only written
+    // AFTER a prompt ack returns a run_id, so it cannot see such orphans).
+    // Anonymous runs (no --agent-id) have no stable id to bind.
+    if let Some(aid) = agent_id.as_deref() {
+        store.append(Event::WorkerSessionBound {
+            goal_id: goal_id.clone(),
+            agent_id: aid.to_string(),
+            session_id: session_id.clone(),
+            ts: crate::state::now_epoch(),
+        })?;
+    }
     if let Some(m) = model {
         client.set_model(&session_id, &m).await?;
     }
@@ -5560,6 +5575,45 @@ fn scan_worker_sessions(runs_dir: &std::path::Path, goal_id: &str) -> Vec<Worker
     out
 }
 
+/// Merge the authoritative agent→session bindings from the goal ledger
+/// (`WorkerSessionBound`, folded into `Goal.worker_sessions`) with the
+/// `.live.jsonl` run-header scan (which carries run_id/todo_id/wall_ts
+/// metadata). The ledger binding wins for `session_id` because it is written
+/// BEFORE the first prompt, so it also covers orphans the header scan cannot
+/// see (a prompt/parse failure or a client kill before the run_header is
+/// written). For old ledgers with no bindings, the scan alone is the fallback.
+fn bound_worker_sessions(
+    goal: &crate::state::Goal,
+    runs_dir: &std::path::Path,
+    goal_id: &str,
+) -> Vec<WorkerSession> {
+    let scanned = scan_worker_sessions(runs_dir, goal_id);
+    let mut out: Vec<WorkerSession> = Vec::new();
+    let mut bound_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (agent_id, session_id) in &goal.worker_sessions {
+        bound_ids.insert(agent_id.clone());
+        let meta = scanned.iter().find(|s| &s.agent_id == agent_id);
+        out.push(WorkerSession {
+            agent_id: agent_id.clone(),
+            session_id: session_id.clone(),
+            run_id: meta.map(|s| s.run_id.clone()).unwrap_or_default(),
+            todo_id: meta.map(|s| s.todo_id.clone()).unwrap_or_default(),
+            wall_ts: meta.map(|s| s.wall_ts).unwrap_or(0),
+            streaming: false,
+        });
+    }
+    // Agents the header scan knows about but that have no ledger binding yet
+    // (old ledgers, or a run that wrote a header before this build introduced
+    // the binding) still surface via the scan.
+    for s in scanned {
+        if !bound_ids.contains(&s.agent_id) {
+            out.push(s);
+        }
+    }
+    out.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+    out
+}
+
 /// `future loop worker list --goal G [--format json]` — the registered workers
 /// of a goal, each mapped to its current backing agent session and whether the
 /// agent is streaming it right now (an in-flight run). This is the loop's
@@ -5590,7 +5644,7 @@ async fn cmd_worker_list(store: &Store, args: &[String]) -> Result<()> {
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
     let runs_dir = std::path::PathBuf::from(store.root_path()).join("runs");
-    let mut sessions = scan_worker_sessions(&runs_dir, &goal_id);
+    let mut sessions = bound_worker_sessions(&goal, &runs_dir, &goal_id);
 
     // Cross-reference the agent's live streaming set so we can report which
     // workers actually have an in-flight run right now.
@@ -5691,11 +5745,14 @@ async fn cmd_worker_stop(store: &mut Store, args: &[String]) -> Result<()> {
     if !all && agent_id.is_none() {
         bail!("specify --agent-id A (one worker) or --all (every worker)");
     }
-    let _goal = store
+    let goal = store
         .replay(&goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
     let runs_dir = std::path::PathBuf::from(store.root_path()).join("runs");
-    let sessions = scan_worker_sessions(&runs_dir, &goal_id);
+    // Authoritative agent→session bindings (ledger) merged with the run-header
+    // scan, so a worker whose turn is orphaned (prompt failed before the
+    // run_header was written) is still discovered and aborted.
+    let sessions = bound_worker_sessions(&goal, &runs_dir, &goal_id);
 
     // Select targets: the named agent, or every worker with a live session.
     let targets: Vec<WorkerSession> = match agent_id.as_deref() {
@@ -7280,6 +7337,13 @@ fn describe_event(event: &crate::store::Event) -> String {
                 agent_id.as_deref().unwrap_or("broadcast")
             );
         }
+        Event::WorkerSessionBound {
+            agent_id,
+            session_id,
+            ..
+        } => {
+            return format!("worker_session_bound agent={agent_id} session={session_id}");
+        }
     };
     kind.to_string()
 }
@@ -7912,6 +7976,12 @@ mod coverage_tests {
             Event::WorkerStopped {
                 goal_id: "g".into(),
                 agent_id: Some("a".into()),
+                ts: 1,
+            },
+            Event::WorkerSessionBound {
+                goal_id: "g".into(),
+                agent_id: "a".into(),
+                session_id: "sess-a".into(),
                 ts: 1,
             },
         ]
@@ -9568,6 +9638,90 @@ mod todo_verify_hint_tests {
         assert!(
             sessions.is_empty(),
             "all bad files must be skipped: {sessions:?}"
+        );
+    }
+
+    #[test]
+    fn bound_worker_sessions_surfaces_orphaned_bindings_and_prefers_ledger_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let runs = dir.path().join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+
+        let header = |sid: &str, agent: &str, run_id: &str, todo_id: &str| {
+            format!(
+                "{{\"type\":\"run_header\",\"wall_ts\":1,\"run_id\":\"{run_id}\",\"session_id\":\"{sid}\",\"agent_id\":\"{agent}\",\"todo_id\":\"{todo_id}\",\"goal_id\":\"g1\"}}\n"
+            )
+        };
+        // worker-a has a scanned header (older session) AND a newer ledger binding.
+        std::fs::write(
+            runs.join("a.live.jsonl"),
+            header("sess-a-old", "worker-a", "r-a", "todo-a"),
+        )
+        .unwrap();
+        // worker-b has ONLY a ledger binding — no .live.jsonl (orphaned turn).
+
+        let mut goal = crate::state::Goal::new("g1", "obj", "/tmp");
+        goal.worker_sessions
+            .insert("worker-a".to_string(), "sess-a-new".to_string());
+        goal.worker_sessions
+            .insert("worker-b".to_string(), "sess-b-orphan".to_string());
+
+        let sessions = super::bound_worker_sessions(&goal, &runs, "g1");
+        let by_agent: std::collections::HashMap<&str, &super::WorkerSession> = sessions
+            .iter()
+            .map(|s| (s.agent_id.as_str(), s))
+            .collect();
+
+        // Orphaned binding surfaces even without a run header.
+        assert_eq!(
+            by_agent.get("worker-b").map(|s| s.session_id.as_str()),
+            Some("sess-b-orphan"),
+            "an orphaned turn (binding with no run header) must be discoverable"
+        );
+        // Ledger binding wins over the scanned (stale) session id, but the
+        // scanned run_id/todo_id metadata is still carried over.
+        let a = by_agent.get("worker-a").unwrap();
+        assert_eq!(a.session_id, "sess-a-new");
+        assert_eq!(a.run_id, "r-a");
+        assert_eq!(a.todo_id, "todo-a");
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn worker_session_bound_event_folds_latest_session() {
+        use crate::store::Event;
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = crate::store::Store::open(dir.path().to_str().unwrap()).unwrap();
+        let mut goal = crate::state::Goal::new("g1", "obj", "/tmp");
+        goal.registered_agents = vec!["w1".to_string()];
+        store.register(&goal).unwrap();
+        store
+            .append(Event::GoalStarted {
+                goal_id: "g1".to_string(),
+                ts: 1,
+            })
+            .unwrap();
+        store
+            .append(Event::WorkerSessionBound {
+                goal_id: "g1".to_string(),
+                agent_id: "w1".to_string(),
+                session_id: "sess-1".to_string(),
+                ts: 1,
+            })
+            .unwrap();
+        store
+            .append(Event::WorkerSessionBound {
+                goal_id: "g1".to_string(),
+                agent_id: "w1".to_string(),
+                session_id: "sess-2".to_string(),
+                ts: 2,
+            })
+            .unwrap();
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert_eq!(
+            goal.worker_sessions.get("w1").map(String::as_str),
+            Some("sess-2"),
+            "latest binding must win"
         );
     }
 }

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -9667,10 +9667,8 @@ mod todo_verify_hint_tests {
             .insert("worker-b".to_string(), "sess-b-orphan".to_string());
 
         let sessions = super::bound_worker_sessions(&goal, &runs, "g1");
-        let by_agent: std::collections::HashMap<&str, &super::WorkerSession> = sessions
-            .iter()
-            .map(|s| (s.agent_id.as_str(), s))
-            .collect();
+        let by_agent: std::collections::HashMap<&str, &super::WorkerSession> =
+            sessions.iter().map(|s| (s.agent_id.as_str(), s)).collect();
 
         // Orphaned binding surfaces even without a run header.
         assert_eq!(

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -885,6 +885,14 @@ pub struct Goal {
     /// decides whether to resume it or start fresh. Written at run exit.
     #[serde(default)]
     pub session_retention: Option<SessionRetention>,
+    /// Durable agent-id → session-id bindings, folded from `WorkerSessionBound`
+    /// (latest wins). This is the authoritative map `worker stop` / `worker list`
+    /// use to locate a worker's backing agent session — written BEFORE the first
+    /// prompt of a run, so it survives a prompt/parse failure that leaves the
+    /// turn orphaned (a case the `.live.jsonl` run_header scan cannot see,
+    /// because the header is only written AFTER the prompt ack returns a run_id).
+    #[serde(default)]
+    pub worker_sessions: std::collections::BTreeMap<String, String>,
     /// The supervising (orchestrator) agent session id, registered via
     /// `supervisor register`. Workers enqueue reports to this session when
     /// they need the supervisor's intervention (completion / failure / a user
@@ -1031,6 +1039,7 @@ impl Goal {
             semantic_history: vec![],
             replan_rule_set: None,
             session_retention: None,
+            worker_sessions: std::collections::BTreeMap::new(),
             supervisor_session_id: None,
             pending_steer: None,
         }

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -257,6 +257,18 @@ pub enum Event {
         workspaces: Vec<String>,
         ts: u64,
     },
+    /// Bind a worker's agent session to its agent-id BEFORE the run starts
+    /// prompting. This is the authoritative agent→session mapping for
+    /// `worker stop`/`worker list`, recorded before the first `prompt` so a
+    /// prompt/parse failure (or a client SIGKILL) cannot orphan the turn
+    /// beyond reach — the `.live.jsonl` run_header, written only after a
+    /// prompt ack returns a run_id, cannot see such orphans.
+    WorkerSessionBound {
+        goal_id: String,
+        agent_id: String,
+        session_id: String,
+        ts: u64,
+    },
     /// P0-1: advisory write-lock record — an agent with declared workspaces
     /// claimed a todo and now occupies its workspace set. `forced` marks a
     /// claim that overrode a live workspace conflict via `--force`.
@@ -611,7 +623,8 @@ impl Event {
             | Event::ReplanRuleSetUpdated { goal_id, .. }
             | Event::SupervisorRegistered { goal_id, .. }
             | Event::WorkerSteered { goal_id, .. }
-            | Event::WorkerStopped { goal_id, .. } => goal_id,
+            | Event::WorkerStopped { goal_id, .. }
+            | Event::WorkerSessionBound { goal_id, .. } => goal_id,
         }
     }
 }
@@ -1657,6 +1670,16 @@ fn apply(goal: &mut Goal, event: Event) {
                 capabilities,
                 workspaces,
             });
+        }
+        Event::WorkerSessionBound {
+            agent_id,
+            session_id,
+            ..
+        } => {
+            // Latest binding wins; a worker that restarts and re-binds to a
+            // fresh session overwrites its stale mapping so `worker stop`/
+            // `worker list` never abort a dead session id.
+            goal.worker_sessions.insert(agent_id, session_id);
         }
         // P0-1: advisory write-lock records are projection-only — occupancy
         // is derived from profiles + live leases; the event is the audit

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -197,6 +197,34 @@ fn command_error_paths() {
 }
 
 #[test]
+fn prompt_decodes_typed_payload_when_data_is_empty() {
+    // The agent retired command-response dual-write: a typed `prompt` ack
+    // arrives with an EMPTY `data` string and its run_id inside the typed
+    // `payload` oneof. The client must decode the typed payload first, not
+    // read `data` (which would yield Null → "missing run_id: null").
+    rt().block_on(async {
+        use future_rpc::proto::{response_payload, PromptAck, ResponsePayload};
+        let typed = ResponsePayload {
+            kind: Some(response_payload::Kind::Prompt(PromptAck {
+                run_id: "typed-run-1".to_string(),
+                run_epoch: 0,
+                accepted_state: "running".to_string(),
+                run_sequence: None,
+                queue_position: None,
+            })),
+        };
+        let st = MockState {
+            typed_payloads: [("prompt".to_string(), typed)].into_iter().collect(),
+            ..Default::default()
+        };
+        let (addr, _) = spawn_mock(st).await;
+        let mut client = AgentClient::connect(&addr).await.unwrap();
+        let run_id = client.prompt("s", "do work", "req-1").await.unwrap();
+        assert_eq!(run_id, "typed-run-1");
+    });
+}
+
+#[test]
 fn list_streaming_sessions_parses_ids_and_defaults_empty() {
     rt().block_on(async {
         let (addr, shared) = spawn_mock(MockState::default()).await;

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -61,6 +61,10 @@ pub struct MockState {
     pub attach_after_idx: Vec<i64>,
     /// Per-command raw `data` payload override (valid JSON or not).
     pub raw: HashMap<String, String>,
+    /// Per-command typed `payload` override (typed-RPC contract). When set for
+    /// a command the mock answers with an EMPTY `data` string and this payload,
+    /// mirroring the agent's retired dual-write behavior.
+    pub typed_payloads: HashMap<String, future_rpc::proto::ResponsePayload>,
     pub models_payload: Option<String>,
     /// Command types seen, in order (for assertions).
     pub recorded: Vec<String>,
@@ -184,6 +188,11 @@ impl FutureAgent for MockAgent {
             // delete_session / abort): empty data → Value::Null path.
             _ => String::new(),
         };
+        if let Some(payload) = st.typed_payloads.get(&cmd.r#type).cloned() {
+            let mut resp = response(&cmd, true, String::new(), String::new());
+            resp.get_mut().payload = Some(payload);
+            return Ok(resp);
+        }
         Ok(response(&cmd, true, data, String::new()))
     }
 


### PR DESCRIPTION
## 背景

ASC S4R3 编排实战中暴露两个 loop bug（均为真实生产故障）：

### 1. `prompt response missing run_id: null`（typed-RPC 解码漏迁移）

agent 已退役 command-response 双写，typed 命令（`prompt`）的 payload 走 `RpcResponse.payload` oneof、`data` 清空。但 loop 的 `AgentClient::call` 仍直接读 `data`，导致每个 typed 命令都返回 Null → `missing run_id: null`。

后果：10 个 worker 的 turn 实际已执行（session 正常写盘），但 loop 客户端误判失败退出，`.future/loop/runs/` 空、todo 全卡 open。

修复：`call()` 改为 typed-first 解码（`response.payload.is_some()` 时走 `future_rpc::decode::response_data`，untyped 命令保留严格 JSON 解析）。

### 2. `worker stop` 无法 abort 孤儿 turn

`worker stop` 只扫 `.live.jsonl` run_header 找 session，而 run_header 在 `prompt` ack 返回 run_id 之后才写。prompt 失败/客户端被杀 → 无 header → 孤儿 turn 对 `worker stop` 不可见，继续在 agent server 里烧 token（实测 47min 无管控）。

修复：新增 `Event::WorkerSessionBound`（agent-id → session-id），在首次 prompt 前写入 ledger 并折叠进 `Goal.worker_sessions`；`worker stop`/`worker list` 改读该权威映射（`.live.jsonl` 降级为 fallback 提供 run_id/todo_id 展示元数据）。

## 变更

- `orchestration/loop/src/agent_client.rs` — typed-first decode + 回归测试
- `orchestration/loop/src/state.rs` — `Goal.worker_sessions` 字段
- `orchestration/loop/src/store.rs` — `WorkerSessionBound` 事件 + apply 折叠
- `orchestration/loop/src/console.rs` — prompt 前落绑定、stop/list 读绑定、describe_event
- `orchestration/loop/tests/` — mock typed_payloads + 4 个新测试
- `skills` 指针 bump → future-skills v3.8.0（依赖 future-skills PR #24）

## 测试

`cargo test -p future-loop` 全绿（370 lib + 全部集成），`cargo clippy -p future-loop --all-targets` 无告警。

## 依赖

skills 指针指向 `future-skills` commit `3560b7b`，需先合并 **future-skills PR #24**。