### PR TITLE
Fix manual context compaction recovery

### DIFF
--- a/agent/src/compaction/semantic.rs
+++ b/agent/src/compaction/semantic.rs
@@ -215,10 +215,6 @@ fn plan(
     if threshold_gated && tokens_before <= window.saturating_sub(reserve) {
         return Ok(PlannedPreparation::Unchanged(prompt));
     }
-    if let Some(on_started) = on_started {
-        on_started();
-    }
-
     let costs = prompt
         .messages
         .iter()
@@ -258,6 +254,26 @@ fn plan(
         || (cut == prompt.messages.len() && !allow_full_active_turn)
     {
         return Err(ContextError::NoValidBoundary);
+    }
+
+    // A projected prompt may consist solely of the existing internal
+    // checkpoint when the user compacts twice without adding another turn.
+    // That checkpoint is useful model context but is deliberately excluded
+    // from the next summary input. Treat this as a clean no-op instead of
+    // emitting started/failed lifecycle events for an empty summary request.
+    let has_compactable_content = prompt.messages[..cut]
+        .iter()
+        .filter(|item| internal_summary(&item.message).is_none())
+        .any(|item| {
+            !serialize_message(&item.message, SerializationMode::Normal)
+                .trim()
+                .is_empty()
+        });
+    if !has_compactable_content {
+        return Ok(PlannedPreparation::Unchanged(prompt));
+    }
+    if let Some(on_started) = on_started {
+        on_started();
     }
 
     let removed = prompt.messages[..cut].to_vec();
@@ -1492,6 +1508,37 @@ mod tests {
         assert_eq!(checkpoint.trigger, CompactionTrigger::Manual);
         assert_eq!(checkpoint.phase, Some(CompactionPhase::Standalone));
         assert_eq!(provider.requests.lock().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn repeated_manual_compaction_without_new_content_is_unchanged() {
+        let provider = ScriptedProvider::new([]);
+        let mut checkpoint = projected(
+            "user",
+            "[Context compaction: existing summary]",
+            "checkpoint-entry",
+        );
+        crate::compaction::stamp_internal_checkpoint_message(
+            &mut checkpoint.message,
+            "checkpoint-entry",
+        );
+        let mut prompt = test_prompt();
+        prompt.messages = vec![checkpoint];
+
+        let prepared = test_manager()
+            .prepare_semantic_with_phase(
+                prompt,
+                CompactionTrigger::Manual,
+                CompactionPhase::Standalone,
+                None,
+                &provider,
+                &AtomicBool::new(false),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(prepared, ContextPreparation::Unchanged { .. }));
+        assert!(provider.requests.lock().is_empty());
     }
 
     #[test]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -651,6 +651,7 @@ impl ServerSession {
         };
         match prepared {
             crate::compaction::ContextPreparation::Unchanged { prompt } => Ok(serde_json::json!({
+                "alreadyCompacted": active_checkpoint.is_some(),
                 "tokensBefore": prompt.usage.estimated_input_tokens,
                 "tokensAfter": prompt.usage.estimated_input_tokens,
                 "summary": "",
@@ -2712,6 +2713,7 @@ mod tests {
         // session has not filled its in-memory message cache yet.
         session.messages.write().clear();
         let result = session.compact("").unwrap();
+        assert!(result["checkpointId"].as_str().is_some());
         assert!(result["messagesRemoved"].as_i64().unwrap() > 0);
         assert!(result["summary"].is_string());
         let started = events.try_recv().unwrap();
@@ -2721,6 +2723,95 @@ mod tests {
         let started_data: serde_json::Value = serde_json::from_str(&started.data).unwrap();
         let committed_data: serde_json::Value = serde_json::from_str(&committed.data).unwrap();
         assert_eq!(started_data["operation_id"], committed_data["operation_id"]);
+    }
+
+    #[test]
+    fn repeated_manual_compaction_after_restart_uses_persisted_checkpoint() {
+        let mut session = make_test_session("compact-restart");
+        session.agent_loop.try_write().unwrap().provider = Arc::new(SummaryProvider);
+        session.model = "glm-4.5v".to_string();
+        {
+            let mut messages = session.messages.write();
+            for (role, text) in [
+                ("user", "test the tools"),
+                ("assistant", "I will test them"),
+                ("user", "continue"),
+                ("assistant", "all tool tests passed"),
+            ] {
+                messages.push(crate::types::AgentMessage {
+                    role: role.to_string(),
+                    content: vec![crate::types::ContentBlock::text(text)],
+                    ..Default::default()
+                });
+            }
+            for message in messages.iter_mut() {
+                message.ensure_journal_entry_id();
+            }
+            let mut entries = vec![crate::session::SessionEntry::session_info(
+                serde_json::json!({"cwd": session.cwd, "model": session.model}),
+                session.model.clone(),
+                session.thinking_level.clone(),
+            )];
+            entries.extend(messages.iter().map(crate::session::agent_message_to_entry));
+            let snapshot = crate::session::Session::snapshot(
+                session.session_id.clone(),
+                session.cwd.clone(),
+                session.model.clone(),
+                String::new(),
+                String::new(),
+                entries,
+            );
+            session.session_manager.save(&snapshot).unwrap();
+        }
+        let first = session.compact("").unwrap();
+        assert!(first["checkpointId"].as_str().is_some());
+
+        // Simulate an Agent restart: construct a fresh ServerSession against
+        // the same persisted JSONL, with an empty in-memory message cache and a
+        // provider that would fail if a second summary request were attempted.
+        // The durable checkpoint must be enough to recognize a consecutive
+        // manual compaction as a clean no-op across process boundaries.
+        let mut restarted = ServerSession::new(
+            session.session_id.clone(),
+            Arc::new(tokio::sync::RwLock::new(Loop::new(
+                Arc::new(FailingProvider),
+                "mock",
+            ))),
+            session.session_manager.clone(),
+            &session.cwd,
+            Arc::new(SseBroadcaster::new()),
+            ApprovalGate::default(),
+            session.model_registry.clone(),
+        );
+        restarted.model = session.model.clone();
+        let persisted = restarted
+            .session_manager
+            .load(&restarted.session_id)
+            .unwrap();
+        let persisted_checkpoint =
+            crate::session::latest_context_checkpoint(&persisted.entries).unwrap();
+        let restored_messages =
+            crate::session::entries_to_agent_messages(&persisted.entries, false);
+        let restored_prompt = crate::compaction::project_prompt_context(
+            &restored_messages,
+            Some(&persisted_checkpoint),
+            None,
+            64_000,
+        );
+        assert_eq!(restored_prompt.messages.len(), 1);
+        assert_eq!(
+            restored_prompt.messages[0]
+                .message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("internal_context_checkpoint")),
+            Some(&serde_json::Value::Bool(true)),
+        );
+        let mut restarted_events = restarted.broadcaster.subscribe();
+        let repeated = restarted.compact("").unwrap();
+        assert_eq!(repeated["alreadyCompacted"], true);
+        assert_eq!(repeated["messagesRemoved"], 0);
+        assert!(restarted_events.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -585,6 +585,10 @@ pub async fn reload_agent_credentials() -> Result<(), crate::AppError> {
 pub struct SyncFutureModelsResult {
     pub synced: bool,
     pub model_count: usize,
+    // Older Agents predate the typed-RPC revision field. Preserve the legacy
+    // JSON fallback by treating its absence as the initial revision.
+    #[serde(default)]
+    pub revision: i64,
 }
 
 /// Ask the agent to synchronously fetch the Future provider's models (warming
@@ -602,6 +606,7 @@ pub async fn sync_future_models() -> Result<SyncFutureModelsResult, crate::AppEr
             return Ok(SyncFutureModelsResult {
                 model_count: 0,
                 synced: false,
+                revision: 0,
             });
         }
     };
@@ -2068,11 +2073,12 @@ mod bridge_tests {
 
         mock.push_data(
             "sync_future_models",
-            serde_json::json!({"synced": true, "modelCount": 7}),
+            serde_json::json!({"synced": true, "modelCount": 7, "revision": 11}),
         );
         let result = sync_future_models().await.expect("sync");
         assert!(result.synced);
         assert_eq!(result.model_count, 7);
+        assert_eq!(result.revision, 11);
 
         // Down agent → zeroed result.
         let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
@@ -2081,6 +2087,7 @@ mod bridge_tests {
         std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
         assert!(!result.synced);
         assert_eq!(result.model_count, 0);
+        assert_eq!(result.revision, 0);
 
         mock.push(
             "sync_future_models",

--- a/desktop/src-tauri/src/commands/agent.rs
+++ b/desktop/src-tauri/src/commands/agent.rs
@@ -136,6 +136,7 @@ mod tests {
         let result = sync_future_models().await.expect("sync");
         assert!(result.synced);
         assert_eq!(result.model_count, 3);
+        assert_eq!(result.revision, 0);
         script_mock_agent(MockScript::default());
     }
 

--- a/desktop/src/features/agent/AgentThread.tsx
+++ b/desktop/src/features/agent/AgentThread.tsx
@@ -260,7 +260,12 @@ export function AgentThread({
     try {
       const result = await compactThreadContext(thread.id);
       if (!result.checkpointId) {
-        emitFutureEvent("toast", { message: t("composer.compactionNotNeeded"), tone: "info" });
+        emitFutureEvent("toast", {
+          message: t(result.alreadyCompacted
+            ? "composer.compactionNoNewContent"
+            : "composer.compactionNotNeeded"),
+          tone: "info",
+        });
       }
     }
     catch (error) {

--- a/desktop/src/features/agent/Composer.tsx
+++ b/desktop/src/features/agent/Composer.tsx
@@ -297,10 +297,18 @@ function ComposerImpl({
   function submitValue() {
     const trimmed = (editorRef.current?.getContent() ?? "").trim();
     // Block submission while a reply streams (the send button is already an
-    // abort button then; this guard stops Enter from firing a new message) and
-    // while an async send is in flight.
-    if ((!trimmed && attachments.length === 0) || disabled || sendPending || sending)
+    // abort button then), while context compaction is running, and while an
+    // async send is in flight. The editor intentionally remains enabled so the
+    // next message can still be drafted during either operation.
+    if (
+      (!trimmed && attachments.length === 0)
+      || disabled
+      || sendPending
+      || sending
+      || contextActionPending
+    ) {
       return;
+    }
     const clearComposer = () => {
       editorRef.current?.clear();
       setAttachments([]);
@@ -738,7 +746,12 @@ function ComposerImpl({
             : (
                 <button
                   className="inline-flex size-7 items-center justify-center rounded-md bg-accent text-white transition-colors hover:bg-accent-hover disabled:bg-accent-disabled"
-                  disabled={(inputEmpty && attachments.length === 0) || disabled || sendPending}
+                  disabled={
+                    (inputEmpty && attachments.length === 0)
+                    || disabled
+                    || sendPending
+                    || contextActionPending
+                  }
                   type="submit"
                   aria-label={t("composer.send")}
                   title={t("composer.send")}

--- a/desktop/src/features/agent/MessageBlock.tsx
+++ b/desktop/src/features/agent/MessageBlock.tsx
@@ -1,6 +1,6 @@
 import type { AgentMessage, MessageAttachment } from "@future-os/thread-projection";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { FileText, GitBranch, Paperclip, RotateCcw, StepForward } from "lucide-react";
+import { FileText, GitBranch, Paperclip, RotateCcw, StepForward, TriangleAlert } from "lucide-react";
 import { Fragment, memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CopyButton } from "../../components/ui/CopyButton";
@@ -222,6 +222,7 @@ function MessageBlockImpl({
                 <div className="mt-4">
                   <StatusDivider
                     label={message.stopped ? t("thread.responseStopped") : (message.terminationTitle ?? t("thread.responseIncomplete"))}
+                    warning={!message.stopped}
                   />
                   {isLast === true && !message.stopped
                     ? (
@@ -342,22 +343,25 @@ function UserMessageText({ content }: { content: string }) {
   );
 }
 
-function StatusDivider({ label, failed = false, pulsing = false, title }: {
+function StatusDivider({ label, pulsing = false, title, warning = false }: {
   label: string;
-  failed?: boolean;
   pulsing?: boolean;
   title?: string;
+  warning?: boolean;
 }) {
   return (
     <div
       aria-label={label}
       className={cn("flex select-none items-center gap-3 py-1", pulsing && "animate-pulse")}
-      role={failed ? "alert" : "status"}
+      role="status"
       title={title}
     >
-      <span className={cn("h-px flex-1", failed ? "bg-danger/40" : "bg-line")} />
-      <span className={cn("whitespace-nowrap text-xs", failed ? "text-danger" : "text-ink-muted")}>{label}</span>
-      <span className={cn("h-px flex-1", failed ? "bg-danger/40" : "bg-line")} />
+      <span className="h-px flex-1 bg-line" />
+      <span className="flex items-center gap-1 whitespace-nowrap text-xs text-ink-muted">
+        {warning ? <TriangleAlert aria-hidden="true" className="size-3 shrink-0" /> : null}
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-line" />
     </div>
   );
 }
@@ -387,8 +391,14 @@ function CompactionDivider({
               formattedCount: formatNumber(tokensBefore, i18n.language),
             })
           : t("message.compacted");
-  const failed = status === "failed";
-  return <StatusDivider failed={failed} label={label} pulsing={status === "running"} title={error} />;
+  return (
+    <StatusDivider
+      label={label}
+      pulsing={status === "running"}
+      title={error}
+      warning={status === "failed"}
+    />
+  );
 }
 
 /**

--- a/desktop/src/i18n/locales/en/agent.json
+++ b/desktop/src/i18n/locales/en/agent.json
@@ -134,7 +134,8 @@
     "skillsSection": "Skills",
     "compactContext": "Compact",
     "compactContextDescription": "Compact this conversation's context",
-    "compactionNotNeeded": "This conversation does not need compaction yet.",
+    "compactionNotNeeded": "There is no conversation context to compact.",
+    "compactionNoNewContent": "No conversation content was added after the last compaction.",
     "compactionRequestFailed": "Context compaction failed: {{message}}",
     "approval": "Approval mode",
     "approvalTier": {

--- a/desktop/src/i18n/locales/zh/agent.json
+++ b/desktop/src/i18n/locales/zh/agent.json
@@ -135,7 +135,8 @@
     "skillsSection": "技能",
     "compactContext": "压缩",
     "compactContextDescription": "压缩此对话的上下文",
-    "compactionNotNeeded": "当前对话暂时不需要压缩。",
+    "compactionNotNeeded": "当前没有可压缩的对话上下文。",
+    "compactionNoNewContent": "自上次压缩后没有新增对话内容，无需再次压缩。",
     "compactionRequestFailed": "上下文压缩失败：{{message}}",
     "approval": "审批模式",
     "approvalTier": {

--- a/desktop/src/integrations/agent/agentClient.ts
+++ b/desktop/src/integrations/agent/agentClient.ts
@@ -95,6 +95,7 @@ export async function loadAgentModelOptions() {
 
 export interface CompactContextResult {
   checkpointId?: string;
+  alreadyCompacted?: boolean;
   messagesRemoved?: number;
   tokensBefore?: number;
   tokensAfter?: number;
@@ -109,6 +110,7 @@ export function compactThreadContext(threadId: string) {
 export interface SyncFutureModelsResult {
   synced: boolean;
   modelCount: number;
+  revision: number;
 }
 
 /**

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -516,6 +516,8 @@ message CompactResult {
   int64 tokens_after = 2;
   string summary = 3;
   int64 messages_removed = 4;
+  string checkpoint_id = 5;
+  bool already_compacted = 6;
 }
 
 // shell response.
@@ -536,6 +538,7 @@ message CycleModelResult {
 message SyncFutureModelsResult {
   bool synced = 1;
   uint64 model_count = 2;
+  int64 revision = 3;
 }
 
 // refresh_skills response. Field names mirror the wire JSON spelling

--- a/packages/rpc/src/decode.rs
+++ b/packages/rpc/src/decode.rs
@@ -641,6 +641,8 @@ fn commands_from_proto(response: &proto::CommandsResponse) -> crate::payloads_ex
 
 fn compact_from_proto(result: &proto::CompactResult) -> crate::payloads_ext::CompactPayload {
     crate::payloads_ext::CompactPayload {
+        checkpoint_id: (!result.checkpoint_id.is_empty()).then(|| result.checkpoint_id.clone()),
+        already_compacted: result.already_compacted.then_some(true),
         tokens_before: result.tokens_before,
         tokens_after: result.tokens_after,
         summary: result.summary.clone(),
@@ -671,6 +673,7 @@ fn sync_future_models_from_proto(
     crate::payloads_ext::SyncFutureModelsPayload {
         synced: result.synced,
         model_count: result.model_count as usize,
+        revision: result.revision,
     }
 }
 

--- a/packages/rpc/src/encode.rs
+++ b/packages/rpc/src/encode.rs
@@ -573,6 +573,8 @@ fn get_commands(data: &Value) -> Option<proto::CommandsResponse> {
 fn compact(data: &Value) -> Option<proto::CompactResult> {
     let payload: crate::payloads_ext::CompactPayload = serde_json::from_value(data.clone()).ok()?;
     Some(proto::CompactResult {
+        checkpoint_id: payload.checkpoint_id.unwrap_or_default(),
+        already_compacted: payload.already_compacted.unwrap_or(false),
         tokens_before: payload.tokens_before,
         tokens_after: payload.tokens_after,
         summary: payload.summary,
@@ -610,6 +612,7 @@ fn sync_future_models(data: &Value) -> Option<proto::SyncFutureModelsResult> {
     Some(proto::SyncFutureModelsResult {
         synced: payload.synced,
         model_count: payload.model_count as u64,
+        revision: payload.revision,
     })
 }
 

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -497,6 +497,10 @@ pub struct CompactResult {
     pub summary: ::prost::alloc::string::String,
     #[prost(int64, tag = "4")]
     pub messages_removed: i64,
+    #[prost(string, tag = "5")]
+    pub checkpoint_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "6")]
+    pub already_compacted: bool,
 }
 /// shell response.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -524,6 +528,8 @@ pub struct SyncFutureModelsResult {
     pub synced: bool,
     #[prost(uint64, tag = "2")]
     pub model_count: u64,
+    #[prost(int64, tag = "3")]
+    pub revision: i64,
 }
 /// refresh_skills response. Field names mirror the wire JSON spelling
 /// (snake_case).

--- a/packages/rpc/src/parity.rs
+++ b/packages/rpc/src/parity.rs
@@ -476,6 +476,17 @@ fn compact_wire_parity() {
     assert_command_parity(
         "compact",
         json!({
+            "tokensBefore": 0,
+            "tokensAfter": 0,
+            "summary": "",
+            "messagesRemoved": 0
+        }),
+    );
+    assert_command_parity(
+        "compact",
+        json!({
+            "checkpointId": "cp-1",
+            "alreadyCompacted": true,
             "tokensBefore": 100000,
             "tokensAfter": 20000,
             "summary": "The user asked about X.",
@@ -504,7 +515,7 @@ fn cycle_model_wire_parity() {
 fn sync_future_models_wire_parity() {
     assert_command_parity(
         "sync_future_models",
-        json!({"synced": true, "modelCount": 42}),
+        json!({"synced": true, "modelCount": 42, "revision": 7}),
     );
 }
 

--- a/packages/rpc/src/payloads_ext.rs
+++ b/packages/rpc/src/payloads_ext.rs
@@ -175,6 +175,7 @@ pub struct CycleModelPayload {
 pub struct SyncFutureModelsPayload {
     pub synced: bool,
     pub model_count: usize,
+    pub revision: i64,
 }
 
 // ── refresh_skills ───────────────────────────────────────────────────────────
@@ -193,6 +194,10 @@ pub struct RefreshSkillsPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompactPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub already_compacted: Option<bool>,
     pub tokens_before: i64,
     pub tokens_after: i64,
     pub summary: String,


### PR DESCRIPTION
## Summary
- recover repeated manual compaction state across Agent restarts
- distinguish an empty conversation from no new content since the last compaction
- keep status dividers neutral and show warnings without red failure styling
- disable sending, but not drafting, while manual compaction is pending
- complete typed RPC fields for compact results and model revisions

## Validation
- make generate-proto
- cargo fmt --check --all
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- npm --prefix desktop run lint
- git diff --check

Tests are intentionally left to GitHub Actions.