### PR TITLE
fix(desktop): align Runs panel tool rows with run state and streaming targets

### DIFF
--- a/agent/src/tools/mod.rs
+++ b/agent/src/tools/mod.rs
@@ -398,7 +398,10 @@ pub fn write_tool() -> AgentTool {
         "Write content to a file, creating or overwriting. Prefer this for ordinary user-requested file saves.",
         write_schema(),
         write_handler,
-        vec!["When asked to create, save, or overwrite a normal file, prefer this write tool."],
+        vec![
+            "When asked to create, save, or overwrite a normal file, prefer this write tool.",
+            "Emit the `path` field first, before `content`, so the target file is known while the content streams.",
+        ],
     )
 }
 
@@ -468,7 +471,10 @@ pub fn edit_tool() -> AgentTool {
         "Edit a file using exact text replacement. Supports multi-edit via edits array.",
         edit_schema(),
         edit_handler,
-        vec!["Include enough context for unique matching"],
+        vec![
+            "Include enough context for unique matching",
+            "Emit the `path` field first, before `oldText`/`newText`/`edits`, so the target file is known while the edit streams.",
+        ],
     )
 }
 

--- a/desktop/src-tauri/src/agent_bridge/persist.rs
+++ b/desktop/src-tauri/src/agent_bridge/persist.rs
@@ -39,10 +39,17 @@ pub(super) fn persist_run_event(
     // artifact-path extraction both draw from it), and feeding it here keeps it
     // warm in real time instead of waiting for a journal-tail poll. Journal-tail
     // pollers and fork/import synthesis advance the same cache; the projection's
-    // sequence guard makes the overlap idempotent.
+    // sequence guard makes the overlap idempotent. Deltas only reach this fold
+    // via projection snapshots (reattach replay) — the live path keeps
+    // token-heavy events on the cheap notification path in stream.rs.
     if matches!(
         event_type,
-        "tool_start" | "toolcall_start" | "tool_end" | "tool_result"
+        "tool_start"
+            | "toolcall_start"
+            | "tool_delta"
+            | "toolcall_delta"
+            | "tool_end"
+            | "tool_result"
     ) {
         let record = store::RunEventRecord {
             id: store::create_id("event"),

--- a/desktop/src-tauri/src/store/runs.rs
+++ b/desktop/src-tauri/src/store/runs.rs
@@ -833,6 +833,39 @@ fn apply_tool_event(state: &mut ToolProjectionState, event: &RunEventRecord) {
                 });
             }
         }
+        "tool_delta" | "toolcall_delta" => {
+            // Tool arguments stream in fragments after the (empty-args)
+            // input-phase `tool_start`; fold them so the Runs panel can show
+            // the command/target while the model is still emitting the call.
+            // The execution-phase `tool_start` later replaces the accumulated
+            // text with the complete args.
+            let Some((tool_id, text, snapshot)) =
+                parse_tool_delta_payload(event.payload.as_deref())
+            else {
+                return;
+            };
+            let idx = match tool_id {
+                // The id is authoritative: a delta naming an id we haven't
+                // folded means its start never arrived (journal gap) — drop it
+                // rather than misattribute the fragments to another call.
+                Some(id) => index_by_id.get(&id).copied(),
+                // Index-only streams (some providers omit the id on every
+                // fragment): attribute to the newest still-running call — arg
+                // fragments only flow while their call is open, and a
+                // misattributed stream self-corrects when the execution
+                // `tool_start` lands with complete args.
+                None => tools.iter().rposition(|tool| tool.status == "running"),
+            };
+            let Some(idx) = idx else {
+                return;
+            };
+            let input = tools[idx].input.get_or_insert_with(String::new);
+            if snapshot {
+                // Full current state, not an incremental fragment.
+                input.clear();
+            }
+            input.push_str(&text);
+        }
         "tool_end" | "tool_result" => {
             let idx = event_tool_id(event)
                 .as_deref()
@@ -860,6 +893,34 @@ fn event_tool_id(event: &RunEventRecord) -> Option<String> {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     })
+}
+
+/// (`tool_id`, fragment text, snapshot) from a `tool_delta` payload. The id is
+/// absent for providers that stream index-only; `snapshot == true` means the
+/// text carries the provider's full current argument state, not a fragment.
+fn parse_tool_delta_payload(payload: Option<&str>) -> Option<(Option<String>, String, bool)> {
+    let payload = payload?;
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let text = v
+        .get("text")
+        .or_else(|| v.get("delta"))
+        .or_else(|| v.get("content"))
+        .and_then(|s| s.as_str())
+        .unwrap_or("");
+    if text.is_empty() {
+        return None;
+    }
+    let tool_id = ["tool_id", "toolID", "tool_call_id"].iter().find_map(|k| {
+        v.get(*k)
+            .and_then(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    });
+    let snapshot = v
+        .get("snapshot")
+        .and_then(|flag| flag.as_bool())
+        .unwrap_or(false);
+    Some((tool_id, text.to_string(), snapshot))
 }
 
 fn parse_tool_start_payload(payload: Option<&str>) -> (String, String, Option<String>) {
@@ -1418,6 +1479,147 @@ mod tests {
         // create an entry — it returns the empty list.
         let uncached = format!("test_uncached_{}", std::process::id());
         assert!(advance_tool_projection(&uncached, &[]).is_empty());
+    }
+
+    #[test]
+    fn tool_projection_accumulates_streaming_arg_deltas() {
+        let run_id = format!("test_arg_deltas_{}", std::process::id());
+        let tools = advance_tool_projection(
+            &run_id,
+            &[
+                // Input-phase start: native streams announce the call before
+                // any argument text has arrived.
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t1","tool_name":"edit","tool_args":""}"#,
+                    0,
+                ),
+                tool_event(
+                    &run_id,
+                    "tool_delta",
+                    r#"{"tool_id":"t1","text":"{\"file_path\": \"/a"}"#,
+                    1,
+                ),
+                tool_event(
+                    &run_id,
+                    "toolcall_delta",
+                    r#"{"tool_id":"t1","text":".ts\"}"}"#,
+                    2,
+                ),
+                // Execution-phase start replaces the accumulated partial with
+                // the complete args.
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t1","tool_name":"edit","tool_args":{"file_path":"/a.ts","old":"x"}}"#,
+                    3,
+                ),
+            ],
+        );
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            tools[0].input.as_deref(),
+            Some(r#"{"file_path":"/a.ts","old":"x"}"#)
+        );
+
+        let mut cache = TOOL_PROJECTION_CACHE.lock().unwrap_or_else(unpoison);
+        cache.remove(&run_id);
+    }
+
+    #[test]
+    fn tool_projection_keeps_partial_input_until_execution_start() {
+        let run_id = format!("test_partial_args_{}", std::process::id());
+        let tools = advance_tool_projection(
+            &run_id,
+            &[
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t1","tool_name":"write","tool_args":""}"#,
+                    0,
+                ),
+                tool_event(
+                    &run_id,
+                    "tool_delta",
+                    r#"{"tool_id":"t1","text":"{\"path\": \"/tmp/out.md\""}"#,
+                    1,
+                ),
+            ],
+        );
+
+        // No execution start yet: the folded partial args stay as the input so
+        // the Runs panel can surface the target while the model still streams.
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].input.as_deref(), Some(r#"{"path": "/tmp/out.md""#));
+
+        let mut cache = TOOL_PROJECTION_CACHE.lock().unwrap_or_else(unpoison);
+        cache.remove(&run_id);
+    }
+
+    #[test]
+    fn tool_projection_snapshot_delta_replaces_and_idless_delta_targets_newest_running() {
+        let run_id = format!("test_delta_attrs_{}", std::process::id());
+        let tools = advance_tool_projection(
+            &run_id,
+            &[
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t1","tool_name":"shell","tool_args":"{\"command\":\"echo one\"}"}"#,
+                    0,
+                ),
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t2","tool_name":"read","tool_args":""}"#,
+                    1,
+                ),
+                // No tool_id: attributed to the newest still-running call (t2).
+                tool_event(&run_id, "tool_delta", r#"{"text":"{\"path\": \"/b"}"#, 2),
+                tool_event(&run_id, "tool_delta", r#"{"text":".ts\"}"}"#, 3),
+                // Snapshot delta replaces the accumulated text wholesale.
+                tool_event(
+                    &run_id,
+                    "tool_delta",
+                    r#"{"tool_id":"t2","text":"{\"path\": \"/c.ts\"}","snapshot":true}"#,
+                    4,
+                ),
+            ],
+        );
+
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].input.as_deref(), Some(r#"{"command":"echo one"}"#));
+        assert_eq!(tools[1].input.as_deref(), Some(r#"{"path": "/c.ts"}"#));
+
+        let mut cache = TOOL_PROJECTION_CACHE.lock().unwrap_or_else(unpoison);
+        cache.remove(&run_id);
+    }
+
+    #[test]
+    fn tool_projection_ignores_delta_without_a_running_call() {
+        let run_id = format!("test_orphan_delta_{}", std::process::id());
+        let tools = advance_tool_projection(
+            &run_id,
+            &[
+                tool_event(
+                    &run_id,
+                    "tool_start",
+                    r#"{"tool_id":"t1","tool_name":"read","tool_args":"{\"path\":\"/a.ts\"}"}"#,
+                    0,
+                ),
+                tool_event(&run_id, "tool_end", r#"{"tool_id":"t1","text":"ok"}"#, 1),
+                // Delta for an unknown call after the only one ended: dropped.
+                tool_event(&run_id, "tool_delta", r#"{"tool_id":"t9","text":"{}"}"#, 2),
+            ],
+        );
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].input.as_deref(), Some(r#"{"path":"/a.ts"}"#));
+
+        let mut cache = TOOL_PROJECTION_CACHE.lock().unwrap_or_else(unpoison);
+        cache.remove(&run_id);
     }
 
     #[test]

--- a/desktop/src/features/runs/RunsPanel.tsx
+++ b/desktop/src/features/runs/RunsPanel.tsx
@@ -35,8 +35,11 @@ interface RunsPanelProps {
 interface ToolEntry {
   tool: StoredToolCall;
   run: StoredRun;
-  // Exactly one row per active run carries the terminate control — its latest
-  // command — so a multi-command run isn't cluttered with duplicate stop buttons.
+  // Exactly one row per active run carries the terminate control — its newest
+  // still-running command — so a multi-command run isn't cluttered with
+  // duplicate stop buttons, and a completed command never shows one (its run
+  // may still be generating its reply, but interrupting that is the composer's
+  // stop button, not a per-command row).
   terminable: boolean;
 }
 
@@ -227,8 +230,7 @@ function ToolRow({
     = (isShell ? toolCommand(tool.input) : toolTarget(tool.input))
       ?? toolCommand(tool.input)
       ?? toolTarget(tool.input)
-      ?? tool.input
-      ?? toolLabel(tool);
+      ?? fallbackPrimary(tool.input, toolLabel(tool));
   // Shell rows show the command verbatim; file rows (write/edit) get the
   // workspace-relative path, absolute kept for files outside the workspace.
   const primary = isShell
@@ -239,7 +241,7 @@ function ToolRow({
   // real failure, so treat it as failed rather than a perpetual "running".
   const status
     = tool.status === "running" && !isActiveRun(run) ? "failed" : tool.status;
-  const running = status === "running" || terminable;
+  const running = status === "running";
   const meta = [toolLabel(tool), toolStatusLabel(status)]
     .filter(Boolean)
     .join(" · ");
@@ -289,7 +291,10 @@ function ToolRow({
           <div className="flex items-start gap-2">
             <div
               className={cn(
-                "min-w-0 flex-1 wrap-break-word text-xs font-normal leading-5 text-ink",
+                // min-h-5 (one leading-5 line) reserves the target line's
+                // height while a streaming tool call has no parseable target
+                // yet, so the row doesn't jump when the target appears.
+                "min-h-5 min-w-0 flex-1 wrap-break-word text-xs font-normal leading-5 text-ink",
                 isShell ? "whitespace-pre-wrap" : "truncate font-mono",
               )}
               title={rawPrimary}
@@ -365,6 +370,22 @@ function displayName(tool: StoredToolCall) {
   return tool.name.trim().toLowerCase();
 }
 
+/**
+ * The raw input is shown only when it is plain text (legacy records carry the
+ * command as a bare string). A JSON-object input that yielded no field — above
+ * all a still-streaming partial — renders as a blank line instead of a raw
+ * JSON blob, so the row swaps in the parsed target later without noise.
+ */
+function fallbackPrimary(
+  input: string | null | undefined,
+  label: string,
+): string {
+  if (input === null || input === undefined)
+    return label;
+  const first = input.trimStart().charAt(0);
+  return first === "{" || first === "[" ? "" : input;
+}
+
 function isActiveRun(run: StoredRun) {
   return (
     run.status === "queued"
@@ -400,12 +421,20 @@ function buildToolEntries(
       continue;
     }
 
-    const latestId = [...tools].sort(compareToolTimeDesc)[0]?.id;
+    // The terminate control rides the run's newest still-running command. A
+    // completed tool never carries it — otherwise a finished command shows a
+    // "completed" label next to a stop button while the run merely generates
+    // its reply. (filter() copies, so the sort can't reorder the caller's
+    // array.)
+    const runningTools = tools
+      .filter(tool => tool.status === "running")
+      .sort(compareToolTimeDesc);
+    const latestRunningId = runningTools[0]?.id;
     for (const tool of tools) {
       const entry: ToolEntry = {
         tool,
         run,
-        terminable: runActive && tool.id === latestId,
+        terminable: runActive && tool.id === latestRunningId,
       };
       (runActive ? active : finished).push(entry);
     }

--- a/desktop/src/features/runs/RunsPanel.tsx
+++ b/desktop/src/features/runs/RunsPanel.tsx
@@ -35,11 +35,11 @@ interface RunsPanelProps {
 interface ToolEntry {
   tool: StoredToolCall;
   run: StoredRun;
-  // Exactly one row per active run carries the terminate control — its newest
-  // still-running command — so a multi-command run isn't cluttered with
-  // duplicate stop buttons, and a completed command never shows one (its run
-  // may still be generating its reply, but interrupting that is the composer's
-  // stop button, not a per-command row).
+  // A running command of an active run carries the terminate control. The
+  // model can launch several tools at once within one run; each still-running
+  // row gets its own button, all pointing at the same run-level abort. A
+  // completed command never shows one (interrupting the reply phase is the
+  // composer's stop button).
   terminable: boolean;
 }
 
@@ -302,52 +302,62 @@ function ToolRow({
               {primary}
             </div>
           </div>
-          <div className="mt-2 text-xs font-medium text-ink-muted">{meta}</div>
+          {/* Status line is a fixed-height row (min-h-5 == leading-5) so the
+              row doesn't jump whether or not the terminate control is present.
+              The terminate button sits inline at the line's right edge. */}
+          <div className="mt-2 flex min-h-5 items-center justify-between gap-2">
+            <span className="min-w-0 truncate text-xs font-medium text-ink-muted">
+              {meta}
+            </span>
+            {terminable
+              ? (
+                  <span className="flex shrink-0 items-center gap-1">
+                    {confirming
+                      ? (
+                          <>
+                            <span className="text-xs text-ink-muted">
+                              {t("runsPanel.confirmTerminate")}
+                            </span>
+                            <Button
+                              className="h-5 gap-1 px-1.5"
+                              disabled={busy}
+                              onClick={onCancelConfirm}
+                              size="xs"
+                              variant="ghost"
+                            >
+                              {t("runsPanel.cancel")}
+                            </Button>
+                            <Button
+                              className="h-5 gap-1 px-1.5"
+                              disabled={busy}
+                              leftIcon={<CircleStop className="size-3" />}
+                              onClick={onTerminate}
+                              size="xs"
+                              variant="danger"
+                            >
+                              {busy ? t("runsPanel.stopping") : t("runsPanel.terminate")}
+                            </Button>
+                          </>
+                        )
+                      : (
+                          <Button
+                            className="h-5 gap-1 px-1.5"
+                            leftIcon={<CircleStop className="size-3" />}
+                            onClick={onRequestTerminate}
+                            size="xs"
+                            variant="danger-soft"
+                          >
+                            {t("runsPanel.terminate")}
+                          </Button>
+                        )}
+                  </span>
+                )
+              : null}
+          </div>
           {actionError
             ? (
                 <div className="mt-2 line-clamp-3 text-xs leading-5 text-danger">
                   {actionError}
-                </div>
-              )
-            : null}
-          {terminable
-            ? (
-                <div className="mt-3 flex justify-end">
-                  {confirming
-                    ? (
-                        <div className="flex items-center gap-2">
-                          <span className="text-xs text-ink-muted">
-                            {t("runsPanel.confirmTerminate")}
-                          </span>
-                          <Button
-                            disabled={busy}
-                            onClick={onCancelConfirm}
-                            size="xs"
-                            variant="ghost"
-                          >
-                            {t("runsPanel.cancel")}
-                          </Button>
-                          <Button
-                            disabled={busy}
-                            leftIcon={<CircleStop className="size-3.5" />}
-                            onClick={onTerminate}
-                            size="xs"
-                            variant="danger"
-                          >
-                            {busy ? t("runsPanel.stopping") : t("runsPanel.terminate")}
-                          </Button>
-                        </div>
-                      )
-                    : (
-                        <Button
-                          leftIcon={<CircleStop className="size-3.5" />}
-                          onClick={onRequestTerminate}
-                          size="xs"
-                          variant="danger-soft"
-                        >
-                          {t("runsPanel.terminate")}
-                        </Button>
-                      )}
                 </div>
               )
             : null}
@@ -421,20 +431,16 @@ function buildToolEntries(
       continue;
     }
 
-    // The terminate control rides the run's newest still-running command. A
+    // The terminate control rides every still-running command of an active run
+    // (parallel tool calls each get one; the button aborts the whole run). A
     // completed tool never carries it — otherwise a finished command shows a
     // "completed" label next to a stop button while the run merely generates
-    // its reply. (filter() copies, so the sort can't reorder the caller's
-    // array.)
-    const runningTools = tools
-      .filter(tool => tool.status === "running")
-      .sort(compareToolTimeDesc);
-    const latestRunningId = runningTools[0]?.id;
+    // its reply.
     for (const tool of tools) {
       const entry: ToolEntry = {
         tool,
         run,
-        terminable: runActive && tool.id === latestRunningId,
+        terminable: runActive && tool.status === "running",
       };
       (runActive ? active : finished).push(entry);
     }

--- a/desktop/src/features/runs/toolInput.test.ts
+++ b/desktop/src/features/runs/toolInput.test.ts
@@ -30,6 +30,31 @@ describe("toolInput", () => {
     expect(toolTarget(null)).toBeNull();
   });
 
+  it("toolCommand reads a field from a still-streaming partial JSON object", () => {
+    // The value's closing quote has arrived, the rest of the object hasn't.
+    expect(toolCommand("{\"command\": \"cd /tmp && ls\"")).toBe("cd /tmp && ls");
+    // Whitespace variants between key, colon, and value.
+    expect(toolCommand("{\"command\":\"grep -n x\"")).toBe("grep -n x");
+    // Value quote not closed yet — nothing safe to surface.
+    expect(toolCommand("{\"command\": \"cd /tmp")).toBeNull();
+    // A blank extracted value is skipped, not surfaced.
+    expect(toolCommand("{\"command\": \"\"")).toBeNull();
+  });
+
+  it("toolTarget reads a field from a partial JSON object", () => {
+    expect(toolTarget("{\"file_path\": \"src/a.ts\"")).toBe("src/a.ts");
+    // Respects the key set: a partial command is not a target.
+    expect(toolTarget("{\"command\": \"ls\"")).toBeNull();
+    // Escaped content inside the closed quote is decoded.
+    expect(toolTarget("{\"path\": \"a\\\"b.ts\"")).toBe("a\"b.ts");
+  });
+
+  it("partial extraction also unwraps a double-encoded partial payload", () => {
+    // Outer JSON string is complete; the inner object it wraps is partial.
+    const partialDouble = JSON.stringify("{\"file_path\": \"src/a.ts\"");
+    expect(toolTarget(partialDouble)).toBe("src/a.ts");
+  });
+
   it("recordOf narrows objects and rejects arrays / scalars", () => {
     expect(recordOf("{\"a\":1}")).toEqual({ a: 1 });
     expect(recordOf("[1,2,3]")).toBeNull();

--- a/desktop/src/features/runs/toolInput.ts
+++ b/desktop/src/features/runs/toolInput.ts
@@ -69,10 +69,63 @@ export function numberOrStringField(record: Record<string, unknown> | null, keys
 
 /** Extract the `command` field from a (possibly double-encoded) tool input. */
 export function toolCommand(input: string | null | undefined): string | null {
-  return stringField(recordOf(input), "command");
+  return firstStringField(input, "command");
 }
 
 /** Extract the target file path from a (possibly double-encoded) tool input. */
 export function toolTarget(input: string | null | undefined): string | null {
-  return stringField(recordOf(input), ["path", "filePath", "file_path", "targetPath", "target_path", "target"]);
+  return firstStringField(input, [
+    "path",
+    "filePath",
+    "file_path",
+    "targetPath",
+    "target_path",
+    "target",
+  ]);
+}
+
+/**
+ * Field lookup that tolerates an incomplete JSON object: while a tool's
+ * arguments are still streaming (`tool_delta` fragments folded into `input`),
+ * `recordOf` can't parse the text yet, but a `"key": "value"` pair whose value
+ * already closed its quote is safe to read off the raw text. Mirrors
+ * thread-projection's `partialTargetFromArgsText` for the chat-area preview.
+ */
+function firstStringField(
+  input: string | null | undefined,
+  keys: string | string[],
+): string | null {
+  const parsed = parseJsonish(input);
+  if (isRecord(parsed))
+    return stringField(parsed, keys);
+  // `parsed` is the innermost peeled string when the (double-encoded) input
+  // couldn't be parsed all the way down — partial-match whichever text we have.
+  const text
+    = typeof parsed === "string" && parsed.trim()
+      ? parsed
+      : typeof input === "string" && input.trim()
+        ? input
+        : null;
+  return text ? partialStringField(text, keys) : null;
+}
+
+/** First `"key": "<closed quoted value>"` pair present in `text`, or `null`. */
+function partialStringField(
+  text: string,
+  keys: string | string[],
+): string | null {
+  for (const key of keyList(keys)) {
+    const match = new RegExp(`"${key}"\\s*:\\s*("(?:[^"\\\\]|\\\\.)*")`).exec(text);
+    if (!match?.[1])
+      continue;
+    try {
+      const value = JSON.parse(match[1]) as unknown;
+      if (typeof value === "string" && value.trim())
+        return value;
+    }
+    catch {
+      // Unescapable quote content — keep looking.
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## 问题

Runs 面板（右侧上下文）三条体验问题：

1. **已完成的任务还挂着「终止」按钮** — 按钮此前挂在 run 的「最新一条工具」上（按 run 状态判断），而行的状态标签显示工具自身状态。最后一条命令已完成、模型仍在生成收尾回复时，run 仍活跃 → 已完成的行带着终止按钮，与头部「0 运行中」矛盾。
2. **运行中的 Write/Edit 目标路径迟迟不显示** — agent 流式下发工具参数（`tool_start` 空参数 → `tool_delta` 片段 → 执行期 `tool_start` 完整参数），但 GUI 的工具投影此前忽略 `tool_delta`，所以参数流完前目标一直空白。
3. **目标解析出来前后行高抖动** — 目标行为空时高度塌成 0。

## 改动

### 终止按钮语义对齐
- 终止按钮现在挂到「run 活跃时的每条**运行中**工具」上（并行工具调用各挂一个，都指向 run 级 abort）。已完成命令不再显示按钮；纯生成回复阶段用输入框的停止按钮。
- 按钮内联到状态行右侧（`h-5`，与 `leading-5` 等高），状态行固定 `min-h-5`，有无按钮都不抖动。

### 流式目标路径
- **Rust 投影**（`desktop/src-tauri/src/store/runs.rs`）折叠 `tool_delta`/`toolcall_delta`：按 `tool_id` 定位（snapshot 型整体替换、碎片型追加；无 id 的挂到最新运行中工具），执行期 `tool_start` 到达后被完整参数覆盖。
- **前端**（`toolInput.ts`）：JSON 解析失败时，用正则从半截 JSON 里抠出已闭合引号的 `path`/`file_path`/`command` 字段，复用聊天区预览 `thread-projection` 的既有技巧，不引入新依赖。
- JSON 对象输入解析不出字段时渲染空白行而非裸 JSON 串。

### 模型字段顺序（软约束）
- Write/Edit 工具 schema 已声明 `path` 在前，但模型生成长 content 时倾向先吐正文、后补路径。新增 per-tool guideline 要求「先输出 `path` 字段」——软约束，提高常见情况的提前命中率（`agent/src/tools/mod.rs`）。

## 验证

- `make lint-rust`（CI fmt + clippy `-D warnings`，含 desktop/src-tauri）✅
- 桌面前端 `tsc --noEmit` / `eslint` / `vitest run`（664 tests）✅
- desktop/src-tauri `cargo fmt` / `clippy` / `test` ✅
- `make test` 中 `future-channel` 的 5 个 sigint 测试为**既有 flaky**（1.2s sleep 竞态，与本次改动零交集，本地 3 次复跑 2 败 1 过；CI 在 Linux 上跑不受影响）

🤖 Generated with [Claude Code](https://claude.com/claude-code)