### PR TITLE
Unify test, nightly, and dev build channels

### DIFF
--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -2,29 +2,19 @@ name: Build iOS TestFlight
 
 permissions: read-all
 
-# Manual iOS distribution build. Imports the iOS Distribution certificate and
-# App Store provisioning profile from secrets, builds a signed Release .ipa with
-# Expo prebuild + xcodebuild, uploads it to TestFlight via altool, and mirrors
-# the .ipa to OSS.
+# Reusable iOS distribution workflow. Imports the iOS Distribution certificate
+# and App Store provisioning profile from secrets, builds a signed Release .ipa
+# with Expo prebuild + xcodebuild, and uploads it to TestFlight via altool.
 #
-# TestFlight requires a plain numeric marketing version. It was pinned at `0.0.1`
-# until 0.0.1's build number hit 31479016198 (the old github.run_id counter).
-# TestFlight enforces a monotonically increasing build number per marketing
-# version, so switching back to small run_number build numbers under 0.0.1 would
-# be rejected. Bumping the marketing version to `0.0.2` resets the build-number
-# sequence, letting it restart at 1. The store build number (CFBundleVersion /
-# Android versionCode) comes from `github.run_number` via FUTURE_BUILD_NUMBER —
-# this workflow's per-repo counter starting at 1. It must stay small: Android
-# versionCode is an int32, and `github.run_id` (a GitHub-wide counter) already
-# exceeds its limit. Bump the marketing version here only when cutting a real
-# release or resetting the TestFlight build-number sequence again.
+# TestFlight requires a plain numeric marketing version and a monotonically
+# increasing build number per marketing version. Both are required inputs from
+# the coordinator, so this workflow must not be manually dispatched.
 #
 # Keep this workflow restricted to trusted triggers: it imports signing
 # credentials and submits software to Apple's TestFlight service. Do not add
 # pull_request or other events that can execute untrusted code with them.
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       version:
@@ -35,11 +25,6 @@ on:
         description: Monotonic App Store build number supplied by the coordinator.
         required: true
         type: string
-      coordinated:
-        description: Let the caller handle release publication.
-        required: false
-        type: boolean
-        default: false
     secrets:
       IOS_DIST_CERT_P12_BASE64:
         required: true
@@ -53,14 +38,6 @@ on:
         required: true
       APPLE_API_ISSUER:
         required: true
-      OSS_ENDPOINT:
-        required: false
-      OSS_BUCKET:
-        required: false
-      OSS_ACCESS_KEY_ID:
-        required: false
-      OSS_ACCESS_KEY_SECRET:
-        required: false
 
 jobs:
   build:
@@ -71,10 +48,6 @@ jobs:
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
-      OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
-      OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
-      OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -93,9 +66,10 @@ jobs:
         run: |
           set -euo pipefail
           # TestFlight marketing versions must be plain numeric SemVer. The
-          # coordinators pass bundle_version; standalone runs keep 0.0.2.
-          version="${INPUT_VERSION:-0.0.2}"
-          build_number="${INPUT_BUILD_NUMBER:-${{ github.run_number }}}"
+          # coordinators pass bundle_version rather than a dev version with a
+          # commit hash.
+          version="${INPUT_VERSION:?version input is required}"
+          build_number="${INPUT_BUILD_NUMBER:?build_number input is required}"
           echo "FUTURE_VERSION=$version" >> "$GITHUB_ENV"
           echo "FUTURE_BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
           echo "TestFlight version: $version (build $build_number)"
@@ -270,34 +244,6 @@ jobs:
             --apiIssuer "$APPLE_API_ISSUER" \
             --apiKeyPath "$APPLE_API_KEY_DIR" \
             --verbose
-
-      - name: Upload IPA to OSS
-        if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
-        run: |
-          set -euo pipefail
-          : "${IPA_PATH:?IPA_PATH is required}"
-          : "${IPA_NAME:?IPA_NAME is required}"
-
-          version="$FUTURE_VERSION"
-          case "$(uname -m)" in
-            arm64) arch="arm64" ;;
-            x86_64) arch="amd64" ;;
-            *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
-          esac
-          pkg="ossutil-2.3.0-mac-${arch}"
-          curl -fsSL "https://gosspublic.alicdn.com/ossutil/v2/2.3.0/${pkg}.zip" \
-            -o "$RUNNER_TEMP/ossutil.zip"
-          unzip -q "$RUNNER_TEMP/ossutil.zip" -d "$RUNNER_TEMP/ossutil"
-          chmod +x "$RUNNER_TEMP/ossutil/$pkg/ossutil"
-          export PATH="$RUNNER_TEMP/ossutil/$pkg:$PATH"
-
-          region="$(printf '%s' "$OSS_ENDPOINT" \
-            | sed -E 's#^https?://##; s/^oss-//; s/-internal//; s/\.aliyuncs\.com$//')"
-          echo "==> Uploading IPA to oss://$OSS_BUCKET/test/$version/"
-          ossutil cp -f "$IPA_PATH" "oss://$OSS_BUCKET/test/$version/$IPA_NAME" --region "$region"
-          ossutil stat "oss://$OSS_BUCKET/test/$version/$IPA_NAME" --region "$region"
-          echo "==> Download URL:"
-          echo "https://dl.future-os.cn/test/$version/$IPA_NAME"
 
       - name: Clean up signing material
         if: always()

--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -7,7 +7,7 @@ permissions: read-all
 # both but still creates updater artifacts signed by the Tauri updater key.
 # Keep both modes restricted to trusted triggers because both access secrets.
 #
-# Manual builds go to `test/<version>/`. Formal releases call this workflow from
+# Standalone dev builds go to `dev/<artifact-version>/`. Formal releases call this workflow from
 # release.yml and consume its verified artifact; only the coordinator publishes
 # to `releases/` and advances latest.json.
 
@@ -162,6 +162,7 @@ jobs:
         id: v
         env:
           FUTURE_VERSION: ${{ inputs.version }}
+          FUTURE_BUILD_CHANNEL: ${{ github.event_name == 'workflow_dispatch' && !inputs.coordinated && 'dev' || '' }}
         run: node scripts/version.mjs --github-output
 
       - name: Install npm dependencies (Desktop)
@@ -579,9 +580,10 @@ jobs:
         run: |
           set -euo pipefail
           suffix="${{ inputs.signed && '' || '-unsigned' }}"
+          published_version="${{ inputs.coordinated && steps.v.outputs.version || steps.v.outputs.artifact_version }}"
           mkdir -p release-assets
-          dmg_output="release-assets/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}${suffix}.dmg"
-          updater_output="release-assets/FutureOS_${{ steps.v.outputs.version }}_${{ matrix.asset_arch }}${suffix}.app.tar.gz"
+          dmg_output="release-assets/FutureOS_${published_version}_${{ matrix.asset_arch }}${suffix}.dmg"
+          updater_output="release-assets/FutureOS_${published_version}_${{ matrix.asset_arch }}${suffix}.app.tar.gz"
           cp "$DISTRIBUTABLE_DMG" "$dmg_output"
           cp "$MACOS_UPDATER" "$updater_output"
           cp "$MACOS_UPDATER_SIG" "$updater_output.sig"
@@ -622,13 +624,13 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         run: |
           set -euo pipefail
-          version="${{ steps.v.outputs.version }}"
-          echo "==> Uploading macOS artifacts to oss://$OSS_BUCKET/test/$version/"
-          ossutil cp -r -f release-assets/ "oss://$OSS_BUCKET/test/$version/"
+          version="${{ steps.v.outputs.artifact_version }}"
+          echo "==> Uploading macOS artifacts to oss://$OSS_BUCKET/dev/$version/"
+          ossutil cp -r -f release-assets/ "oss://$OSS_BUCKET/dev/$version/"
 
           echo "==> Download URLs:"
           find release-assets -maxdepth 1 -type f -print | while read -r output; do
-            echo "https://dl.future-os.cn/test/$version/$(basename "$output")"
+            echo "https://dl.future-os.cn/dev/$version/$(basename "$output")"
           done
 
       - name: Clean up signing material

--- a/.github/workflows/build-windows-signed.yml
+++ b/.github/workflows/build-windows-signed.yml
@@ -25,7 +25,7 @@ permissions: read-all
 # step fails in seconds if the session is dead, rather than after a 40-minute
 # compile.
 #
-# Manual builds go to `test/<version>/`. Formal releases call this workflow from
+# Standalone dev builds go to `dev/<artifact-version>/`. Formal releases call this workflow from
 # release.yml and consume its verified artifact; only the coordinator publishes
 # to `releases/` and advances latest.json.
 
@@ -136,6 +136,7 @@ jobs:
         id: v
         env:
           FUTURE_VERSION: ${{ inputs.version }}
+          FUTURE_BUILD_CHANNEL: ${{ github.event_name == 'workflow_dispatch' && !inputs.coordinated && 'dev' || '' }}
         run: node scripts/version.mjs --github-output
 
       # Fail now, not after a 40-minute compile: the certificate is only visible
@@ -373,7 +374,8 @@ jobs:
           $installers = @(Get-ChildItem desktop/src-tauri/target/release/bundle/nsis/*.exe)
           if ($installers.Count -ne 1) { throw "Expected exactly one NSIS installer, found $($installers.Count)." }
           $suffix = "${{ inputs.signed && '' || '-unsigned' }}"
-          $output = Join-Path $stage "FutureOS_${{ steps.v.outputs.version }}_x64-setup${suffix}.exe"
+          $publishedVersion = "${{ inputs.coordinated && steps.v.outputs.version || steps.v.outputs.artifact_version }}"
+          $output = Join-Path $stage "FutureOS_${publishedVersion}_x64-setup${suffix}.exe"
           Copy-Item $installers[0].FullName $output
           Copy-Item "$($installers[0].FullName).sig" "$output.sig"
           $portable = "FutureOS-portable-windows${suffix}.zip"
@@ -401,15 +403,15 @@ jobs:
           path: release-assets/*portable-windows*.zip
           retention-days: 7
 
-      - name: Upload to OSS test channel
+      - name: Upload to OSS dev channel
         if: github.event_name == 'workflow_dispatch' && !inputs.coordinated
         shell: powershell
         run: |
-          $version = "${{ steps.v.outputs.version }}"
-          Write-Host "==> Uploading to oss://$env:OSS_BUCKET/test/$version/"
+          $version = "${{ steps.v.outputs.artifact_version }}"
+          Write-Host "==> Uploading to oss://$env:OSS_BUCKET/dev/$version/"
           Get-ChildItem release-assets | Select-Object -ExpandProperty Name
-          ossutil cp -r -f "release-assets\" "oss://$env:OSS_BUCKET/test/$version/"
+          ossutil cp -r -f "release-assets\" "oss://$env:OSS_BUCKET/dev/$version/"
           if ($LASTEXITCODE -ne 0) { throw "ossutil upload failed (exit $LASTEXITCODE)" }
 
           Write-Host "==> Download URLs:"
-          Get-ChildItem release-assets | ForEach-Object { Write-Host "  https://dl.future-os.cn/test/$version/$($_.Name)" }
+          Get-ChildItem release-assets | ForEach-Object { Write-Host "  https://dl.future-os.cn/dev/$version/$($_.Name)" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,19 @@
-name: Build Unsigned
+name: Build Test
 
 permissions: read-all
 
-# Release rehearsal. It invokes the same platform workflows as release.yml,
-# but macOS and Windows skip platform code signing. The complete test release is
-# published under test/<version>/, including its own latest.json; test/latest.json
-# is deliberately never written here.
+# Release rehearsal. It invokes the same platform workflows as release.yml.
+# Normal test builds are unsigned and publish under test/<version>/; nightly
+# builds sign macOS and Windows and publish under nightly/<version>/. Each
+# channel advances its own latest.json only after the complete build succeeds.
 on:
   workflow_dispatch:
+    inputs:
+      nightly:
+        description: Build a signed nightly release.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   version:
@@ -15,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
+      artifact_version: ${{ steps.v.outputs.artifact_version }}
       bundle_version: ${{ steps.v.outputs.bundle_version }}
       build_number: ${{ steps.v.outputs.build_number }}
+      channel: ${{ steps.v.outputs.channel }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -26,27 +34,33 @@ jobs:
           node-version: "24"
       - name: Resolve version
         id: v
+        env:
+          FUTURE_BUILD_CHANNEL: ${{ inputs.nightly && 'nightly' || 'test' }}
+          FUTURE_RUN_NUMBER: ${{ github.run_number }}
         run: |
+          set -euo pipefail
           node scripts/version.mjs --github-output
           echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "channel=$FUTURE_BUILD_CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Build Test channel: $FUTURE_BUILD_CHANNEL (build ${{ github.run_number }})"
 
   macos:
-    name: Build unsigned macOS
+    name: Build macOS
     needs: version
     uses: ./.github/workflows/build-macos-signed.yml
     with:
       version: ${{ needs.version.outputs.version }}
-      signed: false
+      signed: ${{ inputs.nightly }}
       coordinated: true
     secrets: inherit
 
   windows:
-    name: Build unsigned Windows
+    name: Build Windows
     needs: version
     uses: ./.github/workflows/build-windows-signed.yml
     with:
       version: ${{ needs.version.outputs.version }}
-      signed: false
+      signed: ${{ inputs.nightly }}
       coordinated: true
     secrets: inherit
 
@@ -70,17 +84,16 @@ jobs:
     secrets: inherit
 
   ios:
-    name: Build and submit iOS
+    name: Build iOS
     needs: version
     uses: ./.github/workflows/build-ios-testflight.yml
     with:
       version: ${{ needs.version.outputs.bundle_version }}
       build_number: ${{ needs.version.outputs.build_number }}
-      coordinated: true
     secrets: inherit
 
   publish:
-    name: Publish complete test release
+    name: Publish complete test build
     needs: [version, macos, windows, linux, android, ios]
     runs-on: ubuntu-latest
     concurrency:
@@ -92,7 +105,8 @@ jobs:
       OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
       OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
       VERSION: ${{ needs.version.outputs.version }}
-      RELEASE_ORIGIN: https://dl.future-os.cn/test
+      ARTIFACT_VERSION: ${{ needs.version.outputs.artifact_version }}
+      CHANNEL: ${{ needs.version.outputs.channel }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -104,15 +118,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p publish
+          if [[ "$CHANNEL" == "nightly" ]]; then
+            suffix=""
+          else
+            suffix="-unsigned"
+          fi
           names=(
-            "FutureOS_${VERSION}_aarch64-unsigned.dmg"
-            "FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz"
-            "FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz.sig"
-            "FutureOS_${VERSION}_x64-unsigned.dmg"
-            "FutureOS_${VERSION}_x64-unsigned.app.tar.gz"
-            "FutureOS_${VERSION}_x64-unsigned.app.tar.gz.sig"
-            "FutureOS_${VERSION}_x64-setup-unsigned.exe"
-            "FutureOS_${VERSION}_x64-setup-unsigned.exe.sig"
+            "FutureOS_${VERSION}_aarch64${suffix}.dmg"
+            "FutureOS_${VERSION}_aarch64${suffix}.app.tar.gz"
+            "FutureOS_${VERSION}_aarch64${suffix}.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64${suffix}.dmg"
+            "FutureOS_${VERSION}_x64${suffix}.app.tar.gz"
+            "FutureOS_${VERSION}_x64${suffix}.app.tar.gz.sig"
+            "FutureOS_${VERSION}_x64-setup${suffix}.exe"
+            "FutureOS_${VERSION}_x64-setup${suffix}.exe.sig"
             "FutureOS_${VERSION}_amd64.deb"
             "FutureOS_${VERSION}_amd64.deb.sig"
             "FutureOS_${VERSION}_arm64.deb"
@@ -130,7 +149,8 @@ jobs:
               find release-assets -maxdepth 3 -type f -print >&2
               exit 1
             }
-            cp -v "$source" "publish/$name"
+            published_name="${name//$VERSION/$ARTIFACT_VERSION}"
+            cp -v "$source" "publish/$published_name"
           done
           count="$(find publish -type f | wc -l | tr -d ' ')"
           [[ "$count" == "17" ]] || { echo "Expected 17 assets, found $count." >&2; exit 1; }
@@ -138,24 +158,30 @@ jobs:
       - name: Generate Tauri-compatible latest.json
         run: |
           set -euo pipefail
+          if [[ "$CHANNEL" == "nightly" ]]; then
+            suffix=""
+          else
+            suffix="-unsigned"
+          fi
           export PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          export MAC_ARM_FILE="FutureOS_${VERSION}_aarch64-unsigned.dmg"
-          export MAC_ARM_UPDATER_FILE="FutureOS_${VERSION}_aarch64-unsigned.app.tar.gz"
-          export MAC_INTEL_FILE="FutureOS_${VERSION}_x64-unsigned.dmg"
-          export MAC_INTEL_UPDATER_FILE="FutureOS_${VERSION}_x64-unsigned.app.tar.gz"
-          export WINDOWS_FILE="FutureOS_${VERSION}_x64-setup-unsigned.exe"
-          export LINUX_DEB_FILE="FutureOS_${VERSION}_amd64.deb"
-          export LINUX_DEB_ARM_FILE="FutureOS_${VERSION}_arm64.deb"
-          export LINUX_PORTABLE_FILE="FutureOS_${VERSION}_linux_x86_64-portable.tar.gz"
-          export LINUX_PORTABLE_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-portable.tar.gz"
-          export LINUX_CLI_FILE="FutureOS_${VERSION}_linux_x86_64-cli.tar.gz"
-          export LINUX_CLI_ARM_FILE="FutureOS_${VERSION}_linux_aarch64-cli.tar.gz"
-          export ANDROID_APK_FILE="FutureOS_${VERSION}_android-universal.apk"
+          export RELEASE_ORIGIN="https://dl.future-os.cn/$CHANNEL"
+          export MAC_ARM_FILE="FutureOS_${ARTIFACT_VERSION}_aarch64${suffix}.dmg"
+          export MAC_ARM_UPDATER_FILE="FutureOS_${ARTIFACT_VERSION}_aarch64${suffix}.app.tar.gz"
+          export MAC_INTEL_FILE="FutureOS_${ARTIFACT_VERSION}_x64${suffix}.dmg"
+          export MAC_INTEL_UPDATER_FILE="FutureOS_${ARTIFACT_VERSION}_x64${suffix}.app.tar.gz"
+          export WINDOWS_FILE="FutureOS_${ARTIFACT_VERSION}_x64-setup${suffix}.exe"
+          export LINUX_DEB_FILE="FutureOS_${ARTIFACT_VERSION}_amd64.deb"
+          export LINUX_DEB_ARM_FILE="FutureOS_${ARTIFACT_VERSION}_arm64.deb"
+          export LINUX_PORTABLE_FILE="FutureOS_${ARTIFACT_VERSION}_linux_x86_64-portable.tar.gz"
+          export LINUX_PORTABLE_ARM_FILE="FutureOS_${ARTIFACT_VERSION}_linux_aarch64-portable.tar.gz"
+          export LINUX_CLI_FILE="FutureOS_${ARTIFACT_VERSION}_linux_x86_64-cli.tar.gz"
+          export LINUX_CLI_ARM_FILE="FutureOS_${ARTIFACT_VERSION}_linux_aarch64-cli.tar.gz"
+          export ANDROID_APK_FILE="FutureOS_${ARTIFACT_VERSION}_android-universal.apk"
           node <<'NODE'
           const fs = require("node:fs");
           const crypto = require("node:crypto");
           const sha256 = file => crypto.createHash("sha256").update(fs.readFileSync(`publish/${file}`)).digest("hex");
-          const url = file => `${process.env.RELEASE_ORIGIN}/${process.env.VERSION}/${file}`;
+          const url = file => `${process.env.RELEASE_ORIGIN}/${process.env.ARTIFACT_VERSION}/${file}`;
           const updater = file => ({
             url: url(file),
             signature: fs.readFileSync(`publish/${file}.sig`, "utf8").trim(),
@@ -195,21 +221,67 @@ jobs:
       - name: Upload latest.json artifact
         uses: actions/upload-artifact@v7
         with:
-          name: futureos-test-latest-json
+          name: futureos-${{ needs.version.outputs.channel }}-latest-json
           path: latest.json
           if-no-files-found: error
           overwrite: true
           retention-days: 7
       - name: Setup ossutil
         run: bash scripts/setup-ossutil.sh
-      - name: Publish complete versioned test release
+      - name: Publish complete test build
         run: |
           set -euo pipefail
-          target="oss://$OSS_BUCKET/test/$VERSION"
+          target="oss://$OSS_BUCKET/$CHANNEL/$ARTIFACT_VERSION"
           ossutil cp -r -f publish/ "$target/"
           find publish -maxdepth 1 -type f -print0 | while IFS= read -r -d '' file; do
             ossutil stat "$target/$(basename "$file")"
           done
           ossutil cp -f latest.json "$target/latest.json"
           ossutil stat "$target/latest.json"
-          echo "Manifest: https://dl.future-os.cn/test/$VERSION/latest.json"
+          echo "Version manifest: https://dl.future-os.cn/$CHANNEL/$ARTIFACT_VERSION/latest.json"
+
+      - name: Advance channel latest.json
+        run: |
+          set -euo pipefail
+          pointer="oss://$OSS_BUCKET/$CHANNEL/latest.json"
+          if ossutil cp -f "$pointer" current-latest.json; then
+            decision="$(node <<'NODE'
+          const fs = require("node:fs");
+          const current = JSON.parse(fs.readFileSync("current-latest.json", "utf8")).version;
+          const next = process.env.VERSION;
+          const expectedChannel = process.env.CHANNEL;
+          const parse = value => {
+            const match = /^(\d+)\.(\d+)\.(\d+)-(\d+)\+(test|nightly)$/.exec(value);
+            if (!match) throw new Error(`Unsupported channel version: ${value}`);
+            return {
+              numbers: match.slice(1, 5).map(Number),
+              channel: match[5],
+            };
+          };
+          const currentVersion = parse(current);
+          const nextVersion = parse(next);
+          if (currentVersion.channel !== expectedChannel || nextVersion.channel !== expectedChannel) {
+            throw new Error(`Channel mismatch: expected ${expectedChannel}, current ${current}, next ${next}`);
+          }
+          for (let index = 0; index < nextVersion.numbers.length; index += 1) {
+            if (nextVersion.numbers[index] > currentVersion.numbers[index]) {
+              process.stdout.write("advance");
+              process.exit(0);
+            }
+            if (nextVersion.numbers[index] < currentVersion.numbers[index]) {
+              throw new Error(`Refusing to move ${expectedChannel}/latest.json backward from ${current} to ${next}`);
+            }
+          }
+          process.stdout.write("current");
+          NODE
+            )"
+          else
+            decision="advance"
+          fi
+          if [[ "$decision" == "advance" ]]; then
+            ossutil cp -f latest.json "$pointer"
+            ossutil stat "$pointer"
+          else
+            echo "Channel pointer is already at $VERSION; no update needed."
+          fi
+          echo "Channel manifest: https://dl.future-os.cn/$CHANNEL/latest.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           }
 
   macos:
-    name: Build signed macOS
+    name: Build macOS
     needs: version
     uses: ./.github/workflows/build-macos-signed.yml
     with:
@@ -48,7 +48,7 @@ jobs:
     secrets: inherit
 
   windows:
-    name: Build signed Windows
+    name: Build Windows
     needs: version
     uses: ./.github/workflows/build-windows-signed.yml
     with:
@@ -77,13 +77,12 @@ jobs:
     secrets: inherit
 
   ios:
-    name: Build and submit iOS
+    name: Build iOS
     needs: version
     uses: ./.github/workflows/build-ios-testflight.yml
     with:
       version: ${{ needs.version.outputs.bundle_version }}
       build_number: ${{ needs.version.outputs.build_number }}
-      coordinated: true
     secrets: inherit
 
   publish:

--- a/desktop/src-tauri/src/build_info.rs
+++ b/desktop/src-tauri/src/build_info.rs
@@ -2,8 +2,9 @@
 //!
 //! `FUTURE_VERSION` is set by `build.rs` from the `FUTURE_VERSION` env
 //! (see `scripts/version.mjs`). Release builds carry a plain `1.X.Y`; dev builds
-//! carry `0.0.2[-<hash>]` (the iOS TestFlight variant drops the suffix). The
-//! channel is derived from the first version component — `0` means dev, `1`+
+//! carry `0.0.2-<hash>` or `0.0.2-<run_number>+<channel>` (the iOS TestFlight
+//! variant drops the suffix). The channel is derived from the first version
+//! component — `0` means dev, `1`+
 //! means release — so there is a single injected value. See the note in
 //! `scripts/version.mjs` for the one assumption this makes (release versions
 //! must never start with `0`).

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,24 +1,28 @@
 #!/usr/bin/env node
 // Single source of truth for FutureOS build versioning.
 //
-// Three cases, all keyed off "is this a release tag":
+// Coordinated and standalone cases:
+//   - coordinated test     → dev,     version = "0.0.2-<run_number>+test"
+//   - coordinated nightly  → dev,     version = "0.0.2-<run_number>+nightly"
+//   - standalone dev build → dev,     version = "0.0.2-<hash>+dev"
 //   - on a `vX.Y.Z` tag    → release, version = "X.Y.Z"   (X must be ≥ 1)
-//   - other online build   → dev,    version = "0.0.2-<hash>"
-//   - local build          → dev,    version = "0.0.2-<hash>+local"
-//                                      (…+local.dirty when the tree is dirty)
-//   - iOS TestFlight       → dev,    version = "0.0.2"
-//                                      (plain number: TestFlight rejects suffixes;
-//                                      injected via FUTURE_VERSION by the workflow)
+//   - other online build   → dev,     version = "0.0.2-<hash>"
+//   - local build          → dev,     version = "0.0.2-<hash>+local"
+//                                       (…+local.dirty when the tree is dirty)
+//   - iOS TestFlight       → dev,     version = "0.0.2"
+//                                       (plain number: TestFlight rejects suffixes;
+//                                       injected via FUTURE_VERSION by the workflow)
 //
 // The dev minor is pinned at `0.0.2` (DEV_VERSION below), NOT derived from git.
 // CI uses a shallow checkout (fetch-depth: 1), so `git rev-list --count HEAD`
 // always returns 1 there and a commit-count version would be frozen at 0.0.1.
-// The short hash still identifies the exact code; local builds add `+local` (and
+// Standalone builds retain the short hash; coordinated test/nightly builds are
+// traceable through their workflow run number. Local builds add `+local` (and
 // `.dirty` when the tree is dirty) so a tester's laptop build is never mistaken
-// for the matching online build, and a dirty local build's hash must not be
-// trusted verbatim. Store build numbers (Android versionCode / iOS
-// CFBundleVersion) are injected separately by the workflows via github.run_number,
-// so the display version does not need to be monotonic.
+// for the matching online build. Store build numbers (Android versionCode / iOS
+// CFBundleVersion) are injected separately by the workflows via github.run_number.
+// Coordinated test/nightly display versions reuse that counter so desktop
+// updater versions are monotonic within each channel.
 //
 // Bump DEV_VERSION (0.0.2 → 0.0.3) whenever the test-build version should
 // advance — e.g. TestFlight already accepted a larger build number under the
@@ -43,20 +47,52 @@ import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-/** Dev-build display version (semver core; the short hash is appended later). */
+/** Dev-build SemVer core used by hash and coordinated channel versions. */
 const DEV_VERSION = "0.0.2";
 
-/** Resolve the display version string for this build. */
-export function resolveVersion() {
-  // Explicit override (set by CI job env / Makefile) wins.
+/** Resolve the internal and public artifact versions together. */
+export function resolveVersions() {
+  // Explicit overrides (set by CI job env / Makefile) win. Callers that need a
+  // distinct public version must provide both instead of relying on parsing.
   if (process.env.FUTURE_VERSION) {
-    return process.env.FUTURE_VERSION.trim();
+    const version = process.env.FUTURE_VERSION.trim();
+    const artifactVersion =
+      process.env.FUTURE_ARTIFACT_VERSION?.trim() || version;
+    return { version, artifactVersion };
   }
-  // Release tag: refs/tags/vX.Y.Z → X.Y.Z
+  // Release tag: refs/tags/vX.Y.Z → X.Y.Z. Keep this ahead of every dev
+  // channel so a repository-level channel variable can never alter a release.
   const ref = process.env.GITHUB_REF || "";
   const tag = ref.match(/^refs\/tags\/v(\d+\.\d+\.\d+)$/);
   if (tag) {
-    return tag[1];
+    const version = tag[1];
+    return { version, artifactVersion: version };
+  }
+  // Build Test supplies both values so test and nightly updater versions are
+  // monotonically ordered within their respective channels.
+  const buildChannel = process.env.FUTURE_BUILD_CHANNEL?.trim();
+  const runNumber = process.env.FUTURE_RUN_NUMBER?.trim();
+  if (buildChannel || runNumber) {
+    if (!new Set(["test", "nightly", "dev"]).has(buildChannel)) {
+      throw new Error(
+        `FUTURE_BUILD_CHANNEL must be test, nightly, or dev, got ${buildChannel || "empty"}`,
+      );
+    }
+    if (buildChannel === "dev") {
+      if (runNumber) {
+        throw new Error("FUTURE_RUN_NUMBER is not used by the dev channel");
+      }
+      const artifactVersion = `${DEV_VERSION}-${gitShortHash()}`;
+      return { version: `${artifactVersion}+dev`, artifactVersion };
+    }
+    if (!/^[1-9]\d*$/.test(runNumber || "")) {
+      throw new Error(
+        `FUTURE_RUN_NUMBER must be a positive integer, got ${runNumber || "empty"}`,
+      );
+    }
+    const artifactVersion = `${DEV_VERSION}-${runNumber}`;
+    const version = `${artifactVersion}+${buildChannel}`;
+    return { version, artifactVersion };
   }
   // Dev build: pinned 0.0.2 + short hash. The hash locates the exact code and
   // keeps distinct branches from colliding on the same display version. A
@@ -66,20 +102,30 @@ export function resolveVersion() {
   // Online (CI) builds are reproducible from the pushed commit, so the hash
   // stands alone. Local builds add `+local` (and `.dirty` for an uncommitted
   // tree) so a tester's laptop build is never confused with the online one.
+  const artifactVersion = `${DEV_VERSION}-${hash}`;
   if (process.env.GITHUB_ACTIONS || process.env.CI) {
-    return `${DEV_VERSION}-${hash}`;
+    return { version: artifactVersion, artifactVersion };
   }
-  return `${DEV_VERSION}-${hash}+local${gitDirty() ? ".dirty" : ""}`;
+  const version = `${artifactVersion}+local${gitDirty() ? ".dirty" : ""}`;
+  return { version, artifactVersion };
+}
+
+/** Resolve only the internal display version for existing callers. */
+export function resolveVersion() {
+  return resolveVersions().version;
 }
 
 /** Short git hash, or "unknown" outside a git checkout (tarball build). */
 function gitShortHash() {
   try {
-    return execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
-      .toString()
-      .trim() || "unknown";
-  }
-  catch {
+    return (
+      execSync("git rev-parse --short HEAD", {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim() || "unknown"
+    );
+  } catch {
     return "unknown";
   }
 }
@@ -87,11 +133,14 @@ function gitShortHash() {
 /** Whether the working tree has uncommitted changes (untracked included). */
 function gitDirty() {
   try {
-    return execSync("git status --porcelain", { stdio: ["ignore", "pipe", "ignore"] })
-      .toString()
-      .trim().length > 0;
-  }
-  catch {
+    return (
+      execSync("git status --porcelain", {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim().length > 0
+    );
+  } catch {
     return false;
   }
 }
@@ -117,15 +166,18 @@ function patchJson(path, version) {
 
 function main() {
   const arg = process.argv[2];
-  const version = resolveVersion();
+  const { version, artifactVersion } = resolveVersions();
 
   switch (arg) {
     case "--json":
-      process.stdout.write(JSON.stringify({
-        version,
-        isRelease: isRelease(version),
-        bundleVersion: bundleVersion(version),
-      }));
+      process.stdout.write(
+        JSON.stringify({
+          version,
+          isRelease: isRelease(version),
+          bundleVersion: bundleVersion(version),
+          artifactVersion,
+        }),
+      );
       break;
 
     case "--github-output": {
@@ -137,6 +189,7 @@ function main() {
         `version=${version}`,
         `is_release=${isRelease(version)}`,
         `bundle_version=${bundleVersion(version)}`,
+        `artifact_version=${artifactVersion}`,
       ].join("\n");
       writeFileSync(out, `${lines}\n`, { flag: "a" });
       break;
@@ -147,12 +200,15 @@ function main() {
       if (!out) {
         throw new Error("usage: version.mjs --gen-ts <path>");
       }
-      writeFileSync(out, [
-        "// Generated by scripts/version.mjs at build time — do not edit or commit.",
-        `export const VERSION = ${JSON.stringify(version)};`,
-        `export const IS_RELEASE = ${isRelease(version)};`,
-        "",
-      ].join("\n"));
+      writeFileSync(
+        out,
+        [
+          "// Generated by scripts/version.mjs at build time — do not edit or commit.",
+          `export const VERSION = ${JSON.stringify(version)};`,
+          `export const IS_RELEASE = ${isRelease(version)};`,
+          "",
+        ].join("\n"),
+      );
       break;
     }
 


### PR DESCRIPTION
## Summary
- turn Build Test into a shared unsigned test or signed nightly release rehearsal across existing platform workflows
- generate channel-aware application versions while keeping OSS directories and public filenames free of SemVer build metadata
- publish independent test and nightly manifests with forward-only pointers, and place standalone macOS/Windows web builds in the dev channel
- keep iOS reusable-only and normalize the displayed workflow job names
- preserve the formal vX.Y.Z release path and version precedence

## Validation
- version resolution matrix, including formal tag precedence
- Node syntax check
- Prettier check for changed workflows and version script
- YAML parse for all GitHub Actions workflows
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- git diff --check

Local test suites were not run; GitHub Actions owns test execution.