### PR TITLE
Refactor release build workflows

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -4,6 +4,34 @@ permissions: read-all
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact version supplied by the coordinator.
+        required: true
+        type: string
+      build_number:
+        description: Monotonic Android versionCode supplied by the coordinator.
+        required: true
+        type: string
+      coordinated:
+        description: Let the caller publish the collected artifact.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        required: true
+      OSS_ENDPOINT:
+        required: false
+      OSS_BUCKET:
+        required: false
+      OSS_ACCESS_KEY_ID:
+        required: false
+      OSS_ACCESS_KEY_SECRET:
+        required: false
 
 jobs:
   version:
@@ -22,6 +50,9 @@ jobs:
           node-version: "24"
       - name: Resolve version
         id: v
+        env:
+          FUTURE_VERSION: ${{ inputs.version }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
           node scripts/version.mjs --github-output
           # versionCode must be a monotonic integer if this ever goes to Play
@@ -30,7 +61,7 @@ jobs:
           # workflow's own per-repo counter, starting at 1. It resets if the
           # workflow is renamed, but that only matters for Play (not currently
           # used); versionCode monotonicity within a single workflow is enough.
-          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${INPUT_BUILD_NUMBER:-${{ github.run_number }}}" >> "$GITHUB_OUTPUT"
 
   build-apk:
     name: Build APK
@@ -56,15 +87,16 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
         with:
-          packages: 'platforms;android-36 build-tools;36.0.0'
+          packages: "platforms;android-36 build-tools;36.0.0"
 
       - name: Setup ossutil
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: bash scripts/setup-ossutil.sh
 
       - name: Restore keystore
@@ -85,7 +117,6 @@ jobs:
         working-directory: mobile
         run: npm ci
 
-     
       - name: Generate version
         working-directory: mobile
         run: npm run gen-version
@@ -102,7 +133,7 @@ jobs:
         run: |
           V="${{ needs.version.outputs.version }}"
           cp mobile/android/app/build/outputs/apk/release/app-release.apk \
-             "FutureOS_${V}.apk"
+             "FutureOS_${V}_android-universal.apk"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
@@ -110,14 +141,15 @@ jobs:
           name: futureos-android-apk
           if-no-files-found: error
           overwrite: true
-          path: FutureOS_${{ needs.version.outputs.version }}.apk
+          path: FutureOS_${{ needs.version.outputs.version }}_android-universal.apk
           retention-days: 3
 
       - name: Upload APK to OSS
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
           V="${{ needs.version.outputs.version }}"
-          APK="FutureOS_${V}.apk"
+          APK="FutureOS_${V}_android-universal.apk"
           ossutil cp -f "$APK" "oss://$OSS_BUCKET/test/$V/$APK"
           ossutil stat "oss://$OSS_BUCKET/test/$V/$APK"
           echo "==> Download URL:"

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -25,6 +25,42 @@ permissions: read-all
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact marketing version supplied by the coordinator.
+        required: true
+        type: string
+      build_number:
+        description: Monotonic App Store build number supplied by the coordinator.
+        required: true
+        type: string
+      coordinated:
+        description: Let the caller handle release publication.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      IOS_DIST_CERT_P12_BASE64:
+        required: true
+      IOS_DIST_CERT_P12_PWD:
+        required: true
+      IOS_PROVISIONING_PROFILE_BASE64:
+        required: true
+      APPLE_API_KEY:
+        required: true
+      APPLE_API_KEY_ID:
+        required: true
+      APPLE_API_ISSUER:
+        required: true
+      OSS_ENDPOINT:
+        required: false
+      OSS_BUCKET:
+        required: false
+      OSS_ACCESS_KEY_ID:
+        required: false
+      OSS_ACCESS_KEY_SECRET:
+        required: false
 
 jobs:
   version:
@@ -39,15 +75,20 @@ jobs:
 
       - name: Resolve build number
         id: v
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
           # Marketing version bumped to 0.0.2: TestFlight already accepted
           # 0.0.1 with build number 31479016198, so 0.0.1's sequence can only
           # increase; small run_number values must start fresh under 0.0.2.
           # The store build number is this workflow's per-repo run counter
           # (starts at 1; stays within int32).
-          echo "version=0.0.2" >> "$GITHUB_OUTPUT"
-          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
-          echo "TestFlight version: 0.0.2 (build ${{ github.run_number }})"
+          version="${INPUT_VERSION:-0.0.2}"
+          build_number="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
+          echo "TestFlight version: $version (build $build_number)"
 
   build:
     name: Build and upload TestFlight
@@ -163,7 +204,6 @@ jobs:
         working-directory: mobile
         run: npm ci
 
-     
       - name: Prebuild iOS
         working-directory: mobile
         env:
@@ -252,6 +292,7 @@ jobs:
             --verbose
 
       - name: Upload IPA to OSS
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
           : "${IPA_PATH:?IPA_PATH is required}"

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -1,0 +1,246 @@
+name: Build Linux
+
+permissions: read-all
+
+# Linux packages have no platform code-signing identity. Formal release .deb
+# files are nevertheless signed with the existing Tauri updater key so clients
+# can authenticate them before invoking the system package manager.
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact release version supplied by the coordinator.
+        required: false
+        type: string
+        default: ""
+      release:
+        description: Stage artifacts using formal release names.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: false
+      TAURI_UPDATER_PUBLIC_KEY:
+        required: true
+
+jobs:
+  version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Resolve version
+        id: v
+        env:
+          FUTURE_VERSION: ${{ inputs.version }}
+        run: node scripts/version.mjs --github-output
+
+  build:
+    name: Build Linux (${{ matrix.arch }})
+    needs: version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            os: ubuntu-latest
+            deb_arch: amd64
+            artifact_name: futureos-linux
+            release_artifact_name: futureos-linux-release
+          # Build natively: cross-compiling the WebKit-heavy GUI would require
+          # a complete aarch64 sysroot.
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+            deb_arch: arm64
+            artifact_name: futureos-linux-arm64
+            release_artifact_name: futureos-linux-arm64-release
+    env:
+      FUTURE_VERSION: ${{ needs.version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            desktop/src-tauri
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Install Linux system dependencies
+        run: |
+          bash scripts/ci/install-apt-packages.sh \
+            build-essential \
+            curl \
+            file \
+            mold \
+            binutils \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            musl-tools \
+            patchelf \
+            wget
+
+      - name: Install npm dependencies (Desktop)
+        working-directory: desktop
+        run: npm ci
+
+      # Build the unified CLI as a fully static musl binary. It is both the
+      # Tauri sidecar and a standalone distribution for headless Linux hosts.
+      - name: Build CLI binary (Linux, static musl)
+        working-directory: cli
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+        run: |
+          set -euo pipefail
+          target="${{ matrix.arch }}-unknown-linux-musl"
+          rustup target add "$target"
+          cargo build --release --target "$target"
+          triple=$(rustc -Vv | sed -n 's/^host: //p')
+          mkdir -p ../desktop/src-tauri/binaries
+          cp "../target/$target/release/future" "../desktop/src-tauri/binaries/future-$triple"
+          tar -czf "FutureOS_${FUTURE_VERSION}_linux_${{ matrix.arch }}-cli.tar.gz" \
+            -C "../target/$target/release" future
+
+      - name: Set Tauri bundle version
+        run: node scripts/version.mjs --set-bundle
+
+      - name: Build desktop bundle (.deb)
+        if: inputs.release != true
+        working-directory: desktop
+        run: npm run tauri:build
+
+      # Formal Linux builds embed the same updater trust root and endpoint as
+      # macOS and Windows. The .deb itself is signed after it is renamed below;
+      # createUpdaterArtifacts is intentionally omitted because no AppImage is
+      # produced by this workflow.
+      - name: Build desktop bundle (.deb, updater-enabled)
+        if: inputs.release == true
+        env:
+          TAURI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          : "${TAURI_UPDATER_PUBLIC_KEY:?TAURI_UPDATER_PUBLIC_KEY secret is required}"
+          overlay="$RUNNER_TEMP/tauri.linux-updater.json"
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.argv[1], JSON.stringify({
+              plugins: {
+                updater: {
+                  pubkey: process.env.TAURI_UPDATER_PUBLIC_KEY,
+                  endpoints: [
+                    "https://dl.future-os.cn/releases/latest.json"
+                  ]
+                }
+              }
+            }));
+          ' "$overlay"
+          npm --prefix desktop run tauri:build -- --config "$overlay"
+
+      - name: Assemble Linux portable
+        run: |
+          set -euo pipefail
+          dir="futureos-portable-linux"
+          mkdir -p "$dir"
+          cp "desktop/src-tauri/target/release/futureos" "$dir/futureos"
+          cp "target/${{ matrix.arch }}-unknown-linux-musl/release/future" "$dir/future"
+          chmod +x "$dir"/*
+          cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
+          mkdir -p "$dir/licenses/loop"
+          cp LICENSE "$dir/licenses/"
+          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$dir/licenses/loop/"
+          tar -czf "FutureOS_${FUTURE_VERSION}_linux_${{ matrix.arch }}-portable.tar.gz" \
+            -C "$dir" .
+
+      - name: Upload desktop bundle
+        if: inputs.release != true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}
+          if-no-files-found: error
+          overwrite: true
+          path: desktop/src-tauri/target/release/bundle/deb/*.deb
+          retention-days: 3
+
+      - name: Upload Linux portable
+        if: inputs.release != true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}-portable
+          if-no-files-found: error
+          overwrite: true
+          path: FutureOS_*_linux_${{ matrix.arch }}-portable.tar.gz
+          retention-days: 3
+
+      - name: Upload Linux CLI (static)
+        if: inputs.release != true
+        uses: actions/upload-artifact@v7
+        with:
+          name: future-cli-linux-${{ matrix.arch }}
+          if-no-files-found: error
+          overwrite: true
+          path: cli/FutureOS_*_linux_${{ matrix.arch }}-cli.tar.gz
+          retention-days: 3
+
+      - name: Stage release assets
+        if: inputs.release == true
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          : "${TAURI_SIGNING_PRIVATE_KEY:?TAURI_SIGNING_PRIVATE_KEY secret is required}"
+          mkdir -p release-assets
+          deb="$(find desktop/src-tauri/target/release/bundle/deb -maxdepth 1 -name '*.deb' -print -quit)"
+          [[ -n "$deb" ]] || {
+            echo "Tauri produced no .deb bundle" >&2
+            exit 1
+          }
+          release_deb="release-assets/FutureOS_${FUTURE_VERSION}_${{ matrix.deb_arch }}.deb"
+          cp "$deb" "$release_deb"
+          npm --prefix desktop exec -- tauri signer sign "$release_deb"
+          [[ -s "$release_deb.sig" ]] || {
+            echo "Tauri produced no updater signature for $release_deb" >&2
+            exit 1
+          }
+          cp "FutureOS_${FUTURE_VERSION}_linux_${{ matrix.arch }}-portable.tar.gz" "release-assets/"
+          cp "cli/FutureOS_${FUTURE_VERSION}_linux_${{ matrix.arch }}-cli.tar.gz" "release-assets/"
+
+      - name: Upload Linux release assets
+        if: inputs.release == true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.release_artifact_name }}
+          if-no-files-found: error
+          overwrite: true
+          path: release-assets/
+          retention-days: 7

--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -1,11 +1,11 @@
-name: Build FutureOS macOS (signed)
+name: Build macOS signed
 
 permissions: read-all
 
-# Signed and notarized macOS build. Keep this workflow restricted to trusted
-# triggers: it imports the Developer ID certificate and can submit software to
-# Apple's notarization service. Do not add pull_request or other events that can
-# execute untrusted code with the signing credentials.
+# Shared macOS packaging workflow. Signed mode imports the Developer ID
+# certificate and submits to Apple's notarization service; unsigned mode skips
+# both but still creates updater artifacts signed by the Tauri updater key.
+# Keep both modes restricted to trusted triggers because both access secrets.
 #
 # Manual builds go to `test/<version>/`. Formal releases call this workflow from
 # release.yml and consume its verified artifact; only the coordinator publishes
@@ -13,23 +13,39 @@ permissions: read-all
 
 on:
   workflow_dispatch:
+    inputs:
+      signed:
+        description: Sign and notarize with Apple Developer ID.
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
         description: Exact release version supplied by the coordinator.
         required: true
         type: string
+      signed:
+        description: Sign and notarize with Apple Developer ID.
+        required: false
+        type: boolean
+        default: false
+      coordinated:
+        description: Let the caller publish the collected artifacts.
+        required: false
+        type: boolean
+        default: false
     secrets:
       MACOS_CERTIFICATE:
-        required: true
+        required: false
       MACOS_CERTIFICATE_PWD:
-        required: true
+        required: false
       APPLE_API_KEY:
-        required: true
+        required: false
       APPLE_API_KEY_ID:
-        required: true
+        required: false
       APPLE_API_ISSUER:
-        required: true
+        required: false
       TAURI_SIGNING_PRIVATE_KEY:
         required: true
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
@@ -47,7 +63,7 @@ on:
 
 jobs:
   build:
-    name: Build signed and notarized macOS (${{ matrix.name }})
+    name: Build macOS (${{ matrix.name }}, ${{ inputs.signed && 'signed' || 'unsigned' }})
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
@@ -59,13 +75,13 @@ jobs:
           - name: Apple Silicon
             runner: macos-latest
             asset_arch: aarch64
-            artifact_name: futureos-macos-signed
+            artifact_name: futureos-macos
           # Keep the Intel build pinned to a named image: unlike
           # `macos-latest`, this cannot silently switch architectures.
           - name: Intel
             runner: macos-15-intel
             asset_arch: x64
-            artifact_name: futureos-macos-intel-signed
+            artifact_name: futureos-macos-intel
     env:
       OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
       OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
@@ -102,6 +118,7 @@ jobs:
       # ephemeral keychain. Resolve its full identity rather than hard-coding the
       # team or company name, then pass it to Tauri and codesign.
       - name: Install Apple signing certificate
+        if: inputs.signed
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -151,7 +168,6 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-     
       # The unified `future` CLI is the single sidecar (tauri.conf.json
       # bundle.externalBin); the agent runs through `future agent`, so only the
       # CLI needs building and staging.
@@ -177,6 +193,7 @@ jobs:
       # afterwards, so it is a distinct distribution container and is notarized
       # and stapled in the next step.
       - name: Prepare Apple notarization key
+        if: inputs.signed
         env:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -193,6 +210,7 @@ jobs:
       # builds. A per-run overlay keeps unsigned/local builds unchanged while
       # embedding the production updater endpoint/key only in formal artifacts.
       - name: Build desktop bundle (signed, notarized and updater-enabled)
+        if: inputs.signed
         env:
           FUTURE_VERSION: ${{ steps.v.outputs.version }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -224,11 +242,41 @@ jobs:
           ' "$overlay"
           npm --prefix desktop run tauri:build -- --config "$overlay"
 
+      - name: Build desktop bundle (unsigned and updater-enabled)
+        if: ${{ !inputs.signed }}
+        env:
+          FUTURE_VERSION: ${{ steps.v.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          : "${TAURI_SIGNING_PRIVATE_KEY:?TAURI_SIGNING_PRIVATE_KEY secret is required}"
+          : "${TAURI_UPDATER_PUBLIC_KEY:?TAURI_UPDATER_PUBLIC_KEY secret is required}"
+          overlay="$RUNNER_TEMP/tauri.macos-unsigned.json"
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.argv[1], JSON.stringify({
+              bundle: {
+                createUpdaterArtifacts: true,
+                macOS: { signingIdentity: "-" }
+              },
+              plugins: {
+                updater: {
+                  pubkey: process.env.TAURI_UPDATER_PUBLIC_KEY,
+                  endpoints: ["https://dl.future-os.cn/releases/latest.json"]
+                }
+              }
+            }));
+          ' "$overlay"
+          npm --prefix desktop run tauri:build -- --config "$overlay"
+
       # Tauri notarizes the app before it creates the DMG. Apple treats the
       # resulting signed disk image as a separate distribution artifact: submit
       # it after creation and staple its own ticket so installation also works
       # when Gatekeeper cannot reach Apple's notarization service.
       - name: Notarize and staple DMG
+        if: inputs.signed
         timeout-minutes: 60
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -367,6 +415,7 @@ jobs:
       # copies of the app must retain their Developer ID signature and stapled
       # notarization ticket and must pass Gatekeeper assessment.
       - name: Verify distributable macOS artifacts
+        if: inputs.signed
         run: |
           set -euo pipefail
           : "${SIGNED_DMG:?SIGNED_DMG is required}"
@@ -484,29 +533,71 @@ jobs:
 
           echo "MACOS_UPDATER=$updater" >> "$GITHUB_ENV"
           echo "MACOS_UPDATER_SIG=$updater_sig" >> "$GITHUB_ENV"
+          echo "DISTRIBUTABLE_DMG=$dmg" >> "$GITHUB_ENV"
 
-      - name: Stage signed macOS artifacts
+      - name: Inject first-launch note into unsigned DMG
+        if: ${{ !inputs.signed }}
         run: |
           set -euo pipefail
-          mkdir -p signed-release
-          dmg_output="signed-release/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}-sign.dmg"
-          updater_output="signed-release/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}.app.tar.gz"
-          cp "$SIGNED_DMG" "$dmg_output"
+          src="$(find desktop/src-tauri/target/release/bundle/dmg -maxdepth 1 -name '*.dmg' -print -quit)"
+          [[ -n "$src" ]] || { echo "Tauri produced no DMG." >&2; exit 1; }
+          work="$RUNNER_TEMP/rw.dmg"
+          out="$RUNNER_TEMP/out.dmg"
+          mnt="$RUNNER_TEMP/mnt"
+          hdiutil convert "$src" -format UDRW -o "$work"
+          hdiutil resize -size 700m "$work"
+          mkdir -p "$mnt"
+          hdiutil attach "$work" -mountpoint "$mnt" -nobrowse -noverify
+          app="$(find "$mnt" -maxdepth 1 -type d -name '*.app' -print -quit)"
+          [[ -n "$app" ]] || { echo "DMG contains no app bundle." >&2; exit 1; }
+          cp docs/dist/readme-macos.txt "$mnt/Readme.txt"
+          mkdir -p "$mnt/licenses/loop"
+          cp LICENSE "$mnt/licenses/"
+          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$mnt/licenses/loop/"
+          codesign --force --sign - "$app"
+          hdiutil detach "$mnt"
+          hdiutil convert "$work" -format UDZO -o "$out"
+          mv -f "$out" "$src"
+
+      - name: Verify unsigned macOS artifacts
+        if: ${{ !inputs.signed }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmgs=(desktop/src-tauri/target/release/bundle/dmg/*.dmg)
+          updaters=(desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz)
+          updater_sigs=(desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig)
+          [[ ${#dmgs[@]} -eq 1 && -s "${dmgs[0]}" ]] || { echo "Expected one non-empty DMG." >&2; exit 1; }
+          [[ ${#updaters[@]} -eq 1 && -s "${updaters[0]}" ]] || { echo "Expected one non-empty updater archive." >&2; exit 1; }
+          [[ ${#updater_sigs[@]} -eq 1 && -s "${updater_sigs[0]}" ]] || { echo "Expected one non-empty updater signature." >&2; exit 1; }
+          hdiutil verify "${dmgs[0]}"
+          echo "DISTRIBUTABLE_DMG=${dmgs[0]}" >> "$GITHUB_ENV"
+          echo "MACOS_UPDATER=${updaters[0]}" >> "$GITHUB_ENV"
+          echo "MACOS_UPDATER_SIG=${updater_sigs[0]}" >> "$GITHUB_ENV"
+
+      - name: Stage macOS artifacts
+        run: |
+          set -euo pipefail
+          suffix="${{ inputs.signed && '' || '-unsigned' }}"
+          mkdir -p release-assets
+          dmg_output="release-assets/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}${suffix}.dmg"
+          updater_output="release-assets/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}${suffix}.app.tar.gz"
+          cp "$DISTRIBUTABLE_DMG" "$dmg_output"
           cp "$MACOS_UPDATER" "$updater_output"
           cp "$MACOS_UPDATER_SIG" "$updater_output.sig"
           echo "SIGNED_RELEASE_DMG=$dmg_output" >> "$GITHUB_ENV"
 
-      - name: Upload signed macOS artifact
+      - name: Upload macOS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact_name }}
+          name: ${{ matrix.artifact_name }}${{ inputs.signed && '' || '-unsigned' }}
           if-no-files-found: error
           overwrite: true
-          path: signed-release/*
+          path: release-assets/*
           retention-days: 7
 
       - name: Setup ossutil
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
           version="2.3.0"
@@ -527,16 +618,16 @@ jobs:
             | sed -E 's#^https?://##; s/^oss-//; s/-internal//; s/\.aliyuncs\.com$//')"
           echo "OSS_REGION=$region" >> "$GITHUB_ENV"
 
-      - name: Upload signed macOS artifacts to OSS
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload macOS artifacts to OSS
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
           version="${{ steps.v.outputs.version }}"
           echo "==> Uploading macOS artifacts to oss://$OSS_BUCKET/test/$version/"
-          ossutil cp -r -f signed-release/ "oss://$OSS_BUCKET/test/$version/"
+          ossutil cp -r -f release-assets/ "oss://$OSS_BUCKET/test/$version/"
 
           echo "==> Download URLs:"
-          find signed-release -maxdepth 1 -type f -print | while read -r output; do
+          find release-assets -maxdepth 1 -type f -print | while read -r output; do
             echo "https://dl.future-os.cn/test/$version/$(basename "$output")"
           done
 

--- a/.github/workflows/build-windows-signed.yml
+++ b/.github/workflows/build-windows-signed.yml
@@ -1,12 +1,10 @@
-name: Build FutureOS Windows (signed)
+name: Build Windows signed
 
 permissions: read-all
 
-# Signed Windows build. Runs ONLY on the self-hosted Windows runner, because the
-# Certum code signing key lives in a cloud HSM reachable only through a
-# SimplySign Desktop session held open on that machine — a GitHub-hosted runner
-# cannot reach it. Everything else (macOS, Linux, and the unsigned Windows build)
-# stays in build.yml on GitHub-hosted runners.
+# Signed mode runs on the self-hosted Windows runner because the Certum key is
+# reachable only through its SimplySign session. Unsigned mode runs on a clean
+# GitHub-hosted runner and still uses the Tauri updater key.
 #
 # ┌────────────────────────────────────────────────────────────────────────────┐
 # │ SECURITY — DO NOT ADD `pull_request` (OR `pull_request_target`,            │
@@ -33,12 +31,28 @@ permissions: read-all
 
 on:
   workflow_dispatch:
+    inputs:
+      signed:
+        description: Sign with the Windows Authenticode certificate.
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
         description: Exact release version supplied by the coordinator.
         required: true
         type: string
+      signed:
+        description: Sign with the Windows Authenticode certificate.
+        required: false
+        type: boolean
+        default: false
+      coordinated:
+        description: Let the caller publish the collected artifacts.
+        required: false
+        type: boolean
+        default: false
     secrets:
       TAURI_SIGNING_PRIVATE_KEY:
         required: true
@@ -57,9 +71,9 @@ on:
 
 jobs:
   build:
-    name: Build signed Windows
+    name: Build Windows (${{ inputs.signed && 'signed' || 'unsigned' }})
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-    runs-on: [self-hosted, Windows]
+    runs-on: ${{ inputs.signed && fromJSON('["self-hosted","Windows"]') || 'windows-latest' }}
     # ossutil v2 auto-reads the OSS_* env vars; OSS_REGION is derived in the
     # Setup ossutil step (v2 signs with SigV4, which requires a region).
     env:
@@ -88,7 +102,7 @@ jobs:
           ) | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Setup Node.js
-        if: steps.detect.outputs.node == 'false'
+        if: ${{ !inputs.signed || steps.detect.outputs.node == 'false' }}
         uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -96,12 +110,25 @@ jobs:
       # Match the toolchain pinned in rust-toolchain.toml and the other CI
       # workflows, rather than accepting whichever stable version is current.
       - name: Install Rust
-        if: steps.detect.outputs.cargo == 'false'
+        if: inputs.signed && steps.detect.outputs.cargo == 'false'
         shell: powershell
         run: |
           Invoke-WebRequest https://win.rustup.rs -OutFile "$env:RUNNER_TEMP\rustup-init.exe"
           & "$env:RUNNER_TEMP\rustup-init.exe" -y --default-toolchain 1.97.0
           "$env:USERPROFILE\.cargo\bin" | Add-Content -Path $env:GITHUB_PATH
+
+      - name: Setup Rust (GitHub-hosted)
+        if: ${{ !inputs.signed }}
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Enable lld-link if available
+        if: ${{ !inputs.signed }}
+        shell: pwsh
+        run: |
+          $lld = Get-Command lld-link -ErrorAction SilentlyContinue
+          if ($lld) {
+            "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=lld-link" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          }
 
       # Single source of truth: scripts/version.mjs. A `vX.Y.Z` tag → release
       # ("X.Y.Z"); anything else → dev ("0.0.2-<hash>").
@@ -121,6 +148,7 @@ jobs:
       # answers an expired PIN cache with a *dialog box*. Unattended that hangs
       # rather than fails, and the job would otherwise burn the 6-hour default.
       - name: Preflight — signing certificate
+        if: inputs.signed
         shell: powershell
         timeout-minutes: 5
         run: |
@@ -134,7 +162,7 @@ jobs:
       # signer. Landed in a runner-temp dir added to PATH — no global install on
       # this long-lived machine.
       - name: Setup ossutil
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         shell: powershell
         run: |
           if (-not (Get-Command ossutil -ErrorAction SilentlyContinue)) {
@@ -151,7 +179,6 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-     
       # The unified `future` CLI is the single sidecar (tauri.conf.json
       # bundle.externalBin); the agent runs through `future agent`, so only the
       # CLI needs building and staging.
@@ -171,6 +198,7 @@ jobs:
       # this is the last moment the sidecar can be signed without unpacking the
       # installer afterwards.
       - name: Sign sidecar
+        if: inputs.signed
         shell: powershell
         timeout-minutes: 15
         run: |
@@ -192,6 +220,7 @@ jobs:
       # sign command aborts the bundle — Tauri propagates the non-zero exit — so a
       # half-signed installer is never produced.
       - name: Build desktop bundle (signed)
+        if: inputs.signed
         shell: powershell
         timeout-minutes: 120
         env:
@@ -226,12 +255,47 @@ jobs:
             Remove-Item -Force $overlay -ErrorAction SilentlyContinue
           }
 
+      - name: Build desktop bundle (unsigned)
+        if: ${{ !inputs.signed }}
+        shell: pwsh
+        timeout-minutes: 120
+        env:
+          FUTURE_VERSION: ${{ steps.v.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+        run: |
+          if (-not $env:TAURI_SIGNING_PRIVATE_KEY) { throw "TAURI_SIGNING_PRIVATE_KEY secret is required" }
+          if (-not $env:TAURI_UPDATER_PUBLIC_KEY) { throw "TAURI_UPDATER_PUBLIC_KEY secret is required" }
+          $overlay = Join-Path $env:RUNNER_TEMP "tauri.windows-unsigned.json"
+          $config = @{
+            bundle = @{ createUpdaterArtifacts = $true }
+            plugins = @{
+              updater = @{
+                pubkey = $env:TAURI_UPDATER_PUBLIC_KEY
+                endpoints = @("https://dl.future-os.cn/releases/latest.json")
+              }
+            }
+          }
+          $json = $config | ConvertTo-Json -Depth 10
+          [IO.File]::WriteAllText($overlay, $json, [Text.UTF8Encoding]::new($false))
+          Push-Location desktop
+          try {
+            npm run tauri:build -- --config $overlay
+            if ($LASTEXITCODE -ne 0) { throw "tauri build failed (exit $LASTEXITCODE)" }
+          }
+          finally {
+            Pop-Location
+            Remove-Item -Force $overlay -ErrorAction SilentlyContinue
+          }
+
       # Portable (install-free) build: the desktop exe plus the unified CLI binary,
       # all in one directory. Signed here rather than assumed: the bundler signs
       # its own copies on the way into the installer, so whether
       # target/release/futureos.exe itself ends up signed is its business. Signing
       # the staged copies makes the zip's contents certain either way.
       - name: Assemble Windows portable (signed)
+        if: inputs.signed
         shell: powershell
         timeout-minutes: 15
         run: |
@@ -249,11 +313,26 @@ jobs:
           }
           Compress-Archive -Path "$dir/*" -DestinationPath "FutureOS-portable-windows.zip" -Force
 
+      - name: Assemble Windows portable (unsigned)
+        if: ${{ !inputs.signed }}
+        shell: pwsh
+        run: |
+          $dir = "futureos-portable"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          Copy-Item "desktop/src-tauri/target/release/futureos.exe" "$dir/FutureOS.exe"
+          Copy-Item "target/release/future.exe" "$dir/future.exe"
+          Copy-Item "docs/dist/readme-windows.txt" "$dir/Readme.txt"
+          New-Item -ItemType Directory -Force -Path "$dir/licenses/loop" | Out-Null
+          Copy-Item "LICENSE" "$dir/licenses/"
+          Copy-Item "orchestration/loop/LICENSE", "orchestration/loop/NOTICE", "orchestration/loop/UPSTREAM.md" "$dir/licenses/loop/"
+          Compress-Archive -Path "$dir/*" -DestinationPath "FutureOS-portable-windows-unsigned.zip" -Force
+
       # Independent of what the bundler claims it did. The signature is the entire
       # point of this workflow, so a silently-unsigned artifact — or an
       # untimestamped one, which dies the day the certificate expires and takes
       # every already-shipped installer with it — must block the upload.
       - name: Verify signatures
+        if: inputs.signed
         shell: powershell
         run: |
           . scripts/lib/windows-signing.ps1
@@ -273,52 +352,64 @@ jobs:
           }
           if ($bad) { throw "Not properly signed: $($bad -join ', ')" }
 
-      - name: Stage signed artifacts
+      - name: Verify updater signature
+        if: ${{ !inputs.signed }}
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem desktop/src-tauri/target/release/bundle/nsis/*.exe -ErrorAction SilentlyContinue)
+          if ($installers.Count -ne 1) { throw "Expected exactly one NSIS installer, found $($installers.Count)." }
+          $signature = "$($installers[0].FullName).sig"
+          if (-not (Test-Path $signature) -or (Get-Item $signature).Length -eq 0) {
+            throw "Tauri produced no non-empty updater signature."
+          }
+
+      - name: Stage Windows artifacts
         shell: powershell
         run: |
-          $stage = "signed-release"
+          $stage = "release-assets"
           Remove-Item -Recurse -Force $stage -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
 
-          Get-ChildItem desktop/src-tauri/target/release/bundle/nsis/*.exe | ForEach-Object {
-            $name = "$([IO.Path]::GetFileNameWithoutExtension($_.Name))-sign$($_.Extension)"
-            $output = Join-Path $stage $name
-            Copy-Item $_.FullName $output
-            Copy-Item "$($_.FullName).sig" "$output.sig"
-          }
-          Copy-Item "FutureOS-portable-windows.zip" (Join-Path $stage "FutureOS-portable-windows-sign.zip")
+          $installers = @(Get-ChildItem desktop/src-tauri/target/release/bundle/nsis/*.exe)
+          if ($installers.Count -ne 1) { throw "Expected exactly one NSIS installer, found $($installers.Count)." }
+          $suffix = "${{ inputs.signed && '' || '-unsigned' }}"
+          $output = Join-Path $stage "FutureOS_${{ steps.v.outputs.version }}_x64-setup${suffix}.exe"
+          Copy-Item $installers[0].FullName $output
+          Copy-Item "$($installers[0].FullName).sig" "$output.sig"
+          $portable = "FutureOS-portable-windows${suffix}.zip"
+          Copy-Item $portable (Join-Path $stage $portable)
 
           Get-ChildItem $stage | Select-Object -ExpandProperty Name
 
-      - name: Upload signed Windows installer artifact
+      - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v7
         with:
-          name: futureos-windows-signed
+          name: futureos-windows${{ inputs.signed && '' || '-unsigned' }}
           if-no-files-found: error
           overwrite: true
           path: |
-            signed-release/*-setup-sign.exe
-            signed-release/*-setup-sign.exe.sig
+            release-assets/*-setup*.exe
+            release-assets/*-setup*.exe.sig
           retention-days: 7
 
-      - name: Upload signed Windows portable artifact
+      - name: Upload Windows portable artifact
         uses: actions/upload-artifact@v7
         with:
-          name: futureos-windows-portable-signed
+          name: futureos-windows-portable${{ inputs.signed && '' || '-unsigned' }}
           if-no-files-found: error
           overwrite: true
-          path: signed-release/*-portable-windows-sign.zip
+          path: release-assets/*portable-windows*.zip
           retention-days: 7
 
       - name: Upload to OSS test channel
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         shell: powershell
         run: |
           $version = "${{ steps.v.outputs.version }}"
           Write-Host "==> Uploading to oss://$env:OSS_BUCKET/test/$version/"
-          Get-ChildItem signed-release | Select-Object -ExpandProperty Name
-          ossutil cp -r -f "signed-release\" "oss://$env:OSS_BUCKET/test/$version/"
+          Get-ChildItem release-assets | Select-Object -ExpandProperty Name
+          ossutil cp -r -f "release-assets\" "oss://$env:OSS_BUCKET/test/$version/"
           if ($LASTEXITCODE -ne 0) { throw "ossutil upload failed (exit $LASTEXITCODE)" }
 
           Write-Host "==> Download URLs:"
-          Get-ChildItem signed-release | ForEach-Object { Write-Host "  https://dl.future-os.cn/test/$version/$($_.Name)" }
+          Get-ChildItem release-assets | ForEach-Object { Write-Host "  https://dl.future-os.cn/test/$version/$($_.Name)" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,21 @@
-name: Build FutureOS app
+name: Build Unsigned
 
 permissions: read-all
 
+# Release rehearsal. It invokes the same platform workflows as release.yml,
+# but macOS and Windows skip platform code signing. The complete test release is
+# published under test/<version>/, including its own latest.json; test/latest.json
+# is deliberately never written here.
 on:
   workflow_dispatch:
 
 jobs:
-  # Compute the build version once (single source of truth: scripts/version.mjs).
-  # Manual builds resolve to a development version (`0.0.2-<hash>`).
   version:
     name: Resolve version
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
-      is_release: ${{ steps.v.outputs.is_release }}
-      bundle_version: ${{ steps.v.outputs.bundle_version }}
+      build_number: ${{ steps.v.outputs.build_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -24,301 +25,190 @@ jobs:
           node-version: "24"
       - name: Resolve version
         id: v
-        run: node scripts/version.mjs --github-output
+        run: |
+          node scripts/version.mjs --github-output
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
 
-  build:
-    name: Build ${{ matrix.name }}
+  macos:
+    name: Build unsigned macOS
     needs: version
-    runs-on: ${{ matrix.os }}
-    # Injected into every build step so Rust build.rs (FUTURE_VERSION → agent,
-    # Desktop) and the TS build scripts (generated version module) all agree.
-    env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macOS
-            os: macos-latest
-            artifact_name: futureos-macos
-            bundle_path: desktop/src-tauri/target/release/bundle/dmg/*.dmg
-          - name: macOS Intel
-            os: macos-15-intel
-            artifact_name: futureos-macos-intel
-            bundle_path: desktop/src-tauri/target/release/bundle/dmg/*.dmg
-          - name: Windows
-            os: windows-latest
-            artifact_name: futureos-windows
-            bundle_path: desktop/src-tauri/target/release/bundle/nsis/*.exe
-          - name: Linux
-            os: ubuntu-latest
-            artifact_name: futureos-linux
-            bundle_path: desktop/src-tauri/target/release/bundle/deb/*.deb
-            cli_arch: x86_64
-          # Native arm64 runner — cross-compiling the WebKit-heavy GUI from
-          # x86_64 would need a full aarch64 sysroot; building natively is far
-          # simpler. Note: arm64 runners are free for public repos, billed for
-          # private ones.
-          - name: Linux ARM
-            os: ubuntu-24.04-arm
-            artifact_name: futureos-linux-arm64
-            bundle_path: desktop/src-tauri/target/release/bundle/deb/*.deb
-            cli_arch: aarch64
+    uses: ./.github/workflows/build-macos-signed.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      signed: false
+      coordinated: true
+    secrets: inherit
 
+  windows:
+    name: Build unsigned Windows
+    needs: version
+    uses: ./.github/workflows/build-windows-signed.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      signed: false
+      coordinated: true
+    secrets: inherit
+
+  linux:
+    name: Build Linux
+    needs: version
+    uses: ./.github/workflows/build-linux.yaml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      release: true
+    secrets: inherit
+
+  android:
+    name: Build Android APK
+    needs: version
+    uses: ./.github/workflows/build-android-apk.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      build_number: ${{ needs.version.outputs.build_number }}
+      coordinated: true
+    secrets: inherit
+
+  ios:
+    name: Build and submit iOS
+    needs: version
+    uses: ./.github/workflows/build-ios-testflight.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      build_number: ${{ needs.version.outputs.build_number }}
+      coordinated: true
+    secrets: inherit
+
+  publish:
+    name: Publish complete test release
+    needs: [version, macos, windows, linux, android, ios]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: futureos-test-publish
+      cancel-in-progress: false
+    env:
+      OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+      OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
+      OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+      OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+      VERSION: ${{ needs.version.outputs.version }}
+      RELEASE_ORIGIN: https://dl.future-os.cn/test
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7
         with:
-          node-version: "24"
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      # Pinned to match rust-toolchain.toml so CI and local dev use the same
-      # compiler. Bump both together.
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            desktop/src-tauri
-          # Persist the target dir even when a later step fails, so a broken
-          # release run doesn't throw away a full cold compile.
-          cache-on-failure: true
-          # Cache every dependency crate, not just direct workspace deps —
-          # covers transitive/build-dep crates that otherwise recompile.
-          cache-all-crates: true
-
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          bash scripts/ci/install-apt-packages.sh \
-            build-essential \
-            curl \
-            file \
-            mold \
-            binutils \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            musl-tools \
-            patchelf \
-            wget
-
-      # No protoc needed here: proto generation is gated on REGENERATE_PROTO and
-      # the generated code is checked in, so packaging builds never run protoc.
-
-      # Linking the agent and the (large, WebView-heavy) Tauri binary dominates
-      # the Windows job; lld-link links far faster than MSVC link.exe. Opt into
-      # it for CI ONLY — via the target-specific linker env var, so .cargo/
-      # config.toml is untouched and local Windows devs keep the default linker.
-      # Self-healing: only enabled when lld-link is actually on PATH (it ships
-      # with the LLVM preinstalled on windows-latest), so a future runner-image
-      # change that drops LLVM silently falls back to link.exe instead of failing
-      # the build. lld-link honours the /DEBUG:NONE rustflag from config.toml.
-      - name: Enable lld-link if available (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $lld = Get-Command lld-link -ErrorAction SilentlyContinue
-          if ($lld) {
-            Write-Host "Using lld-link at $($lld.Source)"
-            "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=lld-link" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          } else {
-            Write-Host "lld-link not found — falling back to MSVC link.exe"
-          }
-
-      - name: Install npm dependencies (Desktop)
-        working-directory: desktop
-        run: npm ci
-
-     
-      # Windows Defender real-time scanning inspects every intermediate file the
-      # Rust compiler and linker emit — thousands of them — and is the single
-      # biggest drag on the Windows job. Turn it off for the runner (which has
-      # admin rights); it's a throwaway VM. Never fail the build if Defender is
-      # policy-managed and refuses.
-      - name: Disable Windows Defender real-time scanning
-        if: runner.os == 'Windows'
-        shell: pwsh
-        continue-on-error: true
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
-
-      # Compile the CLI into a standalone binary (Rust workspace member).
-      - name: Build CLI binary (macOS)
-        if: runner.os == 'macOS'
-        working-directory: cli
-        run: |
-          cargo build --release
-          # Stage it as a Tauri sidecar too (bundle.externalBin) so the CLI ships
-          # inside the installers, not just the portable packages.
-          triple=$(rustc -Vv | sed -n 's/^host: //p')
-          mkdir -p ../desktop/src-tauri/binaries
-          cp ../target/release/future "../desktop/src-tauri/binaries/future-$triple"
-
-      # Linux: build the CLI as a FULLY STATIC musl binary, not against glibc.
-      # The glibc build would only run on distros with a glibc at least as new
-      # as the runner image; the static binary runs on any Linux of this arch
-      # (old distros, Alpine, bare containers). It is staged as the Tauri
-      # sidecar — so the bundled CLI/TUI stays usable even on systems where the
-      # GUI itself can't start (missing WebKitGTK, old glibc) — and packed as a
-      # standalone CLI-only tarball for servers. musl-tools provides musl-gcc
-      # for the C dependencies (ring).
-      - name: Build CLI binary (Linux, static musl)
-        if: runner.os == 'Linux'
-        working-directory: cli
-        env:
-          CC_x86_64_unknown_linux_musl: musl-gcc
-          CC_aarch64_unknown_linux_musl: musl-gcc
+          path: release-assets
+      - name: Stage and validate release assets
         run: |
           set -euo pipefail
-          target="$(uname -m)-unknown-linux-musl"
-          rustup target add "$target"
-          cargo build --release --target "$target"
-          # Stage it as a Tauri sidecar too (bundle.externalBin) so the CLI ships
-          # inside the installers, not just the portable packages. The sidecar
-          # filename uses the host (glibc) triple; Tauri only copies the file
-          # and doesn't care how the binary is linked.
-          triple=$(rustc -Vv | sed -n 's/^host: //p')
-          mkdir -p ../desktop/src-tauri/binaries
-          cp "../target/$target/release/future" "../desktop/src-tauri/binaries/future-$triple"
-          # Standalone CLI-only distribution (CLI + TUI + agent in one static
-          # binary) for servers and distros the GUI can't run on.
-          tar -czf "future-$target.tar.gz" -C "../target/$target/release" future
+          mkdir -p publish
+          names=(
+            "FutureOS_${VERSION}_aarch64-unsigned.dmg"
+            "FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz"
+            "FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64-unsigned.dmg"
+            "FutureOS_${VERSION}_x64-unsigned.app.tar.gz"
+            "FutureOS_${VERSION}_x64-unsigned.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64-setup-unsigned.exe"
+            "FutureOS_${VERSION}_x64-setup-unsigned.exe.sig"
+            "FutureOS_${VERSION}_amd64.deb"
+            "FutureOS_${VERSION}_amd64.deb.sig"
+            "FutureOS_${VERSION}_arm64.deb"
+            "FutureOS_${VERSION}_arm64.deb.sig"
+            "FutureOS_${VERSION}_linux_x86_64-portable.tar.gz"
+            "FutureOS_${VERSION}_linux_aarch64-portable.tar.gz"
+            "FutureOS_${VERSION}_linux_x86_64-cli.tar.gz"
+            "FutureOS_${VERSION}_linux_aarch64-cli.tar.gz"
+            "FutureOS_${VERSION}_android-universal.apk"
+          )
+          for name in "${names[@]}"; do
+            source="$(find release-assets -type f -name "$name" -print -quit)"
+            [[ -n "$source" ]] || {
+              echo "Required test release asset is missing: $name" >&2
+              find release-assets -maxdepth 3 -type f -print >&2
+              exit 1
+            }
+            cp -v "$source" "publish/$name"
+          done
+          count="$(find publish -type f | wc -l | tr -d ' ')"
+          [[ "$count" == "17" ]] || { echo "Expected 17 assets, found $count." >&2; exit 1; }
 
-      - name: Build CLI binary (Windows)
-        if: runner.os == 'Windows'
-        working-directory: cli
-        shell: pwsh
-        run: |
-          cargo build --release
-          # Stage it as a Tauri sidecar too (bundle.externalBin) so the CLI ships
-          # inside the NSIS installer, not just the portable zip.
-          $triple = (rustc -Vv | Select-String '^host:').Line.Split(' ')[1]
-          New-Item -ItemType Directory -Force -Path ../desktop/src-tauri/binaries | Out-Null
-          Copy-Item "../target/release/future.exe" "../desktop/src-tauri/binaries/future-$triple.exe"
-
-      # Pin the Tauri installer version to the plain semver core (NSIS rejects
-      # SemVer suffixes). The display version keeps the full FUTURE_VERSION.
-      - name: Set Tauri bundle version
-        run: node scripts/version.mjs --set-bundle
-
-      - name: Build desktop bundle
-        working-directory: desktop
-        run: npm run tauri:build
-
-      # macOS: the unified `future` CLI is the Tauri sidecar (bundle.externalBin); the
-      # agent runs through `future agent`, so only the CLI binary sits in the .app.
-      # already sit in the .app's Contents/MacOS, signed by Tauri. We only need
-      # to drop the first-launch (Gatekeeper) note into the dmg — the .app is
-      # unsigned/un-notarized. Tauri's dmg is read-only, so round-trip it through
-      # a read-write image, add the note, and re-seal the .app ad-hoc.
-      - name: Inject first-launch note into macOS dmg
-        if: runner.os == 'macOS'
+      - name: Generate Tauri-compatible latest.json
         run: |
           set -euo pipefail
-          src=$(ls desktop/src-tauri/target/release/bundle/dmg/*.dmg | head -n1)
-          work="$RUNNER_TEMP/rw.dmg"
-          out="$RUNNER_TEMP/out.dmg"
-          mnt="$RUNNER_TEMP/mnt"
-          hdiutil convert "$src" -format UDRW -o "$work"
-          hdiutil resize -size 700m "$work"
-          mkdir -p "$mnt"
-          hdiutil attach "$work" -mountpoint "$mnt" -nobrowse -noverify
-          app=$(ls -d "$mnt"/*.app | head -n1)
-          cp "docs/dist/readme-macos.txt" "$mnt/Readme.txt"
-          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
-          mkdir -p "$mnt/licenses/loop"
-          cp LICENSE "$mnt/licenses/"
-          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$mnt/licenses/loop/"
-          codesign --force --sign - "$app"
-          hdiutil detach "$mnt"
-          hdiutil convert "$work" -format UDZO -o "$out"
-          mv -f "$out" "$src"
+          export PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export MAC_ARM_FILE="FutureOS_${VERSION}_aarch64-unsigned.dmg"
+          export MAC_ARM_UPDATER_FILE="FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz"
+          export MAC_INTEL_FILE="FutureOS_${VERSION}_x64-unsigned.dmg"
+          export MAC_INTEL_UPDATER_FILE="FutureOS_${VERSION}_x64-unsigned.app.tar.gz"
+          export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup-unsigned.exe"
+          export LINUX_DEB_FILE="FutureOS_${VERSION}_amd64.deb"
+          export LINUX_DEB_ARM_FILE="FutureOS_${VERSION}_arm64.deb"
+          export LINUX_PORTABLE_FILE="FutureOS_${VERSION}_linux_x86_64-portable.tar.gz"
+          export LINUX_PORTABLE_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-portable.tar.gz"
+          export LINUX_CLI_FILE="FutureOS_${VERSION}_linux_x86_64-cli.tar.gz"
+          export LINUX_CLI_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-cli.tar.gz"
+          export ANDROID_APK_FILE="FutureOS_${VERSION}_android-universal.apk"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const crypto = require("node:crypto");
+          const sha256 = file => crypto.createHash("sha256").update(fs.readFileSync(`publish/${file}`)).digest("hex");
+          const url = file => `${process.env.RELEASE_ORIGIN}/${process.env.VERSION}/${file}`;
+          const updater = file => ({
+            url: url(file),
+            signature: fs.readFileSync(`publish/${file}.sig`, "utf8").trim(),
+            sha256: sha256(file),
+          });
+          const asset = file => ({ url: url(file), sha256: sha256(file) });
+          const manifest = {
+            version: process.env.VERSION,
+            pub_date: process.env.PUB_DATE,
+            platforms: {
+              "darwin-aarch64": updater(process.env.MAC_ARM_UPDATER_FILE),
+              "darwin-x86_64": updater(process.env.MAC_INTEL_UPDATER_FILE),
+              "windows-x86_64": updater(process.env.WINDOWS_FILE),
+              "linux-x86_64-deb": updater(process.env.LINUX_DEB_FILE),
+              "linux-aarch64-deb": updater(process.env.LINUX_DEB_ARM_FILE),
+            },
+            assets: {
+              "darwin-aarch64": asset(process.env.MAC_ARM_FILE),
+              "darwin-x86_64": asset(process.env.MAC_INTEL_FILE),
+              "windows-x86_64": asset(process.env.WINDOWS_FILE),
+              "linux-x86_64-deb": asset(process.env.LINUX_DEB_FILE),
+              "linux-aarch64-deb": asset(process.env.LINUX_DEB_ARM_FILE),
+              "linux-x86_64": asset(process.env.LINUX_DEB_FILE),
+              "linux-x86_64-portable": asset(process.env.LINUX_PORTABLE_FILE),
+              "linux-x86_64-cli": asset(process.env.LINUX_CLI_FILE),
+              "linux-aarch64": asset(process.env.LINUX_DEB_ARM_FILE),
+              "linux-aarch64-portable": asset(process.env.LINUX_PORTABLE_ARM_FILE),
+              "linux-aarch64-cli": asset(process.env.LINUX_CLI_ARM_FILE),
+              "android-universal": asset(process.env.ANDROID_APK_FILE),
+              "android": asset(process.env.ANDROID_APK_FILE),
+            },
+          };
+          fs.writeFileSync("latest.json", `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
+          cat latest.json
 
-      - name: Upload desktop bundle
+      - name: Upload latest.json artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact_name }}
+          name: futureos-test-latest-json
+          path: latest.json
           if-no-files-found: error
           overwrite: true
-          path: ${{ matrix.bundle_path }}
-          # Dev/test bundles — expire fast so the shared Actions storage quota
-          # doesn't fill up. Release assets live on the GitHub Release, not here.
-          retention-days: 3
-
-      # Portable (install-free) Windows build: the desktop exe plus the agent and
-      # CLI binary, all in one directory. The agent runs through `future agent`
-      # (embedded), so only the unified CLI is staged next to the exe. Requires
-      # the WebView2 Evergreen runtime (ships with Win 10/11).
-      - name: Assemble Windows portable
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $triple = (rustc -Vv | Select-String '^host:').Line.Split(' ')[1]
-          $dir = "futureos-portable"
-          New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          Copy-Item "desktop/src-tauri/target/release/futureos.exe" "$dir/FutureOS.exe"
-          Copy-Item "target/release/future.exe" "$dir/future.exe"
-          Copy-Item "docs/dist/readme-windows.txt" "$dir/Readme.txt"
-          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
-          New-Item -ItemType Directory -Force -Path "$dir/licenses/loop" | Out-Null
-          Copy-Item "LICENSE" "$dir/licenses/"
-          Copy-Item "orchestration/loop/LICENSE", "orchestration/loop/NOTICE", "orchestration/loop/UPSTREAM.md" "$dir/licenses/loop/"
-          Compress-Archive -Path "$dir/*" -DestinationPath "FutureOS-portable-windows.zip" -Force
-
-      - name: Upload Windows portable
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v7
-        with:
-          name: futureos-windows-portable
-          if-no-files-found: error
-          overwrite: true
-          path: FutureOS-portable-windows.zip
-          retention-days: 3
-
-      # Portable (install-free) Linux build: the desktop binary plus the unified
-      # CLI binary, all in one directory.
-      - name: Assemble Linux portable
-        if: runner.os == 'Linux'
+          retention-days: 7
+      - name: Setup ossutil
+        run: bash scripts/setup-ossutil.sh
+      - name: Publish complete versioned test release
         run: |
           set -euo pipefail
-          dir="futureos-portable-linux"
-          mkdir -p "$dir"
-          cp "desktop/src-tauri/target/release/futureos" "$dir/futureos"
-          # The static musl CLI build — see the CLI build step above.
-          cp "target/$(uname -m)-unknown-linux-musl/release/future" "$dir/future"
-          chmod +x "$dir"/*
-          cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
-          # License & attribution notices (MIT + Apache-2.0 LoopX-derived loop).
-          mkdir -p "$dir/licenses/loop"
-          cp LICENSE "$dir/licenses/"
-          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$dir/licenses/loop/"
-          tar -czf FutureOS-portable-linux.tar.gz -C "$dir" .
-
-      - name: Upload Linux portable
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact_name }}-portable
-          if-no-files-found: error
-          overwrite: true
-          path: FutureOS-portable-linux.tar.gz
-          retention-days: 3
-
-      - name: Upload Linux CLI (static)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v7
-        with:
-          name: future-cli-linux-${{ matrix.cli_arch }}
-          if-no-files-found: error
-          overwrite: true
-          path: cli/future-*-unknown-linux-musl.tar.gz
-          retention-days: 3
+          target="oss://$OSS_BUCKET/test/$VERSION"
+          ossutil cp -r -f publish/ "$target/"
+          find publish -maxdepth 1 -type f -print0 | while IFS= read -r -d '' file; do
+            ossutil stat "$target/$(basename "$file")"
+          done
+          ossutil cp -f latest.json "$target/latest.json"
+          ossutil stat "$target/latest.json"
+          echo "Manifest: https://dl.future-os.cn/test/$VERSION/latest.json"

--- a/.github/workflows/publish-installers.yml
+++ b/.github/workflows/publish-installers.yml
@@ -1,4 +1,4 @@
-name: publish-installers
+name: Publish Installers
 
 # Syncs the one-line installer scripts to the OSS bucket root so they are
 # served from https://dl.future-os.cn/install.sh and /install.ps1. Manual

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
-name: Release FutureOS
+name: Build Release
 
 permissions: read-all
 
-# Formal releases have one coordinator. Platform jobs may finish in any order,
-# but the public latest.json pointer is advanced only after every installer has
-# been built, signed where applicable, collected, hashed, uploaded and checked.
 on:
   push:
     tags:
@@ -28,9 +25,6 @@ jobs:
         id: v
         run: |
           node scripts/version.mjs --github-output
-          # Store build number (CFBundleVersion / Android versionCode) must be a
-          # monotonic integer. github.run_number is this workflow's own counter,
-          # starting at 1 — kept small because Android versionCode is an int32.
           echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
       - name: Require a plain release version
         env:
@@ -48,6 +42,8 @@ jobs:
     uses: ./.github/workflows/build-macos-signed.yml
     with:
       version: ${{ needs.version.outputs.version }}
+      signed: true
+      coordinated: true
     secrets: inherit
 
   windows:
@@ -56,414 +52,38 @@ jobs:
     uses: ./.github/workflows/build-windows-signed.yml
     with:
       version: ${{ needs.version.outputs.version }}
+      signed: true
+      coordinated: true
     secrets: inherit
 
-  # Linux packages are unsigned (no code-signing equivalent), so the build is
-  # inlined here instead of a reusable workflow: .deb for Debian/Ubuntu plus
-  # the portable tarball for every other distro, on both architectures. The
-  # matrix mirrors build.yml's tested Linux jobs exactly: x86_64 on
-  # ubuntu-latest and native aarch64 on ubuntu-24.04-arm (cross-compiling the
-  # WebKit-heavy GUI from x86_64 would need a full aarch64 sysroot).
   linux:
-    name: Build Linux (${{ matrix.arch }})
+    name: Build Linux
     needs: version
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            os: ubuntu-latest
-            deb_arch: amd64
-            artifact_name: futureos-linux-release
-            # x86_64 keeps its historical arch-less filename; ARM assets get an
-            # -arm64 suffix so both can live in the same release directory.
-            portable_name: FutureOS-portable-linux.tar.gz
-          - arch: aarch64
-            os: ubuntu-24.04-arm
-            deb_arch: arm64
-            artifact_name: futureos-linux-arm64-release
-            portable_name: FutureOS-portable-linux-arm64.tar.gz
-    env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            desktop/src-tauri
-          cache-on-failure: true
-          cache-all-crates: true
-
-      # Same package set as build.yml's tested Linux jobs (both architectures).
-      - name: Install Linux system dependencies
-        run: |
-          bash scripts/ci/install-apt-packages.sh \
-            build-essential \
-            curl \
-            file \
-            mold \
-            binutils \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            musl-tools \
-            patchelf \
-            wget
-
-      - name: Install npm dependencies (Desktop)
-        working-directory: desktop
-        run: npm ci
-
-     
-      # Identical to build.yml's Linux CLI step: a FULLY STATIC musl binary,
-      # not glibc-linked. The glibc build would only run on distros with a
-      # glibc at least as new as the runner image; the static binary runs on
-      # any Linux of this arch (old distros, Alpine, bare containers).
-      - name: Build CLI binary (Linux, static musl)
-        working-directory: cli
-        env:
-          CC_x86_64_unknown_linux_musl: musl-gcc
-          CC_aarch64_unknown_linux_musl: musl-gcc
-        run: |
-          set -euo pipefail
-          target="${{ matrix.arch }}-unknown-linux-musl"
-          rustup target add "$target"
-          cargo build --release --target "$target"
-          # Stage it as a Tauri sidecar too (bundle.externalBin) so the CLI ships
-          # inside the .deb, not just the portable tarball. The sidecar filename
-          # uses the host (glibc) triple; Tauri only copies the file and doesn't
-          # care how the binary is linked.
-          triple=$(rustc -Vv | sed -n 's/^host: //p')
-          mkdir -p ../desktop/src-tauri/binaries
-          cp "../target/$target/release/future" "../desktop/src-tauri/binaries/future-$triple"
-
-      - name: Set Tauri bundle version
-        run: node scripts/version.mjs --set-bundle
-
-      - name: Build desktop bundle (.deb)
-        working-directory: desktop
-        run: npm run tauri:build
-
-      # Same layout as build.yml's tested Linux portable step.
-      - name: Assemble Linux portable
-        run: |
-          set -euo pipefail
-          dir="futureos-portable-linux"
-          mkdir -p "$dir"
-          cp "desktop/src-tauri/target/release/futureos" "$dir/futureos"
-          # The static musl CLI build — see the CLI build step above.
-          cp "target/${{ matrix.arch }}-unknown-linux-musl/release/future" "$dir/future"
-          chmod +x "$dir"/*
-          cp "docs/dist/readme-linux.txt" "$dir/Readme.txt"
-          # License & attribution notices: root MIT, plus the Apache-2.0
-          # LoopX-derived future-loop component (LICENSE/NOTICE/UPSTREAM).
-          mkdir -p "$dir/licenses/loop"
-          cp LICENSE "$dir/licenses/"
-          cp orchestration/loop/LICENSE orchestration/loop/NOTICE orchestration/loop/UPSTREAM.md "$dir/licenses/loop/"
-          tar -czf "${{ matrix.portable_name }}" -C "$dir" .
-
-      - name: Stage release assets
-        run: |
-          set -euo pipefail
-          mkdir -p release-assets
-          deb="$(find desktop/src-tauri/target/release/bundle/deb -maxdepth 1 -name '*.deb' -print -quit)"
-          [[ -n "$deb" ]] || {
-            echo "Tauri produced no .deb bundle" >&2
-            exit 1
-          }
-          cp "$deb" "release-assets/FutureOS_${FUTURE_VERSION}_${{ matrix.deb_arch }}.deb"
-          cp "${{ matrix.portable_name }}" "release-assets/"
-
-      - name: Upload Linux release assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact_name }}
-          if-no-files-found: error
-          overwrite: true
-          path: release-assets/
-          retention-days: 7
+    uses: ./.github/workflows/build-linux.yaml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      release: true
+    secrets: inherit
 
   android:
     name: Build Android APK
     needs: version
-    runs-on: ubuntu-latest
-    env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-      FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v4
-        with:
-          packages: 'platforms;android-36 build-tools;36.0.0'
-
-      - name: Restore keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-        run: |
-          mkdir -p mobile/android/app
-          echo "$KEYSTORE_BASE64" | base64 -d > mobile/android/app/futureos-release.keystore
-          cat > mobile/android/app/keystore.properties <<EOF
-          storeFile=futureos-release.keystore
-          storePassword=$KEYSTORE_PASSWORD
-          keyAlias=futureos
-          keyPassword=$KEYSTORE_PASSWORD
-          EOF
-
-      - name: Install dependencies
-        working-directory: mobile
-        run: npm ci
-
-     
-      - name: Generate version
-        working-directory: mobile
-        run: npm run gen-version
-
-      - name: Prebuild Android
-        working-directory: mobile
-        run: npx expo prebuild --platform android
-
-      - name: Build release APK
-        working-directory: mobile/android
-        run: ./gradlew assembleRelease
-
-      - name: Rename APK
-        run: |
-          V="${{ needs.version.outputs.version }}"
-          cp mobile/android/app/build/outputs/apk/release/app-release.apk \
-             "FutureOS_${V}.apk"
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: futureos-android-release
-          if-no-files-found: error
-          overwrite: true
-          path: FutureOS_${{ needs.version.outputs.version }}.apk
-          retention-days: 7
+    uses: ./.github/workflows/build-android-apk.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      build_number: ${{ needs.version.outputs.build_number }}
+      coordinated: true
+    secrets: inherit
 
   ios:
     name: Build and submit iOS
     needs: version
-    runs-on: macos-latest
-    timeout-minutes: 120
-    env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-      FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
-      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install Apple signing certificate
-        env:
-          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
-          IOS_DIST_CERT_P12_PWD: ${{ secrets.IOS_DIST_CERT_P12_PWD }}
-          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          set -euo pipefail
-          : "${IOS_DIST_CERT_P12_BASE64:?IOS_DIST_CERT_P12_BASE64 secret is required}"
-          : "${IOS_DIST_CERT_P12_PWD:?IOS_DIST_CERT_P12_PWD secret is required}"
-          : "${IOS_PROVISIONING_PROFILE_BASE64:?IOS_PROVISIONING_PROFILE_BASE64 secret is required}"
-
-          keychain="$RUNNER_TEMP/futureos-signing.keychain-db"
-          keychain_password="$(openssl rand -base64 32)"
-          certificate="$RUNNER_TEMP/futureos-ios-signing.p12"
-          profile="$RUNNER_TEMP/FutureOS_AppStore.mobileprovision"
-
-          printf '%s' "$IOS_DIST_CERT_P12_BASE64" | base64 -D > "$certificate"
-          printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 -D > "$profile"
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          cp "$profile" "$HOME/Library/MobileDevice/Provisioning Profiles/"
-
-          profile_name="$(security cms -D -i "$profile" 2>/dev/null \
-            | plutil -extract Name raw - 2>/dev/null || true)"
-          if [[ -z "$profile_name" ]]; then
-            echo "Could not read provisioning profile name from: $profile" >&2
-            exit 1
-          fi
-          echo "PROVISIONING_PROFILE=$profile_name" >> "$GITHUB_ENV"
-          echo "Provisioning profile: $profile_name"
-
-          security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$certificate" \
-            -k "$keychain" \
-            -P "$IOS_DIST_CERT_P12_PWD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
-          security set-key-partition-list \
-            -S apple-tool:,apple:,codesign: \
-            -s -k "$keychain_password" "$keychain"
-          security list-keychains -d user -s "$keychain"
-          rm -f "$certificate"
-
-          identity_line="$(security find-identity -v -p codesigning "$keychain" \
-            | grep '"iPhone Distribution:' | head -n 1 || true)"
-          if [[ -z "$identity_line" ]]; then
-            echo "No iPhone Distribution identity found in the imported certificate." >&2
-            security find-identity -v -p codesigning "$keychain" >&2 || true
-            exit 1
-          fi
-          identity="${identity_line#*\"}"
-          identity="${identity%%\"*}"
-          team_id="$(printf '%s' "$identity" | sed -n 's/.*(\([A-Z0-9]*\))$/\1/p')"
-          [[ -n "$team_id" ]] || { echo "Could not extract team ID from: $identity" >&2; exit 1; }
-          echo "SIGNING_IDENTITY=$identity" >> "$GITHUB_ENV"
-          echo "DEVELOPMENT_TEAM=$team_id" >> "$GITHUB_ENV"
-          echo "Using signing identity: $identity_line"
-
-      - name: Prepare App Store Connect API key
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          set -euo pipefail
-          : "${APPLE_API_KEY:?APPLE_API_KEY secret is required}"
-          : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID secret is required}"
-          : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
-          keys_dir="$HOME/.appstoreconnect/private_keys"
-          mkdir -p "$keys_dir"
-          printf '%s' "$APPLE_API_KEY" | base64 -D > "$keys_dir/AuthKey_${APPLE_API_KEY_ID}.p8"
-          chmod 600 "$keys_dir/AuthKey_${APPLE_API_KEY_ID}.p8"
-          echo "APPLE_API_KEY_DIR=$keys_dir" >> "$GITHUB_ENV"
-
-      - name: Install dependencies
-        working-directory: mobile
-        run: npm ci
-
-     
-      - name: Prebuild iOS
-        working-directory: mobile
-        env:
-          FUTURE_VERSION: ${{ needs.version.outputs.version }}
-        run: npx expo prebuild --platform ios
-
-      - name: Build and export signed .ipa
-        working-directory: mobile/ios
-        env:
-          FUTURE_VERSION: ${{ needs.version.outputs.version }}
-          FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
-          DEVELOPMENT_TEAM: ${{ env.DEVELOPMENT_TEAM }}
-          SIGNING_IDENTITY: ${{ env.SIGNING_IDENTITY }}
-          PROVISIONING_PROFILE: ${{ env.PROVISIONING_PROFILE }}
-        run: |
-          set -euo pipefail
-          : "${DEVELOPMENT_TEAM:?DEVELOPMENT_TEAM is required}"
-          : "${SIGNING_IDENTITY:?SIGNING_IDENTITY is required}"
-          : "${PROVISIONING_PROFILE:?PROVISIONING_PROFILE is required}"
-
-          xcodebuild -workspace FutureOS.xcworkspace \
-            -scheme FutureOS \
-            -configuration Release \
-            -destination 'generic/platform=iOS' \
-            -archivePath "$RUNNER_TEMP/FutureOS.xcarchive" \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-            CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
-            PROVISIONING_PROFILE_SPECIFIER="$PROVISIONING_PROFILE" \
-            archive
-
-          export_options="$RUNNER_TEMP/ExportOptions.plist"
-          cat > "$export_options" <<PLIST
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key><string>app-store-connect</string>
-            <key>uploadSymbols</key><true/>
-            <key>compileBitcode</key><false/>
-            <key>teamID</key><string>$DEVELOPMENT_TEAM</string>
-            <key>signingStyle</key><string>manual</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>cn.futureos.mobile</key><string>$PROVISIONING_PROFILE</string>
-            </dict>
-          </dict>
-          </plist>
-          PLIST
-
-          xcodebuild -exportArchive \
-            -archivePath "$RUNNER_TEMP/FutureOS.xcarchive" \
-            -exportPath "$RUNNER_TEMP/FutureOS-export" \
-            -exportOptionsPlist "$export_options"
-
-          ipa="$(find "$RUNNER_TEMP/FutureOS-export" -maxdepth 1 -name '*.ipa' -print -quit)"
-          [[ -n "$ipa" && -s "$ipa" ]] || { echo "Exported .ipa not found." >&2; exit 1; }
-          echo "IPA_PATH=$ipa" >> "$GITHUB_ENV"
-
-      - name: Submit to App Store Connect
-        env:
-          APPLE_API_KEY_DIR: ${{ env.APPLE_API_KEY_DIR }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          set -euo pipefail
-          : "${IPA_PATH:?IPA_PATH is required}"
-          : "${APPLE_API_KEY_DIR:?APPLE_API_KEY_DIR is required}"
-          : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID secret is required}"
-          : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
-          [[ -s "$IPA_PATH" ]] || { echo "IPA is missing or empty: $IPA_PATH" >&2; exit 1; }
-
-          xcrun altool --upload-app \
-            --file "$IPA_PATH" \
-            --type ios \
-            --apiKey "$APPLE_API_KEY_ID" \
-            --apiIssuer "$APPLE_API_ISSUER" \
-            --apiKeyPath "$APPLE_API_KEY_DIR" \
-            --verbose
-
-      - name: Clean up signing material
-        if: always()
-        run: |
-          rm -f "$HOME/.appstoreconnect/private_keys/AuthKey_*.p8"
-          rm -f "$RUNNER_TEMP"/AuthKey_*.p8 "$RUNNER_TEMP/futureos-ios-signing.p12"
-          keychain="$RUNNER_TEMP/futureos-signing.keychain-db"
-          if [[ -f "$keychain" ]]; then
-            security delete-keychain "$keychain" || true
-          fi
+    uses: ./.github/workflows/build-ios-testflight.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      build_number: ${{ needs.version.outputs.build_number }}
+      coordinated: true
+    secrets: inherit
 
   publish:
     name: Publish complete release
@@ -484,45 +104,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
       - name: Download release artifacts
         uses: actions/download-artifact@v7
         with:
           path: release-assets
-
-      # Website installers and Tauri updater packages are all immutable,
-      # versioned release assets. Portable packages remain tester-only.
       - name: Stage and validate release assets
         run: |
           set -euo pipefail
           mkdir -p publish
-
-          mac_arm="FutureOS_${VERSION}_aarch64-sign.dmg"
-          mac_arm_updater="FutureOS_${VERSION}_aarch64.app.tar.gz"
-          mac_intel="FutureOS_${VERSION}_x64-sign.dmg"
-          mac_intel_updater="FutureOS_${VERSION}_x64.app.tar.gz"
-          windows="FutureOS_${VERSION}_x64-setup-sign.exe"
-          linux_deb="FutureOS_${VERSION}_amd64.deb"
-          linux_deb_arm="FutureOS_${VERSION}_arm64.deb"
-          linux_portable="FutureOS-portable-linux.tar.gz"
-          linux_portable_arm="FutureOS-portable-linux-arm64.tar.gz"
-          android_apk="FutureOS_${VERSION}.apk"
-
-          for name in \
-            "$mac_arm" \
-            "$mac_arm_updater" \
-            "$mac_arm_updater.sig" \
-            "$mac_intel" \
-            "$mac_intel_updater" \
-            "$mac_intel_updater.sig" \
-            "$windows" \
-            "$windows.sig" \
-            "$linux_deb" \
-            "$linux_deb_arm" \
-            "$linux_portable" \
-            "$linux_portable_arm" \
-            "$android_apk"
-          do
+          names=(
+            "FutureOS_${VERSION}_aarch64.dmg"
+            "FutureOS_${VERSION}_aarch64.app.tar.gz"
+            "FutureOS_${VERSION}_aarch64.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64.dmg"
+            "FutureOS_${VERSION}_x64.app.tar.gz"
+            "FutureOS_${VERSION}_x64.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64-setup.exe"
+            "FutureOS_${VERSION}_x64-setup.exe.sig"
+            "FutureOS_${VERSION}_amd64.deb"
+            "FutureOS_${VERSION}_amd64.deb.sig"
+            "FutureOS_${VERSION}_arm64.deb"
+            "FutureOS_${VERSION}_arm64.deb.sig"
+            "FutureOS_${VERSION}_linux_x86_64-portable.tar.gz"
+            "FutureOS_${VERSION}_linux_aarch64-portable.tar.gz"
+            "FutureOS_${VERSION}_linux_x86_64-cli.tar.gz"
+            "FutureOS_${VERSION}_linux_aarch64-cli.tar.gz"
+            "FutureOS_${VERSION}_android-universal.apk"
+          )
+          for name in "${names[@]}"; do
             source="$(find release-assets -type f -name "$name" -print -quit)"
             [[ -n "$source" ]] || {
               echo "Required release asset is missing: $name" >&2
@@ -531,38 +140,25 @@ jobs:
             }
             cp -v "$source" "publish/$name"
           done
-
-          # Already-released clients derive these historical filenames from
-          # `version` alone. Keep byte-identical aliases for one-way migration
-          # into the first updater-enabled release.
-          cp -v "publish/$mac_arm" "publish/FutureOS_${VERSION}_aarch64.dmg"
-          cp -v "publish/$mac_intel" "publish/FutureOS_${VERSION}_x64.dmg"
-          cp -v "publish/$windows" "publish/FutureOS_${VERSION}_x64-setup.exe"
-
           count="$(find publish -type f | wc -l | tr -d ' ')"
-          [[ "$count" == "16" ]] || {
-            echo "Expected exactly sixteen public release assets, found $count." >&2
-            exit 1
-          }
+          [[ "$count" == "17" ]] || { echo "Expected 17 assets, found $count." >&2; exit 1; }
 
-      # Keep version/pub_date exactly as before for third-party consumers.
-      # `platforms` is Tauri's signed in-place updater index; the additive
-      # `assets` map is the website's direct-download index.
       - name: Generate Tauri-compatible latest.json
         run: |
           set -euo pipefail
           export PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          export MAC_ARM_FILE="FutureOS_${VERSION}_aarch64-sign.dmg"
+          export MAC_ARM_FILE="FutureOS_${VERSION}_aarch64.dmg"
           export MAC_ARM_UPDATER_FILE="FutureOS_${VERSION}_aarch64.app.tar.gz"
-          export MAC_INTEL_FILE="FutureOS_${VERSION}_x64-sign.dmg"
+          export MAC_INTEL_FILE="FutureOS_${VERSION}_x64.dmg"
           export MAC_INTEL_UPDATER_FILE="FutureOS_${VERSION}_x64.app.tar.gz"
-          export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup-sign.exe"
+          export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup.exe"
           export LINUX_DEB_FILE="FutureOS_${VERSION}_amd64.deb"
           export LINUX_DEB_ARM_FILE="FutureOS_${VERSION}_arm64.deb"
-          export LINUX_PORTABLE_FILE="FutureOS-portable-linux.tar.gz"
-          export LINUX_PORTABLE_ARM_FILE="FutureOS-portable-linux-arm64.tar.gz"
-          export ANDROID_APK_FILE="FutureOS_${VERSION}.apk"
-
+          export LINUX_PORTABLE_FILE="FutureOS_${VERSION}_linux_x86_64-portable.tar.gz"
+          export LINUX_PORTABLE_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-portable.tar.gz"
+          export LINUX_CLI_FILE="FutureOS_${VERSION}_linux_x86_64-cli.tar.gz"
+          export LINUX_CLI_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-cli.tar.gz"
+          export ANDROID_APK_FILE="FutureOS_${VERSION}_android-universal.apk"
           node <<'NODE'
           const fs = require("node:fs");
           const crypto = require("node:crypto");
@@ -581,24 +177,27 @@ jobs:
               "darwin-aarch64": updater(process.env.MAC_ARM_UPDATER_FILE),
               "darwin-x86_64": updater(process.env.MAC_INTEL_UPDATER_FILE),
               "windows-x86_64": updater(process.env.WINDOWS_FILE),
+              "linux-x86_64-deb": updater(process.env.LINUX_DEB_FILE),
+              "linux-aarch64-deb": updater(process.env.LINUX_DEB_ARM_FILE),
             },
             assets: {
               "darwin-aarch64": asset(process.env.MAC_ARM_FILE),
               "darwin-x86_64": asset(process.env.MAC_INTEL_FILE),
               "windows-x86_64": asset(process.env.WINDOWS_FILE),
-              // install.sh keys on these: linux-<arch> (.deb) for Debian
-              // systems, linux-<arch>-portable for every other distro. No
-              // `platforms` entries — Linux has no Tauri updater signing key.
+              "linux-x86_64-deb": asset(process.env.LINUX_DEB_FILE),
+              "linux-aarch64-deb": asset(process.env.LINUX_DEB_ARM_FILE),
               "linux-x86_64": asset(process.env.LINUX_DEB_FILE),
               "linux-x86_64-portable": asset(process.env.LINUX_PORTABLE_FILE),
+              "linux-x86_64-cli": asset(process.env.LINUX_CLI_FILE),
               "linux-aarch64": asset(process.env.LINUX_DEB_ARM_FILE),
               "linux-aarch64-portable": asset(process.env.LINUX_PORTABLE_ARM_FILE),
+              "linux-aarch64-cli": asset(process.env.LINUX_CLI_ARM_FILE),
+              "android-universal": asset(process.env.ANDROID_APK_FILE),
               "android": asset(process.env.ANDROID_APK_FILE),
             },
           };
           fs.writeFileSync("latest.json", `${JSON.stringify(manifest, null, 2)}\n`);
           NODE
-
           cat latest.json
 
       - name: Publish GitHub Release
@@ -611,45 +210,21 @@ jobs:
           files: |
             publish/*
             latest.json
-
       - name: Setup ossutil
         run: bash scripts/setup-ossutil.sh
-
-      # Upload immutable versioned assets first. `latest.json` is the commit
-      # point: it is written only after OSS confirms every referenced object is
-      # present, so clients either see the previous complete release or this one.
       - name: Upload and verify versioned release assets
         run: |
           set -euo pipefail
           target="oss://$OSS_BUCKET/releases/$VERSION"
           ossutil cp -r -f publish/ "$target/"
-          for name in \
-            "FutureOS_${VERSION}_aarch64-sign.dmg" \
-            "FutureOS_${VERSION}_aarch64.dmg" \
-            "FutureOS_${VERSION}_aarch64.app.tar.gz" \
-            "FutureOS_${VERSION}_aarch64.app.tar.gz.sig" \
-            "FutureOS_${VERSION}_x64-sign.dmg" \
-            "FutureOS_${VERSION}_x64.dmg" \
-            "FutureOS_${VERSION}_x64.app.tar.gz" \
-            "FutureOS_${VERSION}_x64.app.tar.gz.sig" \
-            "FutureOS_${VERSION}_x64-setup-sign.exe" \
-            "FutureOS_${VERSION}_x64-setup.exe" \
-            "FutureOS_${VERSION}_x64-setup-sign.exe.sig" \
-            "FutureOS_${VERSION}_amd64.deb" \
-            "FutureOS_${VERSION}_arm64.deb" \
-            "FutureOS-portable-linux.tar.gz" \
-            "FutureOS-portable-linux-arm64.tar.gz" \
-            "FutureOS_${VERSION}.apk"
-          do
-            ossutil stat "$target/$name"
+          find publish -maxdepth 1 -type f -print0 | while IFS= read -r -d '' file; do
+            ossutil stat "$target/$(basename "$file")"
           done
-
+          ossutil cp -f latest.json "$target/latest.json"
+          ossutil stat "$target/latest.json"
       - name: Advance latest.json
         run: |
           set -euo pipefail
-          # A slower, older release must never overwrite a newer pointer. The
-          # job-level concurrency serializes publishers; this version check also
-          # makes reruns and out-of-order build completion safe.
           ossutil cp -f "oss://$OSS_BUCKET/releases/latest.json" current-latest.json
           CURRENT_VERSION="$(node -e '
             const fs = require("node:fs");
@@ -668,6 +243,5 @@ jobs:
             }
           }
           NODE
-
           ossutil cp -f latest.json "oss://$OSS_BUCKET/releases/latest.json"
           ossutil stat "oss://$OSS_BUCKET/releases/latest.json"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,7 +15,7 @@ $Base = if ($env:FUTUREOS_BASE) { $env:FUTUREOS_BASE } else { 'https://dl.future
 $Version = $env:FUTUREOS_VERSION
 
 if ($Version) {
-    # Byte-identical alias of the signed installer, kept for the pinned-version path.
+    # Signed release installers use the canonical name without a signing suffix.
     $Url = "$Base/$Version/FutureOS_${Version}_x64-setup.exe"
     $Sha = $null
 } else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,14 +40,13 @@ esac
 
 fetch() { curl -fsSL --proto '=https' --tlsv1.2 "$1"; }
 
-# Asset URL+SHA-256 for one release file, read from the `assets` section of
-# the pretty-printed release manifest (latest.json). Filename-keyed (e.g.
-# "FutureOS_v0.1.2_aarch64-sign.dmg") -> "URL SHA256".
+# Asset URL+SHA-256 for one key in the `assets` section of the pretty-printed
+# release manifest (latest.json), e.g. "linux-x86_64-deb" -> "URL SHA256".
 manifest_asset() {
-  awk -v f="$1" '
+  awk -v key="$1" '
     /"assets":/ { in_assets=1; next }
-    in_assets && $0 ~ f {
-      u=$0; getline; s=$0;
+    in_assets && index($0, "\"" key "\"") {
+      getline; u=$0; getline; s=$0;
       gsub(/^.*"url": *"/,"",u); gsub(/".*$/,"",u);
       gsub(/^.*"sha256": *"/,"",s); gsub(/".*$/,"",s);
       print u, s; exit
@@ -87,13 +86,17 @@ resolve_latest() {
 
 # Resolve the download URL+SHA-256 for one asset key (e.g. "darwin-aarch64").
 # The pinned-version path constructs the URL directly and skips verification,
-# since there is no manifest to check against.
+# since there is no manifest lookup in that flow yet.
 ASSET_URL=""
 ASSET_SHA=""
 resolve_asset() {
-  local key="$1" filename="$2"
+  local key="$1" filename="$2" fallback_key="${3:-}" manifest_value=""
   if [[ -z "${FUTUREOS_VERSION:-}" ]]; then
-    read -r ASSET_URL ASSET_SHA <<< "$(manifest_asset "$filename")" || true
+    manifest_value="$(manifest_asset "$key")"
+    if [[ -z "$manifest_value" && -n "$fallback_key" ]]; then
+      manifest_value="$(manifest_asset "$fallback_key")"
+    fi
+    read -r ASSET_URL ASSET_SHA <<< "$manifest_value" || true
     [[ -n "$ASSET_URL" ]] || die "no release asset '$key' in $LATEST"
   else
     ASSET_URL="$BASE/$VERSION/$filename"
@@ -105,14 +108,14 @@ resolve_asset() {
 install_macos() {
   local filename dmg mnt dmg_arch
   resolve_latest
-  # Release artifacts use the short "x64" for Intel (FutureOS_<v>_x64-sign.dmg),
+  # Release artifacts use the short "x64" for Intel (FutureOS_<v>_x64.dmg),
   # while latest.json asset keys use the Rust-style "x86_64".
   case "$ARCH" in
     x86_64)  dmg_arch="x64" ;;
     aarch64) dmg_arch="aarch64" ;;
     *) die "unsupported architecture: $ARCH" ;;
   esac
-  filename="FutureOS_${VERSION}_${dmg_arch}-sign.dmg"
+  filename="FutureOS_${VERSION}_${dmg_arch}.dmg"
   resolve_asset "darwin-$ARCH" "$filename"
   say "Installing FutureOS $VERSION ($OS-$ARCH)"
   say "Downloading $ASSET_URL"
@@ -151,23 +154,28 @@ install_linux() {
       *) die "unsupported architecture: $ARCH" ;;
     esac
     pkg_type="deb"
-    key="linux-$ARCH"
+    key="linux-$ARCH-deb"
     filename="FutureOS_${VERSION}_${DEB_ARCH}.deb"
     say "Debian-based system detected — installing the .deb package"
   else
     pkg_type="portable"
     key="linux-$ARCH-portable"
-    # x86_64 keeps its historical arch-less filename; aarch64 tarballs carry
-    # the -arm64 suffix (see release.yml's linux matrix).
+    # Release filenames always carry the normalized Linux architecture.
     case "$ARCH" in
-      x86_64)  filename="FutureOS-portable-linux.tar.gz" ;;
-      aarch64) filename="FutureOS-portable-linux-arm64.tar.gz" ;;
+      x86_64)  filename="FutureOS_${VERSION}_linux_x86_64-portable.tar.gz" ;;
+      aarch64) filename="FutureOS_${VERSION}_linux_aarch64-portable.tar.gz" ;;
       *) die "unsupported architecture: $ARCH" ;;
     esac
     say "Non-Debian system detected — installing the portable tarball"
   fi
 
-  resolve_asset "$key" "$filename"
+  if [[ "$pkg_type" == "deb" ]]; then
+    # Prefer the explicit package-format key. Fall back to the historical key
+    # while old manifests may still be served by mirrors or pinned caches.
+    resolve_asset "$key" "$filename" "linux-$ARCH"
+  else
+    resolve_asset "$key" "$filename"
+  fi
   say "Installing FutureOS $VERSION ($OS-$ARCH, $pkg_type)"
   say "Downloading $ASSET_URL"
   pkg="$TMP/FutureOS.$pkg_type"


### PR DESCRIPTION
Summary:
- reuse the existing macOS, Windows, Linux, Android, and iOS workflows from both Build Unsigned and Build Release
- add unsigned macOS and Windows modes that keep Tauri updater signatures without requiring platform signing services
- publish complete version-scoped manifests and consistently version Linux portable, CLI, and Android artifacts
- keep Build Unsigned under test/<version>/ without advancing a channel-level latest.json

Validation:
- actionlint passed for changed workflows (ignoring the validator version lacking the macos-15-intel label)
- Prettier checks passed
- YAML parsing passed
- bash -n scripts/install.sh passed
- git diff --cached --check passed
- local test suites not run; GitHub Actions owns tests