### PR TITLE
Inline platform version resolution

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -34,43 +34,10 @@ on:
         required: false
 
 jobs:
-  version:
-    name: Resolve version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      is_release: ${{ steps.v.outputs.is_release }}
-      build_number: ${{ steps.v.outputs.build_number }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      - name: Resolve version
-        id: v
-        env:
-          FUTURE_VERSION: ${{ inputs.version }}
-          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
-        run: |
-          node scripts/version.mjs --github-output
-          # versionCode must be a monotonic integer if this ever goes to Play
-          # Store. github.run_id is a GitHub-wide counter that has already
-          # exceeded Android's int32 limit, so use github.run_number — this
-          # workflow's own per-repo counter, starting at 1. It resets if the
-          # workflow is renamed, but that only matters for Play (not currently
-          # used); versionCode monotonicity within a single workflow is enough.
-          echo "build_number=${INPUT_BUILD_NUMBER:-${{ github.run_number }}}" >> "$GITHUB_OUTPUT"
-
   build-apk:
     name: Build APK
-    needs: version
     runs-on: ubuntu-latest
     env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-      FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
-      IS_RELEASE: ${{ needs.version.outputs.is_release }}
       OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
       OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
       OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
@@ -83,6 +50,18 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
+
+      - name: Resolve version
+        env:
+          FUTURE_VERSION: ${{ inputs.version }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+          version="$(node scripts/version.mjs)"
+          build_number="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
+          echo "FUTURE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "FUTURE_BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+          echo "Android version: $version (build $build_number)"
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -131,9 +110,8 @@ jobs:
 
       - name: Rename APK
         run: |
-          V="${{ needs.version.outputs.version }}"
           cp mobile/android/app/build/outputs/apk/release/app-release.apk \
-             "FutureOS_${V}_android-universal.apk"
+             "FutureOS_${FUTURE_VERSION}_android-universal.apk"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
@@ -141,16 +119,15 @@ jobs:
           name: futureos-android-apk
           if-no-files-found: error
           overwrite: true
-          path: FutureOS_${{ needs.version.outputs.version }}_android-universal.apk
+          path: FutureOS_*_android-universal.apk
           retention-days: 3
 
       - name: Upload APK to OSS
         if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
-          V="${{ needs.version.outputs.version }}"
-          APK="FutureOS_${V}_android-universal.apk"
-          ossutil cp -f "$APK" "oss://$OSS_BUCKET/test/$V/$APK"
-          ossutil stat "oss://$OSS_BUCKET/test/$V/$APK"
+          APK="FutureOS_${FUTURE_VERSION}_android-universal.apk"
+          ossutil cp -f "$APK" "oss://$OSS_BUCKET/test/$FUTURE_VERSION/$APK"
+          ossutil stat "oss://$OSS_BUCKET/test/$FUTURE_VERSION/$APK"
           echo "==> Download URL:"
-          echo "https://dl.future-os.cn/test/$V/$APK"
+          echo "https://dl.future-os.cn/test/$FUTURE_VERSION/$APK"

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -63,41 +63,11 @@ on:
         required: false
 
 jobs:
-  version:
-    name: Resolve TestFlight version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      build_number: ${{ steps.v.outputs.build_number }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Resolve build number
-        id: v
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
-        run: |
-          # Marketing version bumped to 0.0.2: TestFlight already accepted
-          # 0.0.1 with build number 31479016198, so 0.0.1's sequence can only
-          # increase; small run_number values must start fresh under 0.0.2.
-          # The store build number is this workflow's per-repo run counter
-          # (starts at 1; stays within int32).
-          version="${INPUT_VERSION:-0.0.2}"
-          build_number="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
-          echo "TestFlight version: $version (build $build_number)"
-
   build:
     name: Build and upload TestFlight
-    needs: version
     runs-on: macos-latest
     timeout-minutes: 120
     env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-      FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -115,6 +85,20 @@ jobs:
           node-version: "24"
           cache: npm
           cache-dependency-path: package-lock.json
+
+      - name: Resolve version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+          # TestFlight marketing versions must be plain numeric SemVer. The
+          # coordinators pass bundle_version; standalone runs keep 0.0.2.
+          version="${INPUT_VERSION:-0.0.2}"
+          build_number="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
+          echo "FUTURE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "FUTURE_BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+          echo "TestFlight version: $version (build $build_number)"
 
       # Import the base64-encoded iOS Distribution certificate into an ephemeral
       # keychain, resolve its identity, and write the provisioning profile.
@@ -206,15 +190,11 @@ jobs:
 
       - name: Prebuild iOS
         working-directory: mobile
-        env:
-          FUTURE_VERSION: ${{ needs.version.outputs.version }}
         run: npx expo prebuild --platform ios
 
       - name: Build and export signed .ipa
         working-directory: mobile/ios
         env:
-          FUTURE_VERSION: ${{ needs.version.outputs.version }}
-          FUTURE_BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
           DEVELOPMENT_TEAM: ${{ env.DEVELOPMENT_TEAM }}
           SIGNING_IDENTITY: ${{ env.SIGNING_IDENTITY }}
           PROVISIONING_PROFILE: ${{ env.PROVISIONING_PROFILE }}
@@ -263,7 +243,7 @@ jobs:
             -exportPath "$RUNNER_TEMP/FutureOS-export" \
             -exportOptionsPlist "$export_options"
 
-          app_name="FutureOS_${{ needs.version.outputs.version }}_${{ needs.version.outputs.build_number }}.ipa"
+          app_name="FutureOS_${FUTURE_VERSION}_${FUTURE_BUILD_NUMBER}.ipa"
           ipa="$(find "$RUNNER_TEMP/FutureOS-export" -maxdepth 1 -name '*.ipa' -print -quit)"
           [[ -n "$ipa" && -s "$ipa" ]] || { echo "Exported .ipa not found." >&2; exit 1; }
           cp "$ipa" "$RUNNER_TEMP/$app_name"
@@ -298,7 +278,7 @@ jobs:
           : "${IPA_PATH:?IPA_PATH is required}"
           : "${IPA_NAME:?IPA_NAME is required}"
 
-          version="${{ needs.version.outputs.version }}"
+          version="$FUTURE_VERSION"
           case "$(uname -m)" in
             arm64) arch="arm64" ;;
             x86_64) arch="amd64" ;;

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -28,27 +28,8 @@ on:
         required: true
 
 jobs:
-  version:
-    name: Resolve version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      - name: Resolve version
-        id: v
-        env:
-          FUTURE_VERSION: ${{ inputs.version }}
-        run: node scripts/version.mjs --github-output
-
   build:
     name: Build Linux (${{ matrix.arch }})
-    needs: version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,9 +47,6 @@ jobs:
             deb_arch: arm64
             artifact_name: futureos-linux-arm64
             release_artifact_name: futureos-linux-arm64-release
-    env:
-      FUTURE_VERSION: ${{ needs.version.outputs.version }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -79,6 +57,15 @@ jobs:
           node-version: "24"
           cache: npm
           cache-dependency-path: package-lock.json
+
+      - name: Resolve version
+        env:
+          FUTURE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$(node scripts/version.mjs)"
+          echo "FUTURE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Linux version: $version"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.97.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
+      bundle_version: ${{ steps.v.outputs.bundle_version }}
       build_number: ${{ steps.v.outputs.build_number }}
     steps:
       - name: Checkout
@@ -73,7 +74,7 @@ jobs:
     needs: version
     uses: ./.github/workflows/build-ios-testflight.yml
     with:
-      version: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.bundle_version }}
       build_number: ${{ needs.version.outputs.build_number }}
       coordinated: true
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
+      bundle_version: ${{ steps.v.outputs.bundle_version }}
       build_number: ${{ steps.v.outputs.build_number }}
     steps:
       - name: Checkout
@@ -80,7 +81,7 @@ jobs:
     needs: version
     uses: ./.github/workflows/build-ios-testflight.yml
     with:
-      version: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.bundle_version }}
       build_number: ${{ needs.version.outputs.build_number }}
       coordinated: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- remove the redundant standalone version jobs from the Linux, Android, and iOS reusable workflows
- resolve version and build number inside the actual platform build jobs while honoring coordinator inputs
- pass the plain bundle version to TestFlight so its marketing version remains numeric

## Validation

- `actionlint` passed for all five changed workflows (with the existing old-validator ignore for `macos-15-intel`)
- Prettier check passed
- YAML parse and inline-version structure assertions passed
- `git diff --check` passed
- Local test suites: NOT RUN; GitHub Actions owns build testing