### PR TITLE
refactor(loop): extract is_delivery_verified — fixes clippy 1.96 lint break

### DIFF
--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -1335,11 +1335,17 @@ impl Goal {
                     // the todo's validator): without it such a goal could never
                     // reach terminal closure.
                     && !self.has_passed_validation(&t.id)
-                    && !self
-                        .delivery_state(&t.id)
-                        .is_some_and(|d| d.outcome == crate::work_items::delivery_outcome::OUTCOME_VERIFIED)
+                    && !self.is_delivery_verified(&t.id)
             })
             .collect()
+    }
+
+    /// Whether the orchestrator explicitly resolved this todo's delivery as
+    /// verified (the delivery-closure judgement that #465 lets satisfy the
+    /// validator-receipt floor for pre-receipt-era completions).
+    fn is_delivery_verified(&self, todo_id: &str) -> bool {
+        self.delivery_state(todo_id)
+            .is_some_and(|d| d.outcome == crate::work_items::delivery_outcome::OUTCOME_VERIFIED)
     }
 
     /// Whether any run record for `todo_id` carries a passed independent


### PR DESCRIPTION
#465 nested a `!delivery_state(...).is_some_and(...)` inside the `unvalidated_deliveries` filter; clippy 1.96 (local Homebrew toolchain) flags it as a simplifiable boolean → `make lint-rust` exited 101, which in turn made goal_95c5's close-out verify gate fail. Extracted into a named `is_delivery_verified` helper: same semantics, both 1.96 and 1.97 clean.

Also surfaced during the close-out audit: 8 of goal_95c5's validator receipts were backfilled after honestly re-running each `--verify` command (all green); the 9th (`make lint-rust && make test`) passed only after this fix.