### PR TITLE
fix(loop): open runs.jsonl with read access so LockFileEx succeeds on Windows

### DIFF
--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -1135,10 +1135,20 @@ impl Store {
 
 /// Append under an advisory lock so concurrent processes cannot interleave
 /// a line in the middle of an event/run (LoopX: file_lock).
+///
+/// The handle must be opened with **read** access: on Windows `fs2`'s
+/// `lock_exclusive` is `LockFileEx`, which requires `GENERIC_READ` on the
+/// handle. An append-only (`FILE_APPEND_DATA`-only) handle makes `LockFileEx`
+/// fail with `ERROR_ACCESS_DENIED` (5) on *every* call — which is exactly why
+/// `append_run` always failed on Windows with `Error: append run` and the
+/// `runs.jsonl` audit history was silently dropped. POSIX `fcntl` has no such
+/// requirement, so this bug is Windows-only. (`append_event_locked` already
+/// opens with `read(true)`, which is why event appends never hit it.)
 fn append_locked(path: PathBuf, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     let file = fs::OpenOptions::new()
         .create(true)
+        .read(true)
         .append(true)
         .open(&path)?;
     file.lock_exclusive()?;

--- a/orchestration/loop/tests/store_drive.rs
+++ b/orchestration/loop/tests/store_drive.rs
@@ -322,6 +322,25 @@ fn replay_edge_paths() {
     assert!(store.replay("g1").is_err(), "conflicting ids fail closed");
 }
 
+/// Windows regression: `append_run` opens `runs.jsonl` append-only. On
+/// Windows `fs2::lock_exclusive` is `LockFileEx`, which requires
+/// `GENERIC_READ`; an append-only handle made every `LockFileEx` fail with
+/// `ERROR_ACCESS_DENIED` (5), so `run` aborted with `Error: append run` and
+/// the audit record was silently dropped (`runs.jsonl` stayed empty). The fix
+/// opens the handle with `read(true)`. This test fails on the pre-fix code on
+/// Windows and passes on POSIX either way.
+#[test]
+fn append_run_persists_audit_record() {
+    let (_d, root) = fresh_store("s5-share");
+    let mut store = Store::open(&root).unwrap();
+    registered_goal(&mut store, "g1");
+    store
+        .append_run("g1", &run_record("t1", "completed", now_epoch()))
+        .expect("append_run must succeed and persist the audit record");
+    let goal = store.replay("g1").unwrap().unwrap();
+    assert_eq!(goal.history.len(), 1, "run record persisted, not dropped");
+}
+
 #[test]
 fn replay_skips_malformed_run_lines() {
     let (_d, root) = fresh_store("s5");


### PR DESCRIPTION
## Problem

Every \uture loop run\ on Windows aborted at the end with \Error: append run\, and the per-goal \uns.jsonl\ audit history was silently dropped (the file stayed 0 bytes while the turn itself succeeded). Observed on a real goal whose \uns.jsonl\ was empty across 11 runs.

## Root cause

\Store::append_run\ → \ppend_locked\ opened \uns.jsonl **append-only**. On Windows \s2::lock_exclusive\ is \LockFileEx\, which requires \GENERIC_READ\ on the handle; an append-only (\FILE_APPEND_DATA\-only) handle makes every \LockFileEx\ call fail synchronously with \ERROR_ACCESS_DENIED\ (5). The error was surfaced only as the \nyhow\ context \ppend run\, hiding the real OS error.

POSIX \cntl(F_SETLK)\ has no such read requirement, so the bug is **Windows-only**. \ppend_event_locked\ already opened with \ead(true)\, which is why event appends never hit it — only the run audit did.

Verified empirically: a probe locking an append-only handle returns os error 5 on every call; adding \ead(true)\ succeeds.

## Fix

Open the handle in \ppend_locked\ with \ead(true)\. One-line behavioral change.

## Test

- New regression test \ppend_run_persists_audit_record\ in \	ests/store_drive.rs\ asserts the run audit record is persisted (fails on the pre-fix code on Windows, passes on POSIX either way).
- \eplay_skips_malformed_run_lines\ (which also calls \ppend_run\) now passes on Windows — it was previously failing for the same root cause.

## Notes

Two tests in \store_drive.rs\ (\ppend_requires_registration_and_dedupes\, \	ry_claim_todo_lease_reconstruction\) fail identically on \origin/main\ (verified at the parent commit) — pre-existing, unrelated to this change.