### PR TITLE
Fix mobile outbox cleanup races

### DIFF
--- a/mobile/src/remote/__tests__/draftStorage.test.ts
+++ b/mobile/src/remote/__tests__/draftStorage.test.ts
@@ -6,12 +6,18 @@ import {
   saveSessionDraft,
 } from "../draftStorage";
 
+const mockData = new Map<string, string>();
+
 jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
   default: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
+    getItem: jest.fn(async (key: string) => mockData.get(key) ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      mockData.set(key, value);
+    }),
+    removeItem: jest.fn(async (key: string) => {
+      mockData.delete(key);
+    }),
   },
 }));
 
@@ -50,6 +56,7 @@ const attachment = {
 
 describe("session draft storage", () => {
   beforeEach(() => {
+    mockData.clear();
     jest.clearAllMocks();
   });
 
@@ -140,5 +147,30 @@ describe("session draft storage", () => {
     );
     await clearSessionDraftIfMatches("s1", { text: "hello", attachments: [different] });
     expect(mockedAsync.removeItem).not.toHaveBeenCalled();
+  });
+
+  test("cold acknowledgement cannot delete a draft saved concurrently", async () => {
+    const original = { text: "hello", attachments: [attachment] };
+    await saveSessionDraft("s1", original);
+    let releaseRead!: () => void;
+    const readStarted = new Promise<void>(resolve => {
+      mockedAsync.getItem.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>(release => {
+          releaseRead = release;
+        });
+        return JSON.stringify({ version: 1, ...original });
+      });
+    });
+
+    const clearing = clearSessionDraftIfMatches("s1", original);
+    await readStarted;
+    const newer = { text: "newer edit", attachments: [attachment] };
+    const saving = saveSessionDraft("s1", newer);
+
+    expect(mockedAsync.setItem).toHaveBeenCalledTimes(1);
+    releaseRead();
+    await Promise.all([clearing, saving]);
+    await expect(loadSessionDraft("s1")).resolves.toEqual({ version: 1, ...newer });
   });
 });

--- a/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingContinuationStorage.test.ts
@@ -29,7 +29,10 @@ const pending: PendingContinuation = {
 };
 
 describe("pending continuation storage", () => {
-  beforeEach(() => mockData.clear());
+  beforeEach(() => {
+    mockData.clear();
+    jest.clearAllMocks();
+  });
 
   it("round trips the stable continuation identity", async () => {
     await savePendingContinuation(pending);
@@ -68,5 +71,33 @@ describe("pending continuation storage", () => {
     await expect(loadPendingContinuation()).resolves.toEqual(pending);
     await clearPendingContinuation(pending.commandId);
     await expect(loadPendingContinuation()).resolves.toBeNull();
+  });
+
+  it("cannot delete a newer continuation saved while a matching clear is in flight", async () => {
+    await savePendingContinuation(pending);
+    const AsyncStorage = jest.requireMock("@react-native-async-storage/async-storage") as {
+      getItem: jest.Mock;
+      setItem: jest.Mock;
+    };
+    let releaseRead!: () => void;
+    const readStarted = new Promise<void>(resolve => {
+      AsyncStorage.getItem.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>(release => {
+          releaseRead = release;
+        });
+        return JSON.stringify(pending);
+      });
+    });
+
+    const clearing = clearPendingContinuation(pending.commandId);
+    await readStarted;
+    const newer = { ...pending, commandId: "continue-2", sourceRunId: "run-2" };
+    const saving = savePendingContinuation(newer);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    releaseRead();
+    await Promise.all([clearing, saving]);
+    await expect(loadPendingContinuation()).resolves.toEqual(newer);
   });
 });

--- a/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
@@ -6,12 +6,18 @@ import {
   type PendingPrompt,
 } from "../pendingPromptStorage";
 
+const mockData = new Map<string, string>();
+
 jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
   default: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
+    getItem: jest.fn(async (key: string) => mockData.get(key) ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      mockData.set(key, value);
+    }),
+    removeItem: jest.fn(async (key: string) => {
+      mockData.delete(key);
+    }),
   },
 }));
 
@@ -31,7 +37,10 @@ const pending: PendingPrompt = {
 };
 
 describe("pending prompt storage", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    mockData.clear();
+    jest.clearAllMocks();
+  });
 
   test("round-trips a staged prompt", async () => {
     await savePendingPrompt(pending);
@@ -63,5 +72,29 @@ describe("pending prompt storage", () => {
     mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify(pending));
     await clearPendingPrompt("prompt_1");
     expect(mockedAsync.removeItem).toHaveBeenCalledWith("futureos.remote.pending-prompt.v1");
+  });
+
+  test("a matching clear cannot delete a newer prompt saved concurrently", async () => {
+    await savePendingPrompt(pending);
+    let releaseRead!: () => void;
+    const readStarted = new Promise<void>(resolve => {
+      mockedAsync.getItem.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>(release => {
+          releaseRead = release;
+        });
+        return JSON.stringify(pending);
+      });
+    });
+
+    const clearing = clearPendingPrompt(pending.commandId);
+    await readStarted;
+    const newer = { ...pending, commandId: "prompt_2", text: "newer" };
+    const saving = savePendingPrompt(newer);
+
+    expect(mockedAsync.setItem).toHaveBeenCalledTimes(1);
+    releaseRead();
+    await Promise.all([clearing, saving]);
+    await expect(loadPendingPrompt()).resolves.toEqual(newer);
   });
 });

--- a/mobile/src/remote/__tests__/usePromptOutbox.test.ts
+++ b/mobile/src/remote/__tests__/usePromptOutbox.test.ts
@@ -335,6 +335,31 @@ describe("usePromptOutbox sendMessage", () => {
     await act(async () => h.renderer.unmount());
   });
 
+  it("acquires the send lane before the first storage await", async () => {
+    const promptResponse = deferred<{ data: ReturnType<typeof ack> }>();
+    const requestRetry = jest.fn((request: { type: string }) => {
+      if (request.type === "prompt") return promptResponse.promise;
+      return Promise.resolve({ data: null });
+    });
+    const h = await mountSend({ requestRetry });
+
+    let first!: Promise<void>;
+    await act(async () => {
+      first = h.result.sendMessage("first");
+      await expect(h.result.sendMessage("second")).rejects.toThrow("send_busy");
+    });
+    await flush();
+    expect(requestRetry.mock.calls.filter(([request]) => request.type === "prompt")).toHaveLength(
+      1,
+    );
+
+    promptResponse.resolve({ data: ack() });
+    await act(async () => {
+      await first;
+    });
+    await act(async () => h.renderer.unmount());
+  });
+
   it("rejects attachments when the client does not support file transfer", async () => {
     const h = await mountSend({ fileTransferSupported: false });
     await expect(h.result.sendMessage("hi", [attachment])).rejects.toThrow(

--- a/mobile/src/remote/asyncOperationQueue.ts
+++ b/mobile/src/remote/asyncOperationQueue.ts
@@ -1,0 +1,17 @@
+/**
+ * A small in-process serial lane for storage operations that must preserve
+ * call order across multiple awaits. A rejected operation never poisons the
+ * lane: later work still runs after it settles.
+ */
+export function createAsyncOperationQueue() {
+  let tail: Promise<void> = Promise.resolve();
+
+  return function enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = tail.then(operation, operation);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/mobile/src/remote/draftStorage.ts
+++ b/mobile/src/remote/draftStorage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { File } from "expo-file-system";
+import { createAsyncOperationQueue } from "./asyncOperationQueue";
 import type { MobileAttachment } from "./types";
 
 /**
@@ -17,6 +18,7 @@ export interface SessionDraft {
 
 const DRAFT_VERSION = 1;
 const KEY_PREFIX = "futureos.remote.draft.v1:";
+const enqueueOperation = createAsyncOperationQueue();
 
 function storageKey(sessionId: string): string {
   return `${KEY_PREFIX}${sessionId}`;
@@ -37,7 +39,7 @@ function attachmentFileExists(localUri: string): boolean {
  * Attachments whose backing file no longer exists (a temporary camera/cache
  * file was pruned) are dropped rather than surfacing a dead tap target.
  */
-export async function loadSessionDraft(sessionId: string): Promise<SessionDraft | null> {
+async function loadSessionDraftDirect(sessionId: string): Promise<SessionDraft | null> {
   if (!sessionId) return null;
   try {
     const raw = await AsyncStorage.getItem(storageKey(sessionId));
@@ -63,6 +65,10 @@ export async function loadSessionDraft(sessionId: string): Promise<SessionDraft 
   }
 }
 
+export function loadSessionDraft(sessionId: string): Promise<SessionDraft | null> {
+  return enqueueOperation(() => loadSessionDraftDirect(sessionId));
+}
+
 /**
  * Persist a session's draft. An empty draft (no text and no attachments) clears
  * the slot instead of writing a blank entry, so a composer that was emptied
@@ -73,29 +79,33 @@ export async function saveSessionDraft(
   draft: Omit<SessionDraft, "version">,
 ): Promise<void> {
   if (!sessionId) return;
-  const hasAttachments = (draft.attachments?.length ?? 0) > 0;
-  if (!hasAttachments && (draft.text ?? "").trim().length === 0) {
-    await clearSessionDraft(sessionId);
-    return;
-  }
-  try {
-    await AsyncStorage.setItem(
-      storageKey(sessionId),
-      JSON.stringify({ version: DRAFT_VERSION, ...draft }),
-    );
-  } catch {
-    // Storage full/unavailable — a dropped draft is non-fatal.
-  }
+  await enqueueOperation(async () => {
+    const hasAttachments = (draft.attachments?.length ?? 0) > 0;
+    try {
+      if (!hasAttachments && (draft.text ?? "").trim().length === 0) {
+        await AsyncStorage.removeItem(storageKey(sessionId));
+        return;
+      }
+      await AsyncStorage.setItem(
+        storageKey(sessionId),
+        JSON.stringify({ version: DRAFT_VERSION, ...draft }),
+      );
+    } catch {
+      // Storage full/unavailable — a dropped draft is non-fatal.
+    }
+  });
 }
 
 /** Remove a session's draft (e.g. after its message is sent). */
 export async function clearSessionDraft(sessionId: string): Promise<void> {
   if (!sessionId) return;
-  try {
-    await AsyncStorage.removeItem(storageKey(sessionId));
-  } catch {
-    // Ignore — storage unavailable.
-  }
+  await enqueueOperation(async () => {
+    try {
+      await AsyncStorage.removeItem(storageKey(sessionId));
+    } catch {
+      // Ignore — storage unavailable.
+    }
+  });
 }
 
 /**
@@ -107,15 +117,22 @@ export async function clearSessionDraftIfMatches(
   sessionId: string,
   expected: Pick<SessionDraft, "text" | "attachments">,
 ): Promise<void> {
-  const current = await loadSessionDraft(sessionId);
-  if (!current || current.text.trim() !== expected.text.trim()) return;
-  const identities = (items: MobileAttachment[]) =>
-    items.map(item => `${item.localUri}\u0000${item.name}\u0000${item.transferSize}`).sort();
-  if (
-    JSON.stringify(identities(current.attachments)) !==
-    JSON.stringify(identities(expected.attachments))
-  ) {
-    return;
-  }
-  await clearSessionDraft(sessionId);
+  if (!sessionId) return;
+  await enqueueOperation(async () => {
+    const current = await loadSessionDraftDirect(sessionId);
+    if (!current || current.text.trim() !== expected.text.trim()) return;
+    const identities = (items: MobileAttachment[]) =>
+      items.map(item => `${item.localUri}\u0000${item.name}\u0000${item.transferSize}`).sort();
+    if (
+      JSON.stringify(identities(current.attachments)) !==
+      JSON.stringify(identities(expected.attachments))
+    ) {
+      return;
+    }
+    try {
+      await AsyncStorage.removeItem(storageKey(sessionId));
+    } catch {
+      // Ignore — storage unavailable.
+    }
+  });
 }

--- a/mobile/src/remote/pendingContinuationStorage.ts
+++ b/mobile/src/remote/pendingContinuationStorage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createAsyncOperationQueue } from "./asyncOperationQueue";
 
 export interface PendingContinuation {
   version: 2;
@@ -11,8 +12,9 @@ export interface PendingContinuation {
 }
 
 const KEY = "futureos.remote.pending-continuation.v1";
+const enqueueOperation = createAsyncOperationQueue();
 
-export async function loadPendingContinuation(): Promise<PendingContinuation | null> {
+async function loadPendingContinuationDirect(): Promise<PendingContinuation | null> {
   try {
     const raw = await AsyncStorage.getItem(KEY);
     if (!raw) return null;
@@ -39,17 +41,23 @@ export async function loadPendingContinuation(): Promise<PendingContinuation | n
   }
 }
 
+export function loadPendingContinuation(): Promise<PendingContinuation | null> {
+  return enqueueOperation(loadPendingContinuationDirect);
+}
+
 export async function savePendingContinuation(continuation: PendingContinuation): Promise<void> {
-  await AsyncStorage.setItem(KEY, JSON.stringify(continuation));
+  await enqueueOperation(() => AsyncStorage.setItem(KEY, JSON.stringify(continuation)));
 }
 
 /** Clear only the operation this caller completed; a newer retry must survive. */
 export async function clearPendingContinuation(commandId: string): Promise<void> {
-  const current = await loadPendingContinuation();
-  if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+  await enqueueOperation(async () => {
+    const current = await loadPendingContinuationDirect();
+    if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+  });
 }
 
 /** Drop any continuation, including legacy/malformed records that cannot be decoded safely. */
 export async function discardPendingContinuation(): Promise<void> {
-  await AsyncStorage.removeItem(KEY);
+  await enqueueOperation(() => AsyncStorage.removeItem(KEY));
 }

--- a/mobile/src/remote/pendingPromptStorage.ts
+++ b/mobile/src/remote/pendingPromptStorage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createAsyncOperationQueue } from "./asyncOperationQueue";
 import type { MobileAttachment, ThinkingLevel } from "./types";
 
 export interface PendingPrompt {
@@ -16,8 +17,9 @@ export interface PendingPrompt {
 }
 
 const KEY = "futureos.remote.pending-prompt.v1";
+const enqueueOperation = createAsyncOperationQueue();
 
-export async function loadPendingPrompt(): Promise<PendingPrompt | null> {
+async function loadPendingPromptDirect(): Promise<PendingPrompt | null> {
   try {
     const raw = await AsyncStorage.getItem(KEY);
     if (!raw) return null;
@@ -44,12 +46,18 @@ export async function loadPendingPrompt(): Promise<PendingPrompt | null> {
   }
 }
 
+export function loadPendingPrompt(): Promise<PendingPrompt | null> {
+  return enqueueOperation(loadPendingPromptDirect);
+}
+
 export async function savePendingPrompt(prompt: PendingPrompt): Promise<void> {
-  await AsyncStorage.setItem(KEY, JSON.stringify(prompt));
+  await enqueueOperation(() => AsyncStorage.setItem(KEY, JSON.stringify(prompt)));
 }
 
 /** Clear only the record this caller completed; a newer send must survive. */
 export async function clearPendingPrompt(commandId: string): Promise<void> {
-  const current = await loadPendingPrompt();
-  if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+  await enqueueOperation(async () => {
+    const current = await loadPendingPromptDirect();
+    if (current?.commandId === commandId) await AsyncStorage.removeItem(KEY);
+  });
 }

--- a/mobile/src/remote/usePromptOutbox.ts
+++ b/mobile/src/remote/usePromptOutbox.ts
@@ -215,77 +215,80 @@ export function usePromptOutbox({
       };
       if (streamingRef.current[targetSessionId] ?? false) throw new Error("send_streaming");
 
-      let pending = await loadPendingPrompt();
-      let checkReceipt = false;
-      if (pending && samePendingPrompt(pending, candidate)) {
-        checkReceipt = true;
-      } else {
-        if (pending) {
-          const previousReceipt = promptReceiptSupported
-            ? await pendingPromptReceipt(client, pending.commandId)
-            : null;
-          if (previousReceipt) await clearSessionDraftIfMatches(pending.draftKey, pending);
-          await clearPendingPrompt(pending.commandId);
-        }
-        pending = {
-          version: 1,
-          commandId: randomId("prompt"),
-          ...candidate,
-          createdAt: Date.now(),
-        };
-        await savePendingPrompt(pending);
-      }
-
+      // Acquire the prompt lane before the first storage await. Recovery and a
+      // user tap can otherwise both read the same slot and deliver concurrently.
       sendingRef.current = true;
       setSending(true);
       try {
-        const response = await deliverPendingPrompt(
-          client,
-          pending,
-          checkReceipt,
-          promptReceiptSupported,
-          onUploadProgress,
-        );
-        await clearPendingPrompt(pending.commandId);
-        await clearSessionDraftIfMatches(pending.draftKey, pending);
-        const nextSessionId = response.sessionId || targetSessionId;
-        engine?.mutate(nextSessionId, timeline =>
-          commitAcknowledgedUserMessage(timeline ?? emptyTimeline(), {
-            id: `local:${pending.commandId}`,
-            runId: response.runId,
-            text: text.trim(),
-            ...(attachments.length
-              ? {
-                  attachments: attachments.map(attachment => ({
-                    path: attachment.localUri,
-                    name: attachment.name,
-                    kind: attachment.kind,
-                    mobilePreviewUnsupported: attachment.mobilePreviewUnsupported,
-                  })),
-                }
-              : {}),
-          }),
-        );
-        if (nextSessionId && nextSessionId !== targetSessionId) {
-          const stillViewingSentDraft = conversationEpochRef.current === conversationEpoch;
-          if (stillViewingSentDraft) {
-            selectedRef.current = nextSessionId;
-            setSelectedSessionId(nextSessionId);
-            setDraft(false);
-            setDraftMode("chat");
-            setDraftWorkspaceId("");
+        let pending = await loadPendingPrompt();
+        let checkReceipt = false;
+        if (pending && samePendingPrompt(pending, candidate)) {
+          checkReceipt = true;
+        } else {
+          if (pending) {
+            const previousReceipt = promptReceiptSupported
+              ? await pendingPromptReceipt(client, pending.commandId)
+              : null;
+            if (previousReceipt) await clearSessionDraftIfMatches(pending.draftKey, pending);
+            await clearPendingPrompt(pending.commandId);
           }
-          engine?.mutate(targetSessionId, timeline => ({
-            ...(timeline ?? emptyTimeline()),
-            items: [],
-          }));
-          if (stillViewingSentDraft) void refreshSessions();
+          pending = {
+            version: 1,
+            commandId: randomId("prompt"),
+            ...candidate,
+            createdAt: Date.now(),
+          };
+          await savePendingPrompt(pending);
         }
-      } catch (sendError) {
-        if (!isTransientNatsRequestError(sendError)) {
+        try {
+          const response = await deliverPendingPrompt(
+            client,
+            pending,
+            checkReceipt,
+            promptReceiptSupported,
+            onUploadProgress,
+          );
           await clearPendingPrompt(pending.commandId);
+          await clearSessionDraftIfMatches(pending.draftKey, pending);
+          const nextSessionId = response.sessionId || targetSessionId;
+          engine?.mutate(nextSessionId, timeline =>
+            commitAcknowledgedUserMessage(timeline ?? emptyTimeline(), {
+              id: `local:${pending.commandId}`,
+              runId: response.runId,
+              text: text.trim(),
+              ...(attachments.length
+                ? {
+                    attachments: attachments.map(attachment => ({
+                      path: attachment.localUri,
+                      name: attachment.name,
+                      kind: attachment.kind,
+                      mobilePreviewUnsupported: attachment.mobilePreviewUnsupported,
+                    })),
+                  }
+                : {}),
+            }),
+          );
+          if (nextSessionId && nextSessionId !== targetSessionId) {
+            const stillViewingSentDraft = conversationEpochRef.current === conversationEpoch;
+            if (stillViewingSentDraft) {
+              selectedRef.current = nextSessionId;
+              setSelectedSessionId(nextSessionId);
+              setDraft(false);
+              setDraftMode("chat");
+              setDraftWorkspaceId("");
+            }
+            engine?.mutate(targetSessionId, timeline => ({
+              ...(timeline ?? emptyTimeline()),
+              items: [],
+            }));
+            if (stillViewingSentDraft) void refreshSessions();
+          }
+        } catch (sendError) {
+          if (!isTransientNatsRequestError(sendError)) {
+            await clearPendingPrompt(pending.commandId);
+          }
+          throw sendError;
         }
-        throw sendError;
       } finally {
         sendingRef.current = false;
         setSending(false);
@@ -315,13 +318,14 @@ export function usePromptOutbox({
   const recoverPendingPrompt = useCallback(async () => {
     if (sendingRef.current) return;
     if (pendingRecoveryRef.current) return pendingRecoveryRef.current;
+    const client = clientRef.current;
+    if (!client || !credentialsRef.current) return;
+    // Publish ownership synchronously, before loadPendingPrompt yields.
+    sendingRef.current = true;
+    setSending(true);
     const recovery = (async () => {
-      const client = clientRef.current;
-      if (!client || !credentialsRef.current) return;
       const pending = await loadPendingPrompt();
       if (!pending) return;
-      sendingRef.current = true;
-      setSending(true);
       try {
         const receipt = await deliverPendingPrompt(client, pending, true, promptReceiptSupported);
         await clearPendingPrompt(pending.commandId);
@@ -333,11 +337,10 @@ export function usePromptOutbox({
           await clearPendingPrompt(pending.commandId);
           recordError(recoveryError);
         }
-      } finally {
-        sendingRef.current = false;
-        setSending(false);
       }
     })().finally(() => {
+      sendingRef.current = false;
+      setSending(false);
       pendingRecoveryRef.current = null;
     });
     pendingRecoveryRef.current = recovery;


### PR DESCRIPTION
## Summary
- serialize Mobile pending prompt, continuation, and draft storage operations
- make conditional cleanup indivisible relative to newer writes
- acquire the prompt send lane before the first storage await
- add deterministic concurrency regression coverage

## Validation
- npm --prefix mobile run typecheck
- npm --prefix mobile run lint
- Prettier check on all changed files
- git diff --check
- npm --prefix mobile test -- --no-watchman pendingPromptStorage.test.ts pendingContinuationStorage.test.ts draftStorage.test.ts usePromptOutbox.test.ts (45 tests passed)