### PR TITLE
fix(agent): harden Responses replay and context panels

### DIFF
--- a/agent/src/llm/adapters/openai_responses.rs
+++ b/agent/src/llm/adapters/openai_responses.rs
@@ -7,7 +7,7 @@ use crate::types::{ContentBlock, ProviderMetadata, Usage};
 use anyhow::{anyhow, bail, Result};
 use serde_json::{json, Map, Value};
 use std::any::Any;
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 pub struct OpenAiResponsesAdapter;
 
@@ -20,10 +20,26 @@ struct ResponseToolState {
 }
 
 #[derive(Debug, Default)]
+struct ResponseTextState {
+    id: String,
+    text: String,
+    open: bool,
+}
+
+#[derive(Debug, Default)]
+struct ResponseReasoningState {
+    id: String,
+    summary_parts: BTreeMap<usize, String>,
+    content_parts: BTreeMap<usize, String>,
+    emitted_summary_parts: BTreeSet<usize>,
+}
+
+#[derive(Debug, Default)]
 struct ResponsesState {
-    text_open: BTreeMap<usize, String>,
-    reasoning_open: BTreeMap<usize, String>,
+    texts: BTreeMap<usize, ResponseTextState>,
+    reasoning_open: BTreeMap<usize, ResponseReasoningState>,
     tools: BTreeMap<usize, ResponseToolState>,
+    finished_output_items: BTreeSet<usize>,
     finished: bool,
 }
 
@@ -84,16 +100,39 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
         if let Some(max_tokens) = target.generation.max_output_tokens {
             body["max_output_tokens"] = json!(max_tokens);
         }
+        if let Some(prompt_cache_options) = &config.prompt_cache_options {
+            body["prompt_cache_options"] = prompt_cache_options.clone();
+        }
         let level = target.generation.thinking_level.as_str();
-        if target.capabilities.reasoning.supported && !level.is_empty() && level != "off" {
-            let mapped = target
-                .capabilities
-                .reasoning
-                .levels
-                .get(level)
-                .and_then(Value::as_str)
-                .unwrap_or(level);
-            body["reasoning"] = json!({"effort": mapped, "summary": "auto"});
+        let has_responses_reasoning_config =
+            config.reasoning_context.is_some() || config.reasoning_mode.is_some();
+        if target.capabilities.reasoning.supported
+            && level != "off"
+            && (!level.is_empty() || has_responses_reasoning_config)
+        {
+            let mut reasoning = Map::new();
+            if !level.is_empty() {
+                let mapped = target
+                    .capabilities
+                    .reasoning
+                    .levels
+                    .get(level)
+                    .and_then(Value::as_str)
+                    .unwrap_or(level);
+                reasoning.insert("effort".into(), json!(mapped));
+            }
+            if config.supports_reasoning_summary {
+                reasoning.insert("summary".into(), json!("auto"));
+            }
+            if let Some(context) = &config.reasoning_context {
+                reasoning.insert("context".into(), json!(context));
+            }
+            if let Some(mode) = &config.reasoning_mode {
+                reasoning.insert("mode".into(), json!(mode));
+            }
+            if !reasoning.is_empty() {
+                body["reasoning"] = Value::Object(reasoning);
+            }
         }
         Ok(body)
     }
@@ -157,8 +196,7 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                             .get("id")
                             .and_then(Value::as_str)
                             .unwrap_or("reasoning");
-                        state.reasoning_open.insert(index, id.to_string());
-                        events.push(ModelStreamEvent::ReasoningStart { id: id.to_string() });
+                        open_reasoning(state, index, id, &mut events);
                     }
                     _ => {}
                 }
@@ -172,15 +210,8 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .get("item_id")
                     .and_then(Value::as_str)
                     .unwrap_or("text");
-                if let Entry::Vacant(entry) = state.text_open.entry(index) {
-                    entry.insert(id.to_string());
-                    events.push(ModelStreamEvent::TextStart { id: id.to_string() });
-                }
                 if let Some(delta) = event.get("delta").and_then(Value::as_str) {
-                    events.push(ModelStreamEvent::TextDelta {
-                        id: id.to_string(),
-                        text: delta.to_string(),
-                    });
+                    append_text_delta(state, index, id, delta, &mut events);
                 }
             }
             "response.output_text.done" => {
@@ -188,9 +219,12 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .get("output_index")
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as usize;
-                if let Some(id) = state.text_open.remove(&index) {
-                    events.push(ModelStreamEvent::TextEnd { id });
-                }
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("text");
+                let text = event.get("text").and_then(Value::as_str);
+                reconcile_text(state, index, id, text, true, &mut events);
             }
             "response.refusal.delta" => {
                 let index = event
@@ -201,15 +235,8 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .get("item_id")
                     .and_then(Value::as_str)
                     .unwrap_or("refusal");
-                if let Entry::Vacant(entry) = state.text_open.entry(index) {
-                    entry.insert(id.to_string());
-                    events.push(ModelStreamEvent::TextStart { id: id.to_string() });
-                }
                 if let Some(delta) = event.get("delta").and_then(Value::as_str) {
-                    events.push(ModelStreamEvent::TextDelta {
-                        id: id.to_string(),
-                        text: delta.to_string(),
-                    });
+                    append_text_delta(state, index, id, delta, &mut events);
                 }
             }
             "response.refusal.done" => {
@@ -217,11 +244,14 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .get("output_index")
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as usize;
-                if let Some(id) = state.text_open.remove(&index) {
-                    events.push(ModelStreamEvent::TextEnd { id });
-                }
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("refusal");
+                let text = event.get("refusal").and_then(Value::as_str);
+                reconcile_text(state, index, id, text, true, &mut events);
             }
-            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+            "response.reasoning_summary_part.added" => {
                 let index = event
                     .get("output_index")
                     .and_then(Value::as_u64)
@@ -230,15 +260,109 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .get("item_id")
                     .and_then(Value::as_str)
                     .unwrap_or("reasoning");
-                if let Entry::Vacant(entry) = state.reasoning_open.entry(index) {
-                    entry.insert(id.to_string());
-                    events.push(ModelStreamEvent::ReasoningStart { id: id.to_string() });
+                open_reasoning(state, index, id, &mut events);
+                let summary_index = event
+                    .get("summary_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                if let Some(reasoning) = state.reasoning_open.get_mut(&index) {
+                    reasoning.summary_parts.entry(summary_index).or_default();
                 }
+            }
+            "response.reasoning_summary_text.delta" => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("reasoning");
+                let summary_index = event
+                    .get("summary_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
                 if let Some(delta) = event.get("delta").and_then(Value::as_str) {
-                    events.push(ModelStreamEvent::ReasoningDelta {
-                        id: id.to_string(),
-                        text: delta.to_string(),
-                    });
+                    append_reasoning_summary_delta(
+                        state,
+                        index,
+                        id,
+                        summary_index,
+                        delta,
+                        &mut events,
+                    );
+                }
+            }
+            "response.reasoning_summary_part.done" => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("reasoning");
+                let summary_index = event
+                    .get("summary_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                if let Some(text) = event
+                    .get("part")
+                    .and_then(|part| part.get("text"))
+                    .and_then(Value::as_str)
+                {
+                    reconcile_reasoning_summary(state, index, id, summary_index, text, &mut events);
+                }
+            }
+            "response.reasoning_summary_text.done" => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("reasoning");
+                let summary_index = event
+                    .get("summary_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    reconcile_reasoning_summary(state, index, id, summary_index, text, &mut events);
+                }
+            }
+            "response.reasoning_text.delta" => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("reasoning");
+                let content_index = event
+                    .get("content_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                if let Some(delta) = event.get("delta").and_then(Value::as_str) {
+                    append_reasoning_content(state, index, id, content_index, delta, &mut events);
+                }
+            }
+            "response.reasoning_text.done" => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("reasoning");
+                let content_index = event
+                    .get("content_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    reconcile_reasoning_content(state, index, id, content_index, text, &mut events);
                 }
             }
             "response.function_call_arguments.delta" => {
@@ -263,59 +387,12 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as usize;
                 let item = event.get("item").unwrap_or(&Value::Null);
-                match item.get("type").and_then(Value::as_str).unwrap_or("") {
-                    "function_call" => {
-                        let tool =
-                            state
-                                .tools
-                                .remove(&index)
-                                .unwrap_or_else(|| ResponseToolState {
-                                    item_id: item
-                                        .get("id")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("")
-                                        .into(),
-                                    call_id: item
-                                        .get("call_id")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("")
-                                        .into(),
-                                    name: item
-                                        .get("name")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("")
-                                        .into(),
-                                    arguments: String::new(),
-                                });
-                        let arguments = item
-                            .get("arguments")
-                            .cloned()
-                            .unwrap_or_else(|| Value::String(tool.arguments.clone()));
-                        events.push(ModelStreamEvent::ToolInputEnd {
-                            index,
-                            id: tool.call_id,
-                            name: tool.name,
-                            arguments: parse_json_arguments(&arguments),
-                            provider_metadata: openai_item_metadata(&tool.item_id, None),
-                        });
-                    }
-                    "reasoning" => {
-                        let id = item
-                            .get("id")
-                            .and_then(Value::as_str)
-                            .unwrap_or("reasoning");
-                        state.reasoning_open.remove(&index);
-                        let encrypted = item.get("encrypted_content").and_then(Value::as_str);
-                        events.push(ModelStreamEvent::ReasoningEnd {
-                            id: id.to_string(),
-                            provider_metadata: openai_item_metadata(id, encrypted),
-                        });
-                    }
-                    _ => {}
-                }
+                reconcile_output_item(state, index, item, &mut events);
+                state.finished_output_items.insert(index);
             }
             "response.completed" => {
                 let response = event.get("response").unwrap_or(&Value::Null);
+                reconcile_response_output(state, response, &mut events);
                 let usage = response
                     .get("usage")
                     .filter(|value| !value.is_null())
@@ -344,6 +421,7 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
             }
             "response.incomplete" => {
                 let response = event.get("response").unwrap_or(&Value::Null);
+                reconcile_response_output(state, response, &mut events);
                 let reason = incomplete_reason(response);
                 events.extend(close_open(state));
                 events.push(ModelStreamEvent::Finish {
@@ -417,7 +495,19 @@ fn lower_message(message: &crate::types::AgentMessage, input: &mut Vec<Value>) -
                 let encrypted = openai
                     .and_then(|value| value.get("encrypted_content"))
                     .and_then(Value::as_str);
-                if id.is_some() || encrypted.is_some() {
+                let exact_summary = openai
+                    .and_then(|value| value.get("summary"))
+                    .filter(|value| value.is_array())
+                    .cloned();
+                let exact_content = openai
+                    .and_then(|value| value.get("content"))
+                    .filter(|value| value.is_array())
+                    .cloned();
+                if id.is_some()
+                    || encrypted.is_some()
+                    || exact_summary.is_some()
+                    || exact_content.is_some()
+                {
                     flush_message_content(&message.role, &mut pending_content, input);
                     let mut item = Map::new();
                     item.insert("type".into(), json!("reasoning"));
@@ -427,11 +517,18 @@ fn lower_message(message: &crate::types::AgentMessage, input: &mut Vec<Value>) -
                     if let Some(encrypted) = encrypted {
                         item.insert("encrypted_content".into(), json!(encrypted));
                     }
-                    if !text.is_empty() {
-                        item.insert(
-                            "summary".into(),
-                            json!([{"type": "summary_text", "text": text}]),
-                        );
+                    item.insert(
+                        "summary".into(),
+                        exact_summary.unwrap_or_else(|| {
+                            if text.is_empty() {
+                                Value::Array(Vec::new())
+                            } else {
+                                json!([{"type": "summary_text", "text": text}])
+                            }
+                        }),
+                    );
+                    if let Some(content) = exact_content {
+                        item.insert("content".into(), content);
                     }
                     input.push(Value::Object(item));
                 }
@@ -487,6 +584,335 @@ fn flush_message_content(role: &str, content: &mut Vec<Value>, input: &mut Vec<V
     }));
 }
 
+fn open_text(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    let text = state.texts.entry(index).or_default();
+    if text.id.is_empty() {
+        text.id = id.to_string();
+    }
+    if !text.open {
+        text.open = true;
+        events.push(ModelStreamEvent::TextStart {
+            id: text.id.clone(),
+        });
+    }
+}
+
+fn append_text_delta(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    delta: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    if delta.is_empty() {
+        return;
+    }
+    open_text(state, index, id, events);
+    let text = state.texts.get_mut(&index).expect("text state is open");
+    text.text.push_str(delta);
+    events.push(ModelStreamEvent::TextDelta {
+        id: text.id.clone(),
+        text: delta.to_string(),
+    });
+}
+
+fn reconcile_text(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    complete: Option<&str>,
+    close: bool,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    if let Some(complete) = complete {
+        let suffix = state
+            .texts
+            .get(&index)
+            .and_then(|text| complete.strip_prefix(&text.text))
+            .unwrap_or_else(|| {
+                if state
+                    .texts
+                    .get(&index)
+                    .is_none_or(|text| text.text.is_empty())
+                {
+                    complete
+                } else {
+                    ""
+                }
+            });
+        append_text_delta(state, index, id, suffix, events);
+        if let Some(text) = state.texts.get_mut(&index) {
+            text.text = complete.to_string();
+        }
+    }
+    if close {
+        if let Some(text) = state.texts.get_mut(&index) {
+            if text.open {
+                text.open = false;
+                events.push(ModelStreamEvent::TextEnd {
+                    id: text.id.clone(),
+                });
+            }
+        }
+    }
+}
+
+fn open_reasoning(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    if let Entry::Vacant(entry) = state.reasoning_open.entry(index) {
+        entry.insert(ResponseReasoningState {
+            id: id.to_string(),
+            ..Default::default()
+        });
+        events.push(ModelStreamEvent::ReasoningStart { id: id.to_string() });
+    }
+}
+
+fn append_reasoning_summary_delta(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    summary_index: usize,
+    delta: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    if delta.is_empty() {
+        return;
+    }
+    open_reasoning(state, index, id, events);
+    let reasoning = state
+        .reasoning_open
+        .get_mut(&index)
+        .expect("reasoning state is open");
+    let first_delta_for_part = reasoning.emitted_summary_parts.insert(summary_index);
+    if first_delta_for_part
+        && summary_index > 0
+        && reasoning
+            .summary_parts
+            .iter()
+            .any(|(part_index, text)| *part_index < summary_index && !text.is_empty())
+    {
+        events.push(ModelStreamEvent::ReasoningDelta {
+            id: reasoning.id.clone(),
+            text: "\n\n".to_string(),
+        });
+    }
+    reasoning
+        .summary_parts
+        .entry(summary_index)
+        .or_default()
+        .push_str(delta);
+    events.push(ModelStreamEvent::ReasoningDelta {
+        id: reasoning.id.clone(),
+        text: delta.to_string(),
+    });
+}
+
+fn reconcile_reasoning_summary(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    summary_index: usize,
+    complete: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    open_reasoning(state, index, id, events);
+    let suffix = state
+        .reasoning_open
+        .get(&index)
+        .and_then(|reasoning| reasoning.summary_parts.get(&summary_index))
+        .and_then(|current| complete.strip_prefix(current))
+        .unwrap_or_else(|| {
+            if state
+                .reasoning_open
+                .get(&index)
+                .and_then(|reasoning| reasoning.summary_parts.get(&summary_index))
+                .is_none_or(String::is_empty)
+            {
+                complete
+            } else {
+                ""
+            }
+        });
+    append_reasoning_summary_delta(state, index, id, summary_index, suffix, events);
+    if let Some(reasoning) = state.reasoning_open.get_mut(&index) {
+        reasoning
+            .summary_parts
+            .insert(summary_index, complete.to_string());
+    }
+}
+
+fn append_reasoning_content(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    content_index: usize,
+    delta: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    open_reasoning(state, index, id, events);
+    state
+        .reasoning_open
+        .get_mut(&index)
+        .expect("reasoning state is open")
+        .content_parts
+        .entry(content_index)
+        .or_default()
+        .push_str(delta);
+}
+
+fn reconcile_reasoning_content(
+    state: &mut ResponsesState,
+    index: usize,
+    id: &str,
+    content_index: usize,
+    complete: &str,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    open_reasoning(state, index, id, events);
+    if let Some(reasoning) = state.reasoning_open.get_mut(&index) {
+        reasoning
+            .content_parts
+            .insert(content_index, complete.to_string());
+    }
+}
+
+fn reconcile_response_output(
+    state: &mut ResponsesState,
+    response: &Value,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    let Some(output) = response.get("output").and_then(Value::as_array) else {
+        return;
+    };
+    for (index, item) in output.iter().enumerate() {
+        if !state.finished_output_items.contains(&index) {
+            reconcile_output_item(state, index, item, events);
+            state.finished_output_items.insert(index);
+        }
+    }
+}
+
+fn reconcile_output_item(
+    state: &mut ResponsesState,
+    index: usize,
+    item: &Value,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    match item.get("type").and_then(Value::as_str).unwrap_or("") {
+        "message" => {
+            let id = item.get("id").and_then(Value::as_str).unwrap_or("text");
+            let complete = item
+                .get("content")
+                .and_then(Value::as_array)
+                .map(|content| {
+                    content
+                        .iter()
+                        .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+                            Some("output_text") => part.get("text").and_then(Value::as_str),
+                            Some("refusal") => part.get("refusal").and_then(Value::as_str),
+                            _ => None,
+                        })
+                        .collect::<String>()
+                });
+            reconcile_text(state, index, id, complete.as_deref(), true, events);
+        }
+        "refusal" => {
+            let id = item.get("id").and_then(Value::as_str).unwrap_or("refusal");
+            reconcile_text(
+                state,
+                index,
+                id,
+                item.get("refusal").and_then(Value::as_str),
+                true,
+                events,
+            );
+        }
+        "function_call" => {
+            let tool = state
+                .tools
+                .remove(&index)
+                .unwrap_or_else(|| ResponseToolState {
+                    item_id: item.get("id").and_then(Value::as_str).unwrap_or("").into(),
+                    call_id: item
+                        .get("call_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .into(),
+                    name: item
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .into(),
+                    arguments: String::new(),
+                });
+            let arguments = item
+                .get("arguments")
+                .cloned()
+                .unwrap_or_else(|| Value::String(tool.arguments.clone()));
+            events.push(ModelStreamEvent::ToolInputEnd {
+                index,
+                id: tool.call_id,
+                name: tool.name,
+                arguments: parse_json_arguments(&arguments),
+                provider_metadata: openai_item_metadata(&tool.item_id, None),
+            });
+        }
+        "reasoning" => reconcile_reasoning_item(state, index, item, events),
+        _ => {}
+    }
+}
+
+fn reconcile_reasoning_item(
+    state: &mut ResponsesState,
+    index: usize,
+    item: &Value,
+    events: &mut Vec<ModelStreamEvent>,
+) {
+    let id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("reasoning");
+    open_reasoning(state, index, id, events);
+    if let Some(summary) = item.get("summary").and_then(Value::as_array) {
+        for (summary_index, part) in summary.iter().enumerate() {
+            if let Some(text) = part.get("text").and_then(Value::as_str) {
+                reconcile_reasoning_summary(state, index, id, summary_index, text, events);
+            }
+        }
+    }
+    if let Some(content) = item.get("content").and_then(Value::as_array) {
+        for (content_index, part) in content.iter().enumerate() {
+            if let Some(text) = part.get("text").and_then(Value::as_str) {
+                reconcile_reasoning_content(state, index, id, content_index, text, events);
+            }
+        }
+    }
+    let reasoning = state
+        .reasoning_open
+        .remove(&index)
+        .unwrap_or_else(|| ResponseReasoningState {
+            id: id.to_string(),
+            ..Default::default()
+        });
+    events.push(ModelStreamEvent::ReasoningEnd {
+        id: reasoning.id.clone(),
+        provider_metadata: openai_reasoning_metadata(
+            &reasoning,
+            item.get("encrypted_content").and_then(Value::as_str),
+        ),
+    });
+}
+
 fn arguments_string(value: &Value) -> String {
     match value {
         Value::String(value) => value.clone(),
@@ -502,6 +928,43 @@ fn openai_item_metadata(id: &str, encrypted_content: Option<&str>) -> ProviderMe
     }
     if let Some(encrypted_content) = encrypted_content {
         value.insert("encrypted_content".into(), json!(encrypted_content));
+    }
+    namespaced_metadata("openai", Value::Object(value))
+}
+
+fn openai_reasoning_metadata(
+    reasoning: &ResponseReasoningState,
+    encrypted_content: Option<&str>,
+) -> ProviderMetadata {
+    let mut value = Map::new();
+    if !reasoning.id.is_empty() {
+        value.insert("id".into(), json!(reasoning.id));
+        value.insert("item_id".into(), json!(reasoning.id));
+    }
+    if let Some(encrypted_content) = encrypted_content {
+        value.insert("encrypted_content".into(), json!(encrypted_content));
+    }
+    value.insert(
+        "summary".into(),
+        Value::Array(
+            reasoning
+                .summary_parts
+                .values()
+                .map(|text| json!({"type": "summary_text", "text": text}))
+                .collect(),
+        ),
+    );
+    if !reasoning.content_parts.is_empty() {
+        value.insert(
+            "content".into(),
+            Value::Array(
+                reasoning
+                    .content_parts
+                    .values()
+                    .map(|text| json!({"type": "reasoning_text", "text": text}))
+                    .collect(),
+            ),
+        );
     }
     namespaced_metadata("openai", Value::Object(value))
 }
@@ -590,13 +1053,15 @@ fn response_error_message(response: &Value) -> String {
 
 fn close_open(state: &mut ResponsesState) -> Vec<ModelStreamEvent> {
     let mut events = Vec::new();
-    for (_, id) in std::mem::take(&mut state.text_open) {
-        events.push(ModelStreamEvent::TextEnd { id });
+    for (_, text) in std::mem::take(&mut state.texts) {
+        if text.open {
+            events.push(ModelStreamEvent::TextEnd { id: text.id });
+        }
     }
-    for (_, id) in std::mem::take(&mut state.reasoning_open) {
+    for (_, reasoning) in std::mem::take(&mut state.reasoning_open) {
         events.push(ModelStreamEvent::ReasoningEnd {
-            id,
-            provider_metadata: ProviderMetadata::new(),
+            id: reasoning.id.clone(),
+            provider_metadata: openai_reasoning_metadata(&reasoning, None),
         });
     }
     for (index, tool) in std::mem::take(&mut state.tools) {
@@ -639,6 +1104,62 @@ mod tests {
         lower_message(&message, &mut input).unwrap();
         assert_eq!(input[0]["type"], "reasoning");
         assert_eq!(input[0]["encrypted_content"], "cipher");
+        assert_eq!(
+            input[0]["summary"],
+            json!([{"type": "summary_text", "text": "summary"}])
+        );
+    }
+
+    #[test]
+    fn stateless_reasoning_without_summary_replays_an_empty_summary() {
+        let mut metadata = ProviderMetadata::new();
+        metadata.insert(
+            "openai".into(),
+            json!({"id": "rs_1", "encrypted_content": "cipher"}),
+        );
+        let message = crate::types::AgentMessage {
+            role: "assistant".into(),
+            content: vec![ContentBlock::reasoning("", metadata)],
+            ..Default::default()
+        };
+        let mut input = Vec::new();
+        lower_message(&message, &mut input).unwrap();
+        assert_eq!(input[0]["summary"], json!([]));
+    }
+
+    #[test]
+    fn stateless_reasoning_replays_exact_summary_and_content_parts() {
+        let mut metadata = ProviderMetadata::new();
+        metadata.insert(
+            "openai".into(),
+            json!({
+                "id": "rs_1",
+                "encrypted_content": "cipher",
+                "summary": [
+                    {"type": "summary_text", "text": "step one"},
+                    {"type": "summary_text", "text": "step two"}
+                ],
+                "content": [{"type": "reasoning_text", "text": "raw"}]
+            }),
+        );
+        let message = crate::types::AgentMessage {
+            role: "assistant".into(),
+            content: vec![ContentBlock::reasoning("flattened", metadata)],
+            ..Default::default()
+        };
+        let mut input = Vec::new();
+        lower_message(&message, &mut input).unwrap();
+        assert_eq!(
+            input[0]["summary"],
+            json!([
+                {"type": "summary_text", "text": "step one"},
+                {"type": "summary_text", "text": "step two"}
+            ])
+        );
+        assert_eq!(
+            input[0]["content"],
+            json!([{"type": "reasoning_text", "text": "raw"}])
+        );
     }
 
     #[test]
@@ -974,9 +1495,13 @@ mod tests {
 
     #[test]
     fn build_body_serializes_tools_temperature_and_reasoning() {
-        let mut target = target(ProtocolConfig::OpenAiResponses(
-            OpenAiResponsesConfig::default(),
-        ));
+        let responses_config = OpenAiResponsesConfig {
+            reasoning_context: Some("all_turns".into()),
+            reasoning_mode: Some("pro".into()),
+            prompt_cache_options: Some(json!({"mode": "explicit", "ttl": "30m"})),
+            ..Default::default()
+        };
+        let mut target = target(ProtocolConfig::OpenAiResponses(responses_config));
         target.capabilities.reasoning.supported = true;
         target.generation.temperature = Some(0.5);
         target.generation.max_output_tokens = Some(123);
@@ -1003,7 +1528,16 @@ mod tests {
         assert_eq!(body["max_output_tokens"], 123);
         assert_eq!(
             body["reasoning"],
-            json!({"effort": "high", "summary": "auto"})
+            json!({
+                "effort": "high",
+                "summary": "auto",
+                "context": "all_turns",
+                "mode": "pro"
+            })
+        );
+        assert_eq!(
+            body["prompt_cache_options"],
+            json!({"mode": "explicit", "ttl": "30m"})
         );
         assert_eq!(body["input"][0]["role"], "developer");
     }
@@ -1169,33 +1703,145 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_text_delta_emits_reasoning_events() {
+    fn reasoning_summary_delta_emits_visible_reasoning() {
         let adapter = OpenAiResponsesAdapter;
-        for ty in [
-            "response.reasoning_summary_text.delta",
-            "response.reasoning_text.delta",
-        ] {
-            let mut state = adapter.new_stream_state();
-            let events = adapter
-                .decode_frame(
-                    &frame(
-                        ty,
-                        json!({
-                            "type": ty,
-                            "output_index": 0,
-                            "item_id": "rs_0",
-                            "delta": "think"
-                        }),
-                    ),
-                    state.as_mut(),
-                )
-                .unwrap();
-            assert!(matches!(
-                events.as_slice(),
-                [ModelStreamEvent::ReasoningStart { id }, ModelStreamEvent::ReasoningDelta { text, .. }]
-                    if id == "rs_0" && text == "think"
-            ));
+        let mut state = adapter.new_stream_state();
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.reasoning_summary_text.delta",
+                    json!({
+                        "type": "response.reasoning_summary_text.delta",
+                        "output_index": 0,
+                        "item_id": "rs_0",
+                        "summary_index": 0,
+                        "delta": "think"
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [ModelStreamEvent::ReasoningStart { id }, ModelStreamEvent::ReasoningDelta { text, .. }]
+                if id == "rs_0" && text == "think"
+        ));
+    }
+
+    #[test]
+    fn raw_reasoning_is_preserved_but_not_rendered_as_summary() {
+        let adapter = OpenAiResponsesAdapter;
+        let mut state = adapter.new_stream_state();
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.reasoning_text.delta",
+                    json!({
+                        "type": "response.reasoning_text.delta",
+                        "output_index": 0,
+                        "item_id": "rs_0",
+                        "content_index": 0,
+                        "delta": "raw"
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [ModelStreamEvent::ReasoningStart { id }] if id == "rs_0"
+        ));
+        let events = adapter.finish_stream(state.as_mut()).unwrap();
+        assert!(matches!(
+            events.first(),
+            Some(ModelStreamEvent::ReasoningEnd { provider_metadata, .. })
+                if provider_metadata["openai"]["content"]
+                    == json!([{"type": "reasoning_text", "text": "raw"}])
+        ));
+    }
+
+    #[test]
+    fn reasoning_summary_part_done_preserves_a_summary_without_deltas() {
+        let adapter = OpenAiResponsesAdapter;
+        let mut state = adapter.new_stream_state();
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.reasoning_summary_part.done",
+                    json!({
+                        "type": "response.reasoning_summary_part.done",
+                        "output_index": 0,
+                        "item_id": "rs_0",
+                        "part": {"type": "summary_text", "text": "finished summary"}
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [ModelStreamEvent::ReasoningStart { id }, ModelStreamEvent::ReasoningDelta { text, .. }]
+                if id == "rs_0" && text == "finished summary"
+        ));
+    }
+
+    #[test]
+    fn reasoning_summary_done_preserves_multiple_indexed_parts() {
+        let adapter = OpenAiResponsesAdapter;
+        let mut state = adapter.new_stream_state();
+        let mut events = Vec::new();
+        for (summary_index, text) in [(0, "step one"), (1, "step two")] {
+            events.extend(
+                adapter
+                    .decode_frame(
+                        &frame(
+                            "response.reasoning_summary_text.done",
+                            json!({
+                                "type": "response.reasoning_summary_text.done",
+                                "output_index": 0,
+                                "item_id": "rs_0",
+                                "summary_index": summary_index,
+                                "text": text
+                            }),
+                        ),
+                        state.as_mut(),
+                    )
+                    .unwrap(),
+            );
         }
+        assert!(events.iter().any(|event| {
+            matches!(event, ModelStreamEvent::ReasoningDelta { text, .. } if text == "step two")
+        }));
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.output_item.done",
+                    json!({
+                        "type": "response.output_item.done",
+                        "output_index": 0,
+                        "item": {
+                            "type": "reasoning",
+                            "id": "rs_0",
+                            "summary": [
+                                {"type": "summary_text", "text": "step one"},
+                                {"type": "summary_text", "text": "step two"}
+                            ],
+                            "encrypted_content": "cipher"
+                        }
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [ModelStreamEvent::ReasoningEnd { provider_metadata, .. }]
+                if provider_metadata["openai"]["summary"]
+                    == json!([
+                        {"type": "summary_text", "text": "step one"},
+                        {"type": "summary_text", "text": "step two"}
+                    ])
+        ));
     }
 
     #[test]
@@ -1256,9 +1902,74 @@ mod tests {
             .unwrap();
         assert!(matches!(
             events.as_slice(),
-            [ModelStreamEvent::ReasoningEnd { id, provider_metadata }]
+            [ModelStreamEvent::ReasoningStart { id: start_id }, ModelStreamEvent::ReasoningEnd { id, provider_metadata }]
                 if id == "rs_1"
+                    && start_id == "rs_1"
                     && provider_metadata["openai"]["encrypted_content"] == "cipher"
+        ));
+    }
+
+    #[test]
+    fn output_item_done_recovers_message_without_deltas() {
+        let adapter = OpenAiResponsesAdapter;
+        let mut state = adapter.new_stream_state();
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.output_item.done",
+                    json!({
+                        "type": "response.output_item.done",
+                        "output_index": 0,
+                        "item": {
+                            "type": "message",
+                            "id": "msg_1",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "complete"}]
+                        }
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [ModelStreamEvent::TextStart { id }, ModelStreamEvent::TextDelta { text, .. }, ModelStreamEvent::TextEnd { .. }]
+                if id == "msg_1" && text == "complete"
+        ));
+    }
+
+    #[test]
+    fn response_completed_recovers_output_without_item_done() {
+        let adapter = OpenAiResponsesAdapter;
+        let mut state = adapter.new_stream_state();
+        let events = adapter
+            .decode_frame(
+                &frame(
+                    "response.completed",
+                    json!({
+                        "type": "response.completed",
+                        "response": {
+                            "status": "completed",
+                            "output": [{
+                                "type": "message",
+                                "id": "msg_1",
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": "complete"}]
+                            }]
+                        }
+                    }),
+                ),
+                state.as_mut(),
+            )
+            .unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ModelStreamEvent::TextStart { id },
+                ModelStreamEvent::TextDelta { text, .. },
+                ModelStreamEvent::TextEnd { .. },
+                ModelStreamEvent::Finish { reason: FinishReason::Stop, .. }
+            ] if id == "msg_1" && text == "complete"
         ));
     }
 
@@ -1273,7 +1984,7 @@ mod tests {
                     json!({
                         "type": "response.output_item.done",
                         "output_index": 0,
-                        "item": {"type": "message"}
+                        "item": {"type": "future_unknown"}
                     }),
                 ),
                 state.as_mut(),

--- a/agent/src/llm/schema.rs
+++ b/agent/src/llm/schema.rs
@@ -100,6 +100,10 @@ pub struct OpenAiChatConfig {
 pub struct OpenAiResponsesConfig {
     pub store: bool,
     pub include_encrypted_reasoning: bool,
+    pub supports_reasoning_summary: bool,
+    pub reasoning_context: Option<String>,
+    pub reasoning_mode: Option<String>,
+    pub prompt_cache_options: Option<Value>,
 }
 
 impl Default for OpenAiResponsesConfig {
@@ -107,6 +111,10 @@ impl Default for OpenAiResponsesConfig {
         Self {
             store: false,
             include_encrypted_reasoning: true,
+            supports_reasoning_summary: true,
+            reasoning_context: None,
+            reasoning_mode: None,
+            prompt_cache_options: None,
         }
     }
 }
@@ -297,7 +305,7 @@ impl ResolvedModelTarget {
                 ProtocolConfig::OpenAiChat(parse_chat_config(model)?)
             }
             ApiProtocol::OpenAiResponses => {
-                ProtocolConfig::OpenAiResponses(OpenAiResponsesConfig::default())
+                ProtocolConfig::OpenAiResponses(parse_responses_config(model)?)
             }
             ApiProtocol::AnthropicMessages => {
                 ProtocolConfig::AnthropicMessages(parse_anthropic_config(model)?)
@@ -371,6 +379,69 @@ impl ResolvedModelTarget {
             },
         }
     }
+}
+
+fn parse_responses_config(model: &crate::models::Model) -> Result<OpenAiResponsesConfig> {
+    let optional_string = |key: &str| -> Result<Option<String>> {
+        match model.compat.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(value)) => Ok(Some(value.clone())),
+            Some(_) => bail!(
+                "provider `{}` model `{}` compat.{key} must be a string",
+                model.provider,
+                model.id
+            ),
+        }
+    };
+    let optional_boolean = |key: &str| -> Result<Option<bool>> {
+        match model.compat.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Bool(value)) => Ok(Some(*value)),
+            Some(_) => bail!(
+                "provider `{}` model `{}` compat.{key} must be a boolean",
+                model.provider,
+                model.id
+            ),
+        }
+    };
+
+    let reasoning_context = optional_string("responsesReasoningContext")?;
+    if let Some(value) = reasoning_context.as_deref() {
+        if !matches!(value, "auto" | "current_turn" | "all_turns") {
+            bail!(
+                "provider `{}` model `{}` has unsupported compat.responsesReasoningContext `{value}`",
+                model.provider,
+                model.id
+            );
+        }
+    }
+    let reasoning_mode = optional_string("responsesReasoningMode")?;
+    if let Some(value) = reasoning_mode.as_deref() {
+        if !matches!(value, "standard" | "pro") {
+            bail!(
+                "provider `{}` model `{}` has unsupported compat.responsesReasoningMode `{value}`",
+                model.provider,
+                model.id
+            );
+        }
+    }
+    let prompt_cache_options = match model.compat.get("responsesPromptCacheOptions") {
+        None | Some(Value::Null) => None,
+        Some(Value::Object(value)) => Some(Value::Object(value.clone())),
+        Some(_) => bail!(
+            "provider `{}` model `{}` compat.responsesPromptCacheOptions must be an object",
+            model.provider,
+            model.id
+        ),
+    };
+
+    Ok(OpenAiResponsesConfig {
+        supports_reasoning_summary: optional_boolean("supportsReasoningSummary")?.unwrap_or(true),
+        reasoning_context,
+        reasoning_mode,
+        prompt_cache_options,
+        ..Default::default()
+    })
 }
 
 fn parse_anthropic_config(model: &crate::models::Model) -> Result<AnthropicMessagesConfig> {
@@ -505,6 +576,7 @@ pub fn string_level_map(values: &HashMap<String, Value>) -> HashMap<String, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn expect_chat(protocol: ProtocolConfig) -> OpenAiChatConfig {
         match protocol {
@@ -517,6 +589,13 @@ mod tests {
         match protocol {
             ProtocolConfig::AnthropicMessages(config) => config,
             other => panic!("Anthropic protocol expected, got {other:?}"),
+        }
+    }
+
+    fn expect_responses(protocol: ProtocolConfig) -> OpenAiResponsesConfig {
+        match protocol {
+            ProtocolConfig::OpenAiResponses(config) => config,
+            other => panic!("Responses protocol expected, got {other:?}"),
         }
     }
 
@@ -580,6 +659,39 @@ mod tests {
             target.protocol,
             ProtocolConfig::OpenAiResponses(_)
         ));
+    }
+
+    #[test]
+    fn responses_config_reads_latest_optional_capabilities() {
+        let mut model = crate::models::Model {
+            id: "gpt-5.6-sol".into(),
+            provider: "openai".into(),
+            api: "openai-responses".into(),
+            ..Default::default()
+        };
+        model
+            .compat
+            .insert("responsesReasoningContext".into(), json!("all_turns"));
+        model
+            .compat
+            .insert("responsesReasoningMode".into(), json!("pro"));
+        model.compat.insert(
+            "responsesPromptCacheOptions".into(),
+            json!({"mode": "explicit", "ttl": "30m"}),
+        );
+        model
+            .compat
+            .insert("supportsReasoningSummary".into(), json!(false));
+
+        let target = ResolvedModelTarget::from_model(&model, "key".into(), None, None).unwrap();
+        let config = expect_responses(target.protocol);
+        assert_eq!(config.reasoning_context.as_deref(), Some("all_turns"));
+        assert_eq!(config.reasoning_mode.as_deref(), Some("pro"));
+        assert_eq!(
+            config.prompt_cache_options,
+            Some(json!({"mode": "explicit", "ttl": "30m"}))
+        );
+        assert!(!config.supports_reasoning_summary);
     }
 
     #[test]

--- a/desktop/DEV_MD/COLOR.md
+++ b/desktop/DEV_MD/COLOR.md
@@ -11,68 +11,78 @@ GUI 的颜色全部走 [`tailwind.config.js`](tailwind.config.js) 里定义的**
 ## Token 清单
 
 ### 中性 / 表面
-| token | hex | 用途 |
-|---|---|---|
-| `canvas` | `#f6f7f9` | 最底层画布背景 |
-| `surface` | `#ffffff` | 卡片 / 面板 / 弹层表面 |
+
+| token            | hex       | 用途                                 |
+| ---------------- | --------- | ------------------------------------ |
+| `canvas`         | `#f6f7f9` | 最底层画布背景                       |
+| `surface`        | `#ffffff` | 卡片 / 面板 / 弹层表面               |
+| `surface-panel`  | `#f8faff` | 右侧上下文面板底色（近白、微主题蓝） |
 | `surface-subtle` | `#f1f4f8` | 次级表面(代码块、hover 底、分段背景) |
-| `line` | `#d9dee7` | 标准边框 |
-| `line-soft` | `#e8edf4` | 弱边框 / 分隔线 |
-| `ink` | `#172033` | 主文字 |
-| `ink-soft` | `#5d687a` | 次要文字 |
-| `ink-muted` | `#8a94a6` | 弱化文字 / 占位 / 图标 |
-| `ink-strong` | `#0f172a` | 强调标题 |
+| `line`           | `#d9dee7` | 标准边框                             |
+| `line-soft`      | `#e8edf4` | 弱边框 / 分隔线                      |
+| `ink`            | `#172033` | 主文字                               |
+| `ink-soft`       | `#5d687a` | 次要文字                             |
+| `ink-muted`      | `#8a94a6` | 弱化文字 / 占位 / 图标               |
+| `ink-strong`     | `#0f172a` | 强调标题                             |
 
 ### 强调 / 交互
-| token | hex | 用途 |
-|---|---|---|
-| `accent` | `#2563eb` | 主强调(主按钮、激活态、链接) |
-| `accent-soft` | `#e8f0ff` | 强调浅底 |
-| `accent-hover` | `#1d4ed8` | 强调 hover |
-| `accent-disabled` | `#bfdbfe` | 强调禁用 |
-| `focus` | `#93c5fd` | focus ring |
+
+| token             | hex       | 用途                         |
+| ----------------- | --------- | ---------------------------- |
+| `accent`          | `#2563eb` | 主强调(主按钮、激活态、链接) |
+| `accent-soft`     | `#e8f0ff` | 强调浅底                     |
+| `accent-hover`    | `#1d4ed8` | 强调 hover                   |
+| `accent-disabled` | `#bfdbfe` | 强调禁用                     |
+| `focus`           | `#93c5fd` | focus ring                   |
 
 ### 状态(三件套:文字 / 浅底 / 边框)
+
 每个状态有 `X`(文字)、`X-soft`(浅底)、`X-line`(边框)三个变体,组合用于徽章和提示框。
-| 状态 | `X` text | `X-soft` bg | `X-line` border | 语义 |
-|---|---|---|---|---|
-| `success` | `#15803d` | `#f0fdf4` | `#bbf7d0` | 成功 / 已完成 / applied / 已连接 |
-| `danger` | `#dc2626` | `#fef2f2` | `#fecaca` | 失败 / 危险 / 已断开 / discarded |
-| `warning` | `#b45309` | `#fffbeb` | `#fde68a` | 警告 / 待处理 / pending / 等待审批 |
-| `info` | `#1d4ed8` | `#eff6ff` | `#bfdbfe` | 信息 / 检查中 |
+
+| 状态      | `X` text  | `X-soft` bg | `X-line` border | 语义                               |
+| --------- | --------- | ----------- | --------------- | ---------------------------------- |
+| `success` | `#15803d` | `#f0fdf4`   | `#bbf7d0`       | 成功 / 已完成 / applied / 已连接   |
+| `danger`  | `#dc2626` | `#fef2f2`   | `#fecaca`       | 失败 / 危险 / 已断开 / discarded   |
+| `warning` | `#b45309` | `#fffbeb`   | `#fde68a`       | 警告 / 待处理 / pending / 等待审批 |
+| `info`    | `#1d4ed8` | `#eff6ff`   | `#bfdbfe`       | 信息 / 检查中                      |
 
 > 状态徽章直接用 `<Badge tone="success|danger|warning|info|accent|neutral">`,组件已把三件套烘进去。
 
 ### 活动 / 生成中
-| token | hex | 用途 |
-|---|---|---|
+
+| token        | hex       | 用途                                                                           |
+| ------------ | --------- | ------------------------------------------------------------------------------ |
 | `generating` | `#f59e0b` | 流式生成中指示灯（琥珀色 `animate-ping` 圆点；实心点与半透明光晕同用此 token） |
 
 ### 滚动条（经典 webkit 拇指）
-| token | hex | 用途 |
-|---|---|---|
-| `scrollbar` | `#c8ced9` | 滚动条拇指常态（`styles/globals.css` 经 `theme(colors.scrollbar)` 引用） |
-| `scrollbar-hover` | `#aeb7c6` | 滚动条拇指 hover |
+
+| token             | hex       | 用途                                                                     |
+| ----------------- | --------- | ------------------------------------------------------------------------ |
+| `scrollbar`       | `#c8ced9` | 滚动条拇指常态（`styles/globals.css` 经 `theme(colors.scrollbar)` 引用） |
+| `scrollbar-hover` | `#aeb7c6` | 滚动条拇指 hover                                                         |
 
 ### Diff(GitHub 风格)
-| token | hex | 用途 |
-|---|---|---|
-| `diff-add` | `#e6ffec` | 新增行底色 |
-| `diff-add-line` | `#aadfb8` | 新增行左边框 |
-| `diff-remove` | `#ffebe9` | 删除行底色 |
+
+| token              | hex       | 用途         |
+| ------------------ | --------- | ------------ |
+| `diff-add`         | `#e6ffec` | 新增行底色   |
+| `diff-add-line`    | `#aadfb8` | 新增行左边框 |
+| `diff-remove`      | `#ffebe9` | 删除行底色   |
 | `diff-remove-line` | `#ffc9c9` | 删除行左边框 |
 
 ### 阴影
-| token | 用途 |
-|---|---|
-| `shadow-panel` | 面板 / 卡片浮起 |
-| `shadow-dialog` | 对话框 / 弹层 |
-| `shadow-sidebar-divider` | 左侧栏分割线内侧柔和阴影 |
-| `shadow-sidebar-floating` | 左侧栏浮动预览阴影 |
+
+| token                     | 用途                     |
+| ------------------------- | ------------------------ |
+| `shadow-panel`            | 面板 / 卡片浮起          |
+| `shadow-dialog`           | 对话框 / 弹层            |
+| `shadow-sidebar-divider`  | 左侧栏分割线内侧柔和阴影 |
+| `shadow-sidebar-floating` | 左侧栏浮动预览阴影       |
 
 ### 遮罩层 / Overlay
-| token | 值 | 用途 |
-|---|---|---|
+
+| token     | 值                   | 用途                                                            |
+| --------- | -------------------- | --------------------------------------------------------------- |
 | `overlay` | `rgba(0, 0, 0, 0.6)` | 全屏模态背景遮罩(纯黑 60%,alpha 已烘进 token,直接 `bg-overlay`) |
 
 > 遮罩色与导航蓝黑 `ink-strong`(`#0f172a`)语义不同,单列一个 token。所有模态(对话框、设置、文件预览等)都经共享 `components/ui/Overlay` 复用这一层(`bg-overlay` + `backdrop-blur-[1px]`)——**不要**在别处另写遮罩色;要调整深浅统一改 token,改模糊改 `Overlay`。
@@ -80,7 +90,7 @@ GUI 的颜色全部走 [`tailwind.config.js`](tailwind.config.js) 里定义的**
 ## 选色速查
 
 - 文字 → `ink` / `ink-soft` / `ink-muted` / `ink-strong`
-- 背景 → `canvas`(最底) / `surface`(卡片) / `surface-subtle`(次级)
+- 背景 → `canvas`(最底) / `surface`(卡片与弹层) / `surface-panel`(右侧上下文面板) / `surface-subtle`(次级)
 - 边框 → `line` / `line-soft`
 - 主操作 / 激活 → `accent`(+ `accent-hover` / `accent-disabled`);focus ring → `focus`
 - 状态(成功 / 失败 / 警告 / 信息)→ `<Badge tone>`,或手动 `text-X` + `bg-X-soft` + `border-X-line`

--- a/desktop/src/components/layout/ContextPanel.tsx
+++ b/desktop/src/components/layout/ContextPanel.tsx
@@ -1,5 +1,10 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
-import type { StoredRun, StoredThread, StoredToolCall, StoredWorkspace } from "../../integrations/storage/threadStore";
+import type {
+  StoredRun,
+  StoredThread,
+  StoredToolCall,
+  StoredWorkspace,
+} from "../../integrations/storage/threadStore";
 import type { ContextTab } from "./hooks/useContextData";
 import { PanelRightClose, PanelRightOpen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -86,7 +91,9 @@ export function ContextPanel({
   onToggleExpanded,
 }: ContextPanelProps) {
   const { t } = useTranslation("layout");
-  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
+  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(
+    null,
+  );
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
   // Guards the once-per-open default-tab seed: armed (false) while the panel is
@@ -96,8 +103,11 @@ export function ContextPanel({
   const activeThreadId = activeThread?.id ?? null;
   const activeThreadMode = activeThread?.mode ?? null;
   const activeWorkspaceId = activeThread?.workspaceId ?? null;
-  const workspaceScopeReady = activeThreadId === null || activeWorkspace?.id === activeWorkspaceId;
-  const activeWorkspacePath = workspaceScopeReady ? activeWorkspace?.path ?? null : null;
+  const workspaceScopeReady
+    = activeThreadId === null || activeWorkspace?.id === activeWorkspaceId;
+  const activeWorkspacePath = workspaceScopeReady
+    ? (activeWorkspace?.path ?? null)
+    : null;
 
   const {
     runs,
@@ -121,21 +131,31 @@ export function ContextPanel({
   // Workspace-mode threads (git or not) show Review (§14.6); chat keeps Artifacts.
   // Tab choice is driven by capabilities (cheap), not the whole-tree git diff (C3).
   const isWorkspaceThread = activeThreadMode === "workspace";
-  const workspaceKindPending = activeThreadId !== null && isWorkspaceThread && reviewCapabilities === null;
-  const tabs = workspaceKindPending ? pendingTabs : isWorkspaceThread ? gitTabs : fileTabs;
+  const workspaceKindPending
+    = activeThreadId !== null && isWorkspaceThread && reviewCapabilities === null;
+  const tabs = workspaceKindPending
+    ? pendingTabs
+    : isWorkspaceThread
+      ? gitTabs
+      : fileTabs;
   const changePreview = reviewCapabilities?.changePreview ?? "ready";
-  const hasContextData = runs.length > 0
-    || artifacts.length > 0
-    || (gitReviews.branch?.files.length ?? 0) > 0
-    || (gitReviews.uncommitted?.files.length ?? 0) > 0;
-  const showInitialLoading = loading && (!hasContextData || workspaceKindPending);
+  const hasContextData
+    = runs.length > 0
+      || artifacts.length > 0
+      || (gitReviews.branch?.files.length ?? 0) > 0
+      || (gitReviews.uncommitted?.files.length ?? 0) > 0;
+  const showInitialLoading
+    = loading && (!hasContextData || workspaceKindPending);
   const selectedArtifact = selectedArtifactId
-    ? artifacts.find(artifact => artifact.id === selectedArtifactId) ?? null
+    ? (artifacts.find(artifact => artifact.id === selectedArtifactId) ?? null)
     : null;
   // The Runs panel drills into a single tool call; find it (and its owning run)
   // across the per-run tool map so the inspector reuses the run detail view.
   const selectedTool = selectedToolId
-    ? Object.entries(toolsByRun).reduce<{ run: StoredRun; tool: StoredToolCall } | null>((found, [runId, tools]) => {
+    ? Object.entries(toolsByRun).reduce<{
+      run: StoredRun;
+      tool: StoredToolCall;
+    } | null>((found, [runId, tools]) => {
         if (found)
           return found;
         const tool = tools.find(entry => entry.id === selectedToolId);
@@ -164,32 +184,41 @@ export function ContextPanel({
     await refreshContext();
   }
 
-  const handleSelectRun = useCallback((runId: string) => {
-    setSelectedRunId(runId);
-    setSelectedToolId(null);
-    setSelectedArtifactId(null);
-    if (activeTab !== "runs") {
-      onTabChange("runs");
-    }
-  }, [activeTab, onTabChange]);
+  const handleSelectRun = useCallback(
+    (runId: string) => {
+      setSelectedRunId(runId);
+      setSelectedToolId(null);
+      setSelectedArtifactId(null);
+      if (activeTab !== "runs") {
+        onTabChange("runs");
+      }
+    },
+    [activeTab, onTabChange],
+  );
 
-  const handleSelectTool = useCallback((toolId: string) => {
-    setSelectedToolId(toolId);
-    setSelectedRunId(null);
-    setSelectedArtifactId(null);
-    if (activeTab !== "runs") {
-      onTabChange("runs");
-    }
-  }, [activeTab, onTabChange]);
+  const handleSelectTool = useCallback(
+    (toolId: string) => {
+      setSelectedToolId(toolId);
+      setSelectedRunId(null);
+      setSelectedArtifactId(null);
+      if (activeTab !== "runs") {
+        onTabChange("runs");
+      }
+    },
+    [activeTab, onTabChange],
+  );
 
-  const handleSelectArtifact = useCallback((artifactId: string) => {
-    setSelectedArtifactId(artifactId);
-    setSelectedRunId(null);
-    if (activeTab !== "artifacts") {
-      onTabChange("artifacts");
-    }
-    setSelectedToolId(null);
-  }, [activeTab, onTabChange]);
+  const handleSelectArtifact = useCallback(
+    (artifactId: string) => {
+      setSelectedArtifactId(artifactId);
+      setSelectedRunId(null);
+      if (activeTab !== "artifacts") {
+        onTabChange("artifacts");
+      }
+      setSelectedToolId(null);
+    },
+    [activeTab, onTabChange],
+  );
 
   useEffect(() => {
     setSelectedArtifactId(null);
@@ -206,8 +235,13 @@ export function ContextPanel({
       seededForOpenRef.current = false; // Re-arm for the next open.
       return;
     }
-    if (activeThreadId === null || workspaceKindPending || seededForOpenRef.current)
+    if (
+      activeThreadId === null
+      || workspaceKindPending
+      || seededForOpenRef.current
+    ) {
       return;
+    }
     seededForOpenRef.current = true;
     // If a tool / run inspection just opened the panel it already picked the
     // runs tab — leave that choice alone.
@@ -216,7 +250,15 @@ export function ContextPanel({
     const preferred: ContextTab = "files";
     if (activeTab !== preferred)
       onTabChange(preferred);
-  }, [expanded, activeThreadId, workspaceKindPending, activeTab, onTabChange, selectedToolId, selectedRunId]);
+  }, [
+    expanded,
+    activeThreadId,
+    workspaceKindPending,
+    activeTab,
+    onTabChange,
+    selectedToolId,
+    selectedRunId,
+  ]);
 
   useEffect(() => {
     const unsubscribers = [
@@ -250,7 +292,14 @@ export function ContextPanel({
       }),
     ];
     return () => unsubscribers.forEach(unsubscribe => unsubscribe());
-  }, [expanded, handleSelectArtifact, handleSelectRun, handleSelectTool, onTabChange, onToggleExpanded]);
+  }, [
+    expanded,
+    handleSelectArtifact,
+    handleSelectRun,
+    handleSelectTool,
+    onTabChange,
+    onToggleExpanded,
+  ]);
 
   if (!expanded) {
     return (
@@ -268,7 +317,7 @@ export function ContextPanel({
 
   return (
     <aside
-      className="relative flex shrink-0 flex-col border-l border-line-soft bg-surface"
+      className="relative flex shrink-0 flex-col border-l border-line-soft bg-surface-panel"
       style={{ width }}
     >
       {/* Divider: drag to resize the center/right split. Sits astride the left
@@ -297,7 +346,9 @@ export function ContextPanel({
         onMouseDown={startWindowDrag}
       >
         <div className="inline-block max-w-full">
-          <label className="sr-only" htmlFor="context-panel-view">{t("contextPanel.panelView")}</label>
+          <label className="sr-only" htmlFor="context-panel-view">
+            {t("contextPanel.panelView")}
+          </label>
           <Select
             className="w-fit min-w-24 max-w-full py-0 font-normal hover:border-line"
             id="context-panel-view"
@@ -307,7 +358,9 @@ export function ContextPanel({
             wrapperClassName="max-w-full"
           >
             {tabs.map(tab => (
-              <option key={tab.value} value={tab.value}>{t(tab.labelKey)}</option>
+              <option key={tab.value} value={tab.value}>
+                {t(tab.labelKey)}
+              </option>
             ))}
           </Select>
         </div>
@@ -317,40 +370,59 @@ export function ContextPanel({
           onClick={onToggleExpanded}
         />
       </header>
-      <div className={activeTab === "files"
-        ? "min-h-0 flex-1 overflow-hidden"
-        : activeTab === "runs"
-          ? "min-h-0 flex-1 overflow-hidden"
-          : activeTab === "review"
-            ? "min-h-0 flex-1 overflow-hidden pt-2"
-            : "min-h-0 flex-1 overflow-auto px-4 pb-4 pt-2"}
+      <div
+        className={
+          activeTab === "files"
+            ? "min-h-0 flex-1 overflow-hidden"
+            : activeTab === "runs"
+              ? "min-h-0 flex-1 overflow-hidden"
+              : activeTab === "review"
+                ? "min-h-0 flex-1 overflow-hidden pt-2"
+                : "min-h-0 flex-1 overflow-auto px-4 pb-4 pt-2"
+        }
       >
-        {showInitialLoading ? <div className="py-4 text-sm text-ink-muted">{t("contextPanel.loading")}</div> : null}
-        {!showInitialLoading && !activeThread ? <EmptyState title={t("contextPanel.noThreadSelected")} /> : null}
+        {showInitialLoading
+          ? (
+              <div className="py-4 text-sm text-ink-muted">
+                {t("contextPanel.loading")}
+              </div>
+            )
+          : null}
+        {!showInitialLoading && !activeThread
+          ? (
+              <EmptyState title={t("contextPanel.noThreadSelected")} />
+            )
+          : null}
         {!showInitialLoading && activeThread && activeTab === "runs"
-          ? selectedTool
-            ? (
-                <div className="h-full overflow-auto px-4 pb-4">
-                  <RunInspectPanel
-                    compact
-                    run={selectedTool.run}
-                    tools={[selectedTool.tool]}
-                    onBack={() => setSelectedToolId(null)}
-                  />
-                </div>
-              )
-            : selectedToolId
-              ? <div className="px-4 py-4 text-sm text-ink-muted">{t("contextPanel.loading")}</div>
-              : (
-                  <RunsPanel
-                    runs={runs}
-                    toolsByRun={toolsByRun}
-                    scope={runsScope}
-                    onArchiveFinished={handleArchiveFinishedRuns}
-                    onInspectTool={handleSelectTool}
-                    onTerminateRun={handleTerminateRun}
-                  />
-                )
+          ? (
+              selectedTool
+                ? (
+                    <div className="h-full overflow-auto px-4 pb-4">
+                      <RunInspectPanel
+                        compact
+                        run={selectedTool.run}
+                        tools={[selectedTool.tool]}
+                        onBack={() => setSelectedToolId(null)}
+                      />
+                    </div>
+                  )
+                : selectedToolId
+                  ? (
+                      <div className="px-4 py-4 text-sm text-ink-muted">
+                        {t("contextPanel.loading")}
+                      </div>
+                    )
+                  : (
+                      <RunsPanel
+                        runs={runs}
+                        toolsByRun={toolsByRun}
+                        scope={runsScope}
+                        onArchiveFinished={handleArchiveFinishedRuns}
+                        onInspectTool={handleSelectTool}
+                        onTerminateRun={handleTerminateRun}
+                      />
+                    )
+            )
           : null}
         {!showInitialLoading && activeThread && activeTab === "review"
           ? (
@@ -368,26 +440,33 @@ export function ContextPanel({
             disabled `@`-reference renderer. Kept wired so restoring the tab is a
             one-line change. */}
         {!showInitialLoading && activeThread && activeTab === "artifacts"
-          ? selectedArtifact
-            ? (
-                <ArtifactDetailPanel
-                  artifact={selectedArtifact}
-                  onBack={() => setSelectedArtifactId(null)}
-                  onChanged={refreshContext}
-                />
-              )
-            : (
-                <ArtifactsPanel
-                  artifacts={artifacts}
-                  onChanged={refreshContext}
-                  onSelectArtifact={handleSelectArtifact}
-                  threadId={activeThread.id}
-                  workspacePath={activeWorkspace?.path ?? null}
-                />
-              )
+          ? (
+              selectedArtifact
+                ? (
+                    <ArtifactDetailPanel
+                      artifact={selectedArtifact}
+                      onBack={() => setSelectedArtifactId(null)}
+                      onChanged={refreshContext}
+                    />
+                  )
+                : (
+                    <ArtifactsPanel
+                      artifacts={artifacts}
+                      onChanged={refreshContext}
+                      onSelectArtifact={handleSelectArtifact}
+                      threadId={activeThread.id}
+                      workspacePath={activeWorkspace?.path ?? null}
+                    />
+                  )
+            )
           : null}
         {!showInitialLoading && activeThread && activeTab === "files"
-          ? <FileTreePanel isWorkspace={isWorkspaceThread} rootPath={activeWorkspace?.path ?? null} />
+          ? (
+              <FileTreePanel
+                isWorkspace={isWorkspaceThread}
+                rootPath={activeWorkspace?.path ?? null}
+              />
+            )
           : null}
       </div>
     </aside>

--- a/desktop/src/components/ui/CopyablePre.tsx
+++ b/desktop/src/components/ui/CopyablePre.tsx
@@ -31,10 +31,11 @@ export function CopyablePre({
         onCopy={() => void copy(text)}
         variant="floating"
       />
-      <pre className={cn(
-        fill ? "min-h-0" : maxHeightClassName,
-        "overflow-auto whitespace-pre-wrap wrap-break-word rounded-md bg-surface-subtle p-2 pr-9 text-[11px] leading-4 text-ink-soft",
-      )}
+      <pre
+        className={cn(
+          fill ? "min-h-0" : maxHeightClassName,
+          "overflow-auto whitespace-pre-wrap wrap-break-word rounded-md border border-line-soft bg-surface/50 p-2 pr-9 text-[11px] leading-4 text-ink-soft",
+        )}
       >
         <code>{text}</code>
       </pre>

--- a/desktop/src/components/ui/EmptyState.tsx
+++ b/desktop/src/components/ui/EmptyState.tsx
@@ -1,8 +1,27 @@
-export function EmptyState({ detail, title }: { detail?: string; title: string }) {
+import { cn } from "../../lib/cn";
+
+export function EmptyState({
+  className,
+  detail,
+  title,
+}: {
+  className?: string;
+  detail?: string;
+  title: string;
+}) {
   return (
-    <div className="rounded-md border border-dashed border-line-soft bg-surface/60 p-4 text-center">
+    <div
+      className={cn(
+        "rounded-md border border-dashed border-line-soft bg-surface/60 p-4 text-center",
+        className,
+      )}
+    >
       <div className="text-sm font-medium text-ink-soft">{title}</div>
-      {detail ? <div className="mt-1 text-xs leading-5 text-ink-muted">{detail}</div> : null}
+      {detail
+        ? (
+            <div className="mt-1 text-xs leading-5 text-ink-muted">{detail}</div>
+          )
+        : null}
     </div>
   );
 }

--- a/desktop/src/features/filetree/FileTreePanel.tsx
+++ b/desktop/src/features/filetree/FileTreePanel.tsx
@@ -29,7 +29,13 @@ import { useFileTree } from "./useFileTree";
  * default; a real workspace shows the button and reveals dotfiles by default
  * (users work with `.gitignore`, `.env`, etc. there).
  */
-export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | null; isWorkspace: boolean }) {
+export function FileTreePanel({
+  rootPath,
+  isWorkspace,
+}: {
+  rootPath: string | null;
+  isWorkspace: boolean;
+}) {
   const { t } = useTranslation("filetree");
   const [showHidden, setShowHidden] = useState(isWorkspace);
   // Re-apply the mode's default when the thread (root) changes — a manual toggle
@@ -72,38 +78,56 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
       void openPath(rootPath).catch(() => {});
   }, [rootPath]);
 
-  const openEntry = useCallback(async (entry: DirEntry) => {
-    try {
-      await openPath(entry.path);
-    }
-    catch {
-      emitFutureEvent("toast", { message: t("openFailed"), tone: "error" });
-    }
-  }, [t]);
+  const openEntry = useCallback(
+    async (entry: DirEntry) => {
+      try {
+        await openPath(entry.path);
+      }
+      catch {
+        emitFutureEvent("toast", { message: t("openFailed"), tone: "error" });
+      }
+    },
+    [t],
+  );
 
-  const handleOpenFile = useCallback((entry: DirEntry) => {
-    if (entry.isDir)
-      return;
-    if (previewKindForPath(entry.path)) {
-      setPreviewTarget(entry);
-    }
-    else {
-      void openEntry(entry);
-    }
-  }, [openEntry]);
+  const handleOpenFile = useCallback(
+    (entry: DirEntry) => {
+      if (entry.isDir)
+        return;
+      if (previewKindForPath(entry.path)) {
+        setPreviewTarget(entry);
+      }
+      else {
+        void openEntry(entry);
+      }
+    },
+    [openEntry],
+  );
 
   // Attach a file as an `@`-mention pill in the active composer. The pill wants
   // a workspace-relative, POSIX-separated path (the same form the mention picker
   // produces); the tree holds absolute paths, so relativize against the root.
-  const attachEntry = useCallback((entry: DirEntry) => {
-    const relative = relativizeWorkspacePath(entry.path, rootPath).replace(/\\/g, "/");
-    emitFutureEvent("attach-file-to-context", { path: relative, name: entry.name });
-  }, [rootPath]);
+  const attachEntry = useCallback(
+    (entry: DirEntry) => {
+      const relative = relativizeWorkspacePath(entry.path, rootPath).replace(
+        /\\/g,
+        "/",
+      );
+      emitFutureEvent("attach-file-to-context", {
+        path: relative,
+        name: entry.name,
+      });
+    },
+    [rootPath],
+  );
 
-  const handleContextMenu = useCallback((entry: DirEntry, event: ReactMouseEvent<HTMLElement>) => {
-    setMenuTarget(entry);
-    menu.open(event);
-  }, [menu]);
+  const handleContextMenu = useCallback(
+    (entry: DirEntry, event: ReactMouseEvent<HTMLElement>) => {
+      setMenuTarget(entry);
+      menu.open(event);
+    },
+    [menu],
+  );
 
   const menuItems: LinkMenuItem[] = menuTarget
     ? menuTarget.isDir
@@ -111,9 +135,18 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
       : [
           { label: t("menu.attach"), onSelect: () => attachEntry(menuTarget) },
           ...(previewKindForPath(menuTarget.path)
-            ? [{ label: t("menu.preview"), onSelect: () => setPreviewTarget(menuTarget) }]
+            ? [
+                {
+                  label: t("menu.preview"),
+                  onSelect: () => setPreviewTarget(menuTarget),
+                },
+              ]
             : []),
-          { divider: true, label: t("menu.open"), onSelect: () => void openEntry(menuTarget) },
+          {
+            divider: true,
+            label: t("menu.open"),
+            onSelect: () => void openEntry(menuTarget),
+          },
         ]
     : [];
 
@@ -128,10 +161,12 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
   }, [tree]);
 
   const rootEntries = tree.rootEntries;
-  const previewKind = previewTarget ? previewKindForPath(previewTarget.path) : null;
+  const previewKind = previewTarget
+    ? previewKindForPath(previewTarget.path)
+    : null;
   // While the shared cursor-anchored menu is open, keep its target row's `...`
   // trigger visible instead of fading out with hover.
-  const activeMenuPath = menu.position ? menuTarget?.path ?? null : null;
+  const activeMenuPath = menu.position ? (menuTarget?.path ?? null) : null;
 
   // Anti-flicker (mirrors ContextPanel's delayed spinner): while the root has no
   // entries yet, hold the "loading" line back for a beat. A cache-warm switch
@@ -172,7 +207,11 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
           </Button>
           <Button
             disabled={refreshing || !rootPath}
-            leftIcon={<RefreshCw className={`size-3.5${refreshing ? " animate-spin" : ""}`} />}
+            leftIcon={(
+              <RefreshCw
+                className={`size-3.5${refreshing ? " animate-spin" : ""}`}
+              />
+            )}
             onClick={() => void handleRefresh()}
             size="sm"
             variant="toolbar"
@@ -184,20 +223,34 @@ export function FileTreePanel({ rootPath, isWorkspace }: { rootPath: string | nu
 
       {/* Every state stays mounted in one edge-to-edge scroll region so the
           boundary and scrollbar do not jump while the tree loads. */}
-      <div className="group relative min-h-0 flex-1 border-t border-line-soft">
+      <div className="group relative min-h-0 flex-1 border-t border-line-soft/70">
         <div
-          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface"
+          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface/50"
           onScroll={listScrollbar.handleScroll}
           ref={listScrollbar.scrollRef}
         >
           {rootEntries === null
-            ? tree.rootErrored
-              ? <div className="flex h-full items-center justify-center text-sm text-ink-muted">{t("loadFailed")}</div>
-              : showLoading
-                ? <div className="flex h-full items-center justify-center text-sm text-ink-muted">{t("loading")}</div>
-                : null
+            ? (
+                tree.rootErrored
+                  ? (
+                      <div className="flex h-full items-center justify-center text-sm text-ink-muted">
+                        {t("loadFailed")}
+                      </div>
+                    )
+                  : showLoading
+                    ? (
+                        <div className="flex h-full items-center justify-center text-sm text-ink-muted">
+                          {t("loading")}
+                        </div>
+                      )
+                    : null
+              )
             : rootEntries.length === 0
-              ? <div className="flex h-full items-center justify-center text-sm text-ink-muted">{t("empty")}</div>
+              ? (
+                  <div className="flex h-full items-center justify-center text-sm text-ink-muted">
+                    {t("empty")}
+                  </div>
+                )
               : (
                   <ul>
                     {rootEntries.map(entry => (

--- a/desktop/src/features/review/CollapsibleFileDiff.tsx
+++ b/desktop/src/features/review/CollapsibleFileDiff.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
-import { ChevronDown, ChevronRight, ChevronsDown, ChevronsUp, FileDiff } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronsDown,
+  ChevronsUp,
+  FileDiff,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 /**
@@ -28,15 +34,21 @@ export function CollapsibleFileDiff({
   children: ReactNode;
 }) {
   return (
-    <section className={open ? "border-b border-line-soft bg-surface" : "bg-surface"}>
+    <section
+      className={
+        open ? "border-b border-line-soft bg-surface/30" : "bg-transparent"
+      }
+    >
       <button
-        className="group sticky top-0 z-10 flex w-full items-center justify-between gap-2 border-b border-line-soft bg-surface px-2.5 py-1.5 text-left"
+        className="group sticky top-0 z-10 flex w-full items-center justify-between gap-2 border-b border-line-soft bg-surface/50 px-2.5 py-1.5 text-left"
         onClick={onToggle}
         type="button"
       >
         <span className="flex min-w-0 items-center gap-1.5">
           <FileDiff className="size-3.5 shrink-0 text-ink-soft" />
-          <span className="min-w-0 truncate text-left text-xs font-medium text-ink-soft [direction:rtl]">{title}</span>
+          <span className="min-w-0 truncate text-left text-xs font-medium text-ink-soft [direction:rtl]">
+            {title}
+          </span>
         </span>
         <span className="flex shrink-0 items-center gap-1.5 text-xs">
           {headerExtras}
@@ -49,8 +61,12 @@ export function CollapsibleFileDiff({
               )
             : null}
           {open
-            ? <ChevronDown className="size-3.5 text-ink-muted opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100" />
-            : <ChevronRight className="size-3.5 text-ink-muted opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100" />}
+            ? (
+                <ChevronDown className="size-3.5 text-ink-muted opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100" />
+              )
+            : (
+                <ChevronRight className="size-3.5 text-ink-muted opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100" />
+              )}
         </span>
       </button>
       {open ? <div>{children}</div> : null}
@@ -62,7 +78,13 @@ export function CollapsibleFileDiff({
  * "Expand all / Collapse all" toggle shown above a file-diff list. Shared by the
  * working-tree (git) and last-run (shadow) review views.
  */
-export function ExpandCollapseAll({ hasOpen, onToggle }: { hasOpen: boolean; onToggle: () => void }) {
+export function ExpandCollapseAll({
+  hasOpen,
+  onToggle,
+}: {
+  hasOpen: boolean;
+  onToggle: () => void;
+}) {
   const { t } = useTranslation("review");
   const label = hasOpen ? t("collapseAll") : t("expandAll");
   return (
@@ -73,7 +95,13 @@ export function ExpandCollapseAll({ hasOpen, onToggle }: { hasOpen: boolean; onT
       title={label}
       type="button"
     >
-      {hasOpen ? <ChevronsUp className="size-4" /> : <ChevronsDown className="size-4" />}
+      {hasOpen
+        ? (
+            <ChevronsUp className="size-4" />
+          )
+        : (
+            <ChevronsDown className="size-4" />
+          )}
     </button>
   );
 }

--- a/desktop/src/features/review/GitChangesReview.tsx
+++ b/desktop/src/features/review/GitChangesReview.tsx
@@ -1,4 +1,7 @@
-import type { GitReview, GitReviewFile } from "../../integrations/storage/types";
+import type {
+  GitReview,
+  GitReviewFile,
+} from "../../integrations/storage/types";
 import { GitBranch } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { DiffView } from "../../components/ui/DiffView";
@@ -18,33 +21,51 @@ export function WorkingTreeReview({
   const { t } = useTranslation("review");
   const { files } = review;
   // Files default collapsed; open state is keyed by path.
-  const { hasOpen, isOpen, toggle, toggleAll } = useExpandableFiles(files, file => file.path);
+  const { hasOpen, isOpen, toggle, toggleAll } = useExpandableFiles(
+    files,
+    file => file.path,
+  );
   const fileScrollbar = useFloatingScrollbar();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 px-4 py-2">
         <ReviewHeader review={review} files={files} showBranch={showBranch} />
-        {files.length > 0 ? <ExpandCollapseAll hasOpen={hasOpen} onToggle={toggleAll} /> : null}
+        {files.length > 0
+          ? (
+              <ExpandCollapseAll hasOpen={hasOpen} onToggle={toggleAll} />
+            )
+          : null}
       </div>
-      <div className="group relative min-h-0 flex-1 border-t border-line-soft">
+      <div className="group relative min-h-0 flex-1 border-t border-line-soft/70">
         <div
-          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto"
+          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface/50"
           onScroll={fileScrollbar.handleScroll}
           ref={fileScrollbar.scrollRef}
         >
           {files.length === 0
-            ? <EmptyState title={t("workingTree.emptyTitle")} detail={t("workingTree.emptyDetail")} />
-            : files.map(file => (
-                <GitFileDiff
-                  file={file}
-                  key={file.path}
-                  open={isOpen(file)}
-                  onToggle={() => toggle(file)}
+            ? (
+                <EmptyState
+                  className="m-4"
+                  title={t("workingTree.emptyTitle")}
+                  detail={t("workingTree.emptyDetail")}
                 />
-              ))}
+              )
+            : (
+                files.map(file => (
+                  <GitFileDiff
+                    file={file}
+                    key={file.path}
+                    open={isOpen(file)}
+                    onToggle={() => toggle(file)}
+                  />
+                ))
+              )}
         </div>
-        <FloatingScrollbar scrollbar={fileScrollbar.scrollbar} onPointerDown={fileScrollbar.handleThumbPointerDown} />
+        <FloatingScrollbar
+          scrollbar={fileScrollbar.scrollbar}
+          onPointerDown={fileScrollbar.handleThumbPointerDown}
+        />
       </div>
     </div>
   );
@@ -54,7 +75,11 @@ export function ReviewHeader({
   review,
   files,
   showBranch,
-}: { review: GitReview; files: GitReviewFile[]; showBranch: boolean }) {
+}: {
+  review: GitReview;
+  files: GitReviewFile[];
+  showBranch: boolean;
+}) {
   const { i18n } = useTranslation("review");
   const numberFormat = new Intl.NumberFormat(i18n.language);
   return (
@@ -63,7 +88,9 @@ export function ReviewHeader({
         ? (
             <div className="inline-flex min-w-0 items-center gap-1.5 text-ink">
               <GitBranch className="size-3.5 shrink-0 text-ink-soft" />
-              <span className="truncate font-medium">{review.branch ?? "HEAD"}</span>
+              <span className="truncate font-medium">
+                {review.branch ?? "HEAD"}
+              </span>
             </div>
           )
         : null}
@@ -124,14 +151,33 @@ function GitFileDiff({
       onToggle={onToggle}
     >
       {file.omissionReason === "sensitive"
-        ? <div className="px-3 py-3 text-xs text-warning">{t("file.sensitiveContent")}</div>
+        ? (
+            <div className="px-3 py-3 text-xs text-warning">
+              {t("file.sensitiveContent")}
+            </div>
+          )
         : file.binary
-          ? <div className="px-3 py-3 text-xs text-ink-muted">{t("binary.notSupported")}</div>
-          : file.omissionReason === "too_large" || file.omissionReason === "total_limit"
-            ? <div className="px-3 py-3 text-xs text-ink-muted">{t("git.diffOmitted")}</div>
+          ? (
+              <div className="px-3 py-3 text-xs text-ink-muted">
+                {t("binary.notSupported")}
+              </div>
+            )
+          : file.omissionReason === "too_large"
+            || file.omissionReason === "total_limit"
+            ? (
+                <div className="px-3 py-3 text-xs text-ink-muted">
+                  {t("git.diffOmitted")}
+                </div>
+              )
             : file.diff
-              ? <DiffView diff={file.diff} />
-              : <div className="px-3 py-3 text-xs text-ink-muted">{t("git.noTextDiff")}</div>}
+              ? (
+                  <DiffView diff={file.diff} />
+                )
+              : (
+                  <div className="px-3 py-3 text-xs text-ink-muted">
+                    {t("git.noTextDiff")}
+                  </div>
+                )}
     </CollapsibleFileDiff>
   );
 }

--- a/desktop/src/features/review/LastRunReview.tsx
+++ b/desktop/src/features/review/LastRunReview.tsx
@@ -1,5 +1,8 @@
 import type { TFunction } from "i18next";
-import type { LastRunReviewData, StoredReviewFileChange } from "../../integrations/storage/types";
+import type {
+  LastRunReviewData,
+  StoredReviewFileChange,
+} from "../../integrations/storage/types";
 import { AlertTriangle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { DiffView } from "../../components/ui/DiffView";
@@ -29,26 +32,57 @@ export function LastRunReview({
   const { i18n, t } = useTranslation("review");
   // Files default collapsed; open state is keyed by file-change id.
   const files = review?.files ?? [];
-  const { hasOpen, isOpen, toggle, toggleAll } = useExpandableFiles(files, file => file.id);
+  const { hasOpen, isOpen, toggle, toggleAll } = useExpandableFiles(
+    files,
+    file => file.id,
+  );
   const fileScrollbar = useFloatingScrollbar();
 
-  if (changePreview === "unsupported_too_large")
-    return <EmptyState title={t("lastRun.tooLargeTitle")} detail={t("lastRun.tooLargeDetail")} />;
+  if (changePreview === "unsupported_too_large") {
+    return (
+      <EmptyState
+        className="m-4"
+        title={t("lastRun.tooLargeTitle")}
+        detail={t("lastRun.tooLargeDetail")}
+      />
+    );
+  }
 
-  if (loading && !review)
-    return <div className="rounded-md border border-line-soft bg-surface p-3 text-sm text-ink-muted">{t("lastRun.loading")}</div>;
+  if (loading && !review) {
+    return (
+      <div className="rounded-md border border-line-soft bg-surface p-3 text-sm text-ink-muted">
+        {t("lastRun.loading")}
+      </div>
+    );
+  }
 
-  if (error)
-    return <div className="rounded-md border border-danger-line bg-danger-soft p-3 text-sm text-danger">{error}</div>;
+  if (error) {
+    return (
+      <div className="rounded-md border border-danger-line bg-danger-soft p-3 text-sm text-danger">
+        {error}
+      </div>
+    );
+  }
 
-  if (!review)
-    return <EmptyState title={t("lastRun.noReviewTitle")} detail={t("lastRun.noReviewDetail")} />;
+  if (!review) {
+    return (
+      <EmptyState
+        className="m-4"
+        title={t("lastRun.noReviewTitle")}
+        detail={t("lastRun.noReviewDetail")}
+      />
+    );
+  }
 
   const { changeset } = review;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="shrink-0 space-y-3 px-4 py-2">
-        <RunReviewBanners review={review} retrying={retrying} onRetry={onRetry} />
+        <RunReviewBanners
+          review={review}
+          retrying={retrying}
+          onRetry={onRetry}
+        />
         <div className="flex items-center justify-between gap-2">
           <ReviewStats
             additions={changeset.additions}
@@ -56,27 +90,42 @@ export function LastRunReview({
             filesChanged={changeset.filesChanged}
             numberFormat={new Intl.NumberFormat(i18n.language)}
           />
-          {files.length > 0 ? <ExpandCollapseAll hasOpen={hasOpen} onToggle={toggleAll} /> : null}
+          {files.length > 0
+            ? (
+                <ExpandCollapseAll hasOpen={hasOpen} onToggle={toggleAll} />
+              )
+            : null}
         </div>
       </div>
-      <div className="group relative min-h-0 flex-1 border-t border-line-soft">
+      <div className="group relative min-h-0 flex-1 border-t border-line-soft/70">
         <div
-          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto"
+          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface/50"
           onScroll={fileScrollbar.handleScroll}
           ref={fileScrollbar.scrollRef}
         >
           {files.length === 0
-            ? <EmptyState title={t("lastRun.noFilesTitle")} detail={t("lastRun.noFilesDetail")} />
-            : files.map(file => (
-                <ChangesetFileChange
-                  file={file}
-                  key={file.id}
-                  open={isOpen(file)}
-                  onToggle={() => toggle(file)}
+            ? (
+                <EmptyState
+                  className="m-4"
+                  title={t("lastRun.noFilesTitle")}
+                  detail={t("lastRun.noFilesDetail")}
                 />
-              ))}
+              )
+            : (
+                files.map(file => (
+                  <ChangesetFileChange
+                    file={file}
+                    key={file.id}
+                    open={isOpen(file)}
+                    onToggle={() => toggle(file)}
+                  />
+                ))
+              )}
         </div>
-        <FloatingScrollbar scrollbar={fileScrollbar.scrollbar} onPointerDown={fileScrollbar.handleThumbPointerDown} />
+        <FloatingScrollbar
+          scrollbar={fileScrollbar.scrollbar}
+          onPointerDown={fileScrollbar.handleThumbPointerDown}
+        />
       </div>
     </div>
   );
@@ -99,8 +148,13 @@ function RunReviewBanners({
     banners.push({ key: "recovered", text: t("banner.recovered") });
   if (review.snapshotStatus === "partial")
     banners.push({ key: "partial", text: t("banner.partial") });
-  if (review.snapshotStatus === "incomplete")
-    banners.push({ key: "incomplete", text: t("banner.incomplete"), retry: true });
+  if (review.snapshotStatus === "incomplete") {
+    banners.push({
+      key: "incomplete",
+      text: t("banner.incomplete"),
+      retry: true,
+    });
+  }
   if (review.snapshotStatus === "unavailable")
     banners.push({ key: "unavailable", text: t("banner.unavailable") });
 
@@ -164,14 +218,30 @@ function ChangesetFileChange({
       onToggle={onToggle}
     >
       {file.omissionReason === "sensitive"
-        ? <div className="px-3 py-3 text-xs text-warning">{t("file.sensitiveContent")}</div>
+        ? (
+            <div className="px-3 py-3 text-xs text-warning">
+              {t("file.sensitiveContent")}
+            </div>
+          )
         : file.binary
-          ? <BinaryFileDetail file={file} />
+          ? (
+              <BinaryFileDetail file={file} />
+            )
           : file.diff
-            ? <DiffView diff={file.diff} />
-            : <div className="px-3 py-3 text-xs text-ink-muted">{t("file.noTextDiff")}</div>}
+            ? (
+                <DiffView diff={file.diff} />
+              )
+            : (
+                <div className="px-3 py-3 text-xs text-ink-muted">
+                  {t("file.noTextDiff")}
+                </div>
+              )}
       {file.diffTruncated
-        ? <div className="px-3 py-2 text-xs text-warning">{t("file.diffTruncated")}</div>
+        ? (
+            <div className="px-3 py-2 text-xs text-warning">
+              {t("file.diffTruncated")}
+            </div>
+          )
         : null}
     </CollapsibleFileDiff>
   );

--- a/desktop/src/features/review/ReviewPanel.tsx
+++ b/desktop/src/features/review/ReviewPanel.tsx
@@ -1,7 +1,13 @@
-import type { GitReview, LastRunReviewData } from "../../integrations/storage/types";
+import type {
+  GitReview,
+  LastRunReviewData,
+} from "../../integrations/storage/types";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getLastRunReview, retryRunReview } from "../../integrations/storage/threadStore";
+import {
+  getLastRunReview,
+  retryRunReview,
+} from "../../integrations/storage/threadStore";
 import { errorMessage } from "../../lib/errors";
 import { onFutureEvent } from "../../lib/futureEvents";
 import { useAsyncResource } from "../../lib/useAsyncResource";
@@ -28,9 +34,16 @@ export function ReviewPanel({
   // Capabilities arrive on the lightweight, non-diff context refresh. Use that
   // stable fact while the two expensive git diffs load, rather than briefly
   // rendering this as the non-git last-run-only view.
-  const reviewKind = isGitWorkspace === null
-    ? review === null ? "loading" : review.isGitWorkspace ? "git" : "non_git"
-    : isGitWorkspace ? "git" : "non_git";
+  const reviewKind
+    = isGitWorkspace === null
+      ? review === null
+        ? "loading"
+        : review.isGitWorkspace
+          ? "git"
+          : "non_git"
+      : isGitWorkspace
+        ? "git"
+        : "non_git";
   const isGit = reviewKind === "git";
   const [activeView, setActiveView] = useState<ReviewView>("branch");
   const [retrying, setRetrying] = useState(false);
@@ -39,9 +52,10 @@ export function ReviewPanel({
   // Cancellation-safe per-thread load: a slow getLastRunReview for a previous
   // thread can no longer land under the thread we've since switched to.
   const runResource = useAsyncResource<LastRunReviewData | null>(
-    () => changePreview === "unsupported_too_large"
-      ? Promise.resolve(null)
-      : getLastRunReview(threadId),
+    () =>
+      changePreview === "unsupported_too_large"
+        ? Promise.resolve(null)
+        : getLastRunReview(threadId),
     [threadId, changePreview],
     null,
   );
@@ -58,10 +72,14 @@ export function ReviewPanel({
   }, [threadId, reviewKind]);
 
   // Refresh when a Run on this thread finishes (its changeset just landed).
-  useEffect(() => onFutureEvent("review-updated", (detail) => {
-    if (detail.threadId === threadId)
-      reload();
-  }), [threadId, reload]);
+  useEffect(
+    () =>
+      onFutureEvent("review-updated", (detail) => {
+        if (detail.threadId === threadId)
+          reload();
+      }),
+    [threadId, reload],
+  );
 
   async function handleRetry() {
     const runId = runReview?.run?.id ?? runReview?.changeset.runId;
@@ -96,7 +114,9 @@ export function ReviewPanel({
   if (!isGit) {
     return (
       <div className="flex h-full min-h-0 flex-col">
-        <div className="shrink-0 px-4 pb-3 text-xs font-medium text-ink-muted">{t("lastRunHeading")}</div>
+        <div className="shrink-0 px-4 pb-3 text-xs font-medium text-ink-muted">
+          {t("lastRunHeading")}
+        </div>
         {lastRun}
       </div>
     );
@@ -106,24 +126,55 @@ export function ReviewPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="mx-4 grid shrink-0 grid-cols-3 gap-1 rounded-md border border-line-soft bg-surface p-1">
-        <ViewTab active={activeView === "branch"} label={t("tab.branch")} onClick={() => setActiveView("branch")} />
-        <ViewTab active={activeView === "uncommitted"} label={t("tab.uncommitted")} onClick={() => setActiveView("uncommitted")} />
-        <ViewTab active={activeView === "last_run"} label={t("tab.lastRun")} onClick={() => setActiveView("last_run")} />
+      <div className="mx-4 grid shrink-0 grid-cols-3 gap-1 rounded-md border border-line-soft bg-transparent p-1">
+        <ViewTab
+          active={activeView === "branch"}
+          label={t("tab.branch")}
+          onClick={() => setActiveView("branch")}
+        />
+        <ViewTab
+          active={activeView === "uncommitted"}
+          label={t("tab.uncommitted")}
+          onClick={() => setActiveView("uncommitted")}
+        />
+        <ViewTab
+          active={activeView === "last_run"}
+          label={t("tab.lastRun")}
+          onClick={() => setActiveView("last_run")}
+        />
       </div>
       {activeView === "last_run"
-        ? lastRun
-        : reviewData ? <WorkingTreeReview review={reviewData} showBranch={activeView === "branch"} /> : null}
+        ? (
+            lastRun
+          )
+        : reviewData
+          ? (
+              <WorkingTreeReview
+                review={reviewData}
+                showBranch={activeView === "branch"}
+              />
+            )
+          : null}
     </div>
   );
 }
 
-function ViewTab({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+function ViewTab({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
   return (
     <button
-      className={active
-        ? "h-8 rounded bg-surface-subtle text-sm font-medium text-ink"
-        : "h-8 rounded text-sm font-medium text-ink-muted transition-colors hover:text-ink"}
+      className={
+        active
+          ? "h-8 rounded bg-accent-soft/70 text-sm font-medium text-accent"
+          : "h-8 rounded text-sm font-medium text-ink-muted transition-colors hover:text-ink"
+      }
       onClick={onClick}
       type="button"
     >

--- a/desktop/src/features/runs/RunInspectPanel.tsx
+++ b/desktop/src/features/runs/RunInspectPanel.tsx
@@ -3,7 +3,14 @@ import type {
   StoredToolCall,
   StoredToolOutput,
 } from "../../integrations/storage/threadStore";
-import { ArrowLeft, RotateCcw, Search, StepForward, Terminal, Wrench } from "lucide-react";
+import {
+  ArrowLeft,
+  RotateCcw,
+  Search,
+  StepForward,
+  Terminal,
+  Wrench,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "../../components/ui/Badge";
@@ -19,9 +26,19 @@ import { formatDuration, formatTime } from "../../lib/date";
 import { emitFutureEvent } from "../../lib/futureEvents";
 import { isRecord } from "../../lib/objects";
 import { useAsyncResource } from "../../lib/useAsyncResource";
-import { formatRunStatus, runTone, shortId, toolStatusLabel } from "./runDisplayFormatters";
+import {
+  formatRunStatus,
+  runTone,
+  shortId,
+  toolStatusLabel,
+} from "./runDisplayFormatters";
 import { RunError } from "./RunError";
-import { numberOrStringField, parseJsonish, recordOf, stringField } from "./toolInput";
+import {
+  numberOrStringField,
+  parseJsonish,
+  recordOf,
+  stringField,
+} from "./toolInput";
 
 interface RunInspectPanelProps {
   run: StoredRun;
@@ -36,23 +53,38 @@ interface RunDetails {
   outputsByTool: Record<string, StoredToolOutput[]>;
 }
 
-export function RunInspectPanel({ compact = false, onBack, run, tools }: RunInspectPanelProps) {
+export function RunInspectPanel({
+  compact = false,
+  onBack,
+  run,
+  tools,
+}: RunInspectPanelProps) {
   const { i18n, t } = useTranslation("runs");
   const [query, setQuery] = useState("");
   const sortedTools = useMemo(
-    () => [...tools].sort((left, right) => (left.startedAt ?? left.createdAt) - (right.startedAt ?? right.createdAt)),
+    () =>
+      [...tools].sort(
+        (left, right) =>
+          (left.startedAt ?? left.createdAt)
+          - (right.startedAt ?? right.createdAt),
+      ),
     [tools],
   );
   const { data: details, error } = useAsyncResource<RunDetails>(
     async () => {
-      const outputEntries = await Promise.all(sortedTools.map(async (tool) => {
-        try {
-          return [tool.id, await listToolOutputs(tool.runId, tool.id)] as const;
-        }
-        catch {
-          return [tool.id, [] as StoredToolOutput[]] as const;
-        }
-      }));
+      const outputEntries = await Promise.all(
+        sortedTools.map(async (tool) => {
+          try {
+            return [
+              tool.id,
+              await listToolOutputs(tool.runId, tool.id),
+            ] as const;
+          }
+          catch {
+            return [tool.id, [] as StoredToolOutput[]] as const;
+          }
+        }),
+      );
       return { outputsByTool: Object.fromEntries(outputEntries) };
     },
     [sortedTools],
@@ -60,27 +92,49 @@ export function RunInspectPanel({ compact = false, onBack, run, tools }: RunInsp
   );
   const outputsByTool = details.outputsByTool;
   const filteredTools = useMemo(
-    () => sortedTools.filter(tool => eventMatchesQuery(toolSearchText(tool, outputsByTool[tool.id] ?? []), query)),
+    () =>
+      sortedTools.filter(tool =>
+        eventMatchesQuery(
+          toolSearchText(tool, outputsByTool[tool.id] ?? []),
+          query,
+        ),
+      ),
     [outputsByTool, query, sortedTools],
   );
   const primaryTool = sortedTools[0];
 
   return (
-    <div className={cn(compact ? "flex h-full min-h-0 flex-col gap-1" : "space-y-3")}>
+    <div
+      className={cn(
+        compact ? "flex h-full min-h-0 flex-col gap-1" : "space-y-3",
+      )}
+    >
       {compact
         ? (
             <div className="flex h-8 shrink-0 items-center justify-between gap-2">
               {primaryTool
                 ? (
-                    <Badge tone={primaryTool.status === "completed" ? "success" : primaryTool.status === "failed" ? "danger" : "neutral"}>
+                    <Badge
+                      tone={
+                        primaryTool.status === "completed"
+                          ? "success"
+                          : primaryTool.status === "failed"
+                            ? "danger"
+                            : "neutral"
+                      }
+                    >
                       {toolStatusLabel(primaryTool.status)}
                     </Badge>
                   )
-                : <span />}
+                : (
+                    <span />
+                  )}
               <BackButton compact onBack={onBack} />
             </div>
           )
-        : <BackButton onBack={onBack} />}
+        : (
+            <BackButton onBack={onBack} />
+          )}
 
       {compact
         ? (
@@ -94,32 +148,54 @@ export function RunInspectPanel({ compact = false, onBack, run, tools }: RunInsp
                     tool={primaryTool}
                   />
                 )
-              : <div className="rounded-md border border-dashed border-line-soft p-3 text-sm text-ink-muted">{t("runInspect.noToolCalls")}</div>
+              : (
+                  <div className="rounded-md border border-dashed border-line-soft p-3 text-sm text-ink-muted">
+                    {t("runInspect.noToolCalls")}
+                  </div>
+                )
           )
         : (
             <>
               <section className="rounded-md border border-line-soft bg-surface p-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <h3 className="truncate text-sm font-semibold text-ink">{shortId(run.id)}</h3>
+                    <h3 className="truncate text-sm font-semibold text-ink">
+                      {shortId(run.id)}
+                    </h3>
                     <div className="mt-1 text-xs text-ink-muted">
-                      {run.startedAt ? formatTime(storedTimeToIso(run.startedAt), i18n.language) : formatTime(storedTimeToIso(run.createdAt), i18n.language)}
-                      {run.endedAt ? ` - ${formatTime(storedTimeToIso(run.endedAt), i18n.language)}` : ""}
+                      {run.startedAt
+                        ? formatTime(storedTimeToIso(run.startedAt), i18n.language)
+                        : formatTime(storedTimeToIso(run.createdAt), i18n.language)}
+                      {run.endedAt
+                        ? ` - ${formatTime(storedTimeToIso(run.endedAt), i18n.language)}`
+                        : ""}
                     </div>
                   </div>
-                  <Badge tone={runTone(run.status)}>{formatRunStatus(run.status)}</Badge>
+                  <Badge tone={runTone(run.status)}>
+                    {formatRunStatus(run.status)}
+                  </Badge>
                 </div>
                 <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
                   <div>
                     <dt className="text-ink-muted">{t("runInspect.model")}</dt>
-                    <dd className="mt-0.5 truncate text-ink-soft">{run.modelId ?? "-"}</dd>
+                    <dd className="mt-0.5 truncate text-ink-soft">
+                      {run.modelId ?? "-"}
+                    </dd>
                   </div>
                   <div>
                     <dt className="text-ink-muted">{t("runInspect.tools")}</dt>
                     <dd className="mt-0.5 text-ink-soft">{sortedTools.length}</dd>
                   </div>
                 </dl>
-                {run.errorMessage ? <RunError errorMessage={run.errorMessage} errorType={run.errorType} variant="banner" /> : null}
+                {run.errorMessage
+                  ? (
+                      <RunError
+                        errorMessage={run.errorMessage}
+                        errorType={run.errorType}
+                        variant="banner"
+                      />
+                    )
+                  : null}
                 {canRecoverRun(run)
                   ? (
                       <div className="mt-3 flex flex-wrap gap-2">
@@ -162,16 +238,30 @@ export function RunInspectPanel({ compact = false, onBack, run, tools }: RunInsp
                   <Wrench className="size-3.5" />
                   {t("runInspect.toolCalls")}
                 </div>
-                {error ? <div className="rounded-md border border-danger-line bg-danger-soft p-2 text-xs leading-5 text-danger">{error}</div> : null}
+                {error
+                  ? (
+                      <div className="rounded-md border border-danger-line bg-danger-soft p-2 text-xs leading-5 text-danger">
+                        {error}
+                      </div>
+                    )
+                  : null}
                 {filteredTools.length === 0
-                  ? <div className="rounded-md border border-dashed border-line-soft p-3 text-sm text-ink-muted">{sortedTools.length === 0 ? t("runInspect.noToolCalls") : t("runInspect.noMatchingToolCalls")}</div>
-                  : filteredTools.map(tool => (
-                      <ToolCallDetail
-                        key={tool.id}
-                        outputs={outputsByTool[tool.id] ?? []}
-                        tool={tool}
-                      />
-                    ))}
+                  ? (
+                      <div className="rounded-md border border-dashed border-line-soft p-3 text-sm text-ink-muted">
+                        {sortedTools.length === 0
+                          ? t("runInspect.noToolCalls")
+                          : t("runInspect.noMatchingToolCalls")}
+                      </div>
+                    )
+                  : (
+                      filteredTools.map(tool => (
+                        <ToolCallDetail
+                          key={tool.id}
+                          outputs={outputsByTool[tool.id] ?? []}
+                          tool={tool}
+                        />
+                      ))
+                    )}
               </section>
             </>
           )}
@@ -179,7 +269,13 @@ export function RunInspectPanel({ compact = false, onBack, run, tools }: RunInsp
   );
 }
 
-function BackButton({ compact = false, onBack }: { compact?: boolean; onBack: () => void }) {
+function BackButton({
+  compact = false,
+  onBack,
+}: {
+  compact?: boolean;
+  onBack: () => void;
+}) {
   const { t } = useTranslation("runs");
   return (
     <Button
@@ -217,7 +313,11 @@ function canRecoverRun(run: StoredRun) {
 }
 
 function dispatchRunRecovery(run: StoredRun, action: "continue" | "retry") {
-  emitFutureEvent("recover-run", { action, runId: run.id, triggerMessageId: run.triggerMessageId });
+  emitFutureEvent("recover-run", {
+    action,
+    runId: run.id,
+    triggerMessageId: run.triggerMessageId,
+  });
 }
 
 function ToolCallDetail({
@@ -235,25 +335,43 @@ function ToolCallDetail({
 }) {
   const { t } = useTranslation("runs");
   const details = toolDetails(tool, outputs);
-  const inputText = details.command ?? details.path ?? tool.input ?? t("runInspect.noInput");
+  const inputText
+    = details.command ?? details.path ?? tool.input ?? t("runInspect.noInput");
   const rawOutputs = outputs.filter(output => !isStructuredOutput(output));
   // For write/edit the interesting artifact is what was written, not the
   // "Written to …" acknowledgement — show the content and drop the output.
-  const isFileEdit = displayToolName(tool) === "write" || displayToolName(tool) === "edit";
+  const isFileEdit
+    = displayToolName(tool) === "write" || displayToolName(tool) === "edit";
   const writtenText = isFileEdit ? writtenContent(recordOf(tool.input)) : null;
 
   return (
-    <div className={fill ? "flex min-h-0 flex-col" : "rounded-md border border-line-soft bg-surface p-3"}>
+    <div
+      className={
+        fill
+          ? "flex min-h-0 flex-col"
+          : "rounded-md border border-line-soft bg-surface p-3"
+      }
+    >
       {showHeader
         ? (
             <div className="flex shrink-0 items-center justify-between gap-2">
               <div className="flex min-w-0 items-center gap-1.5">
                 <Terminal className="size-4 shrink-0 text-ink-muted" />
-                <span className="truncate text-xs font-medium text-ink">{tool.name || t("runInspect.toolFallback")}</span>
+                <span className="truncate text-xs font-medium text-ink">
+                  {tool.name || t("runInspect.toolFallback")}
+                </span>
               </div>
               {showStatus
                 ? (
-                    <Badge tone={tool.status === "completed" ? "success" : tool.status === "failed" ? "danger" : "neutral"}>
+                    <Badge
+                      tone={
+                        tool.status === "completed"
+                          ? "success"
+                          : tool.status === "failed"
+                            ? "danger"
+                            : "neutral"
+                      }
+                    >
                       {toolStatusLabel(tool.status)}
                     </Badge>
                   )
@@ -261,28 +379,55 @@ function ToolCallDetail({
             </div>
           )
         : null}
-      <ToolDetailFields details={details} noTopMargin={!showHeader} tool={tool} />
+      <ToolDetailFields
+        details={details}
+        noTopMargin={!showHeader}
+        tool={tool}
+      />
       <div className="mt-2 shrink-0">
         <div className="mb-1 text-[11px] font-medium text-ink-muted">
-          {details.command ? t("runInspect.command") : details.path ? t("runInspect.target") : t("runInspect.input")}
+          {details.command
+            ? t("runInspect.command")
+            : details.path
+              ? t("runInspect.target")
+              : t("runInspect.input")}
         </div>
         <CopyablePre maxHeightClassName="max-h-40" text={inputText} />
       </div>
       {isFileEdit
-        ? (writtenText
-            ? (
-                <div className={cn("mt-2", fill ? "flex min-h-0 flex-col" : "shrink-0")}>
-                  <div className="mb-1 shrink-0 text-[11px] font-medium text-ink-muted">{t("runInspect.content")}</div>
-                  <CopyablePre fill={fill} maxHeightClassName="max-h-96" text={writtenText} />
-                </div>
-              )
-            : null)
+        ? (
+            writtenText
+              ? (
+                  <div
+                    className={cn("mt-2", fill ? "flex min-h-0 flex-col" : "shrink-0")}
+                  >
+                    <div className="mb-1 shrink-0 text-[11px] font-medium text-ink-muted">
+                      {t("runInspect.content")}
+                    </div>
+                    <CopyablePre
+                      fill={fill}
+                      maxHeightClassName="max-h-96"
+                      text={writtenText}
+                    />
+                  </div>
+                )
+              : null
+          )
         : (
             <>
               {details.stdout
                 ? (
-                    <div className={cn("mt-2", fill && rawOutputs.length === 0 ? "flex min-h-0 flex-col" : "shrink-0")}>
-                      <div className="mb-1 shrink-0 text-[11px] font-medium text-ink-muted">stdout</div>
+                    <div
+                      className={cn(
+                        "mt-2",
+                        fill && rawOutputs.length === 0
+                          ? "flex min-h-0 flex-col"
+                          : "shrink-0",
+                      )}
+                    >
+                      <div className="mb-1 shrink-0 text-[11px] font-medium text-ink-muted">
+                        stdout
+                      </div>
                       <CopyablePre
                         fill={fill && rawOutputs.length === 0}
                         maxHeightClassName="max-h-40"
@@ -294,16 +439,27 @@ function ToolCallDetail({
               {details.stderr
                 ? (
                     <div className="mt-2 shrink-0">
-                      <div className="mb-1 text-[11px] font-medium text-danger">stderr</div>
-                      <CopyablePre maxHeightClassName="max-h-40" text={details.stderr} />
+                      <div className="mb-1 text-[11px] font-medium text-danger">
+                        stderr
+                      </div>
+                      <CopyablePre
+                        maxHeightClassName="max-h-40"
+                        text={details.stderr}
+                      />
                     </div>
                   )
                 : null}
               {rawOutputs.length > 0
                 ? (
-                    <div className={cn("mt-2 space-y-2", fill && "flex min-h-0 flex-col")}>
+                    <div
+                      className={cn("mt-2 space-y-2", fill && "flex min-h-0 flex-col")}
+                    >
                       {rawOutputs.map(output => (
-                        <ToolOutputPreview fill={fill} key={output.id} output={output} />
+                        <ToolOutputPreview
+                          fill={fill}
+                          key={output.id}
+                          output={output}
+                        />
                       ))}
                     </div>
                   )
@@ -336,8 +492,20 @@ function ToolDetailFields({
   const { i18n, t } = useTranslation("runs");
   const fields = [
     ["kind", t("runInspect.field.kind"), tool.kind],
-    ["started", t("runInspect.field.started"), tool.startedAt ? formatTime(storedTimeToIso(tool.startedAt), i18n.language) : null],
-    ["ended", t("runInspect.field.ended"), tool.endedAt ? formatTime(storedTimeToIso(tool.endedAt), i18n.language) : null],
+    [
+      "started",
+      t("runInspect.field.started"),
+      tool.startedAt
+        ? formatTime(storedTimeToIso(tool.startedAt), i18n.language)
+        : null,
+    ],
+    [
+      "ended",
+      t("runInspect.field.ended"),
+      tool.endedAt
+        ? formatTime(storedTimeToIso(tool.endedAt), i18n.language)
+        : null,
+    ],
     ["duration", t("runInspect.field.duration"), details.duration],
     ["cwd", t("runInspect.field.cwd"), details.cwd],
     ["exit", t("runInspect.field.exit"), details.exitStatus],
@@ -348,18 +516,36 @@ function ToolDetailFields({
     return null;
 
   return (
-    <dl className={cn("grid shrink-0 grid-cols-2 gap-2 rounded-md bg-surface-subtle p-2 text-[11px]", !noTopMargin && "mt-2")}>
+    <dl
+      className={cn(
+        "grid shrink-0 grid-cols-2 gap-2 rounded-md border border-line-soft bg-surface/50 p-2 text-[11px]",
+        !noTopMargin && "mt-2",
+      )}
+    >
       {fields.map(([key, label, value]) => (
-        <div className={key === "cwd" || key === "path" ? "col-span-2 min-w-0" : "min-w-0"} key={key}>
+        <div
+          className={
+            key === "cwd" || key === "path" ? "col-span-2 min-w-0" : "min-w-0"
+          }
+          key={key}
+        >
           <dt className="text-ink-muted">{label}</dt>
-          <dd className="mt-0.5 truncate text-ink-soft" title={value}>{value}</dd>
+          <dd className="mt-0.5 truncate text-ink-soft" title={value}>
+            {value}
+          </dd>
         </div>
       ))}
     </dl>
   );
 }
 
-function ToolOutputPreview({ fill = false, output }: { fill?: boolean; output: StoredToolOutput }) {
+function ToolOutputPreview({
+  fill = false,
+  output,
+}: {
+  fill?: boolean;
+  output: StoredToolOutput;
+}) {
   const { t } = useTranslation("runs");
   const [expanded, setExpanded] = useState(false);
   const text = output.content ?? output.kind;
@@ -368,7 +554,9 @@ function ToolOutputPreview({ fill = false, output }: { fill?: boolean; output: S
   return (
     <div className={cn(fill && "flex min-h-0 flex-col")}>
       <div className="mb-1 flex shrink-0 items-center justify-between gap-2">
-        <span className="truncate text-[11px] font-medium text-ink-muted">{outputKindLabel(output.kind, t)}</span>
+        <span className="truncate text-[11px] font-medium text-ink-muted">
+          {outputKindLabel(output.kind, t)}
+        </span>
         {!fill && long
           ? (
               <button
@@ -399,14 +587,25 @@ function displayToolName(tool: StoredToolCall) {
  * for edit (single `newText`/`newString`, or every hunk of an `edits[]` batch).
  */
 function writtenContent(input: Record<string, unknown> | null): string | null {
-  const direct = stringField(input, ["content", "newText", "newString", "new_string", "newContent", "new_content"]);
+  const direct = stringField(input, [
+    "content",
+    "newText",
+    "newString",
+    "new_string",
+    "newContent",
+    "new_content",
+  ]);
   if (direct)
     return direct;
 
   const edits = input?.edits;
   if (Array.isArray(edits)) {
     const parts = edits
-      .map(edit => (isRecord(edit) ? stringField(edit, ["newText", "newString", "new_string"]) : null))
+      .map(edit =>
+        isRecord(edit)
+          ? stringField(edit, ["newText", "newString", "new_string"])
+          : null,
+      )
       .filter((part): part is string => Boolean(part));
     if (parts.length > 0)
       return parts.join("\n\n");
@@ -423,21 +622,71 @@ function outputKindLabel(kind: string, t: (key: string) => string) {
   return kind;
 }
 
-function toolDetails(tool: StoredToolCall, outputs: StoredToolOutput[]): ToolDetails {
+function toolDetails(
+  tool: StoredToolCall,
+  outputs: StoredToolOutput[],
+): ToolDetails {
   const input = recordOf(tool.input);
-  const outputObjects = outputs.map(output => toolOutputObject(output)).filter(isRecord);
+  const outputObjects = outputs
+    .map(output => toolOutputObject(output))
+    .filter(isRecord);
   const firstOutput = firstRecord(outputObjects);
-  const durationMs = tool.startedAt && tool.endedAt ? tool.endedAt - tool.startedAt : null;
+  const durationMs
+    = tool.startedAt && tool.endedAt ? tool.endedAt - tool.startedAt : null;
 
   return {
-    command: stringField(input, ["command", "cmd", "shellCommand", "shell_command"]),
-    cwd: stringField(input, ["cwd", "workingDirectory", "working_directory", "workdir"])
-      ?? stringField(firstOutput, ["cwd", "workingDirectory", "working_directory", "workdir"]),
-    duration: durationMs !== null ? formatDuration(durationMs, { subSecond: true }) : durationField(firstOutput),
-    exitStatus: numberOrStringField(firstOutput, ["exitStatus", "exit_status", "exitCode", "exit_code", "statusCode", "status_code"]),
-    path: stringField(input, ["path", "filePath", "file_path", "targetPath", "target_path", "target"]),
-    stderr: stringField(firstOutput, ["stderr", "standardError", "standard_error", "error"]),
-    stdout: stringField(firstOutput, ["stdout", "standardOutput", "standard_output", "text", "result"]),
+    command: stringField(input, [
+      "command",
+      "cmd",
+      "shellCommand",
+      "shell_command",
+    ]),
+    cwd:
+      stringField(input, [
+        "cwd",
+        "workingDirectory",
+        "working_directory",
+        "workdir",
+      ])
+      ?? stringField(firstOutput, [
+        "cwd",
+        "workingDirectory",
+        "working_directory",
+        "workdir",
+      ]),
+    duration:
+      durationMs !== null
+        ? formatDuration(durationMs, { subSecond: true })
+        : durationField(firstOutput),
+    exitStatus: numberOrStringField(firstOutput, [
+      "exitStatus",
+      "exit_status",
+      "exitCode",
+      "exit_code",
+      "statusCode",
+      "status_code",
+    ]),
+    path: stringField(input, [
+      "path",
+      "filePath",
+      "file_path",
+      "targetPath",
+      "target_path",
+      "target",
+    ]),
+    stderr: stringField(firstOutput, [
+      "stderr",
+      "standardError",
+      "standard_error",
+      "error",
+    ]),
+    stdout: stringField(firstOutput, [
+      "stdout",
+      "standardOutput",
+      "standard_output",
+      "text",
+      "result",
+    ]),
   };
 }
 
@@ -450,8 +699,22 @@ function isStructuredOutput(output: StoredToolOutput) {
   if (!isRecord(value))
     return false;
   return Boolean(
-    stringField(value, ["stdout", "standardOutput", "standard_output", "stderr", "standardError", "standard_error"])
-    || numberOrStringField(value, ["exitStatus", "exit_status", "exitCode", "exit_code", "statusCode", "status_code"]),
+    stringField(value, [
+      "stdout",
+      "standardOutput",
+      "standard_output",
+      "stderr",
+      "standardError",
+      "standard_error",
+    ])
+    || numberOrStringField(value, [
+      "exitStatus",
+      "exit_status",
+      "exitCode",
+      "exit_code",
+      "statusCode",
+      "status_code",
+    ]),
   );
 }
 
@@ -460,9 +723,17 @@ function firstRecord(values: unknown[]) {
 }
 
 function durationField(value: Record<string, unknown> | null) {
-  const raw = numberOrStringField(value, ["durationMs", "duration_ms", "elapsedMs", "elapsed_ms", "duration"]);
+  const raw = numberOrStringField(value, [
+    "durationMs",
+    "duration_ms",
+    "elapsedMs",
+    "elapsed_ms",
+    "duration",
+  ]);
   if (!raw)
     return null;
   const numeric = Number(raw);
-  return Number.isFinite(numeric) ? formatDuration(numeric, { subSecond: true }) : raw;
+  return Number.isFinite(numeric)
+    ? formatDuration(numeric, { subSecond: true })
+    : raw;
 }

--- a/desktop/src/features/runs/RunsPanel.tsx
+++ b/desktop/src/features/runs/RunsPanel.tsx
@@ -1,6 +1,15 @@
 import type { RunsContextScope } from "../../components/layout/hooks/useContextData";
-import type { StoredRun, StoredToolCall } from "../../integrations/storage/threadStore";
-import { Archive, ChevronRight, CircleStop, Pencil, TerminalSquare } from "lucide-react";
+import type {
+  StoredRun,
+  StoredToolCall,
+} from "../../integrations/storage/threadStore";
+import {
+  Archive,
+  ChevronRight,
+  CircleStop,
+  Pencil,
+  TerminalSquare,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/ui/Button";
@@ -31,31 +40,56 @@ interface ToolEntry {
   terminable: boolean;
 }
 
-export function RunsPanel({ onArchiveFinished, onInspectTool, onTerminateRun, runs, scope, toolsByRun }: RunsPanelProps) {
+export function RunsPanel({
+  onArchiveFinished,
+  onInspectTool,
+  onTerminateRun,
+  runs,
+  scope,
+  toolsByRun,
+}: RunsPanelProps) {
   const { t } = useTranslation("runs");
   const [confirmRunId, setConfirmRunId] = useState<string | null>(null);
   const [busyRunId, setBusyRunId] = useState<string | null>(null);
-  const [actionErrors, setActionErrors] = useState<Record<string, string | undefined>>({});
+  const [actionErrors, setActionErrors] = useState<
+    Record<string, string | undefined>
+  >({});
   const [archiving, setArchiving] = useState(false);
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const listScrollbar = useFloatingScrollbar();
 
-  const allEntries = useMemo(() => buildToolEntries(runs, toolsByRun), [runs, toolsByRun]);
-  const entries = useMemo(() => allEntries.filter(entry => !entry.run.archivedAt), [allEntries]);
-  const { runningCount, finishedCount } = useMemo(() => countEntries(entries), [entries]);
+  const allEntries = useMemo(
+    () => buildToolEntries(runs, toolsByRun),
+    [runs, toolsByRun],
+  );
+  const entries = useMemo(
+    () => allEntries.filter(entry => !entry.run.archivedAt),
+    [allEntries],
+  );
+  const { runningCount, finishedCount } = useMemo(
+    () => countEntries(entries),
+    [entries],
+  );
 
   if (entries.length === 0) {
-    const hasArchivedPrograms = allEntries.some(entry => entry.run.archivedAt);
+    const hasArchivedPrograms = allEntries.some(
+      entry => entry.run.archivedAt,
+    );
     return (
       <div className="flex h-full min-h-0 flex-col">
-        <div className="group relative min-h-0 flex-1 border-t border-line-soft">
+        <div className="group relative min-h-0 flex-1 border-t border-line-soft/70">
           <div
-            className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto"
+            className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface/50"
             onScroll={listScrollbar.handleScroll}
             ref={listScrollbar.scrollRef}
           >
             <EmptyState
-              detail={t(hasArchivedPrograms ? "runsPanel.emptyDetailArchived" : "runsPanel.emptyDetailNeverRun")}
+              className="m-4"
+              detail={t(
+                hasArchivedPrograms
+                  ? "runsPanel.emptyDetailArchived"
+                  : "runsPanel.emptyDetailNeverRun",
+              )}
               title={t("runsPanel.emptyTitle")}
             />
           </div>
@@ -109,7 +143,10 @@ export function RunsPanel({ onArchiveFinished, onInspectTool, onTerminateRun, ru
       <div className="shrink-0 px-4 py-1.5">
         <div className="flex items-center justify-between gap-3">
           <div className="text-xs text-ink-muted">
-            {t("runsPanel.runningFinished", { running: runningCount, finished: finishedCount })}
+            {t("runsPanel.runningFinished", {
+              running: runningCount,
+              finished: finishedCount,
+            })}
           </div>
           <Button
             disabled={archiving || finishedCount === 0}
@@ -122,12 +159,16 @@ export function RunsPanel({ onArchiveFinished, onInspectTool, onTerminateRun, ru
           </Button>
         </div>
         {archiveError
-          ? <div className="mt-2 line-clamp-3 text-xs leading-5 text-danger">{archiveError}</div>
+          ? (
+              <div className="mt-2 line-clamp-3 text-xs leading-5 text-danger">
+                {archiveError}
+              </div>
+            )
           : null}
       </div>
-      <div className="group relative min-h-0 flex-1 border-t border-line-soft">
+      <div className="group relative min-h-0 flex-1 border-t border-line-soft/70">
         <div
-          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto"
+          className="floating-scrollbar h-full overflow-x-hidden overflow-y-auto bg-surface/50"
           onScroll={listScrollbar.handleScroll}
           ref={listScrollbar.scrollRef}
         >
@@ -182,20 +223,26 @@ function ToolRow({
   const { run, terminable, tool } = entry;
   const name = displayName(tool);
   const isShell = name === "shell";
-  const rawPrimary = (isShell ? toolCommand(tool.input) : toolTarget(tool.input))
-    ?? toolCommand(tool.input)
-    ?? toolTarget(tool.input)
-    ?? tool.input
-    ?? toolLabel(tool);
+  const rawPrimary
+    = (isShell ? toolCommand(tool.input) : toolTarget(tool.input))
+      ?? toolCommand(tool.input)
+      ?? toolTarget(tool.input)
+      ?? tool.input
+      ?? toolLabel(tool);
   // Shell rows show the command verbatim; file rows (write/edit) get the
   // workspace-relative path, absolute kept for files outside the workspace.
-  const primary = isShell ? rawPrimary : relativizeWorkspacePath(rawPrimary, workspacePath);
+  const primary = isShell
+    ? rawPrimary
+    : relativizeWorkspacePath(rawPrimary, workspacePath);
   // Show the tool's own status, never the run's. A tool still marked "running"
   // after its run has ended was interrupted — we can't tell a user abort from a
   // real failure, so treat it as failed rather than a perpetual "running".
-  const status = tool.status === "running" && !isActiveRun(run) ? "failed" : tool.status;
+  const status
+    = tool.status === "running" && !isActiveRun(run) ? "failed" : tool.status;
   const running = status === "running" || terminable;
-  const meta = [toolLabel(tool), toolStatusLabel(status)].filter(Boolean).join(" · ");
+  const meta = [toolLabel(tool), toolStatusLabel(status)]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <div
@@ -221,8 +268,22 @@ function ToolRow({
             aligned with the command's first line when that command wraps. */}
         <span className="flex h-5 shrink-0 items-center">
           {isShell
-            ? <TerminalSquare className={cn("size-4", running ? "text-accent" : "text-ink-muted")} />
-            : <Pencil className={cn("size-4", running ? "text-accent" : "text-ink-muted")} />}
+            ? (
+                <TerminalSquare
+                  className={cn(
+                    "size-4",
+                    running ? "text-accent" : "text-ink-muted",
+                  )}
+                />
+              )
+            : (
+                <Pencil
+                  className={cn(
+                    "size-4",
+                    running ? "text-accent" : "text-ink-muted",
+                  )}
+                />
+              )}
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-start gap-2">
@@ -236,11 +297,13 @@ function ToolRow({
               {primary}
             </div>
           </div>
-          <div className="mt-2 text-xs font-medium text-ink-muted">
-            {meta}
-          </div>
+          <div className="mt-2 text-xs font-medium text-ink-muted">{meta}</div>
           {actionError
-            ? <div className="mt-2 line-clamp-3 text-xs leading-5 text-danger">{actionError}</div>
+            ? (
+                <div className="mt-2 line-clamp-3 text-xs leading-5 text-danger">
+                  {actionError}
+                </div>
+              )
             : null}
           {terminable
             ? (
@@ -248,8 +311,15 @@ function ToolRow({
                   {confirming
                     ? (
                         <div className="flex items-center gap-2">
-                          <span className="text-xs text-ink-muted">{t("runsPanel.confirmTerminate")}</span>
-                          <Button disabled={busy} onClick={onCancelConfirm} size="xs" variant="ghost">
+                          <span className="text-xs text-ink-muted">
+                            {t("runsPanel.confirmTerminate")}
+                          </span>
+                          <Button
+                            disabled={busy}
+                            onClick={onCancelConfirm}
+                            size="xs"
+                            variant="ghost"
+                          >
                             {t("runsPanel.cancel")}
                           </Button>
                           <Button
@@ -296,11 +366,17 @@ function displayName(tool: StoredToolCall) {
 }
 
 function isActiveRun(run: StoredRun) {
-  return run.status === "queued" || run.status === "running" || run.status === "waiting_approval";
+  return (
+    run.status === "queued"
+    || run.status === "running"
+    || run.status === "waiting_approval"
+  );
 }
 
 function compareToolTimeDesc(left: StoredToolCall, right: StoredToolCall) {
-  return (right.startedAt ?? right.createdAt) - (left.startedAt ?? left.createdAt);
+  return (
+    (right.startedAt ?? right.createdAt) - (left.startedAt ?? left.createdAt)
+  );
 }
 
 /**
@@ -308,7 +384,10 @@ function compareToolTimeDesc(left: StoredToolCall, right: StoredToolCall) {
  * active runs' tools first, then finished ones — so each command is its own row
  * instead of collapsing a run into a single card.
  */
-function buildToolEntries(runs: StoredRun[], toolsByRun: Record<string, StoredToolCall[]>): ToolEntry[] {
+function buildToolEntries(
+  runs: StoredRun[],
+  toolsByRun: Record<string, StoredToolCall[]>,
+): ToolEntry[] {
   const active: ToolEntry[] = [];
   const finished: ToolEntry[] = [];
   for (const run of runs) {
@@ -323,7 +402,11 @@ function buildToolEntries(runs: StoredRun[], toolsByRun: Record<string, StoredTo
 
     const latestId = [...tools].sort(compareToolTimeDesc)[0]?.id;
     for (const tool of tools) {
-      const entry: ToolEntry = { tool, run, terminable: runActive && tool.id === latestId };
+      const entry: ToolEntry = {
+        tool,
+        run,
+        terminable: runActive && tool.id === latestId,
+      };
       (runActive ? active : finished).push(entry);
     }
   }
@@ -343,8 +426,7 @@ function countEntries(entries: ToolEntry[]) {
   for (const entry of entries) {
     if (entry.tool.status === "running" && isActiveRun(entry.run))
       runningCount += 1;
-    else
-      finishedCount += 1;
+    else finishedCount += 1;
   }
   return { finishedCount, runningCount };
 }

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
         // ─── Neutrals / surfaces ──────────────────────────────
         canvas: "#f6f7f9",
         surface: "#ffffff",
+        "surface-panel": "#f8faff",
         "surface-subtle": "#f1f4f8",
         line: "#d9dee7",
         "line-soft": "#e8edf4",
@@ -45,15 +46,16 @@ export default {
         "diff-remove": "#ffebe9",
         "diff-remove-line": "#ffc9c9",
         // ─── Overlay / scrim (modal backdrop, see components/ui/Overlay) ──
-        overlay: "rgba(0, 0, 0, 0.6)"
+        overlay: "rgba(0, 0, 0, 0.6)",
       },
       boxShadow: {
-        panel: "0 1px 2px rgba(23, 32, 51, 0.06), 0 12px 28px rgba(23, 32, 51, 0.07)",
+        panel:
+          "0 1px 2px rgba(23, 32, 51, 0.06), 0 12px 28px rgba(23, 32, 51, 0.07)",
         dialog: "0 24px 60px rgba(15, 23, 42, 0.18)",
         "sidebar-divider": "inset -8px 0 16px -16px rgba(23, 32, 51, 0.15)",
-        "sidebar-floating": "6px 0 16px rgba(23, 32, 51, 0.05)"
-      }
-    }
+        "sidebar-floating": "6px 0 16px rgba(23, 32, 51, 0.05)",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- preserve and replay Responses reasoning summaries, encrypted metadata, tool deltas, and terminal state safely
- expose current Responses compatibility options for reasoning and prompt cache behavior
- refine right context panel surfaces, list fill behavior, empty-state spacing, and translucent code/output cards

## Validation
- cargo fmt --check --manifest-path agent/Cargo.toml
- cargo clippy --all-targets --manifest-path agent/Cargo.toml -- -D warnings
- cargo test --manifest-path agent/Cargo.toml (1587 unit tests plus integration suites)
- npm run lint (desktop)
- real Responses provider validation: multi-tool calls, Unicode tool args, expected tool failure, history replay, cancellation recovery