### PR TITLE
feat(loop): align envelope/succession/docs with ARCHITECTURE.md design

### DIFF
--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -380,13 +380,23 @@ It carries **two layers**, and deliberately not a third:
   it is where "durable artifacts, not session memory" actually lands.
 
 **Not in the envelope: the kernel's scheduling internals.** The should-run
-verdict, mode, and reason are the kernel's *own* decision state, addressed
-to the orchestrator and the operator — not to the worker. Putting them in
-the worker's prompt would leak the scheduler's hesitation into the executor
-(a worker's job is how to do the work, not whether the kernel thought it
-should run) and blur the observe/decide split. The envelope tells the
-worker *what to do and the context to do it well*; it does not tell the
+verdict, mode, and arbitration disposition are the kernel's *own* decision
+state, addressed to the orchestrator and the operator — not to the worker.
+Putting them in the worker's prompt would leak the scheduler's hesitation into
+the executor (a worker's job is how to do the work, not whether the kernel
+thought it should run) and blur the observe/decide split. The envelope tells
+the worker *what to do and the context to do it well*; it does not tell the
 worker what the kernel was thinking.
+
+**In the envelope: the observable signals.** Signals (outcome floor,
+oscillation, failure count, no-progress) are a different kind of quantity:
+observations about the *work*, recomputed from the ledger — not the kernel's
+hesitation. Principle 1 promises them as advisories "in the turn envelope",
+and that is where they live: the envelope's context layer carries a `signals`
+block recomputed by the same kernel detectors that render the delivery
+reason's advisories (one detector set, two consumers — the orchestrator reads
+them in the packet reason, the worker reads them in the envelope). What to do
+about a signal is, as everywhere, a decision — never a kernel directive.
 
 **One envelope, no special cases.** A first turn, a resumed turn, and an
 ordinary turn all use the same envelope; the differences fall out of

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -305,11 +305,18 @@ turn envelope 是编排者/内核与 worker 之间唯一的信息接口——wor
   让 worker 不重复劳动、不再踩已知的坑——「持久产物而非 session 记忆」
   正落在这里。
 
-**不在信封里：内核的调度内部状态。** should-run 判定、mode、reason 是内核
-*自己的*决策状态，是给编排者和 operator 看的——不是给 worker 的。把它们
-放进 worker 的 prompt，等于把调度器的犹豫泄漏进执行者（worker 该关心的是
-怎么干活，不是内核觉得该不该跑），也模糊了观察/决策的分离。信封告诉
-worker *做什么、以及做好它所需的上下文*；不告诉 worker 内核在想什么。
+**不在信封里：内核的调度内部状态。** should-run 判定、mode、arbitration
+处置是内核*自己的*决策状态，是给编排者和 operator 看的——不是给 worker
+的。把它们放进 worker 的 prompt，等于把调度器的犹豫泄漏进执行者（worker
+该关心的是怎么干活，不是内核觉得该不该跑），也模糊了观察/决策的分离。信封
+告诉 worker *做什么、以及做好它所需的上下文*；不告诉 worker 内核在想什么。
+
+**在信封里：可观察信号。** 信号（outcome floor、oscillation、失败计数、
+无进展）是另一类量：它们是对*工作本身*的观察、从账本重算——不是调度器的
+犹豫。原则 1 承诺信号以 advisory 形式进 turn envelope，它们确实在那里：
+信封的上下文层携带一个 `signals` 块，由与 delivery reason 的 advisory
+相同的内核检测器重算（一套检测器、两个消费者——编排者从 packet reason 读，
+worker 从信封读）。对信号如何处置，一如全程，是决策而非内核指令。
 
 **一个信封，没有特例。** 第一回合、resume 的回合、普通回合用同一个信封，
 差异完全由账本此刻装着什么自然产生。第一回合的信封自然短（没有失败史、

--- a/orchestration/loop/src/agents/multi_agent.rs
+++ b/orchestration/loop/src/agents/multi_agent.rs
@@ -498,6 +498,47 @@ pub fn successions(store: &Store, goal_id: &str) -> Result<Vec<SuccessionRecord>
     Ok(out)
 }
 
+/// Auto-promote every currently-met succession trigger for `goal_id` by
+/// recording its `SuccessionOccurred` event (the declarative contract says a
+/// primary whose lease expired or whose heartbeat went silent is succeeded
+/// by its `backup_for` peer — the scheduler tick drives this periodically, so
+/// promotion happens without an explicit `agent succession apply`). Idempotent
+/// per trigger episode: re-recording the same (primary, backup, reason)
+/// returns the existing event id (see [`record_succession`]). Returns the
+/// succession records that landed (empty when no trigger is met, the goal is
+/// gone, or no contract is set).
+pub fn auto_promote_successions(
+    store: &mut Store,
+    goal_id: &str,
+    now: u64,
+) -> Result<Vec<SuccessionRecord>> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(vec![]);
+    };
+    let Some(contract) = latest_contract(store, goal_id)? else {
+        return Ok(vec![]);
+    };
+    let candidates = succession_candidates(&goal, &contract, now);
+    for candidate in &candidates {
+        record_succession(store, goal_id, candidate)?;
+    }
+    if candidates.is_empty() {
+        return Ok(vec![]);
+    }
+    // Re-read the ledger and return only the episodes we just promoted, so the
+    // caller sees exactly what landed (already-recorded episodes are returned
+    // with their existing event id, not a duplicate).
+    let promoted = successions(store, goal_id)?
+        .into_iter()
+        .filter(|r| {
+            candidates
+                .iter()
+                .any(|c| c.primary == r.primary && c.backup == r.backup && c.reason == r.reason)
+        })
+        .collect();
+    Ok(promoted)
+}
+
 /// Attention hints for recorded successions — one item per role slot
 /// (latest succession per primary wins). A succession is considered
 /// recovered once the primary's scheduler heartbeat lands at or after the

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3227,6 +3227,7 @@ async fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
         record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
         print_monitor_poll_plan(store, &goal_id)?;
         notify_dead_holders(store, &goal_id).await?;
+        crate::agents::multi_agent::auto_promote_successions(store, &goal_id, now)?;
         return Ok(());
     }
 
@@ -3241,6 +3242,7 @@ async fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
     record_tick_heartbeat(store, &goal_id, &agent, &action, &state)?;
     print_monitor_poll_plan(store, &goal_id)?;
     notify_dead_holders(store, &goal_id).await?;
+    crate::agents::multi_agent::auto_promote_successions(store, &goal_id, now)?;
     Ok(())
 }
 
@@ -4243,9 +4245,6 @@ async fn run_turns(
             turn,
             goal.history.last(),
             true,
-            // G-9: embed the decision summary (mode/reason/arbitration) in
-            // the turn envelope.
-            Some(&packet),
             Some(runs_dir),
             Some(&progress),
             turn_note.as_deref(),
@@ -7324,8 +7323,17 @@ fn cmd_turn(store: &Store, args: &[String]) -> Result<()> {
     let packet =
         crate::decision::decide_for(&goal, std::time::SystemTime::now(), agent_id.as_deref());
     let prev = goal.history.last().filter(|r| r.todo_id == todo_id);
-    let envelope = crate::turn_envelope::compose_turn_envelope(&goal, todo, Some(&packet), prev);
+    let envelope = crate::turn_envelope::compose_turn_envelope(&goal, todo, prev);
     println!("{envelope}");
+    // The worker prompt no longer carries the kernel's scheduling internals
+    // (ARCHITECTURE.md "Not in the envelope"), so surface the decision summary
+    // separately to keep `turn`'s operator visibility into what the kernel
+    // decided for this todo.
+    println!("{}", crate::cli_projection::render_decision_line(&packet));
+    println!("reason: {}", packet.reason);
+    if let Some(arb) = &packet.scheduler_arbitration {
+        println!("arbitration: {}", arb.disposition.as_str());
+    }
     Ok(())
 }
 

--- a/orchestration/loop/src/decision/mod.rs
+++ b/orchestration/loop/src/decision/mod.rs
@@ -52,9 +52,8 @@ use self::goal_boundary::goal_boundary_json;
 use self::heartbeat_recommendation::recommendation;
 use self::identity::identity_gate;
 use self::monitor::{monitor_outcome, MonitorOutcome};
-use self::oscillation::oscillation_replan_reason;
 use self::primary_action::agent_channel;
-use self::stall::{is_monitor_stalled, outcome_floor_breach};
+use self::stall::is_monitor_stalled;
 use crate::quota::error_codes::DecisionReasonCode;
 
 pub use self::arbitration::{
@@ -64,6 +63,7 @@ pub use self::arbitration::{
 pub use self::goal_boundary::compose_goal_boundary;
 pub use self::monitor::{monitor_poll_classification, MONITOR_NO_CHANGE_BACKOFF_SECS};
 pub use self::oscillation::OSCILLATION_PATTERN_LEN;
+pub use self::stall::todo_signals;
 pub use self::stall::{MAX_REPAIR_ATTEMPTS, MONITOR_NO_CHANGE_REPLAN_THRESHOLD};
 pub use crate::quota::slot_accounting::QUOTA_ALLOWED_SLOTS;
 pub use crate::state::now_epoch;
@@ -183,36 +183,11 @@ pub fn decide_for(goal: &Goal, now: SystemTime, agent_id: Option<&str>) -> Shoul
     // observations the agent reads and acts on; the kernel surfaces them in
     // the delivery reason but never converts them into a `replan`.
     if let Some(todo) = runnable_todos.first() {
-        let mut advisories: Vec<String> = vec![];
-        if let Some(signal) = outcome_floor_breach(goal) {
-            advisories.push(format!(
-                "[signal: {signal} — consider changing strategy or superseding a stale todo]"
-            ));
-        }
-        if let Some(signal) = oscillation_replan_reason(goal) {
-            advisories.push(format!(
-                "[signal: {signal} — consider a different validator or splitting the todo]"
-            ));
-        }
-        if todo.failed_attempts > 0 {
-            advisories.push(format!(
-                "[signal: todo {} has {} failed attempt(s) — consider superseding or asking the operator]",
-                todo.id, todo.failed_attempts
-            ));
-        }
-        // LLM-zombie signal (was a forced replan in #343; now an advisory —
-        // the kernel surfaces it, the agent decides whether to restart with a
-        // fresh session).
-        let no_progress_turns = goal
-            .turn_no_progress
-            .iter()
-            .filter(|np| np.todo_id == todo.id)
-            .count() as u32;
-        if no_progress_turns >= LLM_ZOMBIE_TURN_THRESHOLD {
-            advisories.push(format!(
-                "[signal: {no_progress_turns} turns with no write-class tool (write/edit/shell) — the worker may be stuck; consider restarting with a fresh session]"
-            ));
-        }
+        // Rule signals are shared surface: the exact same advisory strings are
+        // recomputed into the turn envelope's context layer (see
+        // `turn_envelope::compose_todo_signals`), so the worker reads what the
+        // orchestrator reads.
+        let advisories: Vec<String> = stall::todo_signals(goal, todo);
         let attempt = todo.failed_attempts + 1;
         let (reason, code) = if attempt > 1 {
             (

--- a/orchestration/loop/src/decision/stall.rs
+++ b/orchestration/loop/src/decision/stall.rs
@@ -1,7 +1,14 @@
 //! Stall semantics — conditions that force a replan instead of delivery:
 //! outcome-floor breaches, exhausted repair budgets, and stalled monitors.
+//! Also owns the shared SIGNAL TEXT: the advisory strings the decision kernel
+//! puts in the delivery reason are the exact strings the turn envelope's
+//! context layer recomputes (ARCHITECTURE.md: signals are advisories surfaced
+//! in the turn envelope; one detector set, two consumers).
 
 use crate::state::{Goal, TaskClass, Todo};
+
+use super::oscillation::oscillation_replan_reason;
+use super::LLM_ZOMBIE_TURN_THRESHOLD;
 
 /// Consecutive no-change monitor polls before the monitor is considered
 /// stalled (LoopX replan trigger).
@@ -29,6 +36,46 @@ pub(crate) fn outcome_floor_breach(goal: &Goal) -> Option<String> {
     } else {
         None
     }
+}
+
+/// The advisory signals for ONE runnable advancement todo, as they appear in
+/// the delivery reason and (recomputed from the ledger) in the turn envelope:
+/// outcome floor, oscillation, failure count, and the LLM-zombie
+/// (no-write-tool) warning. Each is an observation the reading agent acts on;
+/// none of them is a kernel-forced replan. Order and wording are part of the
+/// surface — both consumers must render these verbatim.
+pub fn todo_signals(goal: &Goal, todo: &Todo) -> Vec<String> {
+    let mut advisories: Vec<String> = vec![];
+    if let Some(signal) = outcome_floor_breach(goal) {
+        advisories.push(format!(
+            "[signal: {signal} — consider changing strategy or superseding a stale todo]"
+        ));
+    }
+    if let Some(signal) = oscillation_replan_reason(goal) {
+        advisories.push(format!(
+            "[signal: {signal} — consider a different validator or splitting the todo]"
+        ));
+    }
+    if todo.failed_attempts > 0 {
+        advisories.push(format!(
+            "[signal: todo {} has {} failed attempt(s) — consider superseding or asking the operator]",
+            todo.id, todo.failed_attempts
+        ));
+    }
+    // LLM-zombie signal (was a forced replan in #343; now an advisory —
+    // the kernel surfaces it, the agent decides whether to restart with a
+    // fresh session).
+    let no_progress_turns = goal
+        .turn_no_progress
+        .iter()
+        .filter(|np| np.todo_id == todo.id)
+        .count() as u32;
+    if no_progress_turns >= LLM_ZOMBIE_TURN_THRESHOLD {
+        advisories.push(format!(
+            "[signal: {no_progress_turns} turns with no write-class tool (write/edit/shell) — the worker may be stuck; consider restarting with a fresh session]"
+        ));
+    }
+    advisories
 }
 
 /// Any open advancement todo has blown through its repair budget.

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 
 use crate::agent_client::{AgentClient, RunSummary, TurnProgressTracker};
-use crate::decision::{compose_goal_boundary, compose_turn_envelope, compose_turn_message};
+use crate::decision::{compose_goal_boundary, compose_turn_envelope};
 use crate::state::{
     now_epoch, task_validation_receipt, Goal, RecoveryKind, RunRecord, TaskValidation, Todo,
     ValidationStatus,
@@ -264,9 +264,6 @@ pub fn incomplete_continue_note(streak: u32, max_retries: u32, todo_id: &str) ->
 }
 
 /// Execute one bounded turn for `todo` and return the ledger entry (spend).
-/// `decision_summary` (G-9): the `ShouldRunPacket` from the decision kernel,
-/// embedded in the turn envelope so the agent sees the decision context
-/// (mode / reason / arbitration) alongside the instruction.
 /// `continue_note`: injected at the top of the turn message when the previous
 /// turn ended incomplete (bounded retry).
 #[allow(clippy::too_many_arguments)]
@@ -279,7 +276,6 @@ pub async fn execute_turn(
     turn: u32,
     prev: Option<&RunRecord>,
     boundary_injected: bool,
-    decision_summary: Option<&crate::contract::ShouldRunPacket>,
     runs_dir: Option<std::path::PathBuf>,
     progress: Option<&TurnProgressTracker>,
     continue_note: Option<&str>,
@@ -289,10 +285,7 @@ pub async fn execute_turn(
             .append_system_prompt(session_id, &compose_goal_boundary(goal))
             .await?;
     }
-    let message = match decision_summary {
-        Some(packet) => compose_turn_envelope(goal, todo, Some(packet), prev),
-        None => compose_turn_message(goal, todo, prev),
-    };
+    let message = compose_turn_envelope(goal, todo, prev);
     // Surface the backing agent session id so in-turn tooling (e.g. trace
     // converters) can locate the real session deterministically instead of
     // guessing by file mtime.

--- a/orchestration/loop/src/turn_envelope.rs
+++ b/orchestration/loop/src/turn_envelope.rs
@@ -1,17 +1,26 @@
 //! Turn envelope (G-9) — the per-turn prompt assembly, expanded from the P0
 //! ~30-line `compose_turn_message` into an envelope: instruction + context +
-//! evidence + decision summary (reference `control_plane/quota/turn_envelope.py`,
-//! 796 lines — we implement the minimal deterministic core the host needs).
+//! evidence (reference `control_plane/quota/turn_envelope.py`, 796 lines — we
+//! implement the minimal deterministic core the host needs).
 //!
 //! The envelope is a plain-text prompt for a policy-free agent: one bounded
 //! turn, no loop policy embedded (all policy stays in the decision kernel).
 //! [`compose_turn_message`] keeps the P0 signature used by the gRPC executor
-//! and delegates here; the richer [`compose_turn_envelope`] carries the
-//! decision summary for hosts that have the packet at hand.
+//! and delegates to [`compose_turn_envelope`]. The kernel's scheduling
+//! internals (the should-run verdict, mode, reason, arbitration) are
+//! deliberately NOT in the envelope — they are addressed to the orchestrator
+//! and operator, not the worker (ARCHITECTURE.md "Not in the envelope").
 
-use crate::contract::ShouldRunPacket;
 use crate::decision::truncate;
 use crate::state::{FailureKind, Goal, RunRecord, Todo, TodoStatus};
+
+/// Recompute the todo's advisory signals from the ledger, using the SAME
+/// kernel detectors the delivery reason uses (shared text in
+/// `decision::stall::todo_signals`) — the envelope's advisory channel.
+/// Exported for the envelope; not a decision: the reading agent acts (or not).
+fn compose_todo_signals(goal: &Goal, todo: &Todo) -> Vec<String> {
+    crate::decision::todo_signals(goal, todo)
+}
 
 /// Envelope schema version (reference `TURN_ENVELOPE_SCHEMA_VERSION`).
 pub const TURN_ENVELOPE_SCHEMA_VERSION: &str = "future_loop_turn_envelope_v0";
@@ -20,6 +29,9 @@ pub const TURN_ENVELOPE_SCHEMA_VERSION: &str = "future_loop_turn_envelope_v0";
 const GOAL_MEMORY_SEMANTIC_EVENTS: usize = 5;
 /// Cap the failure-cause text so a runaway error never bloats the prompt.
 const GOAL_MEMORY_ERROR_CHARS: usize = 200;
+/// Cap the combined upstream-evidence summary a fan-in todo's envelope
+/// injects (a wide fan-in must not bloat the prompt).
+const UPSTREAM_EVIDENCE_CHARS: usize = 1_200;
 
 /// Compose the goal-memory block fed to the orchestrating agent every turn.
 ///
@@ -116,40 +128,30 @@ fn failure_label(r: &RunRecord) -> String {
     }
 }
 
-/// Compose the per-turn packet: todo + resolved gate decisions + prior
-/// evidence (+ decision summary when available).
-///
+/// Compose the per-turn packet: todo + resolved gate decisions + upstream
+/// evidence + prior evidence (+ signals when available).///
 /// P0 signature (executor + worker paths) — delegates to the full envelope
-/// without a decision summary so existing call sites keep working.
+/// so existing call sites keep working.
 pub fn compose_turn_message(goal: &Goal, todo: &Todo, prev: Option<&RunRecord>) -> String {
-    compose_turn_envelope(goal, todo, None, prev)
+    compose_turn_envelope(goal, todo, prev)
 }
 
-/// Full envelope: schema header + decision summary (mode/decision/reason) +
-/// goal context + instruction + resolved gate decisions + prior evidence +
-/// completion-contract footer.
-pub fn compose_turn_envelope(
-    goal: &Goal,
-    todo: &Todo,
-    decision_summary: Option<&ShouldRunPacket>,
-    prev: Option<&RunRecord>,
-) -> String {
+/// Full envelope: schema header + goal context + instruction + resolved gate
+/// decisions + upstream evidence (fan-in) + prior evidence + goal memory +
+/// signals + completion-contract footer.
+///
+/// The kernel's scheduling internals (should-run verdict / mode / arbitration)
+/// are deliberately absent: they are the kernel's own decision state, addressed
+/// to the orchestrator and operator, not to the worker (ARCHITECTURE.md "Not
+/// in the envelope"). The OBSERVABLE SIGNALS (outcome floor, oscillation,
+/// failure count, no-progress) are different in kind: they are observations
+/// about the work, computed from the ledger, and the advisory channel the
+/// architecture promises ("surfaces them as advisories in the turn envelope")
+/// — so they ARE recomputed here, from the same kernel detectors the delivery
+/// reason uses (no duplicated logic).
+pub fn compose_turn_envelope(goal: &Goal, todo: &Todo, prev: Option<&RunRecord>) -> String {
     let mut out = String::new();
     out.push_str(&format!("── {TURN_ENVELOPE_SCHEMA_VERSION} ──\n"));
-    if let Some(p) = decision_summary {
-        out.push_str(&format!(
-            "decision: {} | should_run: {} | mode: {}\n",
-            p.decision,
-            p.should_run,
-            p.interaction_contract.mode.as_str()
-        ));
-        out.push_str(&format!("reason: {}\n", p.reason));
-        if let Some(arb) = &p.scheduler_arbitration {
-            out.push_str(&format!("arbitration: {}\n", arb.disposition.as_str()));
-        }
-    } else {
-        out.push_str("decision: bounded_delivery\n");
-    }
     out.push_str(&format!(
         "goal: {} | objective: {}\n",
         goal.goal_id, goal.objective
@@ -179,6 +181,10 @@ pub fn compose_turn_envelope(
         }
     }
 
+    // Upstream evidence: a fan-in (synthesis) todo ordered after its
+    // done/superseded predecessors carries their evidence summaries.
+    out.push_str(&compose_upstream_evidence(goal, todo));
+
     // Evidence from the previous turn.
     if let Some(p) = prev {
         out.push_str(&format!(
@@ -191,16 +197,74 @@ pub fn compose_turn_envelope(
     // Goal memory: prior failures on this todo + recent semantic history.
     out.push_str(&compose_goal_memory(goal, todo));
 
+    // Signals: observations about THIS todo's work, recomputed from the
+    // ledger with the same kernel detectors the delivery reason uses
+    // (outcome floor / oscillation / failure count / no-progress). The
+    // advisory channel the architecture promises; what to do about a signal
+    // stays the worker's decision.
+    let signals = compose_todo_signals(goal, todo);
+    if !signals.is_empty() {
+        out.push_str(&format!("\nsignals: {}\n", signals.join(" ")));
+    }
     // Completion contract footer (LoopX: completion must declare closure intent).
     out.push_str("\n\nComplete the todo and report what you did and observed.");
     out.push_str("\nOn completion, declare the successor todo or --no-follow-up.");
     out
 }
 
+/// Compose the upstream-evidence block for a fan-in (synthesis) todo.
+///
+/// A synthesis todo is ordered after its upstream predecessors by `--blocks`
+/// (each predecessor id sits in `blocked_by_gate`); its envelope injects each
+/// done/superseded predecessor's completion evidence so the synthesis worker
+/// reads what landed instead of re-deriving it (ARCHITECTURE.md
+/// "Worker↔worker: … its envelope injects their evidence and artifact paths").
+///
+/// The combined summary is capped at [`UPSTREAM_EVIDENCE_CHARS`]. Returns an
+/// empty string when there are no done/superseded predecessors with evidence.
+pub fn compose_upstream_evidence(goal: &Goal, todo: &Todo) -> String {
+    let Some(ids) = todo.blocked_by_gate.as_deref() else {
+        return String::new();
+    };
+    let mut entries: Vec<String> = Vec::new();
+    let mut used = 0usize;
+    for gid in ids.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let Some(pred) = goal.todo(gid) else {
+            continue;
+        };
+        if !matches!(pred.status, TodoStatus::Done | TodoStatus::Superseded) {
+            continue;
+        }
+        let Some(evidence) = pred.evidence.as_deref() else {
+            continue;
+        };
+        let evidence = evidence.trim();
+        if evidence.is_empty() {
+            continue;
+        }
+        let remaining = UPSTREAM_EVIDENCE_CHARS.saturating_sub(used);
+        if remaining == 0 {
+            break;
+        }
+        let snippet = truncate(evidence, remaining);
+        used += snippet.chars().count();
+        entries.push(format!("upstream {}: {}", pred.id, snippet));
+    }
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str("\nUpstream evidence:\n");
+    for e in entries {
+        out.push_str(&e);
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contract::TurnMode;
     use crate::state::Todo;
     use std::time::Duration;
 
@@ -257,20 +321,76 @@ mod tests {
     }
 
     #[test]
-    fn envelope_with_decision_summary_embeds_packet() {
+    fn envelope_omits_kernel_scheduling_internals() {
         let mut g = Goal::new("g1", "o", "/tmp");
         g.add(Todo::monitor("M1", "Watch", Duration::from_secs(3600)));
         g.todo_mut("M1").unwrap().resume_when =
             Some(std::time::SystemTime::now() - Duration::from_secs(5));
-        let packet = crate::decision::decide(&g, std::time::SystemTime::now());
-        assert_eq!(packet.interaction_contract.mode, TurnMode::MonitorPoll);
-        let msg = compose_turn_envelope(&g, g.todo("M1").unwrap(), Some(&packet), None);
-        assert!(msg.contains("decision: run"), "envelope: {msg}");
-        assert!(msg.contains("should_run: true"));
-        assert!(msg.contains("mode: monitor_poll"));
+        let msg = compose_turn_envelope(&g, g.todo("M1").unwrap(), None);
+        // The should-run verdict / mode / arbitration are the kernel's own
+        // decision state, addressed to the orchestrator — never the worker.
+        assert!(!msg.contains("decision:"), "decision: leaked: {msg}");
+        assert!(!msg.contains("should_run:"), "should_run: leaked: {msg}");
+        assert!(!msg.contains("mode:"), "mode: leaked: {msg}");
+        assert!(!msg.contains("arbitration:"), "arbitration: leaked: {msg}");
+    }
+
+    #[test]
+    fn envelope_carries_signals_as_advisories() {
+        // Signals are observations about the work, not kernel decision state:
+        // the architecture surfaces them as advisories in the turn envelope,
+        // recomputed from the ledger with the same detectors as the delivery
+        // reason. This goal has a failed attempt + a breached outcome floor.
+        let mut g = Goal::new("g1", "o", "/tmp");
+        g.add(Todo::advancement("T1", "Work"));
+        g.todo_mut("T1").unwrap().failed_attempts = 2;
+        g.execution_profile.outcome_floor_streak_threshold = 3;
+        g.outcome_streak = 4;
+        let msg = compose_turn_message(&g, g.todo("T1").unwrap(), None);
+        assert!(msg.contains("signals: [signal:"), "envelope: {msg}");
         assert!(
-            msg.contains("arbitration:"),
-            "scheduler arbitration recorded"
+            msg.contains("has 2 failed attempt(s)"),
+            "failure-count signal: {msg}"
+        );
+        assert!(
+            msg.contains("outcome floor"),
+            "outcome-floor signal recomputed: {msg}"
+        );
+        // ...and the same detector text the decision kernel emits:
+        let packet = crate::decision::decide(&g, std::time::SystemTime::now());
+        assert!(packet.reason.contains("has 2 failed attempt(s)"));
+        assert!(packet.reason.contains("outcome floor"));
+    }
+
+    #[test]
+    fn envelope_has_no_signals_block_when_clean() {
+        let mut g = Goal::new("g1", "o", "/tmp");
+        g.add(Todo::advancement("T1", "Work"));
+        let msg = compose_turn_message(&g, g.todo("T1").unwrap(), None);
+        assert!(!msg.contains("signals:"), "envelope: {msg}");
+    }
+
+    #[test]
+    fn envelope_injects_upstream_evidence_for_fan_in() {
+        let mut g = Goal::new("g1", "o", "/tmp");
+        let mut up1 = Todo::advancement("U1", "Probe direction A");
+        up1.status = TodoStatus::Done;
+        up1.evidence = Some("direction A landed: found X".to_string());
+        let mut up2 = Todo::advancement("U2", "Probe direction B");
+        up2.status = TodoStatus::Done;
+        up2.evidence = Some("direction B landed: found Y".to_string());
+        g.add(up1);
+        g.add(up2);
+        g.add(Todo::advancement("S1", "Synthesize the probes").blocking(&["U1", "U2"]));
+        let msg = compose_turn_message(&g, g.todo("S1").unwrap(), None);
+        assert!(msg.contains("Upstream evidence:"), "envelope: {msg}");
+        assert!(
+            msg.contains("upstream U1: direction A landed: found X"),
+            "envelope: {msg}"
+        );
+        assert!(
+            msg.contains("upstream U2: direction B landed: found Y"),
+            "envelope: {msg}"
         );
     }
 

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -568,7 +568,6 @@ fn execute_turn_completed_no_validator() {
             1,
             None,
             false,
-            None,
             Some(runs_dir.clone()),
             None,
             None,
@@ -590,7 +589,7 @@ fn execute_turn_completed_no_validator() {
 }
 
 #[test]
-fn execute_turn_with_decision_summary_and_prev() {
+fn execute_turn_with_prev() {
     rt().block_on(async {
         let (addr, _) = spawn_mock(MockState {
             events: completed_events("mock-run-1"),
@@ -599,7 +598,6 @@ fn execute_turn_with_decision_summary_and_prev() {
         .await;
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let (goal, todo) = sample_goal_with_todo();
-        let packet = future_loop::decision::decide_for(&goal, std::time::SystemTime::now(), None);
         let prev = sample_record("completed");
         let record = execute_turn(
             &mut client,
@@ -610,7 +608,6 @@ fn execute_turn_with_decision_summary_and_prev() {
             2,
             Some(&prev),
             true,
-            Some(&packet),
             None,
             None,
             None,
@@ -647,7 +644,6 @@ fn execute_turn_error_turn_skips_validator() {
             1,
             None,
             true,
-            None,
             None,
             None,
             None,
@@ -691,7 +687,6 @@ fn execute_turn_surfaces_agent_truncation_on_incomplete() {
             None,
             None,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -728,7 +723,6 @@ fn execute_turn_leaves_truncation_none_without_agent_end() {
             None,
             None,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -761,7 +755,6 @@ fn execute_turn_validator_pass_and_fail() {
             None,
             None,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -786,7 +779,6 @@ fn execute_turn_validator_pass_and_fail() {
             1,
             None,
             true,
-            None,
             None,
             None,
             None,

--- a/orchestration/loop/tests/cli_projection_contract.rs
+++ b/orchestration/loop/tests/cli_projection_contract.rs
@@ -16,10 +16,8 @@ use future_loop::turn_envelope::{
 fn turn_envelope_carries_decision_context() {
     let mut goal = Goal::new("g1", "Ship the platform", "/tmp");
     goal.add(Todo::advancement("T1", "Implement the adapter"));
-    let packet = decide(&goal, std::time::SystemTime::now());
-    let msg = compose_turn_envelope(&goal, goal.todo("T1").unwrap(), Some(&packet), None);
+    let msg = compose_turn_envelope(&goal, goal.todo("T1").unwrap(), None);
     assert!(msg.contains(TURN_ENVELOPE_SCHEMA_VERSION));
-    assert!(msg.contains("decision: run"), "decision banner");
     assert!(msg.contains("objective: Ship the platform"), "goal context");
     assert!(
         msg.contains("execution: cadence="),
@@ -31,10 +29,10 @@ fn turn_envelope_carries_decision_context() {
     );
     assert!(msg.contains("Complete the todo and report what you did and observed."));
     assert!(msg.contains("--no-follow-up"), "completion contract footer");
-    assert!(
-        msg.contains("arbitration:"),
-        "scheduler arbitration in envelope"
-    );
+    // The kernel's scheduling internals are NOT part of the worker prompt.
+    assert!(!msg.contains("decision:"), "decision: leaked: {msg}");
+    assert!(!msg.contains("should_run:"), "should_run: leaked: {msg}");
+    assert!(!msg.contains("arbitration:"), "arbitration: leaked: {msg}");
 }
 
 #[test]
@@ -65,6 +63,30 @@ fn turn_envelope_includes_prior_evidence_and_gate_decisions() {
     assert!(msg.contains("Resolved gate decision(s): G1: approved"));
     assert!(msg.contains("Evidence from the previous turn (todo T0)"));
     assert!(msg.contains("prior evidence payload"));
+}
+
+#[test]
+fn turn_envelope_injects_upstream_evidence_for_fan_in() {
+    let mut goal = Goal::new("g1", "o", "/tmp");
+    let mut up1 = Todo::advancement("U1", "Probe direction A");
+    up1.status = future_loop::state::TodoStatus::Done;
+    up1.evidence = Some("direction A landed: found X".into());
+    let mut up2 = Todo::advancement("U2", "Probe direction B");
+    up2.status = future_loop::state::TodoStatus::Done;
+    up2.evidence = Some("direction B landed: found Y".into());
+    goal.add(up1);
+    goal.add(up2);
+    goal.add(Todo::advancement("S1", "Synthesize the probes").blocking(&["U1", "U2"]));
+    let msg = compose_turn_message(&goal, goal.todo("S1").unwrap(), None);
+    assert!(msg.contains("Upstream evidence:"), "envelope: {msg}");
+    assert!(
+        msg.contains("upstream U1: direction A landed: found X"),
+        "envelope: {msg}"
+    );
+    assert!(
+        msg.contains("upstream U2: direction B landed: found Y"),
+        "envelope: {msg}"
+    );
 }
 
 // ── CLI projection: quota output includes breakdown + usage summary ────────

--- a/orchestration/loop/tests/executor_env_drive.rs
+++ b/orchestration/loop/tests/executor_env_drive.rs
@@ -41,7 +41,6 @@ fn validator_spawn_failure_is_inconclusive() {
             None,
             None,
             None,
-            None,
         )
         .await
         .unwrap();

--- a/orchestration/loop/tests/multi_agent_contract.rs
+++ b/orchestration/loop/tests/multi_agent_contract.rs
@@ -9,11 +9,12 @@
 use std::collections::BTreeMap;
 
 use future_loop::agents::multi_agent::{
-    apply_recipe_onboard, collective_turn_ledger, contract_issues, latest_contract, recipe_named,
-    recipes, record_contract, record_recipe, record_succession, succession_attention_items,
-    succession_candidates_with, successions, wake_roster, AgentRecipe, HandoffRule,
-    MultiAgentContract, PeerRole, SuccessionCandidate, MULTI_AGENT_CONTRACT_SCHEMA_VERSION,
-    MULTI_AGENT_RECIPE_SCHEMA_VERSION, SUCCESSION_REASON_LEASE_EXPIRED, SUCCESSION_REASON_OFFLINE,
+    apply_recipe_onboard, auto_promote_successions, collective_turn_ledger, contract_issues,
+    latest_contract, recipe_named, recipes, record_contract, record_recipe, record_succession,
+    succession_attention_items, succession_candidates_with, successions, wake_roster, AgentRecipe,
+    HandoffRule, MultiAgentContract, PeerRole, SuccessionCandidate,
+    MULTI_AGENT_CONTRACT_SCHEMA_VERSION, MULTI_AGENT_RECIPE_SCHEMA_VERSION,
+    SUCCESSION_REASON_LEASE_EXPIRED, SUCCESSION_REASON_OFFLINE,
 };
 use future_loop::state::{now_epoch, Goal, Priority, Todo};
 use future_loop::store::{Event, Store};
@@ -507,6 +508,44 @@ fn succession_triggers_on_offline_heartbeat() {
         .unwrap();
     let goal = store.replay("g1").unwrap().unwrap();
     assert!(succession_candidates_with(&goal, &contract, now, 600).is_empty());
+}
+
+#[test]
+fn auto_promote_records_succession_and_is_idempotent() {
+    let root = tmp_root("auto-promote");
+    let mut store = Store::open(&root).unwrap();
+    goal_with_primary(&mut store, "g1");
+    let contract = contract_with_backup();
+    record_contract(&mut store, "g1", &contract).unwrap();
+
+    let now = now_epoch();
+    // Primary heartbeated two hours ago → offline past the default 30m
+    // threshold, with no manual `apply` in sight.
+    store
+        .append(Event::SchedulerTicked {
+            goal_id: "g1".into(),
+            agent_id: "primary".into(),
+            action: "tick".into(),
+            rrule: None,
+            ts: now - 7200,
+        })
+        .unwrap();
+
+    // Auto-promotion lands a SuccessionOccurred event without `apply`.
+    let promoted = auto_promote_successions(&mut store, "g1", now).unwrap();
+    assert_eq!(promoted.len(), 1);
+    assert_eq!(promoted[0].primary, "primary");
+    assert_eq!(promoted[0].backup, "backup");
+    assert_eq!(promoted[0].reason, SUCCESSION_REASON_OFFLINE);
+    let recorded = successions(&store, "g1").unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].event_id, promoted[0].event_id);
+
+    // Re-running is idempotent: same event id, no duplicate.
+    let again = auto_promote_successions(&mut store, "g1", now).unwrap();
+    assert_eq!(again.len(), 1);
+    assert_eq!(again[0].event_id, promoted[0].event_id);
+    assert_eq!(successions(&store, "g1").unwrap().len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Closes the gaps between the rewritten design doc (\#451) and the code/SKILL.md. Three alignment slices:

**1. Turn envelope — scheduling internals out, observable signals in**
- `compose_turn_envelope` no longer embeds the should-run verdict / mode / arbitration in the worker prompt (ARCHITECTURE.md: 'Not in the envelope: the kernel's scheduling internals'). In practice those lines were constant noise (`run`/`true` every turn — non-run modes break before an envelope is built).
- The advisory **signals** (failure count / outcome floor / oscillation / no-progress) now ride the envelope's context layer as a `signals:` block, recomputed from the ledger via the **same kernel detectors** that render the delivery reason (`stall::todo_signals` is the single shared text — one detector set, two consumers). This resolves the doc's own contradiction: principle 1 promises signals 'as advisories in the turn envelope', while the envelope section banned the `reason` line that carried them.
- `future loop turn` prints the decision summary separately, keeping operator visibility (`cli_registry_contract` green).
- Fan-in synthesis todos now receive their done/superseded `--blocks` predecessors' evidence in the envelope ('its envelope injects their evidence and artifact paths').

**2. Succession auto-promotion**
- `backup_for` edges now actually auto-promote: `scheduler_tick` drives `auto_promote_successions` at both dead-holder check sites (idempotent via `record_succession`'s dedup). Previously the doc said 'auto-promoted (event + attention alert)' but only a manual `agent succession apply` landed the event. `show`/`apply` manual semantics unchanged.

**3. Docs (ARCHITECTURE.md + zh-CN)**
- The envelope rule is split into two explicit statements: scheduling internals never in the envelope; observable signals always recomputed in. No behavior text contradicts principle 1 anymore.

Tests: envelope no-leak / signals-parity-with-delivery-reason / fan-in evidence / succession auto-promote + idempotency; `execute_turn` loses the packet parameter (callers updated). Scoped verification: `cargo test -p future-loop` (64 suites green), clippy `--all-targets -D warnings`, fmt — per the updated CLAUDE.md guidance for module-scoped PRs.