### PR TITLE
fix(desktop): refresh left-rail skills badge after install/uninstall

### DIFF
--- a/desktop/src/features/skills/SkillsView.broadcast.test.tsx
+++ b/desktop/src/features/skills/SkillsView.broadcast.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+// Regression: uninstalling a skill must update the left rail's installed-
+// skills badge. The rail listens for the "skills-changed" window event and
+// re-reads `list_installed_skills` — previously SkillsView refreshed only its
+// own lists and never emitted the event, so the badge kept the stale count.
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onFutureEvent } from "../../lib/futureEvents";
+
+import { flushAsync } from "../../test/renderHook";
+import { SkillsView } from "./SkillsView";
+import "../../test/i18nTestSetup";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (command: string, args?: unknown) => invokeMock(command, args),
+}));
+
+// SkillsView renders LeftPanelTitlebarToggle → useIsFullscreen, which touches
+// the Tauri window API — unavailable (and irrelevant) under jsdom.
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isFullscreen: () => Promise.resolve(false),
+    onResized: () => Promise.resolve(() => {}),
+  }),
+}));
+
+function installedSkill(id: string) {
+  return {
+    id,
+    name: id,
+    description: `desc ${id}`,
+    nameZh: id,
+    descriptionZh: `desc-zh ${id}`,
+    version: "1.0.0",
+  };
+}
+
+function availableSkill(id: string) {
+  return {
+    id,
+    name: id,
+    description: `desc ${id}`,
+    nameZh: id,
+    descriptionZh: `desc-zh ${id}`,
+    category: "cat",
+    categoryZh: "cat-zh",
+    latestVersion: "1.0.0",
+  };
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const matches = [...container.querySelectorAll("button")]
+    .filter(button => button.textContent?.trim() === text);
+  if (matches.length === 0)
+    throw new Error(`no button with text "${text}"`);
+  return matches[0]!;
+}
+
+describe("skillsView skills-changed broadcast", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("emits skills-changed after uninstall so rail-badge listeners re-read", async () => {
+    // Mock backend state: two installed skills; uninstall removes by id.
+    const installed = ["alpha", "beta"];
+    invokeMock.mockImplementation((command: string, args?: { id?: string }) => {
+      if (command === "list_installed_skills")
+        return Promise.resolve(installed.map(installedSkill));
+      if (command === "list_available_skills")
+        return Promise.resolve(installed.map(availableSkill));
+      if (command === "uninstall_skill") {
+        const index = installed.indexOf(args?.id ?? "");
+        if (index >= 0)
+          installed.splice(index, 1);
+        return Promise.resolve(index >= 0);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    // Mirror ActivityRail: on "skills-changed", re-read the installed list and
+    // remember what the badge would show.
+    const badgeReads: number[] = [];
+    const stopRail = onFutureEvent("skills-changed", () => {
+      void invokeMock("list_installed_skills").then((skills: Array<{ id: string }>) => {
+        badgeReads.push(skills.length);
+      });
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(SkillsView, {
+        leftPanelExpanded: true,
+        onToggleLeftPanel: () => {},
+        onStartCoachConversation: async () => {},
+        onTrySkill: () => {},
+      }));
+    });
+    await flushAsync();
+    expect(container.textContent).toContain("alpha");
+
+    // Uninstall "alpha" through the real buttons (uninstall → confirm).
+    await act(async () => {
+      buttonByText(container, "Uninstall").click();
+    });
+    await act(async () => {
+      buttonByText(container, "Confirm uninstall").click();
+    });
+    await flushAsync();
+
+    // The rail's re-read saw the post-uninstall list (1 skill left).
+    expect(badgeReads).toEqual([1]);
+    expect(installed).toEqual(["beta"]);
+
+    stopRail();
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/desktop/src/features/skills/SkillsView.tsx
+++ b/desktop/src/features/skills/SkillsView.tsx
@@ -160,11 +160,15 @@ export function SkillsView({
   // open view reflects them.
   useEffect(() => onFutureEvent("skills-changed", () => void refresh()), [refresh]);
 
+  // Install/uninstall actions broadcast "skills-changed": the left rail
+  // re-reads its badge from it, and this view reloads via its own listener
+  // above (same pattern as the silent auto-upgrade). No explicit refresh here
+  // — the listener already covers it.
   const runAction = useCallback(async (id: string, action: () => Promise<unknown>) => {
     setBusy(current => ({ ...current, [id]: true }));
     try {
       await action();
-      await refresh();
+      emitFutureEvent("skills-changed", undefined);
     }
     catch (error) {
       // Every caller is `void runAction(...)`, so a rejected install/uninstall
@@ -174,10 +178,12 @@ export function SkillsView({
     finally {
       setBusy(current => ({ ...current, [id]: false }));
     }
-  }, [refresh, t]);
+  }, [t]);
 
   // Manual "Upgrade all": overwrite-install every upgradable skill sequentially,
-  // marking each busy, then refresh once. User-initiated, so failures toast.
+  // marking each busy, then broadcast "skills-changed" once (the listener above
+  // reloads this view; the left rail refreshes its badge). User-initiated, so
+  // failures toast.
   const upgradeAll = useCallback(async () => {
     if (skillUpgrades.length === 0)
       return;
@@ -186,7 +192,7 @@ export function SkillsView({
     try {
       for (const { id, version } of skillUpgrades)
         await installSkill(id, version);
-      await refresh();
+      emitFutureEvent("skills-changed", undefined);
     }
     catch (error) {
       emitFutureEvent("toast", { message: t("actionFailed", { message: errorMessage(error) }), tone: "error" });
@@ -194,7 +200,7 @@ export function SkillsView({
     finally {
       setBusy(current => ({ ...current, ...Object.fromEntries(ids.map(id => [id, false])) }));
     }
-  }, [skillUpgrades, refresh, t]);
+  }, [skillUpgrades, t]);
 
   return (
     <section className="flex h-full min-h-0 flex-col bg-surface">


### PR DESCRIPTION
## Problem

After uninstalling a skill on the Skills page, the badge number on the left rail's Skills entry didn't decrease (same staleness after install). It only corrected itself on the next app launch or when the silent auto-upgrade happened to run.

## Root cause

The rail badge ([ActivityRail.tsx](../blob/claude/skill-badge-count/desktop/src/components/layout/ActivityRail.tsx)) re-reads `list_installed_skills` only when the `skills-changed` window event fires. But `SkillsView` never emitted that event — after install/uninstall it refreshed only its own lists. The sole emitter was the silent auto-upgrade hook (`useAutoUpgradeSkills`), so the badge just happened to track upgrades.

## Fix

- `SkillsView.runAction` (install/uninstall/upgrade single skill) and `upgradeAll` now broadcast `skills-changed` on success instead of calling `refresh()` directly — the view reloads via its existing listener (the same pattern the auto-upgrade hook already used). Rail badge updates on the same event.
- Regression test: mounts `SkillsView` in jsdom, uninstalls through the real buttons (uninstall → confirm), and asserts a rail-style `skills-changed` listener re-reads the post-uninstall list. Verified it fails on the old code.

## Checks

- `tsc --noEmit`, eslint on touched files, vitest skills suites: green