### PR TITLE
fix(desktop): handle PowerPoint clipboard images

### DIFF
--- a/desktop/src-tauri/src/commands/files.rs
+++ b/desktop/src-tauri/src/commands/files.rs
@@ -295,8 +295,8 @@ fn safe_file_name(name: &str) -> String {
     }
 }
 
-/// Decode an image and write a downscaled JPEG thumbnail under
-/// `~/.future/app/images/<thread_id>/thumb/<stamp>.jpg`, returning its path.
+/// Decode an image and write a downscaled PNG thumbnail under
+/// `~/.future/app/images/<thread_id>/thumb/<stamp>.png`, returning its path.
 /// Done entirely in Rust so the full-size image (up to tens of MB) never crosses
 /// the IPC bridge to a webview canvas — only the tiny thumbnail is produced. The
 /// decoder's allocation is capped to reject decompression bombs. Returns an error
@@ -335,20 +335,21 @@ pub fn generate_image_thumbnail(
         .map_err(|error| format!("undecodable image: {error}"))?;
     let thumb = img.resize(MAX_EDGE, MAX_EDGE, image::imageops::FilterType::Lanczos3);
 
+    let rgba = thumb.to_rgba8();
     let mut buf = Vec::new();
-    let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, 70);
+    let encoder = image::codecs::png::PngEncoder::new(&mut buf);
     image::ImageEncoder::write_image(
         encoder,
-        thumb.to_rgb8().as_raw(),
+        rgba.as_raw(),
         thumb.width(),
         thumb.height(),
-        image::ExtendedColorType::Rgb8,
+        image::ExtendedColorType::Rgba8,
     )
     .map_err(|error| format!("thumbnail encode failed: {error}"))?;
 
     let dir = crate::store::thread_images_dir(&thread_id)?.join("thumb");
     std::fs::create_dir_all(&dir)?;
-    let path = dir.join(format!("{}.jpg", unique_stamp()));
+    let path = dir.join(format!("{}.png", unique_stamp()));
     std::fs::write(&path, &buf)?;
     Ok(path.display().to_string())
 }
@@ -943,16 +944,20 @@ mod tests {
     }
 
     #[test]
-    fn thumbnail_generates_a_jpeg_for_a_real_image() {
+    fn thumbnail_generates_a_png_and_preserves_alpha() {
         let home = crate::auth_store::test_support::HomeGuard::new("files_thumb_ok");
         let root = future_root("thumb_src2");
         let src = root.join("in.png");
-        image::RgbImage::from_pixel(8, 8, image::Rgb([7, 8, 9]))
+        image::RgbaImage::from_pixel(8, 8, image::Rgba([7, 8, 9, 0]))
             .save(&src)
             .unwrap();
         let thumb = generate_image_thumbnail("thread_x".into(), src.display().to_string()).unwrap();
-        assert!(thumb.ends_with(".jpg"));
+        assert!(thumb.ends_with(".png"));
         assert!(Path::new(&thumb).is_file());
+        assert_eq!(
+            image::open(&thumb).unwrap().to_rgba8().get_pixel(0, 0).0,
+            [7, 8, 9, 0]
+        );
         drop(home);
     }
 

--- a/desktop/src/components/ui/Overlay.tsx
+++ b/desktop/src/components/ui/Overlay.tsx
@@ -9,10 +9,13 @@ import { useOverlayLayer } from "./overlayStack";
  * the backdrop tint, z-index, and escape handling live in one place.
  */
 export function Overlay({
+  backdropBlur = "default",
   children,
   onClose,
   open,
 }: {
+  /** File/image previews can request a stronger blur without affecting dialogs. */
+  backdropBlur?: "default" | "strong";
   children: ReactNode;
   onClose: () => void;
   open: boolean;
@@ -43,7 +46,7 @@ export function Overlay({
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
       <button
         aria-label={t("close")}
-        className="absolute inset-0 cursor-default bg-overlay backdrop-blur-[1px]"
+        className={`absolute inset-0 cursor-default bg-overlay ${backdropBlur === "strong" ? "backdrop-blur-md" : "backdrop-blur-sm"}`}
         onClick={onClose}
         type="button"
       />

--- a/desktop/src/features/agent/MentionEditor.test.ts
+++ b/desktop/src/features/agent/MentionEditor.test.ts
@@ -3,7 +3,7 @@
 import type { ContextToolOption, SkillMentionOption } from "./MentionEditor";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MentionEditor } from "./MentionEditor";
 import { buildSlashMenuGroups, hasMixedSlashResults } from "./slashMenu";
 
@@ -26,6 +26,73 @@ describe("mention editor", () => {
     expect(editor.getAttribute("autocorrect")).toBe("off");
     expect(editor.getAttribute("spellcheck")).toBe("false");
 
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("prefers plain text when the clipboard also contains an image", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onPasteImages = vi.fn();
+    act(() => {
+      root.render(createElement(MentionEditor, {
+        onPasteImages,
+        onSubmit: () => {},
+        placeholder: "Message",
+      }));
+    });
+
+    const editor = container.querySelector<HTMLElement>("[role=\"textbox\"]")!;
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const image = new File(["image"], "rendered.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: (type: string) => type === "text/plain" ? "editable text" : "",
+        items: [{ getAsFile: () => image, kind: "file", type: "image/png" }],
+      },
+    });
+
+    act(() => editor.dispatchEvent(event));
+
+    expect(editor.textContent).toBe("editable text");
+    expect(onPasteImages).not.toHaveBeenCalled();
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("attaches an image-only clipboard", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onPasteImages = vi.fn();
+    act(() => {
+      root.render(createElement(MentionEditor, {
+        onPasteImages,
+        onSubmit: () => {},
+        placeholder: "Message",
+      }));
+    });
+
+    const editor = container.querySelector<HTMLElement>("[role=\"textbox\"]")!;
+    const image = new File(["image"], "image.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: () => "",
+        items: [{ getAsFile: () => image, kind: "file", type: "image/png" }],
+      },
+    });
+
+    act(() => editor.dispatchEvent(event));
+
+    expect(onPasteImages).toHaveBeenCalledWith([image]);
     act(() => root.unmount());
     container.remove();
   });

--- a/desktop/src/features/agent/MentionEditor.tsx
+++ b/desktop/src/features/agent/MentionEditor.tsx
@@ -481,12 +481,15 @@ export function MentionEditor({
   }
 
   function handlePaste(event: ReactClipboardEvent<HTMLDivElement>) {
-    // Pasted images become attachments (handled by the parent), never editor text.
+    // Some apps (notably PowerPoint on macOS) publish both a rendered image and
+    // plain text for copied text boxes. Prefer the editable representation when
+    // both are present; a clipboard that contains only images still attaches.
+    const text = event.clipboardData.getData("text/plain");
     const imageFiles = Array.from(event.clipboardData.items)
       .filter(item => item.kind === "file" && item.type.startsWith("image/"))
       .map(item => item.getAsFile())
       .filter((file): file is File => file !== null);
-    if (imageFiles.length > 0) {
+    if (text.length === 0 && imageFiles.length > 0) {
       event.preventDefault();
       onPasteImages?.(imageFiles);
       return;
@@ -494,7 +497,6 @@ export function MentionEditor({
 
     // Otherwise force plain text so pasted rich HTML can't smuggle markup or
     // block nodes into the editor.
-    const text = event.clipboardData.getData("text/plain");
     event.preventDefault();
     const selection = window.getSelection();
     if (!selection || selection.rangeCount === 0)

--- a/desktop/src/features/agent/MessageBlock.tsx
+++ b/desktop/src/features/agent/MessageBlock.tsx
@@ -441,14 +441,14 @@ function AttachmentChip({ attachment }: { attachment: MessageAttachment }) {
     return (
       <>
         <button
-          className="inline-flex items-center overflow-hidden rounded-md ring-1 ring-line-soft transition-shadow hover:ring-line"
+          className="inline-flex max-w-64 items-center overflow-hidden rounded-md"
           onClick={handleOpen}
           title={attachment.name}
           type="button"
         >
           <img
             alt={attachment.name}
-            className="size-16 object-cover"
+            className="max-h-64 max-w-64 object-contain"
             onError={() => setFailed(true)}
             src={convertFileSrc(attachment.thumbnail)}
           />

--- a/desktop/src/features/filepreview/FilePreviewOverlay.tsx
+++ b/desktop/src/features/filepreview/FilePreviewOverlay.tsx
@@ -50,7 +50,7 @@ export function FilePreviewOverlay({
     return null;
 
   return (
-    <Overlay onClose={onClose} open={open}>
+    <Overlay backdropBlur={kind === "image" ? "strong" : "default"} onClose={onClose} open={open}>
       <IconButton
         className="fixed right-4 top-4 z-10 bg-surface/80 text-ink shadow-panel hover:bg-surface"
         icon={<X className="size-5" />}


### PR DESCRIPTION
## Summary
- prefer copied plain text over a simultaneous PowerPoint image representation
- preserve alpha in generated PNG attachment thumbnails
- keep attachment previews proportional and strengthen preview backdrop blur

## Validation
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings
- npm run lint (desktop)
- GitHub Actions owns test execution