### PR TITLE
Fix canonical run failure recovery

### DIFF
--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -539,6 +539,13 @@ pub(crate) fn cmd_get_session_entries(
             let mut last_assistant_id: Option<String> = None;
             let mut run_stats: std::collections::HashMap<String, (i64, i64, i64, i64)> =
                 std::collections::HashMap::new();
+            // Canonical terminal outcomes keyed by the run id persisted on the
+            // originating user entry. Unlike the assistant-only stats binding,
+            // this survives failures before the first assistant entry exists.
+            let mut run_outcomes: std::collections::HashMap<
+                String,
+                (String, Option<String>, i64),
+            > = std::collections::HashMap::new();
             // Per-run usage deltas from the cumulative session_info snapshots
             // (tokens_in / tokens_cache_r): the snapshot written just before a
             // run_terminal marker is the post-run state, and the one captured at
@@ -563,6 +570,28 @@ pub(crate) fn cmd_get_session_entries(
                         );
                     }
                 } else if marker.entry_type == crate::session::ENTRY_TYPE_RUN_TERMINAL {
+                    if let Some(content) = marker.content.as_ref() {
+                        if let Some(run_id) = content.get("run_id").and_then(|v| v.as_str()) {
+                            let state = match content.get("state").and_then(|v| v.as_str()) {
+                                Some(crate::session::RUN_STATE_ERROR | crate::session::RUN_STATE_INCOMPLETE) => "failed",
+                                Some(state) => state,
+                                None => "failed",
+                            };
+                            let error = content
+                                .get("error")
+                                .and_then(|v| v.as_str())
+                                .filter(|value| !value.trim().is_empty())
+                                .map(str::to_owned);
+                            let duration = content
+                                .get("run_duration_ms")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            run_outcomes.insert(
+                                run_id.to_string(),
+                                (state.to_string(), error, duration),
+                            );
+                        }
+                    }
                     if let (Some(aid), Some(content)) =
                         (last_assistant_id.as_deref(), marker.content.as_ref())
                     {
@@ -676,6 +705,9 @@ pub(crate) fn cmd_get_session_entries(
                         checkpoint: None,
                         tool_call_id: None,
                         tool_result_is_error: None,
+                        run_status: None,
+                        run_error: None,
+                        run_duration_ms: None,
                     };
                     if e.entry_type == crate::session::ENTRY_TYPE_COMPACTION {
                         payload.content = serde_json::Value::String(String::new());
@@ -691,6 +723,17 @@ pub(crate) fn cmd_get_session_entries(
                     // chips after reload — the JSONL is the only message source.
                     if let Some(ref meta) = e.meta {
                         payload.meta = Some(meta.clone());
+                        if let Some((status, error, duration)) = meta
+                            .get("run_id")
+                            .and_then(|value| value.as_str())
+                            .and_then(|run_id| run_outcomes.get(run_id))
+                        {
+                            payload.run_status = Some(status.clone());
+                            payload.run_error = error.clone();
+                            if *duration > 0 {
+                                payload.run_duration_ms = Some(*duration);
+                            }
+                        }
                     }
                     if !e.tool_calls.is_empty() {
                         payload.tool_calls = serde_json::to_value(&e.tool_calls).ok();

--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -542,10 +542,8 @@ pub(crate) fn cmd_get_session_entries(
             // Canonical terminal outcomes keyed by the run id persisted on the
             // originating user entry. Unlike the assistant-only stats binding,
             // this survives failures before the first assistant entry exists.
-            let mut run_outcomes: std::collections::HashMap<
-                String,
-                (String, Option<String>, i64),
-            > = std::collections::HashMap::new();
+            let mut run_outcomes: std::collections::HashMap<String, (String, Option<String>, i64)> =
+                std::collections::HashMap::new();
             // Per-run usage deltas from the cumulative session_info snapshots
             // (tokens_in / tokens_cache_r): the snapshot written just before a
             // run_terminal marker is the post-run state, and the one captured at
@@ -573,7 +571,10 @@ pub(crate) fn cmd_get_session_entries(
                     if let Some(content) = marker.content.as_ref() {
                         if let Some(run_id) = content.get("run_id").and_then(|v| v.as_str()) {
                             let state = match content.get("state").and_then(|v| v.as_str()) {
-                                Some(crate::session::RUN_STATE_ERROR | crate::session::RUN_STATE_INCOMPLETE) => "failed",
+                                Some(
+                                    crate::session::RUN_STATE_ERROR
+                                    | crate::session::RUN_STATE_INCOMPLETE,
+                                ) => "failed",
                                 Some(state) => state,
                                 None => "failed",
                             };
@@ -586,10 +587,8 @@ pub(crate) fn cmd_get_session_entries(
                                 .get("run_duration_ms")
                                 .and_then(|v| v.as_i64())
                                 .unwrap_or(0);
-                            run_outcomes.insert(
-                                run_id.to_string(),
-                                (state.to_string(), error, duration),
-                            );
+                            run_outcomes
+                                .insert(run_id.to_string(), (state.to_string(), error, duration));
                         }
                     }
                     if let (Some(aid), Some(content)) =

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -590,10 +590,7 @@ fn get_session_entries_renders_roles_and_run_stats() {
 #[test]
 fn get_session_entries_projects_replyless_failure_onto_canonical_user_entry() {
     let state = make_app_state();
-    let mut user = crate::session::SessionEntry::new_user(
-        "user",
-        serde_json::json!("question"),
-    );
+    let mut user = crate::session::SessionEntry::new_user("user", serde_json::json!("question"));
     user.meta = Some(serde_json::json!({"run_id": "run-failed"}));
     let terminal = crate::session::SessionEntry::run_terminal(
         "run-failed",

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -523,13 +523,14 @@ fn get_session_entries_renders_roles_and_run_stats() {
         "mock".to_string(),
         "low".to_string(),
     );
-    let user = crate::session::SessionEntry::new_user(
+    let mut user = crate::session::SessionEntry::new_user(
         "user",
         serde_json::json!([
             {"type": "text", "text": "question"},
             {"type": "text", "text": "attachment paths"},
         ]),
     );
+    user.meta = Some(serde_json::json!({"run_id": "run-1"}));
     let mut assistant = crate::session::SessionEntry::new_assistant(
         serde_json::json!([{"type": "text", "text": "answer"}]),
         vec![],
@@ -573,6 +574,8 @@ fn get_session_entries_renders_roles_and_run_stats() {
     assert_eq!(info["content"]["session_name"], "fresh");
     let user_entry = &entries[1];
     assert_eq!(user_entry["content"], "question");
+    assert_eq!(user_entry["run_status"], "completed");
+    assert_eq!(user_entry["run_duration_ms"], 1500);
     let assistant_entry = &entries[2];
     assert_eq!(assistant_entry["content"], "answer");
     assert_eq!(assistant_entry["thinking"], "deep thought");
@@ -582,6 +585,34 @@ fn get_session_entries_renders_roles_and_run_stats() {
     assert_eq!(tool_entry["content"], "tool output");
     assert_eq!(tool_entry["tool_call_id"], "call-1");
     assert_eq!(tool_entry["tool_result_is_error"], false);
+}
+
+#[test]
+fn get_session_entries_projects_replyless_failure_onto_canonical_user_entry() {
+    let state = make_app_state();
+    let mut user = crate::session::SessionEntry::new_user(
+        "user",
+        serde_json::json!("question"),
+    );
+    user.meta = Some(serde_json::json!({"run_id": "run-failed"}));
+    let terminal = crate::session::SessionEntry::run_terminal(
+        "run-failed",
+        crate::session::RUN_STATE_ERROR,
+        0,
+        25,
+        Some("authentication failed"),
+    );
+    save_via(&state, "default", "mock", vec![user, terminal]);
+
+    let resp = parse_response(&handle_command_internal(
+        &state,
+        make_cmd("get_session_entries"),
+    ));
+    let entry = &resp["data"]["entries"][0];
+    assert_eq!(entry["meta"]["run_id"], "run-failed");
+    assert_eq!(entry["run_status"], "failed");
+    assert_eq!(entry["run_error"], "authentication failed");
+    assert_eq!(entry["run_duration_ms"], 25);
 }
 
 #[test]

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -1394,13 +1394,10 @@ fn entries_vec(data: Value) -> Vec<Value> {
         .unwrap_or_default()
 }
 
-/// Add the GUI store's authoritative run outcome to Agent-owned history rows.
-/// The Agent journal deliberately contains conversation content only; mobile
-/// needs this outcome to use the same recovery predicate as the desktop UI.
-/// Failed runs additionally carry `run_error` (the stored raw error) so mobile
-/// can rebuild the same friendly failure bubble the desktop shows on reload.
-/// `run_duration_ms` comes from the same persisted start/end timestamps the
-/// desktop footer uses, including for runs which produced no assistant entry.
+/// Add the GUI store's run outcome to history rows returned by older Agents.
+/// New Agents derive these fields from the authoritative run journal; when
+/// present, those values win. The store remains an additive compatibility
+/// source so mixed-version desktop/mobile deployments keep recovery parity.
 fn entries_with_run_status(session_id: &str, mut entries: Vec<Value>) -> Vec<Value> {
     let outcomes: HashMap<String, (String, Option<String>, Option<i64>)> =
         crate::store::find_thread_by_agent_session(session_id)
@@ -1430,13 +1427,22 @@ fn entries_with_run_status(session_id: &str, mut entries: Vec<Value>) -> Vec<Val
         if let (Some((status, error_message, duration_ms)), Some(object)) =
             (outcome, entry.as_object_mut())
         {
-            object.insert("run_status".to_string(), Value::String(status.clone()));
+            // New agents project the journal's run_terminal outcome directly.
+            // The GUI store is only a compatibility source for older agents;
+            // never overwrite journal authority when both are available.
+            object
+                .entry("run_status".to_string())
+                .or_insert_with(|| Value::String(status.clone()));
             if let Some(duration_ms) = duration_ms {
-                object.insert("run_duration_ms".to_string(), Value::from(*duration_ms));
+                object
+                    .entry("run_duration_ms".to_string())
+                    .or_insert_with(|| Value::from(*duration_ms));
             }
             if status == "failed" {
                 if let Some(message) = error_message.as_ref().filter(|m| !m.trim().is_empty()) {
-                    object.insert("run_error".to_string(), Value::String(message.clone()));
+                    object
+                        .entry("run_error".to_string())
+                        .or_insert_with(|| Value::String(message.clone()));
                 }
             }
         }
@@ -3667,7 +3673,13 @@ mod bridge_tests {
             &session,
             vec![
                 json!({ "entryType": "assistant", "meta": { "run_id": running.id } }),
-                json!({ "entryType": "assistant", "meta": { "run_id": failed.id } }),
+                json!({
+                    "entryType": "assistant",
+                    "meta": { "run_id": failed.id },
+                    "run_status": "completed",
+                    "run_error": "journal truth",
+                    "run_duration_ms": 7
+                }),
                 // An entry referencing a run with no persisted outcome takes
                 // the `outcome.is_none()` (else) arm of the match.
                 json!({ "entryType": "assistant", "meta": { "run_id": "ghost-run" } }),
@@ -3676,10 +3688,11 @@ mod bridge_tests {
         // The running run has no duration (ended_at NULL) and keeps its status.
         assert_eq!(entries[0]["run_status"], json!("running"));
         assert!(entries[0].get("run_duration_ms").is_none());
-        // The failed run carries the stored raw error and a duration.
-        assert_eq!(entries[1]["run_status"], json!("failed"));
-        assert!(entries[1]["run_duration_ms"].is_number());
-        assert_eq!(entries[1]["run_error"], json!("boom"));
+        // Agent journal fields are authoritative when present; the GUI store
+        // only fills missing fields for old agents.
+        assert_eq!(entries[1]["run_status"], json!("completed"));
+        assert_eq!(entries[1]["run_duration_ms"], json!(7));
+        assert_eq!(entries[1]["run_error"], json!("journal truth"));
         // The ghost entry is left untouched.
         assert!(entries[2].get("run_status").is_none());
     }

--- a/desktop/src/components/layout/ActivityRail.tsx
+++ b/desktop/src/components/layout/ActivityRail.tsx
@@ -761,7 +761,7 @@ export function ActivityRail({
                     >
                       <span className="relative inline-flex shrink-0">
                         <Settings className="size-4" />
-                        {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                        {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
                       </span>
                       <span className="truncate">{t("activityRail.settings")}</span>
                     </button>
@@ -772,7 +772,7 @@ export function ActivityRail({
                 icon={(
                   <span className="relative inline-flex">
                     <Settings className="size-4" />
-                    {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                    {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
                   </span>
                 )}
                 label={t("activityRail.settings")}

--- a/desktop/src/features/agent/entryProjection.test.ts
+++ b/desktop/src/features/agent/entryProjection.test.ts
@@ -1,5 +1,5 @@
 import type { SessionEntry } from "@future-os/thread-projection";
-import { entriesToMessages } from "@future-os/thread-projection";
+import { entriesToMessages, entriesToTurns } from "@future-os/thread-projection";
 import { describe, expect, it } from "vitest";
 
 describe("entriesToMessages", () => {
@@ -48,6 +48,76 @@ describe("entriesToMessages", () => {
     expect(messages[0]?.role).toBe("user");
     expect(messages[0]?.content).toBe("写一首长诗");
     expect(messages[0]?.createdAt).toBe(userTs);
+  });
+
+  it("places a reply-less failure on its canonical user turn", () => {
+    const messages = entriesToMessages([
+      {
+        id: "u1",
+        role: "user",
+        content: "first",
+        meta: { run_id: "run-failed" },
+        run_status: "failed",
+        run_error: "authentication failed",
+        run_duration_ms: 120,
+      },
+      {
+        id: "u2",
+        role: "user",
+        content: "second",
+        meta: { run_id: "run-ok" },
+        run_status: "completed",
+      },
+      {
+        id: "a2",
+        role: "assistant",
+        content: "done",
+        meta: { run_id: "run-ok" },
+        run_status: "completed",
+      },
+    ]);
+
+    expect(messages.map(message => message.id)).toEqual([
+      "m_u1",
+      "failed_run-failed",
+      "m_u2",
+      "m_a2",
+    ]);
+    expect(messages[1]).toMatchObject({
+      role: "assistant",
+      runId: "run-failed",
+      status: "failed",
+      runError: "authentication failed",
+      durationMs: 120,
+    });
+    expect(messages[3]?.runId).toBe("run-ok");
+  });
+
+  it("fails closed when user and assistant canonical run ids conflict", () => {
+    const nodes = entriesToTurns([
+      {
+        id: "u1",
+        role: "user",
+        content: "hello",
+        meta: { run_id: "run-user" },
+        run_status: "failed",
+        run_error: "must not attach",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "reply",
+        meta: { run_id: "run-assistant" },
+      },
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    const turn = nodes[0]?.kind === "turn" ? nodes[0].turn : undefined;
+    expect(turn?.identitySource).toBe("conflict");
+    expect(turn?.runId).toBeUndefined();
+    expect(turn?.outcome).toBeUndefined();
+    expect(turn?.assistant?.runId).toBeUndefined();
+    expect(turn?.assistant?.status).toBe("complete");
   });
 
   it("projects output tokens and duration from the final assistant entry", () => {

--- a/desktop/src/features/agent/threadRunProjection.test.ts
+++ b/desktop/src/features/agent/threadRunProjection.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@future-os/thread-projection";
 import type { StoredRun, StoredRunEvent } from "../../integrations/storage/threadStore";
 import { describe, expect, it } from "vitest";
 import {
+  applyJournalRunOutcomes,
   applyRecoveredEvents,
   applyRunMetadata,
   deriveRenderFields,
@@ -117,6 +118,14 @@ function run(id: string, patch: Partial<StoredRun> = {}): StoredRun {
 }
 
 describe("applyRunMetadata", () => {
+  it("localizes a journal-backed failure without requiring a run row", () => {
+    const result = applyJournalRunOutcomes([
+      assistant("a1", { status: "failed", runError: "Authentication failed (401)" }),
+    ]);
+    expect(result[0]?.terminationTitle?.trim()).not.toBe("");
+    expect(result[0]?.terminationNotice?.trim()).not.toBe("");
+  });
+
   it("uses canonical run ids instead of positional or timestamp alignment", () => {
     const result = applyRunMetadata(
       [

--- a/desktop/src/features/agent/threadRunProjection.ts
+++ b/desktop/src/features/agent/threadRunProjection.ts
@@ -493,6 +493,19 @@ export function applyRunMetadata(messages: AgentMessage[], runs: StoredRun[]): A
   return patched;
 }
 
+/** Turn a journal diagnostic into desktop-localized failure presentation. */
+export function applyJournalRunOutcomes(messages: AgentMessage[]): AgentMessage[] {
+  return messages.map(message =>
+    message.status === "failed" && message.runError && !message.terminationNotice
+      ? {
+          ...message,
+          terminationTitle: buildAgentFailureTitle(message.runError),
+          terminationNotice: buildAgentFailureContent(message.runError),
+        }
+      : message,
+  );
+}
+
 function applyRunToMessage(message: AgentMessage, run: StoredRun): AgentMessage {
   // An aborted exchange projects with no content and no reply time (the agent
   // saved no assistant entry). Stamp it with the run's end time — the actual

--- a/desktop/src/features/agent/useThreadMessages.ts
+++ b/desktop/src/features/agent/useThreadMessages.ts
@@ -8,7 +8,7 @@ import { invokeCommand } from "../../integrations/tauri/invoke";
 import { errorMessage } from "../../lib/errors";
 import { emitFutureEvent } from "../../lib/futureEvents";
 import { getThreadMessageSnapshot, setThreadMessageSnapshot } from "./threadMessageCache";
-import { applyRunMetadata, buildStreamingPreview, mergeStreamingPreview, recoverAbortedTurns, recoverFailedRuns } from "./threadRunProjection";
+import { applyJournalRunOutcomes, applyRunMetadata, buildStreamingPreview, mergeStreamingPreview, recoverAbortedTurns, recoverFailedRuns } from "./threadRunProjection";
 
 interface UseThreadMessagesInput {
   threadId: string | null;
@@ -154,7 +154,7 @@ export function useThreadMessages({ threadId, workspaceId, workspacePath, agentS
       const entries = result?.entries ?? [];
       if (!entries.length)
         return { status: "empty" };
-      const messages = entriesToMessages(entries as unknown as import("@future-os/thread-projection").SessionEntry[]);
+      const messages = applyJournalRunOutcomes(entriesToMessages(entries as unknown as import("@future-os/thread-projection").SessionEntry[]));
       if (!messages.length)
         return { status: "empty" };
       // Agent JSONL doesn't record a run's GUI-side outcome (failed/cancelled/

--- a/desktop/src/features/settings/SettingsDialog.tsx
+++ b/desktop/src/features/settings/SettingsDialog.tsx
@@ -142,7 +142,7 @@ export function SettingsDialog({
                       >
                         <span className="relative inline-flex shrink-0">
                           <Icon className="size-4" />
-                          {showDot ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-danger" /> : null}
+                          {showDot ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
                         </span>
                         <span className="truncate">{t(item.labelKey)}</span>
                       </button>

--- a/mobile/src/components/TimelineCard.tsx
+++ b/mobile/src/components/TimelineCard.tsx
@@ -645,7 +645,9 @@ export function TimelineCard({
           {terminationNotice ? (
             <View style={styles.terminationNotice}>
               <StatusDivider
-                label={item.stopped ? t("chat.responseStopped") : friendlyRunErrorTitle(item.error, t)}
+                label={
+                  item.stopped ? t("chat.responseStopped") : friendlyRunErrorTitle(item.error, t)
+                }
               />
               {isLatestAssistant && !item.stopped ? (
                 <Text
@@ -792,7 +794,12 @@ const styles = StyleSheet.create({
   terminationNotice: {
     marginTop: spacing.md,
   },
-  terminationNoticeText: { color: colors.inkSoft, fontSize: 14, lineHeight: 24, marginTop: spacing.sm },
+  terminationNoticeText: {
+    color: colors.inkSoft,
+    fontSize: 14,
+    lineHeight: 24,
+    marginTop: spacing.sm,
+  },
   stoppedNoticeText: { color: colors.inkMuted },
   messageFooter: {
     flexDirection: "row",

--- a/mobile/src/i18n/locales.ts
+++ b/mobile/src/i18n/locales.ts
@@ -137,7 +137,8 @@ export const resources = {
         network:
           "Network error — the model service is unreachable. Check your connection and try again.",
         upstreamDisconnected: "Please wait, then click Continue to resume or try again.",
-        upstreamDisconnectedTitle: "Model service connection interrupted; this response could not finish",
+        upstreamDisconnectedTitle:
+          "Model service connection interrupted; this response could not finish",
         modelResponseError: "Switch models, then click Continue to resume or try again.",
         modelResponseErrorTitle: "Model response error; this response could not finish",
         agentInterrupted: "Restart the app, then click Continue to resume.",

--- a/mobile/src/remote/__tests__/useConversationController.test.ts
+++ b/mobile/src/remote/__tests__/useConversationController.test.ts
@@ -60,9 +60,11 @@ function model(id: string, provider?: string, extra: Partial<RemoteModel> = {}):
 function fakeEngine(): SyncEngine {
   return {
     reconcile: jest.fn(),
-    mutate: jest.fn((_sessionId: string, apply: (tl: ReturnType<typeof emptyTimeline>) => unknown) => {
-      apply(emptyTimeline());
-    }),
+    mutate: jest.fn(
+      (_sessionId: string, apply: (tl: ReturnType<typeof emptyTimeline>) => unknown) => {
+        apply(emptyTimeline());
+      },
+    ),
   } as unknown as SyncEngine;
 }
 
@@ -221,9 +223,7 @@ describe("selectSession", () => {
     await act(async () => {
       await current(h).selectSession("s1");
     });
-    const updater = h.setUnreadSessions.mock.calls[0][0] as (
-      previous: Set<string>,
-    ) => Set<string>;
+    const updater = h.setUnreadSessions.mock.calls[0][0] as (previous: Set<string>) => Set<string>;
     expect(updater(new Set(["s1", "s2"]))).toEqual(new Set(["s2"]));
     const untouched = new Set(["s2"]);
     expect(updater(untouched)).toBe(untouched);

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -82,7 +82,11 @@ export function messageToItems(message: AgentMessage): TimelineItem[] {
 
   const content = message.content ?? "";
   const segments = (message.segments ?? []).map(segmentToTimeline);
-  const hasVisible = content.trim().length > 0 || segments.length > 0;
+  const hasVisible =
+    content.trim().length > 0 ||
+    segments.length > 0 ||
+    message.status === "failed" ||
+    message.stopped === true;
   if (!hasVisible && message.durationMs == null && message.outputTokens == null) return [];
 
   // The copyable/render text: the ordered text blocks, not the flattened
@@ -115,7 +119,10 @@ export function messageToItems(message: AgentMessage): TimelineItem[] {
     ...(message.stopped ? { stopped: true } : {}),
     ...(message.truncated ? { truncated: true } : {}),
   };
-  if (message.status === "failed") item.failed = true;
+  if (message.status === "failed") {
+    item.failed = true;
+    if (message.runError) item.error = message.runError;
+  }
   return [item];
 }
 
@@ -166,6 +173,9 @@ function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
       ...(entry.duration_ms != null ? { duration_ms: entry.duration_ms } : {}),
       ...(entry.input_tokens != null ? { input_tokens: entry.input_tokens } : {}),
       ...(entry.cache_read_tokens != null ? { cache_read_tokens: entry.cache_read_tokens } : {}),
+      ...(entry.run_status != null ? { run_status: entry.run_status } : {}),
+      ...(entry.run_error != null ? { run_error: entry.run_error } : {}),
+      ...(entry.run_duration_ms != null ? { run_duration_ms: entry.run_duration_ms } : {}),
     };
   });
 }
@@ -174,108 +184,7 @@ function toSessionEntries(entries: HistoryEntry[]): SessionEntry[] {
  * shared package (`entriesToMessages`), then mapped to the render contract. */
 export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
   const messages = entriesToMessages(toSessionEntries(entries));
-  // The desktop store's authoritative run outcome, mirrored onto entries by the
-  // remote bridge (`run_status`, plus `run_error` for failed runs).
-  const runOutcomes = new Map(
-    entries
-      .filter(
-        entry => typeof entry.meta?.run_id === "string" && typeof entry.run_status === "string",
-      )
-      .map(
-        entry =>
-          [
-            entry.meta!.run_id!,
-            {
-              status: entry.run_status!,
-              error:
-                typeof entry.run_error === "string" && entry.run_error.trim()
-                  ? entry.run_error
-                  : undefined,
-              durationMs:
-                typeof entry.run_duration_ms === "number" &&
-                Number.isFinite(entry.run_duration_ms) &&
-                entry.run_duration_ms >= 0
-                  ? entry.run_duration_ms
-                  : undefined,
-            },
-          ] as const,
-      ),
-  );
-  const projected = messages.flatMap(message => {
-    const projectedItems = messageToItems(message);
-    const outcome = message.runId ? runOutcomes.get(message.runId) : undefined;
-    if (!outcome) return projectedItems;
-    return projectedItems.map(item =>
-      item.kind === "message" && item.role === "assistant"
-        ? {
-            ...item,
-            ...(outcome.status === "failed" ? { failed: true } : {}),
-            ...(outcome.status === "failed" && outcome.error ? { error: outcome.error } : {}),
-            ...(outcome.status === "cancelled" ? { stopped: true } : {}),
-            ...(item.durationMs == null && outcome.durationMs != null
-              ? { durationMs: outcome.durationMs }
-              : {}),
-          }
-        : item,
-    );
-  });
-  // A run whose first LLM call failed left NO assistant entry in the journal —
-  // the desktop rebuilds its failure bubble from the runs table on reload
-  // (recoverFailedRuns); mobile splices the same bubble right after the user
-  // turn that triggered the run, so the failure survives a re-open.
-  const assistantRunIds = new Set(
-    projected
-      .filter(
-        (item): item is Extract<TimelineItem, { kind: "message" }> =>
-          item.kind === "message" && item.role === "assistant" && typeof item.runId === "string",
-      )
-      .map(item => item.runId!),
-  );
-  // User entries open exchanges 1:1 in journal order (entriesToMessages) and
-  // the shared projection ids them `m_<entry id>` — the same id this file's
-  // toSessionEntries assigns — so a failed run's bubble anchors after its user
-  // item without re-deriving the exchange grouping.
-  const failuresByAnchor = new Map<
-    string,
-    { runId: string; error?: string; durationMs?: number }
-  >();
-  const unanchored: { runId: string; error?: string; durationMs?: number }[] = [];
-  entries.forEach((entry, index) => {
-    if (entry.role !== "user") return;
-    const runId = typeof entry.meta?.run_id === "string" ? entry.meta.run_id : null;
-    if (!runId) return;
-    const outcome = runOutcomes.get(runId);
-    if (outcome?.status !== "failed" || assistantRunIds.has(runId)) return;
-    const failure = { runId, error: outcome.error, durationMs: outcome.durationMs };
-    const text = typeof entry.content === "string" ? entry.content : "";
-    if (text.trim() || (entry.meta?.attachments?.length ?? 0) > 0) {
-      failuresByAnchor.set(`m_${entry.id ?? `entry_${index}`}`, failure);
-    } else {
-      unanchored.push(failure);
-    }
-  });
-  const toFailureBubble = (failure: {
-    runId: string;
-    error?: string;
-    durationMs?: number;
-  }): TimelineItem => ({
-    id: `failed_${failure.runId}`,
-    kind: "message",
-    role: "assistant",
-    text: "",
-    runId: failure.runId,
-    failed: true,
-    ...(failure.error ? { error: failure.error } : {}),
-    ...(failure.durationMs != null ? { durationMs: failure.durationMs } : {}),
-  });
-  const items: TimelineItem[] = [];
-  for (const item of projected) {
-    items.push(item);
-    const failure = failuresByAnchor.get(item.id);
-    if (failure) items.push(toFailureBubble(failure));
-  }
-  for (const failure of unanchored) items.push(toFailureBubble(failure));
-  return { ...emptyTimeline(), items };
+  return { ...emptyTimeline(), items: messages.flatMap(messageToItems) };
 }
 
 /** Message-shaped history fallback (old desktops without get_session_entries). */

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -190,14 +190,13 @@ export interface HistoryEntry {
   input_tokens?: number;
   /** Cache-read subset of input tokens. */
   cache_read_tokens?: number;
-  /** Desktop-store run outcome, added by the remote bridge for recovery parity. */
+  /** Terminal run outcome from the Agent journal (bridge fallback on old Agents). */
   run_status?: "completed" | "failed" | "cancelled" | string;
-  /** Raw run error for `run_status: "failed"` — the bridge pairs it with the
-   *  status so a reloaded timeline can rebuild the desktop's failure bubble. */
+  /** Raw run error for `run_status: "failed"`. */
   run_error?: string;
-  /** Authoritative elapsed run time from the desktop store. This remains
-   * separate from `duration_ms`, which belongs to a persisted assistant entry
-   * and is absent when a run fails before producing one. */
+  /** Terminal elapsed run time. This remains separate from `duration_ms`,
+   * which belongs to a persisted assistant entry and is absent when a run
+   * fails before producing one. */
   run_duration_ms?: number;
   /** RFC3339 entry time; preserved across re-saves so history keeps real times. */
   timestamp?: string;

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -1040,6 +1040,14 @@ message SessionEntry {
   // Authoritative tool-result status. Absent for legacy entries that did not
   // persist an explicit status.
   optional bool tool_result_is_error = 18;
+  // Terminal state of the run identified by meta.run_id. Derived from the
+  // Agent journal's run_terminal marker; absent while active and on old agents.
+  optional string run_status = 19;
+  // Raw terminal error for a failed run. Kept separate from display copy so
+  // each client can localize the user-facing explanation.
+  optional string run_error = 20;
+  // Terminal run duration even when the run produced no assistant entry.
+  optional int64 run_duration_ms = 21;
 }
 
 // One event as replayed by get_events_since. Field names mirror the

--- a/packages/rpc/src/decode.rs
+++ b/packages/rpc/src/decode.rs
@@ -484,6 +484,9 @@ pub(crate) fn session_entry_from_proto(entry: &proto::SessionEntry) -> SessionEn
         checkpoint: entry.checkpoint.as_ref().map(|raw| inflate_json_value(raw)),
         tool_call_id: entry.tool_call_id.clone(),
         tool_result_is_error: entry.tool_result_is_error,
+        run_status: entry.run_status.clone(),
+        run_error: entry.run_error.clone(),
+        run_duration_ms: entry.run_duration_ms,
     }
 }
 

--- a/packages/rpc/src/encode.rs
+++ b/packages/rpc/src/encode.rs
@@ -301,6 +301,9 @@ pub(crate) fn session_entry_to_proto(entry: &SessionEntryPayload) -> proto::Sess
             .map(|value| serde_json::to_string(value).unwrap_or_default()),
         tool_call_id: entry.tool_call_id.clone(),
         tool_result_is_error: entry.tool_result_is_error,
+        run_status: entry.run_status.clone(),
+        run_error: entry.run_error.clone(),
+        run_duration_ms: entry.run_duration_ms,
     }
 }
 

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -1123,6 +1123,17 @@ pub struct SessionEntry {
     /// persist an explicit status.
     #[prost(bool, optional, tag = "18")]
     pub tool_result_is_error: ::core::option::Option<bool>,
+    /// Terminal state of the run identified by meta.run_id. Derived from the
+    /// Agent journal's run_terminal marker; absent while active and on old agents.
+    #[prost(string, optional, tag = "19")]
+    pub run_status: ::core::option::Option<::prost::alloc::string::String>,
+    /// Raw terminal error for a failed run. Kept separate from display copy so
+    /// each client can localize the user-facing explanation.
+    #[prost(string, optional, tag = "20")]
+    pub run_error: ::core::option::Option<::prost::alloc::string::String>,
+    /// Terminal run duration even when the run produced no assistant entry.
+    #[prost(int64, optional, tag = "21")]
+    pub run_duration_ms: ::core::option::Option<i64>,
 }
 /// One event as replayed by get_events_since. Field names mirror the
 /// StreamEvent envelope.

--- a/packages/rpc/src/payloads.rs
+++ b/packages/rpc/src/payloads.rs
@@ -162,6 +162,12 @@ pub struct SessionEntryPayload {
     pub tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_result_is_error: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_duration_ms: Option<i64>,
 }
 
 /// One page returned by `get_session_entries`.
@@ -334,6 +340,9 @@ mod tests {
             checkpoint: None,
             tool_call_id: None,
             tool_result_is_error: None,
+            run_status: None,
+            run_error: None,
+            run_duration_ms: None,
         };
         let value = serde_json::to_value(&payload).unwrap();
         assert_eq!(value["content"], json!("hi"));

--- a/packages/thread-projection/src/events.ts
+++ b/packages/thread-projection/src/events.ts
@@ -66,4 +66,10 @@ export interface SessionEntry {
     algorithm_version?: string;
     summary?: unknown;
   };
+  /** Terminal outcome of meta.run_id, derived from the Agent run journal. */
+  run_status?: "completed" | "failed" | "cancelled" | "incomplete" | string;
+  /** Raw failure diagnostic; clients own localized display copy. */
+  run_error?: string;
+  /** Terminal duration, including reply-less runs. */
+  run_duration_ms?: number;
 }

--- a/packages/thread-projection/src/index.ts
+++ b/packages/thread-projection/src/index.ts
@@ -21,7 +21,8 @@ export {
   isSoftExit,
   nonZeroExitCode,
 } from "./liveApply";
-export { entriesToMessages } from "./projection";
+export { entriesToMessages, entriesToTurns, turnsToMessages } from "./projection";
+export type { SessionProjectionNode, SessionRunOutcome, SessionTurn } from "./projection";
 export {
   asToolKind,
   COLLAPSIBLE_KINDS,

--- a/packages/thread-projection/src/model.ts
+++ b/packages/thread-projection/src/model.ts
@@ -108,6 +108,8 @@ export interface AgentMessage {
   terminationNotice?: string;
   /** Short failure state rendered in the status divider above the guidance. */
   terminationTitle?: string;
+  /** Raw terminal run diagnostic, separate from localized presentation copy. */
+  runError?: string;
   /**
    * The stream ended before the model finished (`agent_end` reason
    * "incomplete"): the text is a truncated prefix, not a finished answer, and

--- a/packages/thread-projection/src/projection.ts
+++ b/packages/thread-projection/src/projection.ts
@@ -32,6 +32,8 @@ function attachmentsFromMeta(
 
 interface ExchangeAcc {
   userMessage?: AgentMessage;
+  /** Canonical identity persisted on the user entry that opened this turn. */
+  userRunId?: string;
   segments: MessageSegment[];
   finalText: string;
   /** Timestamp of the assistant reply (last assistant entry of the exchange wins). */
@@ -45,6 +47,7 @@ interface ExchangeAcc {
   durationMs?: number;
   /** Set only from an assistant entry finalized by the Agent. */
   runId?: string;
+  outcome?: SessionRunOutcome;
   /**
    * Tool activities awaiting their result entry, in call order. A `tool` result
    * entry updates the oldest one's status (the agent executes and appends
@@ -52,6 +55,25 @@ interface ExchangeAcc {
    */
   pendingTools: AgentActivityItem[];
 }
+
+export interface SessionRunOutcome {
+  status: "completed" | "failed" | "cancelled" | "incomplete" | string;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface SessionTurn {
+  key: string;
+  user: AgentMessage;
+  assistant?: AgentMessage;
+  runId?: string;
+  outcome?: SessionRunOutcome;
+  identitySource: "canonical" | "legacy" | "conflict";
+}
+
+export type SessionProjectionNode =
+  | { kind: "turn"; turn: SessionTurn }
+  | { kind: "standalone"; message: AgentMessage };
 
 /**
  * Whether a tool result's content marks a failure: the agent prefixes a tool
@@ -192,6 +214,19 @@ function userMessageFromEntry(entry: SessionEntry, now: string): AgentMessage {
   };
 }
 
+function foldRunOutcome(acc: ExchangeAcc, entry: SessionEntry) {
+  const runId = entry.meta?.run_id;
+  if (!runId || !entry.run_status) return;
+  if (acc.userRunId && runId !== acc.userRunId) return;
+  acc.outcome = {
+    status: entry.run_status,
+    ...(entry.run_error?.trim() ? { error: entry.run_error } : {}),
+    ...(typeof entry.run_duration_ms === "number" && entry.run_duration_ms >= 0
+      ? { durationMs: entry.run_duration_ms }
+      : {}),
+  };
+}
+
 /** Fold one assistant entry into an exchange's accumulator. */
 function foldAssistantEntry(acc: ExchangeAcc, entry: SessionEntry) {
   const key = entryKey(entry);
@@ -278,10 +313,9 @@ function foldToolEntry(acc: ExchangeAcc | null, entry: SessionEntry) {
   }
 }
 
-/** Emit a completed exchange as 1 user message + (when non-empty) 1 assistant. */
-function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
-  if (!acc.userMessage) return;
-  messages.push(acc.userMessage);
+/** Finalize one user-led exchange without losing a reply-less terminal run. */
+function turnFromAcc(acc: ExchangeAcc): SessionTurn | null {
+  if (!acc.userMessage) return null;
   const textSegments = acc.segments.filter((s) => s.kind === "text") as {
     kind: "text";
     id: string;
@@ -295,20 +329,32 @@ function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
   // yet (the agent is still streaming). An empty completed bubble would steal
   // the runId in applyRunMetadata and block upsertStreamingPreview from
   // inserting the live preview when the user returns to this thread.
+  const canonicalConflict = !!acc.userRunId && !!acc.runId && acc.userRunId !== acc.runId;
+  const turnRunId = canonicalConflict ? undefined : (acc.userRunId ?? acc.runId);
+  const outcome = canonicalConflict ? undefined : acc.outcome;
+  const terminalWithoutReply = outcome?.status === "failed" || outcome?.status === "cancelled";
   const hasContent =
     acc.finalText ||
     textSegments.length > 0 ||
     segments.length > 0 ||
     acc.outputTokens !== undefined ||
-    acc.durationMs !== undefined;
+    acc.durationMs !== undefined ||
+    terminalWithoutReply;
+  let assistant: AgentMessage | undefined;
   if (hasContent) {
-    messages.push({
-      id: acc.assistantEntryId ? `m_${acc.assistantEntryId}` : segId(),
+    const stopped = outcome?.status === "cancelled";
+    const failed = outcome?.status === "failed";
+    assistant = {
+      id: acc.assistantEntryId
+        ? `m_${acc.assistantEntryId}`
+        : turnRunId
+          ? `${failed ? "failed" : "stopped"}_${turnRunId}`
+          : segId(),
       role: "assistant",
       authorKey: "author.researchCopilot",
       content: acc.finalText || textSegments.map((s) => s.text).join("\n"),
       segments: segments.length > 0 ? segments : undefined,
-      status: "complete",
+      status: failed ? "failed" : "complete",
       // An aborted exchange has no assistant entry, so no recorded reply time —
       // fall back to the user message's time (a real timestamp) rather than
       // `now`, which would re-stamp the reply "just now" on every reload.
@@ -316,10 +362,28 @@ function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
       outputTokens: acc.outputTokens,
       inputTokens: acc.inputTokens,
       cacheReadTokens: acc.cacheReadTokens,
-      durationMs: acc.durationMs,
-      runId: acc.runId,
-    });
+      durationMs: acc.durationMs ?? outcome?.durationMs,
+      runId: canonicalConflict
+        ? undefined
+        : acc.runId ?? (outcome ? turnRunId : undefined),
+      ...(stopped ? { stopped: true } : {}),
+      ...(outcome?.error
+        ? { runError: outcome.error }
+        : {}),
+    };
   }
+  return {
+    key: acc.userMessage.id,
+    user: acc.userMessage,
+    ...(assistant ? { assistant } : {}),
+    ...(turnRunId ? { runId: turnRunId } : {}),
+    ...(outcome ? { outcome } : {}),
+    identitySource: canonicalConflict
+      ? "conflict"
+      : turnRunId
+        ? "canonical"
+        : "legacy",
+  };
 }
 
 /**
@@ -330,34 +394,56 @@ function flushAcc(messages: AgentMessage[], acc: ExchangeAcc) {
  * Grouping is positional: a user entry always opens a new exchange (each run
  * has exactly one user message, so journal order is conversation order).
  */
-export function entriesToMessages(entries: SessionEntry[]): AgentMessage[] {
-  const messages: AgentMessage[] = [];
+export function entriesToTurns(entries: SessionEntry[]): SessionProjectionNode[] {
+  const nodes: SessionProjectionNode[] = [];
   const now = new Date().toISOString();
+
+  const flush = (acc: ExchangeAcc) => {
+    const turn = turnFromAcc(acc);
+    if (turn) nodes.push({ kind: "turn", turn });
+  };
 
   let acc: ExchangeAcc | null = null;
   for (const entry of entries) {
     if (isCompactionDivider(entry)) {
       if (acc) {
-        flushAcc(messages, acc);
+        flush(acc);
         acc = null;
       }
-      messages.push(dividerMessage(entry, now));
+      nodes.push({ kind: "standalone", message: dividerMessage(entry, now) });
       continue;
     }
     if (entry.role === "user") {
       if (acc) {
-        flushAcc(messages, acc);
+        flush(acc);
         acc = null;
       }
       acc = newExchangeAcc();
       acc.userMessage = userMessageFromEntry(entry, now);
+      if (typeof entry.meta?.run_id === "string" && entry.meta.run_id)
+        acc.userRunId = entry.meta.run_id;
+      foldRunOutcome(acc, entry);
     } else if (entry.role === "assistant") {
       if (!acc) acc = newExchangeAcc();
       foldAssistantEntry(acc, entry);
+      foldRunOutcome(acc, entry);
     } else if (entry.role === "tool") {
       foldToolEntry(acc, entry);
+      if (acc) foldRunOutcome(acc, entry);
     }
   }
-  if (acc) flushAcc(messages, acc);
-  return messages;
+  if (acc) flush(acc);
+  return nodes;
+}
+
+export function turnsToMessages(nodes: SessionProjectionNode[]): AgentMessage[] {
+  return nodes.flatMap(node =>
+    node.kind === "standalone"
+      ? [node.message]
+      : [node.turn.user, ...(node.turn.assistant ? [node.turn.assistant] : [])],
+  );
+}
+
+export function entriesToMessages(entries: SessionEntry[]): AgentMessage[] {
+  return turnsToMessages(entriesToTurns(entries));
 }


### PR DESCRIPTION
## Summary

- project authoritative Agent run-terminal outcomes onto canonical session turns
- recover reply-less failures in the shared desktop/mobile projection without timestamp guessing
- preserve additive compatibility for older Agents and clients
- use blue informational dots for available updates in Settings and BYOK mode
- apply repository-wide formatting

## Validation

- `make lint`
- tests delegated to GitHub Actions