### PR TITLE
feat(loop): add 'future loop report' — worker mid-run progress notes

### DIFF
--- a/orchestration/loop/src/agents/supervisor.rs
+++ b/orchestration/loop/src/agents/supervisor.rs
@@ -14,7 +14,7 @@
 use crate::store::{Event, Store};
 
 pub const SUPERVISOR_RECEIPT_SCHEMA_VERSION: &str = "supervisor_host_receipt_v1";
-pub const SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION: &str = "supervisor_event_projection_v0";
+pub const SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION: &str = "supervisor_event_projection_v1";
 
 /// Supervisor decision kinds (reference supervisor decisions).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -232,6 +232,7 @@ pub fn build_supervisor_event_projection(
     // (the event kind is fixed by the arm that pushed it).
     let mut proposals: Vec<(String, String, String, String, u64)> = vec![];
     let mut receipts: Vec<(&str, &str)> = vec![];
+    let mut progress: Vec<(String, String, String, u64)> = vec![];
     for stored in &events {
         match &stored.event {
             Event::SupervisorProposed {
@@ -255,6 +256,18 @@ pub fn build_supervisor_event_projection(
                 outcome,
                 ..
             } if g == goal_id => receipts.push((decision_id.as_str(), outcome.as_str())),
+            // Worker mid-run progress notes — advisory, projection-only (see
+            // `report` command). Collected for the supervisor's idle-loop
+            // consumption; never a push.
+            Event::ProgressReported {
+                goal_id: g,
+                agent_id,
+                todo_id,
+                message,
+                ts,
+            } if g == goal_id => {
+                progress.push((agent_id.clone(), todo_id.clone(), message.clone(), *ts))
+            }
             _ => {}
         }
     }
@@ -281,6 +294,17 @@ pub fn build_supervisor_event_projection(
             receipt_count: decision_receipts.len() as u32,
         });
     }
+    let progress_items: Vec<serde_json::Value> = progress
+        .into_iter()
+        .map(|(agent_id, todo_id, message, ts)| {
+            serde_json::json!({
+                "agent_id": agent_id,
+                "todo_id": todo_id,
+                "message": message,
+                "ts": ts,
+            })
+        })
+        .collect();
     Ok(serde_json::json!({
         "ok": true,
         "schema_version": SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION,
@@ -288,6 +312,8 @@ pub fn build_supervisor_event_projection(
         "proposal_count": rows.len(),
         "receipt_count": receipt_count,
         "items": rows,
+        "progress_count": progress_items.len(),
+        "progress": progress_items,
         "boundary": {
             "proposal_is_execution_evidence": false,
             "executed_requires_capability_matched_receipt": true,
@@ -354,6 +380,53 @@ mod tests {
         assert_eq!(projection["items"][0]["execution_status"], "executed");
         assert_eq!(projection["items"][0]["kind"], "execute");
         assert_eq!(projection["items"][0]["target_agent_id"], "agent-b");
+    }
+
+    #[test]
+    fn progress_reports_surface_in_projection() {
+        let root = tmp_root("progress");
+        let mut store = Store::open(&root).unwrap();
+        open_goal(&mut store, "g1");
+        store
+            .append(Event::ProgressReported {
+                goal_id: "g1".into(),
+                agent_id: "agent-b".into(),
+                todo_id: "todo-1".into(),
+                message: "submitted attempt 34444, waiting on score".into(),
+                ts: 100,
+            })
+            .unwrap();
+        // A report for another goal must not leak into this projection.
+        let goal2 = crate::state::Goal::new("g2", "obj2", "/tmp");
+        store.register(&goal2).unwrap();
+        store
+            .append(Event::GoalStarted {
+                goal_id: "g2".into(),
+                ts: goal2.created_at,
+            })
+            .unwrap();
+        store
+            .append(Event::ProgressReported {
+                goal_id: "g2".into(),
+                agent_id: "agent-c".into(),
+                todo_id: "".into(),
+                message: "other goal".into(),
+                ts: 101,
+            })
+            .unwrap();
+        let projection = build_supervisor_event_projection(&store, "g1").unwrap();
+        assert_eq!(projection["proposal_count"], 0);
+        assert_eq!(projection["progress_count"], 1);
+        assert_eq!(projection["progress"][0]["agent_id"], "agent-b");
+        assert_eq!(projection["progress"][0]["todo_id"], "todo-1");
+        assert_eq!(
+            projection["progress"][0]["message"],
+            "submitted attempt 34444, waiting on score"
+        );
+        assert_eq!(projection["progress"][0]["ts"], 100);
+        // Projection-only: replay must not mutate the goal kanban.
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert!(goal.todos.is_empty());
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -169,6 +169,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         "scope" => cmd_scope(&store, &args[1..]),
         "lane" => cmd_lane(&store, &args[1..]),
         "supervisor" => cmd_supervisor(&mut store, &args[1..]),
+        "report" => cmd_report(&mut store, &args[1..]),
         "worker" => cmd_worker(&mut store, &args[1..]).await,
         "task-graph" => cmd_task_graph(&store, &args[1..]),
         "attention" => cmd_attention(&store, &args[1..]),
@@ -223,6 +224,7 @@ const JOURNEY_ASSIGNMENTS: &[(&str, Journey)] = &[
     ("scope", Journey::Driver),
     ("lane", Journey::Driver),
     ("supervisor", Journey::Driver),
+    ("report", Journey::Driver),
     ("worker", Journey::Driver),
     // Setup & automation — one-time configuration
     ("models", Journey::Setup),
@@ -339,6 +341,12 @@ fn build_cli_registry() -> CommandRegistry {
         "supervisor",
         "supervisor register|steer|proposal/receipt events (G-16)",
         "supervisor register|steer|propose|receipt|events --goal G ...",
+    );
+    r.command(
+        agent,
+        "report",
+        "worker mid-run progress note (ledger event, projection-side consumption — never a push)",
+        "report --goal G --agent-id A [--todo-id T] --message \"...\"",
     );
     r.command(
         agent,
@@ -6157,6 +6165,54 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// `report --goal G --agent-id A [--todo-id T] --message "..."` — a worker's
+/// best-effort mid-run progress note, appended to the goal ledger as
+/// `ProgressReported`. Deliberately the opposite of the push channel:
+/// no gate, no status transition, no supervisor notification — the event is
+/// projection-only (consumed via `supervisor events --goal G` or a ledger
+/// tail), so a busy worker can narrate milestones (submitted attempt,
+/// waiting on score) without spamming the supervisor session. Idempotency is
+/// the content-derived event id: an identical report within the same second
+/// is a no-op; distinct moments always append (each is a separate milestone).
+/// The message is free text, truncated to a sane bound for ledger hygiene.
+fn cmd_report(store: &mut Store, args: &[String]) -> Result<()> {
+    reject_unknown_flags(args, &["--agent-id", "--goal", "--message", "--todo-id"])?;
+    let mut goal_id = None;
+    let mut agent_id = None;
+    let mut todo_id = None;
+    let mut message = None;
+    parse_pairs(args, |k, v| {
+        if k == "--goal" {
+            goal_id = Some(v);
+        } else if k == "--agent-id" {
+            agent_id = Some(v);
+        } else if k == "--todo-id" {
+            todo_id = Some(v);
+        } else if k == "--message" {
+            message = Some(v);
+        }
+    });
+    let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+    let message = message.ok_or_else(|| anyhow::anyhow!("--message required"))?;
+    // The goal must exist — a report to a phantom goal is a typo, not an
+    // append into a ledger that would never be read.
+    store
+        .replay(&goal_id)?
+        .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
+    let message = crate::decision::truncate(&message, 500);
+    let agent_id = crate::decision::truncate(&agent_id.unwrap_or_default(), 128);
+    let todo_id = crate::decision::truncate(&todo_id.unwrap_or_default(), 128);
+    store.append(Event::ProgressReported {
+        goal_id: goal_id.clone(),
+        agent_id,
+        todo_id,
+        message,
+        ts: now_epoch(),
+    })?;
+    println!("progress reported to goal {goal_id}");
+    Ok(())
+}
+
 // ── task-graph (G-14) ──────────────────────────────────────────────────────
 
 /// `loopx task-graph --goal G` — the todo dependency graph with topological
@@ -7378,6 +7434,16 @@ fn describe_event(event: &crate::store::Event) -> String {
             ..
         } => {
             return format!("worker_session_bound agent={agent_id} session={session_id}");
+        }
+        Event::ProgressReported {
+            agent_id,
+            todo_id,
+            message,
+            ..
+        } => {
+            return format!(
+                "progress_reported agent={agent_id} todo={todo_id} message=\"{message}\""
+            );
         }
     };
     kind.to_string()
@@ -8991,6 +9057,126 @@ mod workspace_guard_cli_tests {
                 Event::AgentRegistered { workspaces, .. } if workspaces.is_empty()
             ),
             "wrong variant or non-empty workspaces: {event:?}"
+        );
+    }
+
+    #[test]
+    fn report_appends_progress_event_and_rejects_phantom_goal() {
+        let mut store = tmp_store("report");
+        open_goal(&mut store, "g1", &["t1"]);
+
+        // Happy path: appends ProgressReported; replay kanban untouched.
+        cmd_report(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--agent-id".to_string(),
+                "worker-a".to_string(),
+                "--todo-id".to_string(),
+                "t1".to_string(),
+                "--message".to_string(),
+                "submitted attempt 34444, waiting on score".to_string(),
+            ],
+        )
+        .unwrap();
+        let events = store.events("g1").unwrap();
+        let reported: Vec<&Event> = events
+            .iter()
+            .filter_map(|se| match &se.event {
+                e @ Event::ProgressReported { .. } => Some(e),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reported.len(), 1);
+        if let Event::ProgressReported {
+            agent_id,
+            todo_id,
+            message,
+            ..
+        } = reported[0]
+        {
+            assert_eq!(agent_id, "worker-a");
+            assert_eq!(todo_id, "t1");
+            assert_eq!(message, "submitted attempt 34444, waiting on score");
+        }
+        // Projection-only: the todo kanban is not mutated by a report.
+        let goal = store.replay("g1").unwrap().unwrap();
+        assert_eq!(goal.todos.len(), 1);
+        assert_eq!(goal.todos[0].status, crate::state::TodoStatus::Open);
+
+        // Missing --message → hard error.
+        let err = cmd_report(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--agent-id".to_string(),
+                "worker-a".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--message required"));
+
+        // Phantom goal → hard error (a report to a nonexistent goal is a typo).
+        let err = cmd_report(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "nope".to_string(),
+                "--agent-id".to_string(),
+                "worker-a".to_string(),
+                "--message".to_string(),
+                "hello".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"));
+
+        // Unknown flag → hard error (CLI strictness).
+        let err = cmd_report(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--bogus".to_string(),
+                "x".to_string(),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown flag"));
+    }
+
+    #[test]
+    fn report_message_is_bounded_for_ledger_hygiene() {
+        let mut store = tmp_store("report-trunc");
+        open_goal(&mut store, "g1", &[]);
+        let long = "x".repeat(5000);
+        cmd_report(
+            &mut store,
+            &[
+                "--goal".to_string(),
+                "g1".to_string(),
+                "--agent-id".to_string(),
+                "worker-a".to_string(),
+                "--message".to_string(),
+                long.clone(),
+            ],
+        )
+        .unwrap();
+        let events = store.events("g1").unwrap();
+        let reported = events
+            .iter()
+            .find_map(|se| match &se.event {
+                Event::ProgressReported { message, .. } => Some(message.clone()),
+                _ => None,
+            })
+            .unwrap();
+        // truncate caps at 500 chars + an ellipsis marker.
+        assert!(reported.len() <= 503, "message must be bounded");
+        assert!(
+            reported.starts_with(&"x".repeat(500)),
+            "message must keep the first 500 chars"
         );
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -397,6 +397,26 @@ pub enum Event {
         seq: u32,
         ts: u64,
     },
+    /// A worker's best-effort mid-run progress note (`future loop report`).
+    /// Deliberately NOT a state transition: no gate, no supervisor
+    /// notification, and the kernel never acts on it. Projection-only —
+    /// `apply` ignores it, so it never touches the kanban; consumption is the
+    /// supervisor's `supervisor events` projection (or a ledger tail). The
+    /// message is free text bounded by the caller (see `cmd_report`);
+    /// agent_id/todo_id are advisory (may be empty) and not validated against
+    /// claims. Idempotency follows the standard content-derived event id: an
+    /// identical re-report within the same second is a no-op, while distinct
+    /// moments (different `ts`) always append — each report is a separate
+    /// milestone, not a retry of the same one.
+    ProgressReported {
+        goal_id: String,
+        #[serde(default)]
+        agent_id: String,
+        #[serde(default)]
+        todo_id: String,
+        message: String,
+        ts: u64,
+    },
     /// P0-2②: outcome_followthrough fired — a delivered-but-unverified work
     /// item aged past the turn threshold, so a follow-up todo was
     /// auto-created (the followup itself is the TodoAdded event; this event
@@ -608,6 +628,7 @@ impl Event {
             | Event::TodoReleased { goal_id, .. }
             | Event::TodoExpired { goal_id, .. }
             | Event::DeliveryOutcomeRecorded { goal_id, .. }
+            | Event::ProgressReported { goal_id, .. }
             | Event::FollowthroughCreated { goal_id, .. }
             | Event::DecisionSummaryRecorded { goal_id, .. }
             | Event::HeartbeatReceiptRecorded { goal_id, .. }
@@ -1955,6 +1976,9 @@ fn apply(goal: &mut Goal, event: Event) {
         // Projection-only: the run client tails the raw ledger for it; replay
         // deliberately ignores it (a stale stop must not kill future runs).
         Event::WorkerStopped { .. } => {}
+        // Projection-only: a progress note is a statement, not a claim — it
+        // never touches the kanban. Consumption is the supervisor projection.
+        Event::ProgressReported { .. } => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Workers can now narrate mid-run milestones (submitted attempt, waiting on a score) as ledger events via `future loop report --goal G --agent-id A [--todo-id T] --message "..."`, consumed through the supervisor events projection — **pull, never push**: no supervisor notification, no kanban mutation (projection-only replay).

Motivation: a supervisor currently only learns about a worker via state-transition pushes (todo completed / failed / infra stop). Intermediate milestones ("submitted attempt 34444, waiting on score") were invisible except by polling files. This adds the pull-side companion: a ledger event + projection row.

## Changes

- **`store.rs`**: `Event::ProgressReported { goal_id, agent_id, todo_id, message, ts }` — projection-only in `apply()` (never touches the kanban); content-derived event-id idempotency (same-second identical report is a no-op)
- **`console.rs`**: `cmd_report` — strict flag validation, `--goal`/`--message` required, phantom-goal rejection, message bounded at 500 chars; registered in CLI registry + journey assignments
- **`agents/supervisor.rs`**: `supervisor events` projection gains `progress` array + `progress_count` (schema `supervisor_event_projection_v0` → `_v1`)
- **Tests**: projection filtering (per-goal) + kanban untouched; cmd_report error paths; message bound

## Design notes

- Deliberately NOT a push: no `notify_supervisor` call, no dedup key beyond the content-derived event id. Progress narration must not spam the supervisor session (cost + transcript pollution).
- No gate: a report is a statement, not a claim — `agent_id`/`todo_id` are advisory, not validated against leases.
- Distinct moments always append (each report is a separate milestone, `ts` differs); same-second identical content is idempotent.

## Validation

- `make lint-rust` (workspace + desktop/src-tauri clippy/fmt, `-D warnings`) ✓
- `cargo test -p future-loop`: 974 passed ✓
- Workspace Rust suites (agent/channel/cli/tui/desktop-rust) ✓ (channel/cli needed `ulimit -n 8192` — macOS fd limit, unrelated)
- Desktop `tsc --noEmit` + eslint + stylelint + vitest (657) ✓
- Mobile typecheck/eslint + jest (532, after `gen-version`) ✓
- Manual e2e: `report` → ledger → `supervisor events` projection roundtrip, same-second idempotency, phantom-goal error ✓