### PR TITLE
fix(loop): make owner-scoped todos visible in status/frontier/scope displays

### DIFF
--- a/orchestration/loop/src/agents/scope.rs
+++ b/orchestration/loop/src/agents/scope.rs
@@ -114,6 +114,21 @@ pub fn identity_scoped_frontier(
         if !is_agent_work(todo) || !is_frontier_active(todo) {
             continue;
         }
+        // Owner scope is checked BEFORE the lease claim: an `owner`-scoped
+        // todo is reserved for its owning agent and is OUTSIDE every other
+        // agent's frontier, even while unclaimed (no lease yet). The old code
+        // only consulted `claimed_by`, so an unclaimed owner-scoped todo
+        // surfaced in EVERY agent's "visible" list and inflated the unclaimed
+        // count (a goal of ten `--owner solver-*` todos showed all ten to
+        // every worker).
+        match todo.owner.as_deref() {
+            Some(o) if o != agent_id => {
+                // Reserved for another agent — OUTSIDE this frontier.
+                other_claimed.push(todo.id.clone());
+                continue;
+            }
+            _ => {}
+        }
         match todo.claimed_by.as_deref() {
             None => {
                 visible_agent.push(todo.id.clone());
@@ -210,6 +225,29 @@ mod tests {
         assert!(b.contains("t3"));
         assert!(!b.contains("t1"), "B must never see A's claimed todo");
         assert_eq!(b.other_agent_claimed_ids, vec!["t1"]);
+    }
+
+    #[test]
+    fn owner_scoped_todo_visible_only_to_its_owner() {
+        // Regression: scope only consulted `claimed_by`, so an unclaimed
+        // `--owner solver-b` todo surfaced in EVERY agent's visible list and
+        // inflated the unclaimed count. Owner-scoped todos must be visible
+        // only to their owner, and counted as other-agent work elsewhere.
+        let mut owned = Todo::advancement("t-owned", "reserved for B");
+        owned.owner = Some("agent-b".into());
+        let goal = goal_with(vec![owned]);
+
+        let a = identity_scoped_frontier(&goal, "agent-a", &[]);
+        assert!(
+            !a.contains("t-owned"),
+            "A must not see B's owner-scoped todo"
+        );
+        assert_eq!(a.other_agent_claimed_ids, vec!["t-owned"]);
+        assert_eq!(a.unclaimed_advancement_count, 0);
+
+        let b = identity_scoped_frontier(&goal, "agent-b", &[]);
+        assert!(b.contains("t-owned"), "B sees its own owner-scoped todo");
+        assert_eq!(b.unclaimed_advancement_count, 1);
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -45,13 +45,34 @@ fn refresh_next_action(store: &Store, goal_id: &str) -> Result<()> {
     let goal = store
         .replay(goal_id)?
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
-    let next = goal
-        .runnable_advancement()
-        .next()
-        .map(|t| t.text.clone())
-        .unwrap_or_else(|| "all todos complete; no further action".to_string());
-    store.set_next_action(goal_id, &next)?;
+    store.set_next_action(goal_id, &next_action_text(&goal))?;
     Ok(())
+}
+
+/// The goal-level Next Action line, owner-aware. The naive
+/// `runnable_advancement()` frontier is the shared pool (agent_id=None) and
+/// drops every owner-scoped todo, so an all-owner-scoped goal read as
+/// "all todos complete; no further action" while work was still waiting on
+/// its owners. This picks the first shared-pool runnable todo when one
+/// exists; otherwise, if only owner-scoped todos remain, it says so
+/// explicitly instead of claiming completion.
+fn next_action_text(goal: &Goal) -> String {
+    let (claimable, owner_scoped) = goal.pending_advancement_owner_aware();
+    if let Some(t) = claimable.first() {
+        return t.text.clone();
+    }
+    if !owner_scoped.is_empty() {
+        let owners: std::collections::BTreeSet<&str> = owner_scoped
+            .iter()
+            .filter_map(|t| t.owner.as_deref())
+            .collect();
+        return format!(
+            "{} owner-scoped todo(s) await their owning agent(s): {}",
+            owner_scoped.len(),
+            owners.into_iter().collect::<Vec<_>>().join(", ")
+        );
+    }
+    "all todos complete; no further action".to_string()
 }
 
 /// Project-local state root: `<cwd>/.future/loop/` (run future-loop from the
@@ -428,7 +449,7 @@ fn build_cli_registry() -> CommandRegistry {
         ops,
         "run",
         "drive one bounded gRPC turn (requires --agent-id; auto-registers)",
-        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--lease-secs N] [--force-workspace]",
+        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-turn-secs N] [--max-incomplete-retries N] [--lease-secs N] [--force-workspace] [--session-policy auto|fresh|resume] [--resume-session ID] [--anonymous]",
     );
 
     let work_items = r.group(
@@ -4416,11 +4437,7 @@ async fn run_turns(
         // model when the follow-up(s) joined the frontier.
         g = run_followthrough_and_refresh(store, goal_id, g)?;
         // Sync Next Action to the frontier (avoid projection gap).
-        let next_text = g
-            .runnable_advancement()
-            .next()
-            .map(|t| t.text.clone())
-            .unwrap_or_else(|| "all todos complete; no further action".to_string());
+        let next_text = next_action_text(&g);
         store.set_next_action(goal_id, &next_text)?;
         println!("   ✔ writeback ok — next action synced");
     }
@@ -7690,6 +7707,46 @@ mod coverage_tests {
             truncation: None,
             validation: None,
         }
+    }
+
+    #[test]
+    fn next_action_text_shows_shared_pool_todo_first() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        g.add(Todo::advancement("T1", "shared work"));
+        assert_eq!(next_action_text(&g), "shared work");
+    }
+
+    #[test]
+    fn next_action_text_names_owners_when_only_owner_scoped_remain() {
+        // Regression: an all-owner-scoped goal read as
+        // "all todos complete; no further action" because the shared-pool
+        // frontier (agent_id=None) dropped every owner-scoped todo. The next
+        // line must surface the owners instead of claiming completion.
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut a = Todo::advancement("T1", "owned A");
+        a.owner = Some("solver-a".to_string());
+        let mut b = Todo::advancement("T2", "owned B");
+        b.owner = Some("solver-b".to_string());
+        g.add(a);
+        g.add(b);
+        let next = next_action_text(&g);
+        assert!(
+            next.contains("owner-scoped") && next.contains("solver-a") && next.contains("solver-b"),
+            "next line must name pending owners, got: {next}"
+        );
+        assert!(
+            !next.contains("all todos complete"),
+            "must not claim completion: {next}"
+        );
+    }
+
+    #[test]
+    fn next_action_text_reports_complete_only_when_nothing_pending() {
+        let g = Goal::new("g", "o", "/tmp");
+        assert_eq!(
+            next_action_text(&g),
+            "all todos complete; no further action"
+        );
     }
 
     fn all_events(todo_id: &str) -> Vec<Event> {

--- a/orchestration/loop/src/decision/frontier.rs
+++ b/orchestration/loop/src/decision/frontier.rs
@@ -27,13 +27,18 @@ pub(crate) fn lane(goal: &Goal) -> &'static str {
 /// Compose the frontier projection snapshot: replan pressure plus the
 /// runnable-frontier and monitor counts.
 pub(crate) fn frontier_projection(goal: &Goal, replan_required: bool) -> FrontierProjection {
+    // Owner-aware pending count: the naive `runnable_advancement().count()`
+    // is the shared-pool (agent_id=None) frontier and so drops every
+    // owner-scoped todo, reporting `unclaimed_advancement=0` while an
+    // all-owner-scoped goal still has real work waiting on its owners.
+    let (claimable, owner_scoped) = goal.pending_advancement_owner_aware();
     FrontierProjection {
         replan_required,
         current_agent_advancement: goal
             .runnable_advancement()
             .filter(|t| t.failed_attempts > 0)
             .count(),
-        unclaimed_advancement: goal.runnable_advancement().count(),
+        unclaimed_advancement: claimable.len() + owner_scoped.len(),
         acceptance_gaps: goal.unsatisfied_gaps().len(),
         monitors_open: goal.open_monitors().count(),
         monitors_due: goal
@@ -86,6 +91,49 @@ mod tests {
         assert_eq!(fp.acceptance_gaps, 1);
         assert_eq!(fp.monitors_open, 1);
         assert_eq!(fp.monitors_due, 1);
+    }
+
+    #[test]
+    fn frontier_projection_counts_owner_scoped_todos_as_pending() {
+        // Regression: the naive `runnable_advancement().count()` is the
+        // shared-pool (agent_id=None) frontier and dropped owner-scoped
+        // todos, reporting unclaimed_advancement=0 while work waited on its
+        // owners. The projection must count owner-scoped todos as pending.
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut owned = Todo::advancement("T1", "owned work");
+        owned.owner = Some("solver-a".to_string());
+        g.add(owned);
+        g.add(Todo::advancement("T2", "shared work"));
+        let fp = frontier_projection(&g, false);
+        assert_eq!(
+            fp.unclaimed_advancement, 2,
+            "owner-scoped + shared todos both count as pending"
+        );
+    }
+
+    #[test]
+    fn pending_advancement_owner_aware_splits_shared_from_owned() {
+        let mut g = Goal::new("g", "o", "/tmp");
+        let mut a = Todo::advancement("T1", "owned A");
+        a.owner = Some("solver-a".to_string());
+        let mut b = Todo::advancement("T2", "owned B");
+        b.owner = Some("solver-b".to_string());
+        g.add(a);
+        g.add(b);
+        g.add(Todo::advancement("T3", "shared"));
+        let (claimable, owner_scoped) = g.pending_advancement_owner_aware();
+        let claimable_ids: Vec<&str> = claimable.iter().map(|t| t.id.as_str()).collect();
+        let owned_ids: Vec<&str> = owner_scoped.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(
+            claimable_ids,
+            vec!["T3"],
+            "only the unowned todo is shared-pool claimable"
+        );
+        assert_eq!(
+            owned_ids,
+            vec!["T1", "T2"],
+            "both owner-scoped todos are pending"
+        );
     }
 
     #[test]

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -1163,6 +1163,49 @@ impl Goal {
         })
     }
 
+    /// Goal-level pending advancement, owner-aware, for the operator-facing
+    /// "is there work left" displays (`status` next line, `frontier show`
+    /// unclaimed count). Unlike `runnable_advancement()` (which is the shared
+    /// pool `agent_id=None` sees and so silently drops owner-scoped todos),
+    /// this counts an open advancement todo as pending when ANY worker can
+    /// claim it — either it is unowned (shared pool) or it is owner-scoped
+    /// and merely waiting for its owning agent. It deliberately does NOT
+    /// apply the live-lease filter (`claimed_by_other`): a todo leased by a
+    /// running worker is still "pending work" from the goal's perspective,
+    /// and the display layer must not report "all complete" while a worker
+    /// is mid-run.
+    ///
+    /// Returns `(claimable, owner_scoped)`: `claimable` = todos any agent can
+    /// run now (unowned, no live lease by another agent); `owner_scoped` =
+    /// todos reserved for a specific owner. Display code uses both so an
+    /// all-owner-scoped goal never reads as "all todos complete".
+    pub fn pending_advancement_owner_aware(&self) -> (Vec<&Todo>, Vec<&Todo>) {
+        let now_sys = SystemTime::now();
+        let now = now_epoch();
+        let mut claimable = vec![];
+        let mut owner_scoped = vec![];
+        for t in &self.todos {
+            let open = t.class == TaskClass::Advancement
+                && (t.status == TodoStatus::Open || t.is_due_deferred(now_sys))
+                && !self.is_blocked(t);
+            if !open {
+                continue;
+            }
+            match t.owner.as_deref() {
+                // Shared pool: pending unless a live lease hides it.
+                None => {
+                    if !t.claimed_by_other(None, now) {
+                        claimable.push(t);
+                    }
+                }
+                // Owner-scoped: always pending (waiting on its owner), even if
+                // the owner currently holds the lease — it is not "done".
+                Some(_) => owner_scoped.push(t),
+            }
+        }
+        (claimable, owner_scoped)
+    }
+
     /// Whether `agent_id` is a registered peer of this goal (LoopX:
     /// coordination.registered_agents — the precondition for quota --agent-id).
     pub fn is_registered_agent(&self, agent_id: Option<&str>) -> bool {


### PR DESCRIPTION
## What

The `--owner` assignment (PR #401) was only honored by the execution-path frontier `runnable_advancement_for(Some(id))`. The three goal-level display projections all ran the shared-pool (`agent_id=None`) frontier and silently dropped owner-scoped todos. An all-owner-scoped goal therefore read as:

- `status` → `next: all todos complete; no further action` (while work waited on its owners)
- `frontier show` → `unclaimed_advancement=0` (while terminal judgement correctly listed N gaps)
- `scope --agent-id X` → every owner-scoped todo visible to every agent (inflated unclaimed count)

Execution (claim/terminal) was unaffected — this is a display-only inconsistency, but it misleads the orchestrator on exactly the multi-worker pattern (`--owner <agent-id>` per worker slice) that the future-loop and asc-solver skills recommend.

## Changes

- **state**: add `Goal::pending_advancement_owner_aware()` — open advancement split into shared-pool-claimable vs owner-scoped-pending (owner-aware, no live-lease filter: a leased todo is still pending work).
- **console**: `next_action_text()` shows the first shared-pool todo, else names the owners of the remaining owner-scoped todos instead of claiming completion; used by `refresh_next_action` and the run writeback sync.
- **frontier**: `unclaimed_advancement` counts owner-scoped todos as pending.
- **scope**: an owner-scoped todo is visible only to its owner (checked before the lease claim) and counts as other-agent work elsewhere.
- **console**: `run --help` now lists the five flags the parser already accepts (`--max-turn-secs`, `--max-incomplete-retries`, `--session-policy`, `--resume-session`, `--anonymous`).

Behavior paths deliberately untouched: `runnable_advancement_for(None)` still feeds the completion-contract successor set and replan facts, preserving shared-pool / backup-takeover semantics.

## Tests

+6 covering owner-aware pending split, frontier count, scope visibility, and next-action text. All existing suites pass.