### PR TITLE
fix(agent): raise LLM stream idle timeout from 45s to 120s

### DIFF
--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -17,12 +17,12 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::info;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 1800;
-const STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
+const STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
 const UPSTREAM_DISCONNECTED: &str = "[UPSTREAM_DISCONNECTED]";
 const MODEL_RESPONSE_ERROR: &str = "[MODEL_RESPONSE_ERROR]";
 
 /// Stream-read idle timeout. Tests override it (a stalled-mock test cannot
-/// wait 45 s of real time) via FUTURE_TEST_STREAM_IDLE_SECS.
+/// wait 120 s of real time) via FUTURE_TEST_STREAM_IDLE_SECS.
 fn stream_idle_timeout_secs() -> u64 {
     #[cfg(test)]
     if let Some(secs) = std::env::var("FUTURE_TEST_STREAM_IDLE_SECS")

--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -382,7 +382,8 @@ pub(super) fn derive_thinking_compat(
 
     // Models that advertise tool_stream support (e.g. GLM series) must send
     // `tool_stream: true` so tool calls stream incrementally instead of only
-    // at the end of a long generation (which can exceed the 45s timeout).
+    // at the end of a long generation (which can exceed the stream-idle
+    // timeout in llm/mod.rs).
     if has("tool_stream") {
         compat.insert("toolStream".into(), serde_json::json!(true));
     }


### PR DESCRIPTION
## What

Raises `STREAM_IDLE_TIMEOUT_SECS` in `agent/src/llm/mod.rs` from 45s to 120s.

## Why

The LLM-layer idle timeout governs the max gap between consecutive upstream bytes before emitting `[UPSTREAM_DISCONNECTED]`. Long-thinking models (GLM, DeepSeek xhigh) legitimately pause tens of seconds mid-generation — e.g. between thinking and tool-call argument JSON — and 45s is too tight, killing healthy runs (`detected_by=upstream_disconnected`).

## Behavior note

With 120s, the run_loop-layer event idle window now fires first for low/minimal thinking budgets (90s); medium (120s) is a tie race; high/xhigh (180s) still sees the LLM layer fire first. For silent low-budget streams `detected_by` flips from `upstream_disconnected` to `idle_timeout`.

## Tests

- `cargo test -p future-agent --lib llm::` — 128 passed
- `cargo test -p future-agent --lib models::future` — 43 passed