### PR TITLE
fix(loop): retry once with suffixed client_request_id on duplicate_request_conflict

### DIFF
--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -4,7 +4,7 @@
 //! pure transport (build the packet, prompt, observe the event stream,
 //! account spend) — all loop policy lives in `decision.rs` / `state.rs`.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::agent_client::{AgentClient, RunSummary, TurnProgressTracker};
 use crate::decision::{compose_goal_boundary, compose_turn_envelope, compose_turn_message};
@@ -301,12 +301,39 @@ pub async fn execute_turn(
         None => format!("session: {session_id}\n{message}"),
     };
     // Idempotency key owned by the orchestrator — retry must not double-execute.
+    // The key is derived from (turn, todo). A worker stopped/restarted within the
+    // SAME turn keeps the key, which is correct for enqueue dedup. But an
+    // aborted turn (worker stop / transport abort) leaves the key registered in
+    // the agent's RunQueue with a DIFFERENT payload digest than the re-entrant
+    // prompt (the rebuilt envelope differs), so a plain re-send returns
+    // duplicate_request_conflict and the run dies at launch. Detect that error
+    // and retry once with a suffixed key: the new key is a genuinely new request
+    // (different payload), so dedup protection is preserved while the launch
+    // survives.
     let client_request_id = format!("turn-{}-{}", turn, todo.id);
 
     let before = client.session_totals(session_id).await?;
-    let run_id = client
-        .prompt(session_id, &message, &client_request_id)
-        .await?;
+    let run_id = match client.prompt(session_id, &message, &client_request_id).await {
+        Ok(run_id) => run_id,
+        Err(error)
+            if error.to_string().contains("duplicate_request_conflict") =>
+        {
+            let retry_id = format!(
+                "{client_request_id}-r{}",
+                &uuid::Uuid::new_v4().simple().to_string()[..8]
+            );
+            client
+                .prompt(session_id, &message, &retry_id)
+                .await
+                .with_context(|| {
+                    format!(
+                        "prompt retry with suffixed client_request_id after \
+                         duplicate_request_conflict (original key: {client_request_id})"
+                    )
+                })?
+        }
+        Err(error) => return Err(error),
+    };
     let live_path = runs_dir.map(|d| d.join(format!("{run_id}.live.jsonl")));
     // Write a run-header line FIRST so the read-only dashboard can associate
     // this live run with its worker/todo and expose real-time token/cost.

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -313,11 +313,12 @@ pub async fn execute_turn(
     let client_request_id = format!("turn-{}-{}", turn, todo.id);
 
     let before = client.session_totals(session_id).await?;
-    let run_id = match client.prompt(session_id, &message, &client_request_id).await {
+    let run_id = match client
+        .prompt(session_id, &message, &client_request_id)
+        .await
+    {
         Ok(run_id) => run_id,
-        Err(error)
-            if error.to_string().contains("duplicate_request_conflict") =>
-        {
+        Err(error) if error.to_string().contains("duplicate_request_conflict") => {
             let retry_id = format!(
                 "{client_request_id}-r{}",
                 &uuid::Uuid::new_v4().simple().to_string()[..8]


### PR DESCRIPTION
## Problem

Field evidence (ASC S4 R5: 10 workers, 61 turns, 24h continuous run):

A worker stopped mid-turn (`worker stop` / transport abort) leaves its `client_request_id` (`turn-1-<todo>`) registered in the agent's RunQueue. Relaunching the same agent for the same todo rebuilds the turn envelope with a **different payload digest**, so the idempotent re-send now trips `DuplicateRequestConflict` and the run dies at launch.

Operators worked around this by discarding the retained session entirely (`--session-policy fresh`) — losing the resumable context that session retention exists to protect. In our round this cost a full hour of worker progress on day 1, plus 3 late-round restart failures.

## Fix

On `duplicate_request_conflict`, retry **once** with a suffixed key (`turn-1-<todo>-r<8-hex>`):

- The original key's digest mismatch proves the re-entrant payload is genuinely different (envelope content changed), so the suffixed request cannot mask a true double-execute — dedup protection is preserved.
- If the retry also fails, the error carries the original key via `anyhow::Context` for diagnosis.

## Why not other approaches

- **Change the key format to include a payload hash**: would break the orchestrator-owned idempotency contract (re-sending the same key for the SAME payload must dedup — e.g. transient gRPC failures during prompt).
- **Clear the stale key from the agent**: requires a new RPC surface; the suffixed-key retry achieves the same with zero protocol change.

## Testing

- `cargo build -p future-loop` ✅
- `cargo test -p future-loop --lib` — 382 passed ✅
- `cargo clippy -p future-loop` ✅