### PR TITLE
ci: per-surface apt install — workspace PRs skip the GUI stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,20 +210,33 @@ jobs:
       # protobuf-compiler is needed only for the `proto codegen is fresh` step
       # below — normal builds never run protoc (generation is gated on
       # REGENERATE_PROTO).
-      - name: Install Linux deps
+      # Base toolchain packages always; the WebKit/GTK/SSL stack ONLY when the
+      # desktop backend is affected (clippy links its -sys build scripts, which
+      # need pkg-config to find the libs). A loop-only PR skips ~40-60s of apt
+      # (the historical flake point: apt fetching from a slow Azure mirror),
+      # and protobuf-compiler is only needed for the proto-freshness step.
+      - name: Install Linux deps (base)
         if: steps.affected.outputs.run == 'true'
         run: |
           bash scripts/ci/install-apt-packages.sh \
             build-essential \
             binutils \
             mold \
-            pkg-config \
+            pkg-config
+
+      # protobuf-compiler is needed only for the `proto codegen is fresh` step
+      # below — normal builds never run protoc (generation is gated on
+      # REGENERATE_PROTO). Install it in that step's own condition so proto-
+      # unrelated PRs skip it entirely.
+      - name: Install Linux deps (desktop GUI stack)
+        if: steps.affected.outputs.run == 'true' && needs.changes.outputs.desktop_tauri == 'true'
+        run: |
+          bash scripts/ci/install-apt-packages.sh \
             libayatana-appindicator3-dev \
             libgtk-3-dev \
             librsvg2-dev \
             libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            protobuf-compiler
+            libwebkit2gtk-4.1-dev
 
       # tauri-build's build script aborts with `resource path ... doesn't exist`
       # unless every `bundle.externalBin` sidecar is present. For lint empty
@@ -246,6 +259,10 @@ jobs:
       # checked in; guard against proto edits that skip `make generate-proto`.
       # Output is deterministic for pinned prost/tonic-build, so a regenerate
       # on the same source must be a no-op.
+      - name: Install protoc
+        if: steps.affected.outputs.run == 'true' && needs.changes.outputs.proto == 'true'
+        run: bash scripts/ci/install-apt-packages.sh protobuf-compiler
+
       - name: proto codegen is fresh
         if: steps.affected.outputs.run == 'true' && needs.changes.outputs.proto == 'true'
         run: |
@@ -454,14 +471,22 @@ jobs:
           cache-on-failure: true
           cache-all-crates: true
 
-      - name: Install Linux system dependencies
+      # Base toolchain always (when Linux runs); the WebKit/GTK/SSL stack only
+      # when the desktop backend is actually affected - a workspace-only PR
+      # skips ~40-60s of apt (the historical flake point).
+      - name: Install Linux system dependencies (base)
         if: (needs.changes.outputs.rust_workspace == 'true' || needs.changes.outputs.desktop_tauri == 'true') && runner.os == 'Linux'
         run: |
           bash scripts/ci/install-apt-packages.sh \
             build-essential \
             binutils \
             mold \
-            pkg-config \
+            pkg-config
+
+      - name: Install Linux system dependencies (desktop GUI stack)
+        if: needs.changes.outputs.desktop_tauri == 'true' && runner.os == 'Linux'
+        run: |
+          bash scripts/ci/install-apt-packages.sh \
             libayatana-appindicator3-dev \
             libgtk-3-dev \
             librsvg2-dev \

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4344,6 +4344,22 @@ async fn run_turns(
                 s.instruction
             ))
         });
+        // Persist the consumption BEFORE the turn runs: if this run dies
+        // mid-turn, the next run still must not re-inject the stale steer.
+        if let Some(steer) = goal.pending_steer.as_ref() {
+            if steer_note
+                .as_ref()
+                .is_some_and(|n| n.contains(steer.instruction.as_str()))
+            {
+                store.append(Event::SteerConsumed {
+                    goal_id: goal_id.to_string(),
+                    agent_id: steer.agent_id.clone(),
+                    steer_ts: steer.ts,
+                    ts: now_epoch(),
+                })?;
+                last_steer_ts = steer.ts;
+            }
+        }
         let continue_note = next_continue_note.take();
         let turn_note = steer_note.or(continue_note);
         let turn_future = execute_turn(
@@ -7583,6 +7599,7 @@ fn describe_event(event: &crate::store::Event) -> String {
     use crate::store::Event;
     let kind = match event {
         Event::GoalStarted { .. } => "goal_started",
+        Event::SteerConsumed { .. } => "steer_consumed",
         Event::TodoAdded { .. } => "todo_added",
         Event::TodoCompleted {
             todo_id,

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -587,6 +587,18 @@ pub enum Event {
         instruction: String,
         ts: u64,
     },
+    /// A run client drained a `WorkerSteered` instruction into a turn
+    /// envelope. Clears the goal's `pending_steer` on replay so a NEW run
+    /// (whose in-memory steer cursor starts at zero) never re-injects the
+    /// stale instruction into its first turn. `agent_id` mirrors the steer's
+    /// targeting; `None` broadcasts consumed every matching broadcast steer.
+    SteerConsumed {
+        goal_id: String,
+        #[serde(default)]
+        agent_id: Option<String>,
+        steer_ts: u64,
+        ts: u64,
+    },
     /// An operator asked a worker to STOP: interrupt any in-flight turn and
     /// exit the run loop at the next turn boundary (unlike `WorkerSteered`,
     /// which drains an instruction and keeps running). `agent_id` `None`
@@ -644,6 +656,7 @@ impl Event {
             | Event::ReplanRuleSetUpdated { goal_id, .. }
             | Event::SupervisorRegistered { goal_id, .. }
             | Event::WorkerSteered { goal_id, .. }
+            | Event::SteerConsumed { goal_id, .. }
             | Event::WorkerStopped { goal_id, .. }
             | Event::WorkerSessionBound { goal_id, .. } => goal_id,
         }
@@ -1991,6 +2004,22 @@ fn apply(goal: &mut Goal, event: Event) {
                 instruction,
                 ts,
             });
+        }
+        // A run client drained the steer into a turn envelope — clear it so
+        // a NEW run (whose in-memory cursor starts at zero) never re-injects
+        // the stale instruction into its first turn. Latest-wins: only clear
+        // when the goal still holds the SAME steer episode (a newer steer may
+        // have arrived between the drain and this event's replay).
+        Event::SteerConsumed {
+            agent_id, steer_ts, ..
+        } => {
+            let same_episode = goal
+                .pending_steer
+                .as_ref()
+                .is_some_and(|s| s.ts == steer_ts && s.agent_id == agent_id);
+            if same_episode {
+                goal.pending_steer = None;
+            }
         }
         // Projection-only: the run client tails the raw ledger for it; replay
         // deliberately ignores it (a stale stop must not kill future runs).

--- a/orchestration/loop/tests/steer_consumed.rs
+++ b/orchestration/loop/tests/steer_consumed.rs
@@ -1,0 +1,76 @@
+//! Steer consumption: once a run drains a `WorkerSteered` instruction into a
+//! turn envelope, the appended `SteerConsumed` event clears `pending_steer`
+//! on replay — so a NEW run client (whose in-memory cursor starts at zero)
+//! never re-injects the stale instruction into its first turn.
+
+use future_loop::state::now_epoch;
+use future_loop::store::{Event, Store};
+
+#[test]
+fn steer_consumed_clears_pending_steer_and_matches_episode() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("loop-root");
+    let mut store = Store::open(root.to_str().unwrap()).unwrap();
+    let goal = future_loop::state::Goal::new("g", "steer", "/tmp");
+    store.register(&goal).unwrap();
+    store
+        .append(Event::GoalStarted {
+            goal_id: "g".into(),
+            ts: 1,
+        })
+        .unwrap();
+
+    let steer_ts = now_epoch() - 10;
+    store
+        .append(Event::WorkerSteered {
+            goal_id: "g".into(),
+            agent_id: Some("w".into()),
+            instruction: "redirect".into(),
+            ts: steer_ts,
+        })
+        .unwrap();
+    let g = store.replay("g").unwrap().unwrap();
+    assert!(
+        g.pending_steer.is_some(),
+        "steer pending before consumption"
+    );
+
+    // The run drains THE SAME episode → cleared.
+    store
+        .append(Event::SteerConsumed {
+            goal_id: "g".into(),
+            agent_id: Some("w".into()),
+            steer_ts,
+            ts: now_epoch(),
+        })
+        .unwrap();
+    let g = store.replay("g").unwrap().unwrap();
+    assert!(
+        g.pending_steer.is_none(),
+        "consumed steer must not re-inject"
+    );
+
+    // A newer steer with a different ts is NOT cleared by a stale consumption.
+    let newer_ts = now_epoch();
+    store
+        .append(Event::WorkerSteered {
+            goal_id: "g".into(),
+            agent_id: Some("w".into()),
+            instruction: "newer redirect".into(),
+            ts: newer_ts,
+        })
+        .unwrap();
+    store
+        .append(Event::SteerConsumed {
+            goal_id: "g".into(),
+            agent_id: Some("w".into()),
+            steer_ts, // stale consumption of the OLD episode
+            ts: now_epoch(),
+        })
+        .unwrap();
+    let g = store.replay("g").unwrap().unwrap();
+    assert!(
+        g.pending_steer.is_some(),
+        "latest-wins: a stale consumption must not clear a newer steer"
+    );
+}


### PR DESCRIPTION
Direct fix for the recurring 'Install Linux deps' flakes (exit 124 on apt downloading ~170 packages from the slow Azure mirror — hit 3× today).

Split every 'Install Linux deps' step by affected surface:
- **base always**: build-essential, binutils, mold, pkg-config (~10 packages, fast)
- **GUI stack (WebKit/GTK/indicator/SSL) only when desktop_tauri is affected** — clippy links its -sys build scripts, so workspace-only changes never need it
- **protobuf-compiler moves into the proto-freshness step's own condition** (only step that runs protoc)

Also split the same way in the build-check job. The tests matrix already gated GUI packages per group. Net effect: loop-only PRs (like today's three) skip ~40-60s of apt and the flake point entirely.