### PR TITLE
fix(loop): dual-mode supervisor notes + derive run index on read (drop the append)

### DIFF
--- a/orchestration/loop/src/agents/supervisor.rs
+++ b/orchestration/loop/src/agents/supervisor.rs
@@ -233,6 +233,7 @@ pub fn build_supervisor_event_projection(
     let mut proposals: Vec<(String, String, String, String, u64)> = vec![];
     let mut receipts: Vec<(&str, &str)> = vec![];
     let mut progress: Vec<(String, String, String, u64)> = vec![];
+    let mut notes: Vec<(String, String, String, String, u64)> = vec![];
     for stored in &events {
         match &stored.event {
             Event::SupervisorProposed {
@@ -268,6 +269,23 @@ pub fn build_supervisor_event_projection(
             } if g == goal_id => {
                 progress.push((agent_id.clone(), todo_id.clone(), message.clone(), *ts))
             }
+            // Supervisor intervention notes (todo completed/failed/infra-stop/
+            // ask_user/host_died) — the durable half of the dual-mode notify
+            // (ledgered first, then pushed). Polled via `supervisor events`.
+            Event::SupervisorNote {
+                goal_id: g,
+                todo_id,
+                note_kind,
+                message,
+                dedup_key,
+                ts,
+            } if g == goal_id => notes.push((
+                todo_id.clone(),
+                note_kind.clone(),
+                message.clone(),
+                dedup_key.clone(),
+                *ts,
+            )),
             _ => {}
         }
     }
@@ -305,6 +323,18 @@ pub fn build_supervisor_event_projection(
             })
         })
         .collect();
+    let note_items: Vec<serde_json::Value> = notes
+        .into_iter()
+        .map(|(todo_id, kind, message, dedup_key, ts)| {
+            serde_json::json!({
+                "todo_id": todo_id,
+                "kind": kind,
+                "message": message,
+                "dedup_key": dedup_key,
+                "ts": ts,
+            })
+        })
+        .collect();
     Ok(serde_json::json!({
         "ok": true,
         "schema_version": SUPERVISOR_EVENT_PROJECTION_SCHEMA_VERSION,
@@ -314,6 +344,8 @@ pub fn build_supervisor_event_projection(
         "items": rows,
         "progress_count": progress_items.len(),
         "progress": progress_items,
+        "note_count": note_items.len(),
+        "notes": note_items,
         "boundary": {
             "proposal_is_execution_evidence": false,
             "executed_requires_capability_matched_receipt": true,

--- a/orchestration/loop/src/compat.rs
+++ b/orchestration/loop/src/compat.rs
@@ -195,7 +195,6 @@ pub fn pid_alive(_pid: u32) -> bool {
 /// Append one run's files (JSON + markdown + index row) into the goal's
 /// state directory (`<cwd>/.future/loop/goals/<id>/runs/`).
 pub fn write_run(goal_dir: &Path, goal_id: &str, record: &crate::state::RunRecord) -> Result<()> {
-    use std::io::Write;
     let dir = goal_dir.join("runs");
     fs::create_dir_all(&dir)?;
     // Run-file names: 2026-08-05T11-03-14-08-00 (offset without +/:)
@@ -235,23 +234,14 @@ pub fn write_run(goal_dir: &Path, goal_id: &str, record: &crate::state::RunRecor
     md.push_str(&format!("- evidence: {}\n", record.evidence));
     fs::write(dir.join(format!("{ts}.md")), md)?;
 
-    // index.jsonl (append)
-    let index_line = format!(
-        "{}\n",
-        json!({
-            "goal_id": goal_id,
-            "timestamp": rfc3339(record.recorded_at),
-            "path": format!("goals/{goal_id}/runs/{ts}.json"),
-            "turn": record.turn,
-            "classification": record.terminal_state,
-        })
-    );
-    fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("index.jsonl"))
-        .and_then(|mut f| f.write_all(index_line.as_bytes()))
-        .context("append runs/index.jsonl")?;
+    // NOTE: the run index is no longer appended here. It was a per-process
+    // `OpenOptions::append` with no cross-process lock, so N concurrent
+    // workers writing a run at once could interleave index rows and drift the
+    // read model (the `run_index drifted — rebuilt` self-heal noise). The
+    // index is now a pure projection derived on read from the run files in
+    // this directory (see `run_index::load_run_index`) — the run JSON/MD
+    // files above remain the single source of truth and are never contended
+    // (each is a unique file).
     Ok(())
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4060,19 +4060,40 @@ fn claim_selected_with_lease(
 /// uses it to decide session retention (resume vs fresh), never the kernel.
 ///
 /// Enqueue an intervention report to the registered supervisor session (the
-/// up channel). `dedup_key` doubles as the idempotency key: re-sending the
-/// same key is a no-op on the agent (`knows_request`), so "state transition
-/// only" notification is enforced by keying on the transition (todo id +
-/// failure count, gate ids, …). No supervisor registered → the report is
-/// dropped (the durable user-gate ledger remains the authoritative
-/// intervention channel).
+/// up channel). Dual-mode: the note is FIRST written to the ledger
+/// ([`crate::store::Event::SupervisorNote`]) — durable, replayable, and
+/// visible to `supervisor events` / `status` even when the push is lost or the
+/// supervisor is busy — and THEN pushed to the supervisor session, which only
+/// wakes an IDLE supervisor (an active orchestrator drains it late).
+/// `dedup_key` doubles as the prompt idempotency key (re-sending the same key
+/// is a no-op on the agent) AND is recorded on the ledger note so the two
+/// channels correlate. No supervisor registered → the note is still ledgered
+/// (a later `supervisor register` reads it back); only the push is skipped.
 #[doc(hidden)] // test-visible seam
+#[allow(clippy::too_many_arguments)]
 pub async fn notify_supervisor(
+    store: &mut Store,
     client: &mut crate::agent_client::AgentClient,
+    goal_id: &str,
     supervisor_session_id: Option<&str>,
+    kind: &str,
+    todo_id: &str,
     message: &str,
     dedup_key: &str,
 ) {
+    // ① Durable ledger note — authoritative intervention channel; survives a
+    // lost/delayed push and a busy supervisor.
+    if let Err(e) = store.append(crate::store::Event::SupervisorNote {
+        goal_id: goal_id.to_string(),
+        todo_id: todo_id.to_string(),
+        note_kind: kind.to_string(),
+        message: message.to_string(),
+        dedup_key: dedup_key.to_string(),
+        ts: crate::state::now_epoch(),
+    }) {
+        println!("   ⚠ supervisor note ledger append failed: {e}");
+    }
+    // ② Best-effort push — wakes an idle supervisor only.
     let Some(sid) = supervisor_session_id else {
         return;
     };
@@ -4089,16 +4110,21 @@ pub async fn notify_supervisor(
 /// that hits the same stop re-notifies only once.
 #[doc(hidden)] // test-visible seam
 pub async fn notify_infra_stop(
+    store: &mut Store,
     client: &mut crate::agent_client::AgentClient,
-    supervisor_session_id: Option<&str>,
     goal_id: &str,
+    supervisor_session_id: Option<&str>,
     todo_id: &str,
     kind: &str,
     detail: &str,
 ) {
     notify_supervisor(
+        store,
         client,
+        goal_id,
         supervisor_session_id,
+        "infra_stopped",
+        todo_id,
         &format!(
             "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion ({kind}) — {detail}"
         ),
@@ -4121,9 +4147,7 @@ pub async fn notify_dead_holders(store: &mut Store, goal_id: &str) -> Result<()>
     let Some(goal) = store.replay(goal_id)? else {
         return Ok(());
     };
-    let Some(supervisor) = goal.supervisor_session_id.clone() else {
-        return Ok(());
-    };
+    let supervisor = goal.supervisor_session_id.clone();
     let dead: Vec<(String, u32)> = crate::work_items::task_lease::dead_holder_todos(&goal)
         .into_iter()
         .filter_map(|t| t.holder_pid.map(|pid| (t.id.clone(), pid)))
@@ -4138,8 +4162,12 @@ pub async fn notify_dead_holders(store: &mut Store, goal_id: &str) -> Result<()>
     };
     for (todo_id, pid) in dead {
         notify_supervisor(
+            store,
             &mut client,
-            Some(supervisor.as_str()),
+            goal_id,
+            supervisor.as_deref(),
+            "host_died",
+            &todo_id,
             &format!(
                 "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion (host_died) — holder pid {pid} is gone (no release); relaunch to reclaim the lease"
             ),
@@ -4165,6 +4193,18 @@ async fn run_turns(
     last_failure_kind: &mut Option<crate::state::FailureKind>,
 ) -> Result<()> {
     let mut turn = 0u32;
+    // P2: goal-monotonic turn counter. `turn` below restarts at 1 on every
+    // `run` process, so a worker relaunched across runs (or resumed after a
+    // timeout) would re-emit `turn-1` heartbeat receipts and decision
+    // summaries, making cross-run provenance unreadable from the ledger. The
+    // number of already-recorded decision summaries equals the count of turns
+    // that have STARTED on this goal (timeout turns included, because the
+    // receipt is written before the turn executes), so offset the local
+    // counter by it to obtain a goal-wide monotonic turn number.
+    let base_turn = store
+        .events(goal_id)
+        .map(|events| crate::quota::decision_summary::decision_summaries(&events).len() as u32)
+        .unwrap_or(0);
     // Continue note for the NEXT turn: set when the previous turn ended
     // incomplete; consumed exactly once by the next execute_turn call.
     let mut next_continue_note: Option<String> = None;
@@ -4204,15 +4244,25 @@ async fn run_turns(
         if turn > max_turns {
             bail!("max-turns ({max_turns}) reached without validated closure");
         }
+        // Goal-wide turn number: `turn` is local to this run process, so every
+        // persisted reference (decision summary, heartbeat receipt, run record,
+        // client_request_id) must use the offset value to stay distinguishable
+        // across runs.
+        let global_turn = base_turn + turn;
         let goal = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
         let mut packet = decide_for(&goal, SystemTime::now(), agent_id);
         // P1-1②③: persist the compact decision projection + the heartbeat
         // receipt for this turn (projection-only; replay ignores both).
-        crate::quota::decision_summary::record_turn_decision(store, &packet, agent_id, turn)?;
+        crate::quota::decision_summary::record_turn_decision(
+            store,
+            &packet,
+            agent_id,
+            global_turn,
+        )?;
         println!(
-            "── turn {turn}: decision={} mode={} | {}",
+            "── turn {global_turn}: decision={} mode={} | {}",
             packet.decision,
             packet.interaction_contract.mode.as_str(),
             packet.reason
@@ -4250,8 +4300,12 @@ async fn run_turns(
             let gate_ids = &packet.interaction_contract.user_channel.todo_ids;
             let key = format!("ask_user:{}", gate_ids.join(","));
             notify_supervisor(
+                store,
                 client,
+                goal_id,
                 goal.supervisor_session_id.as_deref(),
+                "ask_user",
+                &gate_ids.join(","),
                 &format!(
                     "[future-loop] goal {goal_id} needs your decision on user gate(s): {}. Question: {q}",
                     gate_ids.join(", ")
@@ -4379,7 +4433,7 @@ async fn run_turns(
             &boundary,
             agent_id,
             &todo,
-            turn,
+            global_turn,
             goal.history.last(),
             true,
             Some(runs_dir),
@@ -4404,9 +4458,10 @@ async fn run_turns(
                         // polling a dead worker.
                         *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
                         notify_infra_stop(
+                            store,
                             client,
-                            goal.supervisor_session_id.as_deref(),
                             goal_id,
+                            goal.supervisor_session_id.as_deref(),
                             &todo_id,
                             "transport",
                             &format!("{e}"),
@@ -4427,9 +4482,10 @@ async fn run_turns(
                     // otherwise skips the ②/③ reports).
                     *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
                     notify_infra_stop(
+                        store,
                         client,
-                        goal.supervisor_session_id.as_deref(),
                         goal_id,
+                        goal.supervisor_session_id.as_deref(),
                         &todo_id,
                         "timeout",
                         &format!("turn exceeded --max-turn-secs ({max_turn_secs}s)"),
@@ -4447,9 +4503,10 @@ async fn run_turns(
                 Err(e) => {
                     *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
                     notify_infra_stop(
+                        store,
                         client,
-                        goal.supervisor_session_id.as_deref(),
                         goal_id,
+                        goal.supervisor_session_id.as_deref(),
                         &todo_id,
                         "transport",
                         &format!("{e}"),
@@ -4595,8 +4652,12 @@ async fn run_turns(
             // transition keyed on the todo id, so re-notification across runs
             // is deduped).
             notify_supervisor(
+                store,
                 client,
+                goal_id,
                 g.supervisor_session_id.as_deref(),
+                "completed",
+                &todo_id,
                 &format!(
                     "[future-loop] goal {goal_id}: todo {todo_id} completed{} — evidence: {}",
                     if is_last {
@@ -4655,8 +4716,12 @@ async fn run_turns(
                         .unwrap_or_else(|| record.terminal_state.clone()),
                 };
                 notify_supervisor(
+                    store,
                     client,
+                    goal_id,
                     g.supervisor_session_id.as_deref(),
+                    "failed",
+                    &todo_id,
                     &format!(
                         "[future-loop] goal {goal_id}: todo {todo_id} failed (attempt {attempts}) — error: {failure_text}",
                     ),
@@ -4711,9 +4776,10 @@ async fn run_turns(
                     // Keyed on the streak so a relaunch that re-exhausts
                     // re-notifies at the new streak value.
                     notify_infra_stop(
+                        store,
                         client,
-                        g.supervisor_session_id.as_deref(),
                         goal_id,
+                        g.supervisor_session_id.as_deref(),
                         &todo_id,
                         "incomplete_budget",
                         &format!(
@@ -5570,26 +5636,15 @@ fn auto_register_workspaces(cwd: &str) -> Vec<String> {
     }
 }
 
-/// P1-2③: run the drift self-heal at run start and print the repair summary.
-/// Extracted so the drifted-index projection (and both backup-path variants)
-/// are unit-testable without a live agent client.
-fn run_index_self_heal(store: &mut Store, goal_id: &str) -> Result<()> {
-    if let Some(outcome) = crate::runtime::run_index::repair_index_if_drifted(store, goal_id)? {
-        print_run_index_self_heal(&outcome);
-    }
+/// P1-2③: run-index self-heal seam at run start. The run index is no longer
+/// a persisted append-only file (writers stopped appending it — that was the
+/// cross-process interleave drift source — and readers derive it from the run
+/// files on disk via `run_index::load_run_index`). There is therefore nothing
+/// to self-heal at run start; the seam is kept as a no-op so the run path's
+/// intent stays explicit. The legacy `runs index` / `store verify --repair`
+/// commands still rebuild an index.jsonl on demand for human inspection.
+fn run_index_self_heal(_store: &mut Store, _goal_id: &str) -> Result<()> {
     Ok(())
-}
-
-fn print_run_index_self_heal(outcome: &crate::runtime::run_index::IndexRepairOutcome) {
-    let backup = if outcome.rebuilt.backup_path.is_empty() {
-        "none".to_string()
-    } else {
-        outcome.rebuilt.backup_path.clone()
-    };
-    println!(
-        "⚒ projection self-heal: run_index drifted ({} rows) — rebuilt {} rows (backup {backup})",
-        outcome.drift.drift_count, outcome.rebuilt.rows_written,
-    );
 }
 
 /// P0-2①: a completed advancement todo is a delivery pending verification —
@@ -7935,6 +7990,16 @@ fn describe_event(event: &crate::store::Event) -> String {
                 "progress_reported agent={agent_id} todo={todo_id} message=\"{message}\""
             );
         }
+        Event::SupervisorNote {
+            todo_id,
+            note_kind,
+            message,
+            ..
+        } => {
+            return format!(
+                "supervisor_note kind={note_kind} todo={todo_id} message=\"{message}\""
+            );
+        }
     };
     kind.to_string()
 }
@@ -10104,35 +10169,6 @@ mod residual_branch_tests {
         );
     }
 
-    // ── print_run_index_self_heal: empty + non-empty backup ────────────────
-    #[test]
-    fn run_index_self_heal_prints_both_backup_variants() {
-        let drift = crate::runtime::run_index::IndexDriftReport {
-            goal_id: "g".into(),
-            index_path: String::new(),
-            index_rows: 0,
-            run_files: 1,
-            missing_rows: 1,
-            stale_rows: 0,
-            duplicate_rows: 0,
-            drift_count: 1,
-            repair_recommended: true,
-            missing_identities: vec![],
-            stale_identities: vec![],
-        };
-        let mk = |backup: String| crate::runtime::run_index::IndexRepairOutcome {
-            drift: drift.clone(),
-            rebuilt: crate::runtime::run_index::RebuildReport {
-                index_path: String::new(),
-                backup_path: backup,
-                rows_written: 1,
-                non_destructive: true,
-            },
-        };
-        print_run_index_self_heal(&mk(String::new()));
-        print_run_index_self_heal(&mk("index.pre-rebuild-123.jsonl".into()));
-    }
-
     // ── record_delivery_if_advancement: advancement vs non-advancement ─────
     #[test]
     fn record_delivery_only_for_advancement_todos() {
@@ -10153,24 +10189,6 @@ mod residual_branch_tests {
         let goal = store.replay("g").unwrap().unwrap();
         assert!(goal.delivery_state("t1").is_some());
         assert!(goal.delivery_state("m1").is_none());
-    }
-
-    // ── run_index_self_heal: drifted index drives the repair summary ────────
-    #[test]
-    fn run_index_self_heal_detects_and_repairs_drift() {
-        let (_dir, mut store) = tmp_store();
-        registered(&mut store, "g");
-        // Seed a run file (source of truth) with no index row → drift.
-        let runs = store.goal_dir("g").join("runs");
-        std::fs::create_dir_all(&runs).unwrap();
-        std::fs::write(
-            runs.join("a.json"),
-            r#"{"timestamp":"123","turn":1,"terminal_state":"completed"}"#,
-        )
-        .unwrap();
-        run_index_self_heal(&mut store, "g").unwrap();
-        // A clean index now reports no drift (the None arm).
-        run_index_self_heal(&mut store, "g").unwrap();
     }
 
     fn seed_overdue_delivery(store: &mut Store) {

--- a/orchestration/loop/src/runtime/run_compaction.rs
+++ b/orchestration/loop/src/runtime/run_compaction.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-use crate::runtime::run_history::{read_index_rows, row_epoch, RunIndexRow};
+use crate::runtime::run_history::{row_epoch, RunIndexRow};
 
 pub const RUN_ARCHIVE_DIR: &str = "archive";
 
@@ -51,11 +51,9 @@ pub fn archive_runs_before(
     cutoff_epoch: u64,
 ) -> Result<CompactionReport> {
     let runs = crate::runtime::runs_dir(runtime_root, goal_id);
-    let index = runs.join("index.jsonl");
-    if !index.exists() {
-        anyhow::bail!("goal {goal_id} has no run index to compact");
-    }
-    let rows = read_index_rows(&index)?;
+    // The index is a pure projection: derive it from the run files on disk
+    // (no persistent index.jsonl to read or re-point).
+    let rows = crate::runtime::run_index::load_run_index(runtime_root, goal_id)?;
     let archive_dir = runs.join(RUN_ARCHIVE_DIR);
 
     let mut archived: Vec<String> = vec![];
@@ -97,34 +95,9 @@ pub fn archive_runs_before(
         rewritten.push(rewritten_row);
     }
 
-    if !archived.is_empty() {
-        // Backup the pre-compaction index (rollback), then rewrite.
-        let backup = runs.join(format!(
-            "index.pre-compaction-{}.jsonl",
-            crate::state::now_epoch()
-        ));
-        std::fs::copy(&index, &backup).context("backup run index")?;
-        let payload = rewritten
-            .iter()
-            .map(|row| {
-                serde_json::json!({
-                    "goal_id": row.goal_id,
-                    "timestamp": row.timestamp,
-                    "path": row.path,
-                    "turn": row.turn,
-                    "classification": row.classification,
-                })
-            })
-            .collect::<Vec<_>>();
-        let mut text = String::new();
-        for value in payload {
-            text.push_str(&serde_json::to_string(&value)?);
-            text.push('\n');
-        }
-        let tmp = index.with_extension("jsonl.tmp");
-        std::fs::write(&tmp, text).context("write compacted index tmp")?;
-        std::fs::rename(&tmp, &index).context("rename compacted index")?;
-    }
+    // NOTE: the index is no longer persisted, so there is nothing to re-point
+    // or rewrite — `load_run_index` re-derives rows (including archived paths)
+    // from the run files on the next read.
 
     Ok(CompactionReport {
         goal_id: goal_id.to_string(),
@@ -143,8 +116,7 @@ pub fn archive_keeping_latest(
     goal_id: &str,
     keep: usize,
 ) -> Result<CompactionReport> {
-    let index = crate::runtime::index_path(runtime_root, goal_id);
-    let mut rows = read_index_rows(&index)?;
+    let mut rows = crate::runtime::run_index::load_run_index(runtime_root, goal_id)?;
     if rows.len() <= keep {
         return Ok(CompactionReport {
             goal_id: goal_id.to_string(),
@@ -200,15 +172,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let runs = dir.path().join("goals").join("g1").join("runs");
         std::fs::create_dir_all(&runs).unwrap();
-        let index = runs.join("index.jsonl");
-        // A row whose timestamp does not parse is kept verbatim...
+        // A run file whose timestamp does not parse is kept verbatim...
         std::fs::write(
-            &index,
-            "{\"goal_id\":\"g1\",\"timestamp\":\"not-a-date\",\"path\":\"goals/g1/runs/x.json\",\"turn\":0,\"classification\":\"run_recorded\"}\n\
-             {\"goal_id\":\"g1\",\"timestamp\":\"2026-07-01T00:00:00+00:00\",\"path\":\"goals/g1/runs/2026-07-01T00-00-00-00-00.json\",\"turn\":1,\"classification\":\"run_recorded\"}\n",
+            runs.join("x.json"),
+            r#"{"timestamp":"not-a-date","turn":0,"terminal_state":"run_recorded"}"#,
         )
         .unwrap();
-        std::fs::write(runs.join("2026-07-01T00-00-00-00-00.json"), "{}").unwrap();
+        std::fs::write(
+            runs.join("2026-07-01T00-00-00-00-00.json"),
+            r#"{"timestamp":"2026-07-01T00:00:00+00:00","turn":1,"terminal_state":"run_recorded"}"#,
+        )
+        .unwrap();
         // ...and a pre-existing archive destination is left in place (no rename).
         let archive = runs.join("archive");
         std::fs::create_dir_all(&archive).unwrap();
@@ -220,10 +194,13 @@ mod tests {
         let cutoff = crate::scheduler::state::parse_epoch("2026-08-05T00:00:00+00:00").unwrap();
         let report = archive_runs_before(dir.path().to_str().unwrap(), "g1", cutoff).unwrap();
         assert_eq!(report.archived.len(), 1);
-        let rows = read_index_rows(&index).unwrap();
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].path, "goals/g1/runs/x.json", "unparseable row kept");
-        assert!(rows[1].path.contains("archive/"));
+        let rows =
+            crate::runtime::run_index::load_run_index(dir.path().to_str().unwrap(), "g1").unwrap();
+        assert!(
+            rows.iter().any(|r| r.path == "goals/g1/runs/x.json"),
+            "unparseable row kept"
+        );
+        assert!(rows.iter().any(|r| r.path.contains("archive/")));
         // The old run file stays put because the destination already existed.
         assert!(runs.join("2026-07-01T00-00-00-00-00.json").exists());
         let kept = std::fs::read_to_string(archive.join("2026-07-01T00-00-00-00-00.json")).unwrap();
@@ -235,15 +212,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let runs = dir.path().join("goals").join("g1").join("runs");
         std::fs::create_dir_all(&runs).unwrap();
-        let index = runs.join("index.jsonl");
         std::fs::write(
-            &index,
-            "{\"goal_id\":\"g1\",\"timestamp\":\"2026-07-01T00:00:00+00:00\",\"path\":\"goals/g1/runs/2026-07-01T00-00-00-00-00.json\",\"turn\":1,\"classification\":\"run_recorded\"}\n\
-             {\"goal_id\":\"g1\",\"timestamp\":\"2026-08-05T00:00:00+00:00\",\"path\":\"goals/g1/runs/2026-08-05T00-00-00-00-00.json\",\"turn\":2,\"classification\":\"run_recorded\"}\n",
+            runs.join("2026-07-01T00-00-00-00-00.json"),
+            r#"{"timestamp":"2026-07-01T00:00:00+00:00","turn":1,"terminal_state":"run_recorded"}"#,
         )
         .unwrap();
-        std::fs::write(runs.join("2026-07-01T00-00-00-00-00.json"), "{}").unwrap();
-        std::fs::write(runs.join("2026-08-05T00-00-00-00-00.json"), "{}").unwrap();
+        std::fs::write(
+            runs.join("2026-08-05T00-00-00-00-00.json"),
+            r#"{"timestamp":"2026-08-05T00:00:00+00:00","turn":2,"terminal_state":"run_recorded"}"#,
+        )
+        .unwrap();
 
         let now = crate::scheduler::state::parse_epoch("2026-08-05T00:00:00+00:00").unwrap();
         let cutoff = now.saturating_sub(3 * 86400);
@@ -251,21 +229,13 @@ mod tests {
         assert_eq!(report.archived.len(), 1);
         assert!(report.archived[0].contains("archive/"));
         assert!(runs.join("archive/2026-07-01T00-00-00-00-00.json").exists());
-        // The archived row is re-pointed; the fresh row is untouched.
-        let rows = read_index_rows(&index).unwrap();
+        // The archived run re-derives under archive/; the fresh run is intact.
+        let rows =
+            crate::runtime::run_index::load_run_index(dir.path().to_str().unwrap(), "g1").unwrap();
         assert_eq!(rows.len(), 2);
-        assert!(rows[0].path.contains("archive/"));
-        assert_eq!(rows[1].path, "goals/g1/runs/2026-08-05T00-00-00-00-00.json");
-        // Index backup exists (rollback).
-        let backups: Vec<_> = std::fs::read_dir(&runs)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with("index.pre-compaction")
-            })
-            .collect();
-        assert_eq!(backups.len(), 1);
+        assert!(rows.iter().any(|r| r.path.contains("archive/")));
+        assert!(rows
+            .iter()
+            .any(|r| r.path == "goals/g1/runs/2026-08-05T00-00-00-00-00.json"));
     }
 }

--- a/orchestration/loop/src/runtime/run_context_retention.rs
+++ b/orchestration/loop/src/runtime/run_context_retention.rs
@@ -3,10 +3,10 @@
 //! keep the latest N runs (plus a TTL window when configured); older files
 //! become retention candidates that compaction ARCHIVES (never deletes).
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Serialize;
 
-use crate::runtime::run_history::{read_index_rows, row_epoch};
+use crate::runtime::run_history::row_epoch;
 
 pub const DEFAULT_RUN_RETENTION_LIMIT: usize = 50;
 
@@ -43,17 +43,8 @@ pub fn retention_report(
     policy: &RetentionPolicy,
     now_epoch: u64,
 ) -> Result<RetentionReport> {
-    let index = crate::runtime::index_path(runtime_root, goal_id);
-    if !index.exists() {
-        return Ok(RetentionReport {
-            goal_id: goal_id.to_string(),
-            policy: policy.clone(),
-            total: 0,
-            retained: 0,
-            candidates: vec![],
-        });
-    }
-    let mut rows = read_index_rows(&index).context("read run index")?;
+    // The index is a pure projection: derive it from the run files on disk.
+    let mut rows = crate::runtime::run_index::load_run_index(runtime_root, goal_id)?;
     rows.sort_by_key(|b| std::cmp::Reverse(row_epoch(b)));
 
     let cutoff_epoch = policy
@@ -91,14 +82,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let runs = dir.path().join("goals").join("g1").join("runs");
         std::fs::create_dir_all(&runs).unwrap();
-        let mut text = String::new();
-        // 5 runs on distinct August days; now = 08-31, TTL = 7d → cutoff 08-24.
+        // 5 run files on distinct August days; now = 08-31, TTL = 7d → cutoff 08-24.
         for day in [20, 25, 26, 27, 28] {
-            text.push_str(&format!(
-                "{{\"goal_id\":\"g1\",\"timestamp\":\"2026-08-{day:02}T00:00:00+00:00\",\"path\":\"goals/g1/runs/d{day}.json\",\"turn\":1,\"classification\":\"run_recorded\"}}\n"
-            ));
+            let payload = format!(
+                "{{\"timestamp\":\"2026-08-{day:02}T00:00:00+00:00\",\"turn\":1,\"terminal_state\":\"run_recorded\"}}"
+            );
+            std::fs::write(runs.join(format!("d{day}.json")), payload).unwrap();
         }
-        std::fs::write(runs.join("index.jsonl"), text).unwrap();
 
         let now = crate::scheduler::state::parse_epoch("2026-08-31T00:00:00+00:00").unwrap();
         let policy = retention_policy(2, Some(7 * 86400));
@@ -111,7 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_index_is_empty_report() {
+    fn missing_run_dir_is_empty_report() {
         let dir = tempfile::tempdir().unwrap();
         let report = retention_report(
             dir.path().to_str().unwrap(),

--- a/orchestration/loop/src/runtime/run_history.rs
+++ b/orchestration/loop/src/runtime/run_history.rs
@@ -90,8 +90,7 @@ pub fn build_run_history(
     goal_id: &str,
     now_epoch: u64,
 ) -> Result<Option<RunHistoryProjection>> {
-    let index = crate::runtime::index_path(runtime_root, goal_id);
-    let rows = read_index_rows(&index)?;
+    let rows = crate::runtime::run_index::load_run_index(runtime_root, goal_id)?;
     if rows.is_empty() {
         return Ok(None);
     }
@@ -132,9 +131,7 @@ mod tests {
     use super::*;
 
     fn index_row(ts: &str, classification: &str) -> String {
-        format!(
-            "{{\"goal_id\":\"g1\",\"timestamp\":\"{ts}\",\"path\":\"goals/g1/runs/x.json\",\"turn\":1,\"classification\":\"{classification}\"}}\n"
-        )
+        format!("{{\"timestamp\":\"{ts}\",\"turn\":1,\"terminal_state\":\"{classification}\"}}")
     }
 
     #[test]
@@ -142,15 +139,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let runs = dir.path().join("goals").join("g1").join("runs");
         std::fs::create_dir_all(&runs).unwrap();
-        let index = runs.join("index.jsonl");
+        // The index is derived from the run files on disk.
         std::fs::write(
-            &index,
-            format!(
-                "{}{}{}",
-                index_row("2026-08-05T12:00:00+00:00", "run_recorded"),
-                index_row("2026-08-04T12:00:00+00:00", "run_recorded"),
-                index_row("2026-07-20T12:00:00+00:00", "quota_monitor_poll"),
-            ),
+            runs.join("a.json"),
+            index_row("2026-08-05T12:00:00+00:00", "run_recorded"),
+        )
+        .unwrap();
+        std::fs::write(
+            runs.join("b.json"),
+            index_row("2026-08-04T12:00:00+00:00", "run_recorded"),
+        )
+        .unwrap();
+        std::fs::write(
+            runs.join("c.json"),
+            index_row("2026-07-20T12:00:00+00:00", "quota_monitor_poll"),
         )
         .unwrap();
         let now = crate::scheduler::state::parse_epoch("2026-08-05T13:00:00+00:00").unwrap();

--- a/orchestration/loop/src/runtime/run_index.rs
+++ b/orchestration/loop/src/runtime/run_index.rs
@@ -191,6 +191,23 @@ pub fn repair_index_if_drifted(
     Ok(Some(IndexRepairOutcome { drift, rebuilt }))
 }
 
+/// Derive the run index rows for a goal by scanning the run files on disk
+/// (the source of truth). This is the read-side of the "index is a pure
+/// projection" design: writers no longer append a persistent `index.jsonl`
+/// (that was the cross-process interleave drift source), so readers scan the
+/// run dir (including the archive subdir) and derive rows in memory. Rows are
+/// sorted newest-first so callers get a stable, deterministic order.
+pub fn load_run_index(runtime_root: &str, goal_id: &str) -> Result<Vec<RunIndexRow>> {
+    let runs = crate::runtime::runs_dir(runtime_root, goal_id);
+    if !runs.exists() {
+        return Ok(vec![]);
+    }
+    let mut rows: Vec<RunIndexRow> = vec![];
+    collect_run_files(&runs, goal_id, &mut rows)?;
+    rows.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    Ok(rows)
+}
+
 /// Rebuild the run index by rescanning the run files on disk (LoopX
 /// `run_index_rebuild`): the old index is backed up, the new index is
 /// written via tmp+rename, and rows are never deleted. Handles the case

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -417,6 +417,28 @@ pub enum Event {
         message: String,
         ts: u64,
     },
+    /// A supervisor-facing intervention note (todo completed / failed / infra
+    /// stop / user-gate ask / dead-holder). Written to the ledger FIRST and
+    /// THEN pushed to the supervisor session, so an active (busy) supervisor
+    /// that never drains the prompt still sees the note by polling
+    /// `supervisor events` — the notification is durable even when the push
+    /// is lost or delayed. `kind` mirrors the push channel (`completed` /
+    /// `failed` / `infra_stopped` / `ask_user` / `host_died`); `dedup_key` is
+    /// the same idempotency key the prompt push uses, so re-notification
+    /// across runs can be correlated. Projection-only — `apply` ignores it
+    /// (a note never mutates the kanban; consumption is the supervisor
+    /// projection). Distinct notes always append (audit trail); an identical
+    /// note within the same second is a content-derived no-op.
+    SupervisorNote {
+        goal_id: String,
+        #[serde(default)]
+        todo_id: String,
+        note_kind: String,
+        message: String,
+        #[serde(default)]
+        dedup_key: String,
+        ts: u64,
+    },
     /// P0-2②: outcome_followthrough fired — a delivered-but-unverified work
     /// item aged past the turn threshold, so a follow-up todo was
     /// auto-created (the followup itself is the TodoAdded event; this event
@@ -641,6 +663,7 @@ impl Event {
             | Event::TodoExpired { goal_id, .. }
             | Event::DeliveryOutcomeRecorded { goal_id, .. }
             | Event::ProgressReported { goal_id, .. }
+            | Event::SupervisorNote { goal_id, .. }
             | Event::FollowthroughCreated { goal_id, .. }
             | Event::DecisionSummaryRecorded { goal_id, .. }
             | Event::HeartbeatReceiptRecorded { goal_id, .. }
@@ -2027,6 +2050,10 @@ fn apply(goal: &mut Goal, event: Event) {
         // Projection-only: a progress note is a statement, not a claim — it
         // never touches the kanban. Consumption is the supervisor projection.
         Event::ProgressReported { .. } => {}
+        // Projection-only: a supervisor note is already folded into the
+        // supervisor projection (and pushed to the supervisor session); it
+        // never mutates the kanban.
+        Event::SupervisorNote { .. } => {}
     }
 }
 

--- a/orchestration/loop/tests/console_drive_cov100.rs
+++ b/orchestration/loop/tests/console_drive_cov100.rs
@@ -31,11 +31,13 @@ fn parse_catch_all_arms_reject_unknown_flags() {
 }
 
 #[test]
-fn runs_compact_cutoff_without_index_errors() {
+fn runs_compact_cutoff_without_runs_succeeds() {
+    // The run index is now a pure projection derived from the run files on
+    // disk (no persistent index.jsonl), so compacting a goal with no run
+    // files is a clean no-op report (archived=0), not an error.
     let cr = cli_root();
-    let gid = init_goal(&cr, "compact without index");
-    let err = cli_err(&["runs", "compact", "--goal", &gid, "--cutoff", "0"]);
-    assert!(err.contains("no run index"), "{err}");
+    let gid = init_goal(&cr, "compact without runs");
+    cli_ok(&["runs", "compact", "--goal", &gid, "--cutoff", "0"]);
 }
 
 #[test]

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -590,7 +590,9 @@ fn steer_worker_poll_once_aborts_on_targeted_and_broadcast_steer() {
 fn notify_supervisor_enqueues_to_registered_session_only() {
     // Hold the CLI lock so FUTURE_LOOP_AGENT_ADDR set/remove cannot race a
     // concurrent in-process run() driving the same global env.
-    let _cr = cli_root();
+    let cr = cli_root();
+    let gid = init_goal(&cr, "notify seam");
+    let mut store = open_store(&cr);
     let rt = rt();
     let (addr, shared) = rt.block_on(spawn_mock(MockState::default()));
     std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
@@ -601,18 +603,45 @@ fn notify_supervisor_enqueues_to_registered_session_only() {
         .await
         .unwrap();
 
-        // No supervisor registered → dropped, no prompt on the wire.
-        future_loop::console::notify_supervisor(&mut client, None, "hello", "k1").await;
+        // No supervisor registered → ledgered but no prompt on the wire.
+        future_loop::console::notify_supervisor(
+            &mut store,
+            &mut client,
+            &gid,
+            None,
+            "completed",
+            "t1",
+            "hello",
+            "k1",
+        )
+        .await;
         assert!(shared.lock().unwrap().prompt_calls.is_empty());
 
-        // Registered → enqueued to that session with enqueue_if_busy.
-        future_loop::console::notify_supervisor(&mut client, Some("sup-sess"), "hello", "k2").await;
+        // Registered → ledgered AND enqueued to that session (enqueue_if_busy).
+        future_loop::console::notify_supervisor(
+            &mut store,
+            &mut client,
+            &gid,
+            Some("sup-sess"),
+            "completed",
+            "t1",
+            "hello",
+            "k2",
+        )
+        .await;
         let calls = shared.lock().unwrap().prompt_calls.clone();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, "sup-sess");
         assert_eq!(calls[0].1, "enqueue_if_busy");
     });
     std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+    // Both notifications are durable ledger notes (the un-pushed one too).
+    let events = store.events(&gid).unwrap();
+    let notes = events
+        .iter()
+        .filter(|se| matches!(&se.event, future_loop::store::Event::SupervisorNote { .. }))
+        .count();
+    assert_eq!(notes, 2);
 }
 
 /// The dead-worker push: a claimed todo whose holder process is gone is
@@ -746,7 +775,9 @@ fn steer_worker_poll_once_read_errors_and_bad_lines() {
 
 #[test]
 fn notify_supervisor_survives_prompt_failure() {
-    let _cr = cli_root();
+    let cr = cli_root();
+    let gid = init_goal(&cr, "notify fail");
+    let mut store = open_store(&cr);
     let rt = rt();
     let st = MockState {
         fail_commands: ["prompt".to_string()].into_iter().collect(),
@@ -760,8 +791,25 @@ fn notify_supervisor_survives_prompt_failure() {
         )
         .await
         .unwrap();
-        // A failing enqueue is best-effort: the report is dropped, no panic.
-        future_loop::console::notify_supervisor(&mut client, Some("sup-sess"), "hi", "k").await;
+        // A failing enqueue is best-effort: the note is still ledgered, no panic.
+        future_loop::console::notify_supervisor(
+            &mut store,
+            &mut client,
+            &gid,
+            Some("sup-sess"),
+            "failed",
+            "t1",
+            "hi",
+            "k",
+        )
+        .await;
     });
     std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
+    // The durable ledger note survives the prompt failure.
+    let events = store.events(&gid).unwrap();
+    let notes = events
+        .iter()
+        .filter(|se| matches!(&se.event, future_loop::store::Event::SupervisorNote { .. }))
+        .count();
+    assert_eq!(notes, 1);
 }

--- a/orchestration/loop/tests/misc_drive.rs
+++ b/orchestration/loop/tests/misc_drive.rs
@@ -281,17 +281,23 @@ fn runtime_run_history_and_index_arms() {
     let store = open_store(&cr);
     let runs_dir = store.goal_dir(&gid).join("runs");
     std::fs::create_dir_all(&runs_dir).unwrap();
-    // Index rows: malformed line skipped; empty classification → "work";
-    // unparseable timestamp → row_epoch None (skipped in totals).
-    let index = runs_dir.join("index.jsonl");
+    // The run history is a derived projection: it scans run FILES on disk
+    // (there is no persisted index to read). Seed three run files — one with
+    // an unparseable timestamp (row_epoch None, skipped in totals), two with
+    // real timestamps (empty classification → "work").
     std::fs::write(
-        &index,
-        concat!(
-            "{bad json\n",
-            "{\"goal_id\":\"G\",\"timestamp\":\"not-a-date\",\"path\":\"a.json\",\"classification\":\"\"}\n",
-            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"b.json\",\"classification\":\"\"}\n",
-            "{\"goal_id\":\"G\",\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"path\":\"c.json\",\"classification\":\"monitor\"}\n",
-        ),
+        runs_dir.join("a.json"),
+        "{\"timestamp\":\"not-a-date\",\"turn\":1,\"terminal_state\":\"completed\"}",
+    )
+    .unwrap();
+    std::fs::write(
+        runs_dir.join("b.json"),
+        "{\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"turn\":2,\"terminal_state\":\"completed\"}",
+    )
+    .unwrap();
+    std::fs::write(
+        runs_dir.join("c.json"),
+        "{\"timestamp\":\"2026-08-10T00:00:00+00:00\",\"turn\":3,\"terminal_state\":\"monitor\"}",
     )
     .unwrap();
     let projection =
@@ -316,7 +322,8 @@ fn runtime_run_history_and_index_arms() {
     let missing = runs_dir.join("absent.jsonl");
     let report = future_loop::runtime::run_index::detect_duplicates(&missing).unwrap();
     assert_eq!(report.total_rows, 0);
-    // rebuild over an EXISTING index → pre-rebuild backup is written.
+    // rebuild (on-demand, for `runs index --rebuild`) over run files → the
+    // first rebuild writes the index; the second backs up the prior index.
     future_loop::compat::write_run(
         &store.goal_dir(&gid),
         &gid,
@@ -398,9 +405,11 @@ fn run_compaction_arms() {
     let report =
         future_loop::runtime::run_compaction::archive_keeping_latest(&cr.root, &gid3, 1).unwrap();
     assert_eq!(report.archived.len(), 1, "{report:?}");
-    // No index → error.
-    let gid2 = init_goal(&cr, "no index goal");
-    assert!(future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid2, 1).is_err());
+    // No run files → a clean no-op report (the index is a derived projection).
+    let gid2 = init_goal(&cr, "no runs goal");
+    let report =
+        future_loop::runtime::run_compaction::archive_runs_before(&cr.root, &gid2, 1).unwrap();
+    assert_eq!(report.archived.len(), 0, "{report:?}");
 }
 
 // ── cli_projection remaining arms ──────────────────────────────────────────

--- a/orchestration/loop/tests/run_lifecycle_contract.rs
+++ b/orchestration/loop/tests/run_lifecycle_contract.rs
@@ -26,23 +26,29 @@ fn index_row(ts: &str, path: &str, classification: &str) -> String {
     )
 }
 
-fn seed_run_history(root: &str, rows: &[(&str, &str, &str)]) {
+/// Seed run FILES (the source of truth). The run index is a derived
+/// projection (no persisted index.jsonl), so readers scan these files.
+/// Each file carries a real `timestamp` + `terminal_state` payload.
+fn seed_run_files(root: &str, rows: &[(&str, &str, &str)]) {
     let runs = future_loop::runtime::runs_dir(root, "g1");
     std::fs::create_dir_all(&runs).unwrap();
-    let mut text = String::new();
     for (ts, path, classification) in rows {
-        text.push_str(&index_row(ts, path, classification));
         let file_name = path.rsplit('/').next().unwrap();
-        std::fs::write(runs.join(file_name), "{}").unwrap();
+        std::fs::write(
+            runs.join(file_name),
+            format!(
+                "{{\"timestamp\":\"{ts}\",\"turn\":1,\"terminal_state\":\"{classification}\"}}"
+            ),
+        )
+        .unwrap();
     }
-    std::fs::write(runs.join("index.jsonl"), text).unwrap();
 }
 
 /// ── Run history buckets 24h/7d by class (event-ledger proxy) ──────────────
 #[test]
 fn run_history_buckets_by_class() {
     let root = tmp_root("history");
-    seed_run_history(
+    seed_run_files(
         &root,
         &[
             (
@@ -83,7 +89,7 @@ fn run_history_buckets_by_class() {
 #[test]
 fn compaction_archives_old_runs_recoverably() {
     let root = tmp_root("compact");
-    seed_run_history(
+    seed_run_files(
         &root,
         &[
             (
@@ -109,35 +115,22 @@ fn compaction_archives_old_runs_recoverably() {
         "archived, not deleted"
     );
     assert!(runs.join("new.json").exists());
-    // Index re-points the archived row.
-    let rows = run_history::read_index_rows(&runs.join("index.jsonl")).unwrap();
+    // The index re-derives the archived path on the next read (no persistent
+    // index.jsonl to re-point).
+    let rows = run_index::load_run_index(&root, "g1").unwrap();
     let old = rows.iter().find(|r| r.path.contains("old.json")).unwrap();
     assert!(old.path.contains("archive/"));
-    // Pre-compaction backup exists (rollback).
-    let backups: Vec<_> = std::fs::read_dir(&runs)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("index.pre-compaction")
-        })
-        .collect();
-    assert_eq!(backups.len(), 1);
 }
 
 /// ── Index dedup detection + non-destructive rebuild ───────────────────────
 #[test]
 fn index_dedup_and_rebuild() {
     let root = tmp_root("index");
-    seed_run_history(
+    // Seed run FILES (source of truth) + a hand-written index.jsonl carrying
+    // a duplicate row — this exercises the `runs index` on-demand surface.
+    seed_run_files(
         &root,
         &[
-            (
-                "2026-08-05T00:00:00+00:00",
-                "goals/g1/runs/a.json",
-                "run_recorded",
-            ),
             (
                 "2026-08-05T00:00:00+00:00",
                 "goals/g1/runs/a.json",
@@ -151,14 +144,30 @@ fn index_dedup_and_rebuild() {
         ],
     );
     let index = future_loop::runtime::index_path(&root, "g1");
+    std::fs::write(
+        &index,
+        format!(
+            "{}{}",
+            index_row(
+                "2026-08-05T00:00:00+00:00",
+                "goals/g1/runs/a.json",
+                "run_recorded"
+            ),
+            index_row(
+                "2026-08-05T00:00:00+00:00",
+                "goals/g1/runs/a.json",
+                "run_recorded"
+            ),
+        ),
+    )
+    .unwrap();
     let report = run_index::detect_duplicates(&index).unwrap();
     assert_eq!(report.duplicate_groups.len(), 1);
     assert_eq!(report.duplicate_groups[0].line_numbers, vec![1, 2]);
     assert!(report.repairable);
 
     // Rebuild rescans run files and rewrites the index (non-destructive).
-    // Only 2 distinct files exist on disk (the duplicate index row has no
-    // separate artifact), so the rebuilt index has 2 rows.
+    // Only 2 distinct files exist on disk, so the rebuilt index has 2 rows.
     std::fs::write(&index, "garbage\n").unwrap();
     let rebuild = run_index::rebuild_index(&root, "g1").unwrap();
     assert_eq!(rebuild.rows_written, 2);
@@ -182,7 +191,7 @@ fn index_dedup_and_rebuild() {
 #[test]
 fn retention_keeps_latest_and_ttl() {
     let root = tmp_root("retention");
-    seed_run_history(
+    seed_run_files(
         &root,
         &[
             (


### PR DESCRIPTION
fix(loop): dual-mode supervisor notes + derive run index on read (drop the append)

Two changes driven by the multi-worker 16x16 solve:

1. Supervisor notes are now durable (dual-mode notify). Previously the
   completion/failure/infra-stop reports were prompt-only pushes that wake an
   IDLE supervisor session; an active orchestrator (one that is polling
   `status` while watching workers) never drains them, so they queue up and
   arrive only after it goes idle. `notify_supervisor` now writes a
   `SupervisorNote` ledger event FIRST (durable, replayable, surfaced in the
   `supervisor events` projection and `describe_event`) and THEN pushes to the
   supervisor session. Lost/delayed pushes no longer lose the notification —
   the note is readable by polling even when the push is dropped or the
   supervisor is busy. No supervisor registered still ledgers the note (a
   later `supervisor register` reads it back); only the push is skipped.

2. The run index is no longer persisted (append removed). The old
   `write_run` appended `runs/index.jsonl` with a lockless
   `OpenOptions::append` per process, so N concurrent workers writing a run at
   once could interleave rows and drift the read model (the observed
   "run_index drifted — rebuilt" self-heal noise). The index is now a pure
   projection: writers only write the per-run JSON/MD files (each a unique,
   uncontended file), and readers derive the index rows via the new
   `run_index::load_run_index` (scans the run dir incl. archive). run-history,
   compaction, and retention all read through `load_run_index`; `runs index
   --rebuild` / `store verify --repair` remain as on-demand human inspection.
   The run-path `run_index_self_heal` seam is now a no-op.
