### PR TITLE
Improve long conversation loading

### DIFF
--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -495,251 +495,273 @@ pub(crate) fn cmd_get_session_entries(
             serde_json::json!({"entries": []}),
         );
     }
-    let loaded = match session_manager.load(&session_id) {
-        Ok(session) => session,
-        Err(error) => {
-            return RpcResponse::build_fail_code(
-                id,
-                "get_session_entries",
-                "session_history_unreadable",
-                &format!("Unable to load session history: {error}"),
-                serde_json::json!({"sessionId": session_id}),
-            );
-        }
-    };
-    let entries: Vec<serde_json::Value> = {
-        let s = loaded;
-        // The authoritative metadata is the last session_info snapshot
-        // (the append-only commit path appends a fresh one per run). Surface
-        // it in the first session_info slot — where clients (CLI info, fork)
-        // look — and drop the stale earlier ones so callers see exactly one.
-        let authoritative_info = s
-            .entries
-            .iter()
-            .rev()
-            .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
-            .and_then(|e| e.content.clone());
-        let mut emitted_session_info = false;
-        // Per-run output tokens + wall-clock duration live only in the
-        // `run_terminal` marker's content JSON (the assistant entry's content
-        // is a block array, so it can't carry them). Bind each marker to the
-        // assistant entry that precedes it — the run's final reply — so the
-        // GUI/mobile footer ("time · N tokens") survives a reload. Positional
-        // binding (not run_id) because the on-disk assistant entry's meta may
-        // lack run_id on the append-only fast path. Clearing the pointer after
-        // a marker keeps a terminal of a reply-less run (cancel/error before
-        // any assistant entry) from overwriting the previous run's stats.
-        let mut last_assistant_id: Option<String> = None;
-        let mut run_stats: std::collections::HashMap<String, (i64, i64, i64, i64)> =
-            std::collections::HashMap::new();
-        // Per-run usage deltas from the cumulative session_info snapshots
-        // (tokens_in / tokens_cache_r): the snapshot written just before a
-        // run_terminal marker is the post-run state, and the one captured at
-        // the previous run_terminal (or session start) is the pre-run state,
-        // so consecutive-snapshot deltas are exactly this run's billed usage.
-        let mut prev_snapshot: (i64, i64) = (0, 0);
-        let mut current_snapshot: (i64, i64) = (0, 0);
-        for marker in &s.entries {
-            if marker.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
-                last_assistant_id = Some(marker.id.clone());
-            } else if marker.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                if let Some(content) = marker.content.as_ref() {
-                    current_snapshot = (
-                        content
-                            .get("tokens_in")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(current_snapshot.0),
-                        content
-                            .get("tokens_cache_r")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(current_snapshot.1),
-                    );
-                }
-            } else if marker.entry_type == crate::session::ENTRY_TYPE_RUN_TERMINAL {
-                if let (Some(aid), Some(content)) =
-                    (last_assistant_id.as_deref(), marker.content.as_ref())
-                {
-                    let tokens = content
-                        .get("run_tokens")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    let duration = content
-                        .get("run_duration_ms")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    let delta_in = (current_snapshot.0 - prev_snapshot.0).max(0);
-                    let delta_cache = (current_snapshot.1 - prev_snapshot.1).max(0);
-                    run_stats.insert(aid.to_string(), (tokens, duration, delta_in, delta_cache));
-                }
-                last_assistant_id = None;
-                prev_snapshot = current_snapshot;
+    let version_before = session_manager.session_file_version(&session_id).ok();
+    let cached = version_before
+        .as_ref()
+        .and_then(|version| session_manager.cached_display_entries(&session_id, version));
+    let entries = if let Some(entries) = cached {
+        entries
+    } else {
+        let loaded = match session_manager.load(&session_id) {
+            Ok(session) => session,
+            Err(error) => {
+                return RpcResponse::build_fail_code(
+                    id,
+                    "get_session_entries",
+                    "session_history_unreadable",
+                    &format!("Unable to load session history: {error}"),
+                    serde_json::json!({"sessionId": session_id}),
+                );
             }
-        }
-        s.entries
-            .iter()
-            .filter(|e| {
-                if !matches!(
-                    e.entry_type.as_str(),
-                    "user" | "assistant" | "tool" | "session_info" | "compaction"
-                ) {
-                    return false;
+        };
+        let projected: Vec<serde_json::Value> = {
+            let s = loaded;
+            // The authoritative metadata is the last session_info snapshot
+            // (the append-only commit path appends a fresh one per run). Surface
+            // it in the first session_info slot — where clients (CLI info, fork)
+            // look — and drop the stale earlier ones so callers see exactly one.
+            let authoritative_info = s
+                .entries
+                .iter()
+                .rev()
+                .find(|e| e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO)
+                .and_then(|e| e.content.clone());
+            let mut emitted_session_info = false;
+            // Per-run output tokens + wall-clock duration live only in the
+            // `run_terminal` marker's content JSON (the assistant entry's content
+            // is a block array, so it can't carry them). Bind each marker to the
+            // assistant entry that precedes it — the run's final reply — so the
+            // GUI/mobile footer ("time · N tokens") survives a reload. Positional
+            // binding (not run_id) because the on-disk assistant entry's meta may
+            // lack run_id on the append-only fast path. Clearing the pointer after
+            // a marker keeps a terminal of a reply-less run (cancel/error before
+            // any assistant entry) from overwriting the previous run's stats.
+            let mut last_assistant_id: Option<String> = None;
+            let mut run_stats: std::collections::HashMap<String, (i64, i64, i64, i64)> =
+                std::collections::HashMap::new();
+            // Per-run usage deltas from the cumulative session_info snapshots
+            // (tokens_in / tokens_cache_r): the snapshot written just before a
+            // run_terminal marker is the post-run state, and the one captured at
+            // the previous run_terminal (or session start) is the pre-run state,
+            // so consecutive-snapshot deltas are exactly this run's billed usage.
+            let mut prev_snapshot: (i64, i64) = (0, 0);
+            let mut current_snapshot: (i64, i64) = (0, 0);
+            for marker in &s.entries {
+                if marker.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
+                    last_assistant_id = Some(marker.id.clone());
+                } else if marker.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                    if let Some(content) = marker.content.as_ref() {
+                        current_snapshot = (
+                            content
+                                .get("tokens_in")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(current_snapshot.0),
+                            content
+                                .get("tokens_cache_r")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(current_snapshot.1),
+                        );
+                    }
+                } else if marker.entry_type == crate::session::ENTRY_TYPE_RUN_TERMINAL {
+                    if let (Some(aid), Some(content)) =
+                        (last_assistant_id.as_deref(), marker.content.as_ref())
+                    {
+                        let tokens = content
+                            .get("run_tokens")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
+                        let duration = content
+                            .get("run_duration_ms")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
+                        let delta_in = (current_snapshot.0 - prev_snapshot.0).max(0);
+                        let delta_cache = (current_snapshot.1 - prev_snapshot.1).max(0);
+                        run_stats
+                            .insert(aid.to_string(), (tokens, duration, delta_in, delta_cache));
+                    }
+                    last_assistant_id = None;
+                    prev_snapshot = current_snapshot;
                 }
-                // Keep only the first session_info slot; its content is
-                // replaced with the authoritative (last) snapshot below, and
-                // the stale later snapshots are dropped.
-                if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                    if emitted_session_info {
+            }
+            s.entries
+                .iter()
+                .filter(|e| {
+                    if !matches!(
+                        e.entry_type.as_str(),
+                        "user" | "assistant" | "tool" | "session_info" | "compaction"
+                    ) {
                         return false;
                     }
-                    emitted_session_info = true;
-                }
-                true
-            })
-            .map(|e| {
-                let content_text = e
-                    .content
-                    .as_ref()
-                    .map(|c| {
-                        if let Some(arr) = c.as_array() {
-                            let texts = arr.iter().filter_map(|block| {
-                                (block.get("type").and_then(|value| value.as_str()) == Some("text"))
-                                    .then(|| block.get("text").and_then(|text| text.as_str()))
-                                    .flatten()
-                            });
-                            if e.role == "user" {
-                                // A user entry's visible text is only their typed
-                                // message (the first text block). Any later text
-                                // block is agent-injected attachment context
-                                // (file paths), which must not leak into the bubble.
-                                texts.take(1).collect::<Vec<_>>().join(" ")
-                            } else {
-                                texts.collect::<Vec<_>>().join(" ")
-                            }
-                        } else {
-                            c.as_str().unwrap_or("").to_string()
+                    // Keep only the first session_info slot; its content is
+                    // replaced with the authoritative (last) snapshot below, and
+                    // the stale later snapshots are dropped.
+                    if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                        if emitted_session_info {
+                            return false;
                         }
-                    })
-                    .unwrap_or_default();
-                // Build the display content for this entry. Only include the
-                // actual visible text — no thinking or tool formatting.
-                // The forked session's messages should look identical to
-                // original GUI messages (which store thinking/tools in
-                // run events, not in the message content).
-                let full_content = if e.entry_type == "tool" {
-                    // Tool entries: show the result text, or a placeholder.
-                    e.content
-                        .as_ref()
-                        .and_then(serde_json::Value::as_array)
-                        .and_then(|blocks| {
-                            blocks.iter().find_map(|block| {
-                                (block.get("type").and_then(serde_json::Value::as_str)
-                                    == Some("tool_result"))
-                                .then(|| block.get("content").and_then(serde_json::Value::as_str))
-                                .flatten()
-                            })
-                        })
-                        .map(str::to_owned)
-                        .unwrap_or(content_text)
-                } else {
-                    // User and assistant entries: just the text content.
-                    content_text
-                };
-
-                // Typed payload (audit item 1): SessionEntryPayload mirrors
-                // the on-disk entry schema (snake_case keys).
-                let mut payload = crate::rpc::payloads::SessionEntryPayload {
-                    id: e.id.clone(),
-                    entry_type: Some(e.entry_type.clone()),
-                    role: e.role.clone(),
-                    content: serde_json::Value::String(full_content),
-                    name: e.name.clone(),
-                    tool_args: e.tool_args.clone(),
-                    timestamp: e.timestamp.to_rfc3339(),
-                    thinking: None,
-                    meta: None,
-                    tool_calls: None,
-                    output_tokens: None,
-                    duration_ms: None,
-                    input_tokens: None,
-                    cache_read_tokens: None,
-                    checkpoint: None,
-                    tool_call_id: None,
-                    tool_result_is_error: None,
-                };
-                if e.entry_type == crate::session::ENTRY_TYPE_COMPACTION {
-                    payload.content = serde_json::Value::String(String::new());
-                    payload.checkpoint = e.content.clone();
-                }
-                // Include thinking and tool_calls for the new agent-based
-                // message display (entryProjection.ts).
-                if !e.thinking.is_empty() {
-                    payload.thinking = Some(e.thinking.clone());
-                }
-                // Structured per-entry metadata (e.g. user attachments with
-                // their cached thumbnails) so the GUI can rebuild attachment
-                // chips after reload — the JSONL is the only message source.
-                if let Some(ref meta) = e.meta {
-                    payload.meta = Some(meta.clone());
-                }
-                if !e.tool_calls.is_empty() {
-                    payload.tool_calls = serde_json::to_value(&e.tool_calls).ok();
-                }
-                if !e.tool_call_id.is_empty() {
-                    payload.tool_call_id = Some(e.tool_call_id.clone());
-                }
-                if e.entry_type == crate::session::ENTRY_TYPE_TOOL {
-                    payload.tool_result_is_error = e
+                        emitted_session_info = true;
+                    }
+                    true
+                })
+                .map(|e| {
+                    let content_text = e
                         .content
                         .as_ref()
-                        .and_then(serde_json::Value::as_array)
-                        .and_then(|blocks| {
-                            blocks.iter().find(|block| {
-                                block.get("type").and_then(serde_json::Value::as_str)
-                                    == Some("tool_result")
-                            })
+                        .map(|c| {
+                            if let Some(arr) = c.as_array() {
+                                let texts = arr.iter().filter_map(|block| {
+                                    (block.get("type").and_then(|value| value.as_str())
+                                        == Some("text"))
+                                    .then(|| block.get("text").and_then(|text| text.as_str()))
+                                    .flatten()
+                                });
+                                if e.role == "user" {
+                                    // A user entry's visible text is only their typed
+                                    // message (the first text block). Any later text
+                                    // block is agent-injected attachment context
+                                    // (file paths), which must not leak into the bubble.
+                                    texts.take(1).collect::<Vec<_>>().join(" ")
+                                } else {
+                                    texts.collect::<Vec<_>>().join(" ")
+                                }
+                            } else {
+                                c.as_str().unwrap_or("").to_string()
+                            }
                         })
-                        .map(|block| {
-                            block
-                                .get("is_error")
-                                .and_then(serde_json::Value::as_bool)
-                                .unwrap_or(false)
-                        });
-                }
-                // Surface this reply's output tokens + duration on the final
-                // assistant entry of each run (bound from the run_terminal
-                // marker above) so the footer can show "time · N tokens" after
-                // a reload — entriesToMessages / the mobile reducer read these
-                // top-level fields.
-                if e.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
-                    if let Some((tokens, duration, delta_in, delta_cache)) = run_stats.get(&e.id) {
-                        if *tokens > 0 {
-                            payload.output_tokens = Some(*tokens);
-                        }
-                        if *duration > 0 {
-                            payload.duration_ms = Some(*duration);
-                        }
-                        if *delta_in > 0 {
-                            payload.input_tokens = Some(*delta_in);
-                        }
-                        if *delta_cache > 0 {
-                            payload.cache_read_tokens = Some(*delta_cache);
+                        .unwrap_or_default();
+                    // Build the display content for this entry. Only include the
+                    // actual visible text — no thinking or tool formatting.
+                    // The forked session's messages should look identical to
+                    // original GUI messages (which store thinking/tools in
+                    // run events, not in the message content).
+                    let full_content = if e.entry_type == "tool" {
+                        // Tool entries: show the result text, or a placeholder.
+                        e.content
+                            .as_ref()
+                            .and_then(serde_json::Value::as_array)
+                            .and_then(|blocks| {
+                                blocks.iter().find_map(|block| {
+                                    (block.get("type").and_then(serde_json::Value::as_str)
+                                        == Some("tool_result"))
+                                    .then(|| {
+                                        block.get("content").and_then(serde_json::Value::as_str)
+                                    })
+                                    .flatten()
+                                })
+                            })
+                            .map(str::to_owned)
+                            .unwrap_or(content_text)
+                    } else {
+                        // User and assistant entries: just the text content.
+                        content_text
+                    };
+
+                    // Typed payload (audit item 1): SessionEntryPayload mirrors
+                    // the on-disk entry schema (snake_case keys).
+                    let mut payload = crate::rpc::payloads::SessionEntryPayload {
+                        id: e.id.clone(),
+                        entry_type: Some(e.entry_type.clone()),
+                        role: e.role.clone(),
+                        content: serde_json::Value::String(full_content),
+                        name: e.name.clone(),
+                        tool_args: e.tool_args.clone(),
+                        timestamp: e.timestamp.to_rfc3339(),
+                        thinking: None,
+                        meta: None,
+                        tool_calls: None,
+                        output_tokens: None,
+                        duration_ms: None,
+                        input_tokens: None,
+                        cache_read_tokens: None,
+                        checkpoint: None,
+                        tool_call_id: None,
+                        tool_result_is_error: None,
+                    };
+                    if e.entry_type == crate::session::ENTRY_TYPE_COMPACTION {
+                        payload.content = serde_json::Value::String(String::new());
+                        payload.checkpoint = e.content.clone();
+                    }
+                    // Include thinking and tool_calls for the new agent-based
+                    // message display (entryProjection.ts).
+                    if !e.thinking.is_empty() {
+                        payload.thinking = Some(e.thinking.clone());
+                    }
+                    // Structured per-entry metadata (e.g. user attachments with
+                    // their cached thumbnails) so the GUI can rebuild attachment
+                    // chips after reload — the JSONL is the only message source.
+                    if let Some(ref meta) = e.meta {
+                        payload.meta = Some(meta.clone());
+                    }
+                    if !e.tool_calls.is_empty() {
+                        payload.tool_calls = serde_json::to_value(&e.tool_calls).ok();
+                    }
+                    if !e.tool_call_id.is_empty() {
+                        payload.tool_call_id = Some(e.tool_call_id.clone());
+                    }
+                    if e.entry_type == crate::session::ENTRY_TYPE_TOOL {
+                        payload.tool_result_is_error = e
+                            .content
+                            .as_ref()
+                            .and_then(serde_json::Value::as_array)
+                            .and_then(|blocks| {
+                                blocks.iter().find(|block| {
+                                    block.get("type").and_then(serde_json::Value::as_str)
+                                        == Some("tool_result")
+                                })
+                            })
+                            .map(|block| {
+                                block
+                                    .get("is_error")
+                                    .and_then(serde_json::Value::as_bool)
+                                    .unwrap_or(false)
+                            });
+                    }
+                    // Surface this reply's output tokens + duration on the final
+                    // assistant entry of each run (bound from the run_terminal
+                    // marker above) so the footer can show "time · N tokens" after
+                    // a reload — entriesToMessages / the mobile reducer read these
+                    // top-level fields.
+                    if e.entry_type == crate::session::ENTRY_TYPE_ASSISTANT {
+                        if let Some((tokens, duration, delta_in, delta_cache)) =
+                            run_stats.get(&e.id)
+                        {
+                            if *tokens > 0 {
+                                payload.output_tokens = Some(*tokens);
+                            }
+                            if *duration > 0 {
+                                payload.duration_ms = Some(*duration);
+                            }
+                            if *delta_in > 0 {
+                                payload.input_tokens = Some(*delta_in);
+                            }
+                            if *delta_cache > 0 {
+                                payload.cache_read_tokens = Some(*delta_cache);
+                            }
                         }
                     }
-                }
-                // For session_info entries, include the original content
-                // JSON (session_name, cwd, parent_session_id, …) so callers can
-                // read fork metadata without a second RPC.
-                if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
-                    // Use the authoritative (last) snapshot's content so the
-                    // single emitted session_info reflects current metadata,
-                    // not the stale values from session creation.
-                    if let Some(ref content) = authoritative_info {
-                        payload.content = content.clone();
+                    // For session_info entries, include the original content
+                    // JSON (session_name, cwd, parent_session_id, …) so callers can
+                    // read fork metadata without a second RPC.
+                    if e.entry_type == crate::session::ENTRY_TYPE_SESSION_INFO {
+                        // Use the authoritative (last) snapshot's content so the
+                        // single emitted session_info reflects current metadata,
+                        // not the stale values from session creation.
+                        if let Some(ref content) = authoritative_info {
+                            payload.content = content.clone();
+                        }
                     }
-                }
-                serde_json::to_value(&payload).unwrap_or_default()
-            })
-            .collect()
+                    serde_json::to_value(&payload).unwrap_or_default()
+                })
+                .collect()
+        };
+        let projected = std::sync::Arc::new(projected);
+        let version_after = session_manager.session_file_version(&session_id).ok();
+        if let (Some(before), Some(after)) = (version_before.as_ref(), version_after) {
+            if *before == after {
+                session_manager.cache_display_entries(&session_id, after, projected.clone());
+            }
+        }
+        projected
     };
     if let Some(raw_offset) = cmd.offset {
         const PAGE_BYTES: usize = 8 * 1024 * 1024;
@@ -774,7 +796,7 @@ pub(crate) fn cmd_get_session_entries(
     RpcResponse::ok(
         id,
         "get_session_entries",
-        serde_json::json!({"entries": entries}),
+        serde_json::json!({"entries": entries.as_ref()}),
     )
 }
 

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -702,6 +702,26 @@ fn get_session_entries_paginates_only_when_offset_is_explicit() {
     assert_eq!(first["data"]["entries"].as_array().unwrap().len(), 2);
     assert_eq!(first["data"]["hasMore"], true);
     assert_eq!(first["data"]["nextOffset"], 2);
+    let version = state
+        .session_manager
+        .session_file_version("default")
+        .expect("session version");
+    let first_projection = state
+        .session_manager
+        .cached_display_entries("default", &version)
+        .expect("first page caches the stable projection");
+
+    let mut second_cmd = make_cmd("get_session_entries");
+    second_cmd.offset = Some(2);
+    second_cmd.limit = Some(2);
+    let second = parse_response(&handle_command_internal(&state, second_cmd));
+    assert_eq!(second["data"]["entries"].as_array().unwrap().len(), 2);
+    assert_eq!(second["data"]["nextOffset"], 4);
+    let second_projection = state
+        .session_manager
+        .cached_display_entries("default", &version)
+        .expect("second page reuses the stable projection");
+    assert!(Arc::ptr_eq(&first_projection, &second_projection));
 
     let legacy = parse_response(&handle_command_internal(
         &state,
@@ -709,6 +729,20 @@ fn get_session_entries_paginates_only_when_offset_is_explicit() {
     ));
     assert_eq!(legacy["data"]["entries"].as_array().unwrap().len(), 5);
     assert!(legacy["data"].get("hasMore").is_none());
+
+    save_via(
+        &state,
+        "default",
+        "mock",
+        vec![crate::session::SessionEntry::new_user(
+            "user",
+            serde_json::json!("replacement"),
+        )],
+    );
+    assert!(state
+        .session_manager
+        .cached_display_entries("default", &version)
+        .is_none());
 }
 
 // ── coverage batch 1: fork / clone ──────────────────────────────────────

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -17,9 +17,29 @@ use anyhow::{anyhow, Context, Result};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+const DISPLAY_ENTRIES_CACHE_MAX: usize = 12;
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct SessionFileVersion {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+struct DisplayEntriesCacheEntry {
+    session_id: String,
+    version: SessionFileVersion,
+    entries: Arc<Vec<serde_json::Value>>,
+}
 
 pub struct Manager {
     pub dir: PathBuf,
+    /// Bounded LRU of display projections. Pagination requests for one stable
+    /// JSONL version slice this shared projection instead of loading and
+    /// projecting the complete journal again for every page.
+    display_entries_cache: parking_lot::Mutex<Vec<DisplayEntriesCacheEntry>>,
     /// Test-only save-failure injection (number of saves left to fail).
     #[cfg(test)]
     pub(crate) fail_saves_remaining: std::sync::atomic::AtomicU64,
@@ -29,6 +49,7 @@ impl Manager {
     pub fn new(dir: PathBuf) -> Self {
         Self {
             dir,
+            display_entries_cache: parking_lot::Mutex::new(Vec::new()),
             #[cfg(test)]
             fail_saves_remaining: std::sync::atomic::AtomicU64::new(0),
         }
@@ -40,6 +61,53 @@ impl Manager {
 
     pub(crate) fn session_path(&self, id: &str) -> PathBuf {
         self.dir.join(format!("{}.jsonl", id))
+    }
+
+    pub(crate) fn session_file_version(&self, id: &str) -> Result<SessionFileVersion> {
+        let metadata = fs::metadata(self.session_path(id)).context("read session metadata")?;
+        Ok(SessionFileVersion {
+            len: metadata.len(),
+            modified: metadata.modified().ok(),
+        })
+    }
+
+    pub(crate) fn cached_display_entries(
+        &self,
+        id: &str,
+        version: &SessionFileVersion,
+    ) -> Option<Arc<Vec<serde_json::Value>>> {
+        let mut cache = self.display_entries_cache.lock();
+        let index = cache
+            .iter()
+            .position(|entry| entry.session_id == id && entry.version == *version)?;
+        let entry = cache.remove(index);
+        let entries = entry.entries.clone();
+        cache.push(entry);
+        Some(entries)
+    }
+
+    pub(crate) fn cache_display_entries(
+        &self,
+        id: &str,
+        version: SessionFileVersion,
+        entries: Arc<Vec<serde_json::Value>>,
+    ) {
+        let mut cache = self.display_entries_cache.lock();
+        cache.retain(|entry| entry.session_id != id);
+        cache.push(DisplayEntriesCacheEntry {
+            session_id: id.to_string(),
+            version,
+            entries,
+        });
+        if cache.len() > DISPLAY_ENTRIES_CACHE_MAX {
+            cache.remove(0);
+        }
+    }
+
+    fn invalidate_display_entries(&self, id: &str) {
+        self.display_entries_cache
+            .lock()
+            .retain(|entry| entry.session_id != id);
     }
 
     /// Agent-owned event data for a session. Queued prompts are intentionally
@@ -239,7 +307,11 @@ impl Manager {
             .context("open session lock file")?;
         let mut file_lock = fd_lock::RwLock::new(lock_file);
         let _guard = file_lock.write().context("acquire session write lock")?;
-        f(&path)
+        let result = f(&path);
+        if result.is_ok() {
+            self.invalidate_display_entries(session_id);
+        }
+        result
     }
 
     /// Append entries to a session file whose advisory write lock is already
@@ -342,7 +414,9 @@ impl Manager {
         let mut file_lock = fd_lock::RwLock::new(lock_file);
         let _guard = file_lock.write().context("acquire session write lock")?;
 
-        Self::write_entries_atomically(&path, &session.entries)
+        Self::write_entries_atomically(&path, &session.entries)?;
+        self.invalidate_display_entries(&session.id);
+        Ok(())
     }
 
     fn write_entries_atomically(path: &Path, entries: &[SessionEntry]) -> Result<()> {
@@ -645,6 +719,7 @@ impl Manager {
 
     /// Delete a session file
     pub fn delete(&self, id: &str) -> Result<()> {
+        self.invalidate_display_entries(id);
         let path = self.session_path(id);
         // Also remove the lock file if present — no session means no lock.
         let lock_path = path.with_extension("jsonl.lock");

--- a/desktop/src/features/agent/AgentThread.tsx
+++ b/desktop/src/features/agent/AgentThread.tsx
@@ -121,6 +121,10 @@ export function AgentThread({
   const { handleScroll, scrollToLatest, showJumpToLatest } = useStickyAutoScroll({
     scrollRef,
     contentKey: messages,
+    // The delayed loading placeholder temporarily unmounts MessageList. Wait
+    // until the real content is mounted, then the layout effect lands at the
+    // actual bottom before paint.
+    followEnabled: !loadingIndicator,
     onScroll: handleScrollbarVisibility,
     onContentSettled: () => updateFloatingScrollbar(false),
   });
@@ -141,17 +145,6 @@ export function AgentThread({
     userExchangeCount: PAGE_USER_EXCHANGES,
     onScroll: handleScroll,
   });
-
-  // When loading completes (initial load or thread switch), scroll to the
-  // latest message.  useStickyAutoScroll's useLayoutEffect fires on contentKey
-  // (messages) changes, but during loading the MessageList isn't in the DOM yet
-  // — so that scroll is a no-op.  This catches the transition.
-  useEffect(() => {
-    if (!loadingThread) {
-      // Wait one tick for the MessageList to render.
-      requestAnimationFrame(() => scrollToLatest());
-    }
-  }, [loadingThread, scrollToLatest]);
 
   // A run is in flight while its assistant bubble is still streaming; the agent
   // rejects a concurrent prompt, so the composer is disabled until it settles.

--- a/desktop/src/features/agent/threadMessageCache.test.ts
+++ b/desktop/src/features/agent/threadMessageCache.test.ts
@@ -1,0 +1,44 @@
+import type { AgentMessage } from "@future-os/thread-projection";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearThreadMessageSnapshots,
+  getThreadMessageSnapshot,
+  setThreadMessageSnapshot,
+} from "./threadMessageCache";
+
+function messages(id: string): AgentMessage[] {
+  return [{ id, role: "user", content: id }] as AgentMessage[];
+}
+
+beforeEach(() => {
+  clearThreadMessageSnapshots();
+});
+
+describe("threadMessageCache", () => {
+  it("keeps a conversation snapshot, including an empty conversation", () => {
+    const snapshot = messages("m1");
+    setThreadMessageSnapshot("thread-1", "session-1", snapshot);
+    setThreadMessageSnapshot("thread-empty", null, []);
+
+    expect(getThreadMessageSnapshot("thread-1", "session-1")).toBe(snapshot);
+    expect(getThreadMessageSnapshot("thread-empty", null)).toEqual([]);
+    expect(getThreadMessageSnapshot("missing", null)).toBeNull();
+  });
+
+  it("does not reuse a snapshot after the Agent session changes", () => {
+    setThreadMessageSnapshot("thread-1", "session-old", messages("old"));
+
+    expect(getThreadMessageSnapshot("thread-1", "session-new")).toBeNull();
+  });
+
+  it("bounds snapshots and refreshes recency on reads", () => {
+    for (let index = 0; index < 12; index++)
+      setThreadMessageSnapshot(`thread-${index}`, null, messages(`m${index}`));
+
+    expect(getThreadMessageSnapshot("thread-0", null)?.[0]?.id).toBe("m0");
+    setThreadMessageSnapshot("thread-12", null, messages("m12"));
+
+    expect(getThreadMessageSnapshot("thread-0", null)?.[0]?.id).toBe("m0");
+    expect(getThreadMessageSnapshot("thread-1", null)).toBeNull();
+  });
+});

--- a/desktop/src/features/agent/threadMessageCache.ts
+++ b/desktop/src/features/agent/threadMessageCache.ts
@@ -1,0 +1,37 @@
+import type { AgentMessage } from "@future-os/thread-projection";
+
+/** Keep recent conversation snapshots warm across keyed AgentThread remounts. */
+const MAX_CACHED_THREADS = 12;
+
+interface ThreadMessageSnapshot {
+  agentSessionId: string | null;
+  messages: AgentMessage[];
+}
+
+const snapshots = new Map<string, ThreadMessageSnapshot>();
+
+export function getThreadMessageSnapshot(threadId: string, agentSessionId: string | null): AgentMessage[] | null {
+  const snapshot = snapshots.get(threadId);
+  if (!snapshot || snapshot.agentSessionId !== agentSessionId)
+    return null;
+  // Map insertion order is our LRU order.
+  snapshots.delete(threadId);
+  snapshots.set(threadId, snapshot);
+  return snapshot.messages;
+}
+
+export function setThreadMessageSnapshot(threadId: string, agentSessionId: string | null, messages: AgentMessage[]) {
+  snapshots.delete(threadId);
+  snapshots.set(threadId, { agentSessionId, messages });
+  while (snapshots.size > MAX_CACHED_THREADS) {
+    const oldest = snapshots.keys().next().value;
+    if (oldest === undefined)
+      break;
+    snapshots.delete(oldest);
+  }
+}
+
+/** Test-only reset; exported to keep the cache module independently testable. */
+export function clearThreadMessageSnapshots() {
+  snapshots.clear();
+}

--- a/desktop/src/features/agent/useStickyAutoScroll.ts
+++ b/desktop/src/features/agent/useStickyAutoScroll.ts
@@ -10,6 +10,8 @@ interface UseStickyAutoScrollInput {
   scrollRef: RefObject<HTMLElement | null>;
   /** Changing this (e.g. the message list) re-runs the follow effect. */
   contentKey: unknown;
+  /** False while the real message content is temporarily not mounted. */
+  followEnabled?: boolean;
   /** Extra work to run on every scroll event (e.g. floating-scrollbar visibility). */
   onScroll?: () => void;
   /** Run after a content-driven follow settles (e.g. update floating scrollbar). */
@@ -25,6 +27,7 @@ interface UseStickyAutoScrollInput {
 export function useStickyAutoScroll({
   scrollRef,
   contentKey,
+  followEnabled = true,
   onScroll,
   onContentSettled,
 }: UseStickyAutoScrollInput) {
@@ -66,6 +69,8 @@ export function useStickyAutoScroll({
   // useLayoutEffect so the scroll-to-bottom happens before the browser paints,
   // avoiding a visible "flash at top → jump to bottom" when switching threads.
   useLayoutEffect(() => {
+    if (!followEnabled)
+      return;
     const scrollContainer = scrollRef.current;
     if (!scrollContainer)
       return;
@@ -81,7 +86,7 @@ export function useStickyAutoScroll({
       setShowJumpToLatest(distance > JUMP_BUTTON_THRESHOLD_PX);
     }
     onContentSettledRef.current?.();
-  }, [contentKey, scrollRef]);
+  }, [contentKey, followEnabled, scrollRef]);
 
   return { handleScroll, scrollToLatest, showJumpToLatest };
 }

--- a/desktop/src/features/agent/useStickyAutoScrollHook.test.ts
+++ b/desktop/src/features/agent/useStickyAutoScrollHook.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "../../test/renderHook";
+import { useStickyAutoScroll } from "./useStickyAutoScroll";
+
+describe("useStickyAutoScroll", () => {
+  it("waits for temporarily hidden message content before following to the bottom", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientHeight", { configurable: true, value: 200 });
+    Object.defineProperty(container, "scrollHeight", { configurable: true, value: 1_000 });
+    const scrollRef = { current: container as HTMLElement | null };
+    const settled = vi.fn();
+    let followEnabled = false;
+    let contentKey: unknown = "loading";
+    const hook = renderHook(() => useStickyAutoScroll({
+      scrollRef,
+      contentKey,
+      followEnabled,
+      onContentSettled: settled,
+    }));
+
+    contentKey = "messages";
+    hook.rerender();
+    expect(container.scrollTop).toBe(0);
+    expect(settled).not.toHaveBeenCalled();
+
+    followEnabled = true;
+    hook.rerender();
+    expect(container.scrollTop).toBe(1_000);
+    expect(settled).toHaveBeenCalledTimes(1);
+
+    act(() => hook.current.scrollToLatest());
+    expect(container.scrollTop).toBe(1_000);
+    hook.unmount();
+  });
+});

--- a/desktop/src/features/agent/useThreadMessages.ts
+++ b/desktop/src/features/agent/useThreadMessages.ts
@@ -1,12 +1,13 @@
 import type { AgentMessage } from "@future-os/thread-projection";
 import type { StoredRun } from "../../integrations/storage/threadStore";
 import { entriesToMessages, matchesSettledRun } from "@future-os/thread-projection";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import i18n from "../../i18n";
 import { getLatestRun, getRun, getSessionEntries, listRuns } from "../../integrations/storage/threadStore";
 import { invokeCommand } from "../../integrations/tauri/invoke";
 import { errorMessage } from "../../lib/errors";
 import { emitFutureEvent } from "../../lib/futureEvents";
+import { getThreadMessageSnapshot, setThreadMessageSnapshot } from "./threadMessageCache";
 import { applyRunMetadata, buildStreamingPreview, mergeStreamingPreview, recoverAbortedTurns, recoverFailedRuns } from "./threadRunProjection";
 
 interface UseThreadMessagesInput {
@@ -40,7 +41,17 @@ const LOADING_INDICATOR_MIN_MS = 200;
  */
 export function useThreadMessages({ threadId, workspaceId, workspacePath, agentSessionId }: UseThreadMessagesInput) {
   const normalizedAgentSessionId = agentSessionId?.trim() || null;
-  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  // AgentThread is keyed by thread id and therefore remounts on every switch.
+  // Seed the new instance from a small process-local LRU, then revalidate from
+  // the authoritative Agent journal in the background. This preserves the
+  // isolation benefit of keyed instances without flashing a loading placeholder
+  // every time the user revisits a conversation.
+  const [initialSnapshot] = useState(() => (
+    threadId ? getThreadMessageSnapshot(threadId, normalizedAgentSessionId) : null
+  ));
+  const hasWarmSnapshotRef = useRef(initialSnapshot !== null);
+  const cacheEligibleRef = useRef(initialSnapshot !== null);
+  const [messages, setMessages] = useState<AgentMessage[]>(initialSnapshot ?? []);
   // Truthful data-loading state: gates pendingPrompt delivery (useAgentThreadState)
   // and must flip the instant a load starts/ends. The UI reads the debounced
   // `loadingIndicator` below instead, so this can stay honest without flashing.
@@ -53,6 +64,13 @@ export function useThreadMessages({ threadId, workspaceId, workspacePath, agentS
   const [loadingIndicator, setLoadingIndicator] = useState(false);
   const indicatorShownAtRef = useRef<number | null>(null);
   const [recentRun, setRecentRun] = useState<StoredRun | null>(null);
+
+  // Keep the latest committed immutable message array warm for a future keyed
+  // remount. Failed cold loads are deliberately not cached as conversation data.
+  useLayoutEffect(() => {
+    if (threadId && cacheEligibleRef.current)
+      setThreadMessageSnapshot(threadId, normalizedAgentSessionId, messages);
+  }, [messages, normalizedAgentSessionId, threadId]);
 
   // ── Generation counter for message writes ────────────────────────────
   // Within this one thread, a quiet reload (direct replacement) can be in
@@ -197,17 +215,23 @@ export function useThreadMessages({ threadId, workspaceId, workspacePath, agentS
       if (cancelled)
         return;
       if (result.status === "failed") {
-        setMessages([
-          {
-            id: "store_error",
-            role: "assistant",
-            authorKey: "author.system",
-            content: i18n.t("agent:thread.messagesLoadFailed", { message: result.error }),
-            createdAt: new Date().toISOString(),
-          },
-        ]);
+        // A warm snapshot is more useful than replacing the conversation with
+        // a transient refresh error. Cold loads still surface the error.
+        if (!hasWarmSnapshotRef.current) {
+          setMessages([
+            {
+              id: "store_error",
+              role: "assistant",
+              authorKey: "author.system",
+              content: i18n.t("agent:thread.messagesLoadFailed", { message: result.error }),
+              createdAt: new Date().toISOString(),
+            },
+          ]);
+        }
       }
       else {
+        hasWarmSnapshotRef.current = true;
+        cacheEligibleRef.current = true;
         setMessages(result.status === "loaded" ? result.messages : []);
       }
       setLoadingThread(false);
@@ -228,7 +252,16 @@ export function useThreadMessages({ threadId, workspaceId, workspacePath, agentS
   // for at least LOADING_INDICATOR_MIN_MS so it can't flash off immediately.
   useEffect(() => {
     if (loadingThread) {
+      // A cached conversation stays visible while its authoritative journal is
+      // revalidated; the truthful loadingThread flag still gates sending.
+      if (hasWarmSnapshotRef.current) {
+        indicatorShownAtRef.current = null;
+        setLoadingIndicator(false);
+        return;
+      }
       const showTimer = setTimeout(() => {
+        if (hasWarmSnapshotRef.current)
+          return;
         indicatorShownAtRef.current = performance.now();
         setLoadingIndicator(true);
       }, LOADING_INDICATOR_DELAY_MS);

--- a/desktop/src/features/agent/useThreadMessagesHook.test.ts
+++ b/desktop/src/features/agent/useThreadMessagesHook.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import type { AgentMessage } from "@future-os/thread-projection";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "../../test/renderHook";
+import { clearThreadMessageSnapshots, setThreadMessageSnapshot } from "./threadMessageCache";
+import { useThreadMessages } from "./useThreadMessages";
+
+const storageMocks = vi.hoisted(() => ({
+  getLatestRun: vi.fn(),
+  getRun: vi.fn(),
+  getSessionEntries: vi.fn(),
+  listRuns: vi.fn(),
+}));
+
+vi.mock("../../integrations/storage/threadStore", () => storageMocks);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  clearThreadMessageSnapshots();
+  storageMocks.getLatestRun.mockResolvedValue(null);
+  storageMocks.getRun.mockResolvedValue(null);
+  storageMocks.listRuns.mockResolvedValue([]);
+  storageMocks.getSessionEntries.mockReturnValue(new Promise(() => {}));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useThreadMessages warm snapshots", () => {
+  it("keeps cached messages visible without a loading indicator while revalidating", async () => {
+    const cached = [{ id: "cached", role: "user", content: "cached" }] as AgentMessage[];
+    setThreadMessageSnapshot("thread-1", "session-1", cached);
+
+    const hook = renderHook(() => useThreadMessages({
+      threadId: "thread-1",
+      agentSessionId: "session-1",
+    }));
+
+    expect(hook.current.messages).toBe(cached);
+    expect(hook.current.loadingThread).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(hook.current.loadingIndicator).toBe(false);
+    hook.unmount();
+  });
+
+  it("does not show a snapshot from an obsolete Agent session", () => {
+    setThreadMessageSnapshot(
+      "thread-1",
+      "session-old",
+      [{ id: "stale", role: "user", content: "stale" }] as AgentMessage[],
+    );
+
+    const hook = renderHook(() => useThreadMessages({
+      threadId: "thread-1",
+      agentSessionId: "session-new",
+    }));
+
+    expect(hook.current.messages).toEqual([]);
+    hook.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- cache stable Agent display projections across paginated history reads
- keep recent desktop thread snapshots visible during authoritative revalidation
- scroll to the real message list after a delayed loading placeholder clears

## Validation
- npm run lint
- npx vitest run (670 tests)
- cargo test -p future-agent --lib (1592 tests)
- cargo clippy --manifest-path agent/Cargo.toml --all-targets -- -D warnings
- cargo fmt --check --manifest-path agent/Cargo.toml