### PR TITLE
fix(loop): make turn counters monotonic across separate run processes

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4165,6 +4165,18 @@ async fn run_turns(
     last_failure_kind: &mut Option<crate::state::FailureKind>,
 ) -> Result<()> {
     let mut turn = 0u32;
+    // P2: goal-monotonic turn counter. `turn` below restarts at 1 on every
+    // `run` process, so a worker relaunched across runs (or resumed after a
+    // timeout) would re-emit `turn-1` heartbeat receipts and decision
+    // summaries, making cross-run provenance unreadable from the ledger. The
+    // number of already-recorded decision summaries equals the count of turns
+    // that have STARTED on this goal (timeout turns included, because the
+    // receipt is written before the turn executes), so offset the local
+    // counter by it to obtain a goal-wide monotonic turn number.
+    let base_turn = store
+        .events(goal_id)
+        .map(|events| crate::quota::decision_summary::decision_summaries(&events).len() as u32)
+        .unwrap_or(0);
     // Continue note for the NEXT turn: set when the previous turn ended
     // incomplete; consumed exactly once by the next execute_turn call.
     let mut next_continue_note: Option<String> = None;
@@ -4204,15 +4216,25 @@ async fn run_turns(
         if turn > max_turns {
             bail!("max-turns ({max_turns}) reached without validated closure");
         }
+        // Goal-wide turn number: `turn` is local to this run process, so every
+        // persisted reference (decision summary, heartbeat receipt, run record,
+        // client_request_id) must use the offset value to stay distinguishable
+        // across runs.
+        let global_turn = base_turn + turn;
         let goal = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
         let mut packet = decide_for(&goal, SystemTime::now(), agent_id);
         // P1-1②③: persist the compact decision projection + the heartbeat
         // receipt for this turn (projection-only; replay ignores both).
-        crate::quota::decision_summary::record_turn_decision(store, &packet, agent_id, turn)?;
+        crate::quota::decision_summary::record_turn_decision(
+            store,
+            &packet,
+            agent_id,
+            global_turn,
+        )?;
         println!(
-            "── turn {turn}: decision={} mode={} | {}",
+            "── turn {global_turn}: decision={} mode={} | {}",
             packet.decision,
             packet.interaction_contract.mode.as_str(),
             packet.reason
@@ -4379,7 +4401,7 @@ async fn run_turns(
             &boundary,
             agent_id,
             &todo,
-            turn,
+            global_turn,
             goal.history.last(),
             true,
             Some(runs_dir),

--- a/orchestration/loop/src/quota/decision_summary.rs
+++ b/orchestration/loop/src/quota/decision_summary.rs
@@ -57,7 +57,10 @@ pub struct DecisionSummary {
     pub safe_bypass_kind: Option<String>,
     #[serde(default)]
     pub blocked_action_scope: Option<String>,
-    /// Run-turn counter at record time (0 = recorded outside a run loop).
+    /// Goal-level monotonic turn counter at record time (0 = recorded outside
+    /// a run loop). The caller offsets the run-local turn by the number of
+    /// turns already started on the goal, so receipts stay distinguishable
+    /// across separate `run` processes (timeout turns included).
     #[serde(default)]
     pub turn: u32,
 }
@@ -116,7 +119,9 @@ pub fn latest_decision_summary(events: &[StoredEvent]) -> Option<&DecisionSummar
 /// can never change future decisions.
 ///
 /// `turn_instance_id` anchors the receipt the way LoopX keys heartbeat
-/// receipts on (goal, agent, run/turn instance, todo).
+/// receipts on (goal, agent, run/turn instance, todo). The `turn` argument is
+/// a GOAL-LEVEL monotonic counter (not the run-local turn), so receipts stay
+/// distinguishable across separate `run` processes — the caller offsets it.
 pub fn record_turn_decision(
     store: &mut Store,
     packet: &ShouldRunPacket,


### PR DESCRIPTION
## Problem

`run_turns` used a run-local `turn` counter that restarts at `1` on every
`run` process. That counter flows into:

- `DecisionSummary.turn`
- `HeartbeatReceiptRecorded.turn_instance_id` (`turn-{turn}`)
- `RunRecord.turn`
- the `client_request_id`

Under the multi-worker pattern — one `run --max-turns 1` process per worker,
plus relaunch/resume after a timeout — every turn was stamped `turn-1`, so:

- cross-run provenance was unreadable from the ledger (can't tell a worker's
  1st attempt from its 2nd),
- delivery `turns_since_delivery` ages were computed against a reset counter
  (age came out 0 even after several turns).

## Fix

Offset the run-local counter by the number of decision summaries already
recorded on the goal. A decision summary is written *before* each turn
executes (timeout turns included), so that count equals the turns started so
far — a reliable goal-wide base that does not depend on a turn reaching
writeback:

```rust
let base_turn = store
    .events(goal_id)
    .map(|events| decision_summaries(&events).len() as u32)
    .unwrap_or(0);
// ...
let global_turn = base_turn + turn;
```

`global_turn` then replaces the run-local `turn` for every persisted
reference (decision summary, heartbeat receipt, run record, `execute_turn`).

## Changes

- `orchestration/loop/src/console.rs` — compute `base_turn` at run start,
  use `global_turn` throughout the loop.
- `orchestration/loop/src/quota/decision_summary.rs` — update the `turn`
  field / `record_turn_decision` doc comments to the goal-level semantics.
- `skills` — bump submodule for the matching binary-freshness probe fix
  (see future-skills PR #37).

## Tests

- `cargo check -p future-loop` ✅
- `cargo test -p future-loop --lib quota::decision_summary` ✅ (2 passed)
- `cargo test -p future-loop --test quota_read_model_contract` ✅ (8 passed)