### PR TITLE
fix(loop): reject fast-exit detached runs; sync turn-counter docs

### DIFF
--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -3640,6 +3640,12 @@ async fn cmd_models(args: &[String]) -> Result<()> {
 /// the todo mid-turn once the lease expired).
 const DEFAULT_RUN_LEASE_SECS: u64 = 4 * 3600;
 
+/// Grace window (ms) the detached-run parent waits before probing the child
+/// with `try_wait`. Long enough for a mis-dispatched re-exec to fail at CLI
+/// parse time (e.g. `Unknown option: --goal`), short enough to not delay the
+/// orchestrator returning while a healthy child is still starting up.
+const DETACH_LIVENESS_GRACE_MS: u64 = 120;
+
 /// Resolve run identity (G-27): `run` REQUIRES `--agent-id` so the lease
 /// mechanism actually engages — an anonymous run claims nothing and hides
 /// nothing, so two agentless runs deterministically race on the same todo.
@@ -3830,9 +3836,31 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         cmd.stdout(log.try_clone()?)
             .stderr(log)
             .stdin(std::process::Stdio::null());
-        let child = cmd
+        let mut child = cmd
             .spawn()
             .map_err(|e| anyhow::anyhow!("spawn detached run (log {}): {e}", log_path.display()))?;
+        // Defensive liveness check: `spawn` succeeding only means the process
+        // was created, not that it re-dispatched correctly. A bad re-exec
+        // (e.g. the child drops a group layer and lands on an unrelated
+        // command) makes the child exit instantly with a usage error while the
+        // parent would otherwise print a fake pid and return success. Give the
+        // child a short grace window, then reject a fast-exit so the
+        // orchestrator sees the failure instead of a dead worker it must
+        // discover later.
+        tokio::time::sleep(std::time::Duration::from_millis(DETACH_LIVENESS_GRACE_MS)).await;
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                bail!(
+                    "detached run exited immediately ({status}) — check {} for the real error; re-exec may have mis-dispatched",
+                    log_path.display()
+                );
+            }
+            Ok(None) => {}
+            Err(_) => {
+                // A try_wait error is not a crash signal; fall through and let
+                // the normal detached supervision own the child from here.
+            }
+        }
         println!(
             "⏏ detached run pid={} (agent {who}) — log {}",
             child.id(),

--- a/orchestration/loop/src/quota/decision_summary.rs
+++ b/orchestration/loop/src/quota/decision_summary.rs
@@ -57,7 +57,10 @@ pub struct DecisionSummary {
     pub safe_bypass_kind: Option<String>,
     #[serde(default)]
     pub blocked_action_scope: Option<String>,
-    /// Run-turn counter at record time (0 = recorded outside a run loop).
+    /// Goal-level monotonic turn counter at record time (0 = recorded outside
+    /// a run loop). The caller offsets the run-local turn by the number of
+    /// turns already started on the goal, so receipts stay distinguishable
+    /// across separate `run` processes (timeout turns included).
     #[serde(default)]
     pub turn: u32,
 }
@@ -116,7 +119,9 @@ pub fn latest_decision_summary(events: &[StoredEvent]) -> Option<&DecisionSummar
 /// can never change future decisions.
 ///
 /// `turn_instance_id` anchors the receipt the way LoopX keys heartbeat
-/// receipts on (goal, agent, run/turn instance, todo).
+/// receipts on (goal, agent, run/turn instance, todo). The `turn` argument is
+/// a GOAL-LEVEL monotonic counter (not the run-local turn), so receipts stay
+/// distinguishable across separate `run` processes — the caller offsets it.
 pub fn record_turn_decision(
     store: &mut Store,
     packet: &ShouldRunPacket,


### PR DESCRIPTION
## Summary

Two follow-ups to the detached-run (#473) and turn-provenance (#474) fixes.

### 1. Detached-run liveness check

`spawn` succeeding only means the child process was created, not that it
re-dispatched correctly. A mis-dispatched re-exec (e.g. the child drops the
`loop` group and lands on the unrelated one-shot `future run`, which rejects
`--goal`) exits instantly with a usage error — while the parent printed a fake
pid and returned success, leaving the orchestrator to discover a dead worker
later.

This change gives the child a short grace window (120 ms), then `try_wait`s
it: if the child has already exited, `cmd_run` bails with a pointer to the
detached log instead of reporting a fake pid.

### 2. Doc sync for the turn counter

The goal-level monotonic turn counter (`base_turn` + `global_turn`) landed in
#474, but `DecisionSummary::turn` and `record_turn_decision` still described
the old run-local counter. Updated both doc comments to the goal-level
semantics.

## Tests

- `cargo check -p future-loop` ✅
- `cargo test -p future-loop --lib quota::decision_summary` ✅ (2 passed)
- `cargo test -p future-loop --test quota_read_model_contract` ✅ (8 passed)