### PR TITLE
fix(agent): account for non-Future model cost in mixed-model sessions

### DIFF
--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -873,13 +873,15 @@ impl Loop {
                 .map(agent_tool_call_to_tool_call)
                 .collect();
 
-            // Apply the final credit_cost from this LLM call to cumulative_cost.
-            // The upstream API sends progressive credit_cost updates in each
-            // usage chunk; total_usage holds the LAST (complete) value. Adding
-            // it here — once per LLM call — avoids the N× inflation that
-            // would result from accumulating every intermediate chunk.
+            // Apply this LLM call's final cost to cumulative_cost, once per
+            // call (total_usage holds the LAST complete usage chunk — adding
+            // every intermediate chunk would inflate the total N×). Future
+            // providers report an authoritative `credit_cost`; when absent
+            // (most other providers), fall back to a token×price estimate so
+            // mixed-model sessions still account for every request.
             if let Some(ref u) = total_usage {
-                if let Some(cost) = u.credit_cost {
+                let cost = u.credit_cost.unwrap_or_else(|| self.estimate_usage_cost(u));
+                if cost > 0.0 {
                     *self.cumulative_cost.lock() += cost;
                 }
             }
@@ -1108,6 +1110,31 @@ impl Loop {
         // inflates the total by N×. Instead, credit_cost is applied once at
         // the end of the LLM call using the final value from total_usage.
         *total_usage = Some(u.clone());
+    }
+
+    /// Estimate the cost of a single request's final usage when the upstream
+    /// API did not report an authoritative `credit_cost` (most non-Future
+    /// providers). Resolves the model's per-1M-token prices from the shared
+    /// registry and returns zero when the model is unknown or unpriced.
+    fn estimate_usage_cost(&self, usage: &crate::types::Usage) -> f64 {
+        let model_ref = if self.model_ref.is_empty() {
+            self.model.as_str()
+        } else {
+            self.model_ref.as_str()
+        };
+        let Some(model) = self
+            .model_registry
+            .as_ref()
+            .and_then(|registry| registry.read().resolve(model_ref))
+        else {
+            return 0.0;
+        };
+        model.cost.estimate(
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage.cache_read_tokens.unwrap_or(0),
+            usage.cache_write_tokens.unwrap_or(0),
+        )
     }
 }
 
@@ -1685,6 +1712,62 @@ mod tests {
             15
         );
         drop(provider);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_estimates_cost_when_credit_cost_absent() {
+        // A non-Future model: the usage carries no credit_cost, but the catalog
+        // has a price, so the run loop accumulates a token×price estimate
+        // instead of silently dropping the request's cost (mixed-model bug).
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![
+            ModelStreamEvent::Usage(crate::types::Usage {
+                prompt_tokens: 1_000_000,
+                completion_tokens: 1_000_000,
+                total_tokens: 2_000_000,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+                reasoning_tokens: None,
+                credit_cost: None,
+                provider_metadata: None,
+            }),
+            ev_text("answer"),
+            ev_stop(),
+        ])]);
+        let mut loop_ = Loop::new(provider.clone(), "deepseek-chat");
+        loop_.model_ref = "deepseek/deepseek-chat".to_string();
+        loop_.model_registry = Some(std::sync::Arc::new(parking_lot::RwLock::new(
+            crate::models::Registry::from_models_and_auth(
+                vec![crate::models::Model {
+                    id: "deepseek-chat".to_string(),
+                    name: "DeepSeek Chat".to_string(),
+                    provider: "deepseek".to_string(),
+                    api: "chat".to_string(),
+                    base_url: "https://api.deepseek.com".to_string(),
+                    input: vec!["text".to_string()],
+                    output: vec!["text".to_string()],
+                    cost: crate::models::Cost {
+                        input: 1.0,
+                        output: 2.0,
+                        cache_read: 0.0,
+                        cache_write: 0.0,
+                    },
+                    ..Default::default()
+                }],
+                r#"{"deepseek":{"type":"api_key","key":"key"}}"#,
+            ),
+        )));
+        let _ = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        // 1M input × 1.0 + 1M output × 2.0 = 3.0.
+        assert!((*loop_.cumulative_cost.lock() - 3.0).abs() < 1e-9);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/agent/src/models/mod.rs
+++ b/agent/src/models/mod.rs
@@ -75,6 +75,31 @@ pub struct Cost {
     pub cache_write: f64,
 }
 
+impl Cost {
+    /// Estimate the cost (in yuan) of a request's token usage. Prices are per
+    /// 1M tokens. `prompt_tokens` already includes the cached subset, so the
+    /// non-cached remainder is billed at the input rate and the cached tokens
+    /// at their own (usually cheaper or zero) rate — billing both would
+    /// double-count cached input.
+    pub fn estimate(
+        &self,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+        cache_read_tokens: i64,
+        cache_write_tokens: i64,
+    ) -> f64 {
+        let prompt = prompt_tokens.max(0) as f64;
+        let completion = completion_tokens.max(0) as f64;
+        let cache_read = cache_read_tokens.max(0) as f64;
+        let cache_write = cache_write_tokens.max(0) as f64;
+        let uncached_input = (prompt - cache_read - cache_write).max(0.0);
+        (uncached_input / 1_000_000.0) * self.input
+            + (completion / 1_000_000.0) * self.output
+            + (cache_read / 1_000_000.0) * self.cache_read
+            + (cache_write / 1_000_000.0) * self.cache_write
+    }
+}
+
 /// Catalog summary of one built-in provider: how many models it has and its
 /// catalog base URL (no `models.json` overrides applied — clients merge those
 /// themselves, and need the raw catalog URL to detect placeholder URLs), plus
@@ -1060,6 +1085,49 @@ mod tests {
     use super::{Cost, Model, ProviderOverride, Registry};
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn cost_estimate_bills_uncached_input_and_output_separately() {
+        let cost = Cost {
+            input: 4.5,
+            output: 13.5,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        };
+        // 1M prompt + 1M completion, no cache.
+        let est = cost.estimate(1_000_000, 1_000_000, 0, 0);
+        assert!((est - (4.5 + 13.5)).abs() < 1e-9, "{est}");
+    }
+
+    #[test]
+    fn cost_estimate_does_not_double_count_cached_input() {
+        let cost = Cost {
+            input: 4.5,
+            output: 13.5,
+            cache_read: 1.0,
+            cache_write: 0.0,
+        };
+        // 1M prompt tokens, of which 900k were cache reads. Cached input is
+        // billed at the cache_read rate, not the input rate.
+        let est = cost.estimate(1_000_000, 0, 900_000, 0);
+        let expected = (100_000.0 / 1_000_000.0) * 4.5 + (900_000.0 / 1_000_000.0) * 1.0;
+        assert!((est - expected).abs() < 1e-9, "{est} != {expected}");
+    }
+
+    #[test]
+    fn cost_estimate_clamps_negative_and_zeroes() {
+        let cost = Cost {
+            input: 4.5,
+            output: 13.5,
+            cache_read: 1.0,
+            cache_write: 0.0,
+        };
+        // Cache tokens exceeding prompt must not produce a negative uncached
+        // remainder, and negative inputs clamp to zero.
+        assert_eq!(cost.estimate(0, 0, 0, 0), 0.0);
+        assert!(cost.estimate(-5, -5, 0, 0) >= 0.0);
+        assert!(cost.estimate(10, 0, 100, 0) >= 0.0);
+    }
 
     #[test]
     fn derives_max_completion_tokens_field_from_supported_parameters() {

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -408,18 +408,19 @@ fn get_state_internal(
     let cache_r = sess.tokens_cache_r.load(Ordering::Relaxed);
     let cache_w = sess.tokens_cache_w.load(Ordering::Relaxed);
 
-    // Prefer API-reported cost (Future platform returns `credit_cost` in
-    // the usage chunk).  When absent (most non-Future providers don't
-    // report it), fall back to token-count × model-price estimation.
+    // `cumulative_cost` accumulates the cost of every request: Future
+    // providers report an authoritative `credit_cost`, and other providers
+    // fall back to a token×price estimate inside the run loop. The estimate
+    // below is only a legacy fallback for sessions created before per-request
+    // accumulation existed (their journal records token usage but a zero
+    // cumulative cost).
     let api_cost = *sess.cumulative_cost.lock();
     let total_cost = if api_cost > 0.0 {
         api_cost
     } else if let Some(model_config) = registry.resolve(&sess.model) {
-        let input_cost = (tokens_in as f64 / 1_000_000.0) * model_config.cost.input;
-        let output_cost = (tokens_out as f64 / 1_000_000.0) * model_config.cost.output;
-        let cache_read_cost = (cache_r as f64 / 1_000_000.0) * model_config.cost.cache_read;
-        let cache_write_cost = (cache_w as f64 / 1_000_000.0) * model_config.cost.cache_write;
-        input_cost + output_cost + cache_read_cost + cache_write_cost
+        model_config
+            .cost
+            .estimate(tokens_in, tokens_out, cache_r, cache_w)
     } else {
         0.0
     };


### PR DESCRIPTION
## Summary

Footer cost was under-reported when a session mixed Future-platform models with other providers.

## Problem

- Future models return an authoritative `credit_cost` per request, accumulated into `cumulative_cost`.
- Other providers' adapters set `credit_cost: None`, so their cost never entered `cumulative_cost`.
- `get_state_internal` used `if api_cost > 0.0 { api_cost } else { estimate }`, so once any Future request had run, the estimate branch was permanently disabled and non-Future cost was silently dropped.

## Change

- Accumulate per-request cost in the run loop: `credit_cost` when present, otherwise a token×price estimate (`estimate_usage_cost`).
- Extract a shared `Cost::estimate` in `models/mod.rs`, and fix cache double-counting (prompt tokens already include the cached subset, so uncached input is billed at input rate and cached tokens at their own rate, not both).
- `get_state_internal` reuses `Cost::estimate` as a legacy fallback for pre-existing sessions whose journal records tokens but zero cumulative cost.

## Verification

- `cargo clippy -p future-agent --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test -p future-agent --lib cost` (16 passed, incl. new `run_estimates_cost_when_credit_cost_absent` + 3 `Cost::estimate` tests)
- Full `cargo test -p future-agent --lib` (1576 passed)