### PR TITLE
Sync externally created Agent sessions into Desktop

### DIFF
--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -383,7 +383,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
                     "global_events cannot be combined with session/run attachment fields",
                 ));
             }
-            let broadcaster = crate::rpc::global_config_broadcaster();
+            let broadcaster = crate::rpc::global_events_broadcaster();
             let rx = broadcaster.subscribe();
             let revision = crate::rpc::current_config_revision();
             let mut initial = vec![proto::StreamEvent {
@@ -847,6 +847,37 @@ mod tests {
         let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
         assert_eq!(data["revision"], revision);
         assert_eq!(data["providerId"], "custom");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn global_stream_delivers_session_created() {
+        let service = FutureAgentService {
+            state: grpc_app_state(false),
+        };
+        // Filtering to session_created also drops the initial ping.
+        let response = service
+            .stream_events(tonic::Request::new(proto::StreamRequest {
+                event_types: vec!["session_created".to_string()],
+                global_events: true,
+                ..Default::default()
+            }))
+            .await
+            .expect("global subscription succeeds");
+        let mut stream = response.into_inner();
+        crate::rpc::publish_session_created("tui-session", "tui", "/tmp/project");
+        // Parallel tests publish session_created on the same global stream —
+        // drain until THIS announcement arrives.
+        for _ in 0..32 {
+            let event = stream.next().await.unwrap().unwrap();
+            assert_eq!(event.r#type, "session_created");
+            let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
+            if data["sessionId"] == "tui-session" {
+                assert_eq!(data["createdBy"], "tui");
+                assert_eq!(data["cwd"], "/tmp/project");
+                return;
+            }
+        }
+        panic!("session_created for tui-session never arrived on the global stream");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -231,6 +231,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
             mode: cmd.mode,
             custom_instructions: cmd.custom_instructions,
             created_by: cmd.created_by,
+            creator_id: cmd.creator_id,
             source_meta: cmd.source_meta,
             enabled: cmd.enabled,
             command: cmd.command,
@@ -864,7 +865,12 @@ mod tests {
             .await
             .expect("global subscription succeeds");
         let mut stream = response.into_inner();
-        crate::rpc::publish_session_created("tui-session", "tui", "/tmp/project");
+        crate::rpc::publish_session_created_with_creator(
+            "tui-session",
+            "tui",
+            "creator-tui",
+            "/tmp/project",
+        );
         // Parallel tests publish session_created on the same global stream —
         // drain until THIS announcement arrives.
         for _ in 0..32 {
@@ -873,6 +879,7 @@ mod tests {
             let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
             if data["sessionId"] == "tui-session" {
                 assert_eq!(data["createdBy"], "tui");
+                assert_eq!(data["creatorId"], "creator-tui");
                 assert_eq!(data["cwd"], "/tmp/project");
                 return;
             }

--- a/agent/src/rpc/commands/mod.rs
+++ b/agent/src/rpc/commands/mod.rs
@@ -154,7 +154,7 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
         "abort_retry" => run_control::handle_abort_retry(&session, id),
         "cycle_model" => settings::handle_cycle_model(state, &session, id),
         "cycle_thinking_level" => settings::handle_cycle_thinking_level(&session, id),
-        "clone" => session_lifecycle::cmd_clone(state, &session, id),
+        "clone" => session_lifecycle::cmd_clone(state, &session, &cmd, id),
         "export_html" => observability::handle_export_html(&session, id),
         "reload_config" => settings::cmd_reload_config(state, &session, id),
         "set_cwd" => settings::handle_set_cwd(&session, &cmd, id),

--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -895,13 +895,14 @@ pub(crate) fn cmd_fork(
     }
 
     // Extract needed data from session
-    let (session_manager, broadcaster, _cwd, current_session_id) = {
+    let (session_manager, broadcaster, _cwd, current_session_id, parent_created_by) = {
         let sess = session.read();
         (
             sess.session_manager.clone(),
             sess.broadcaster.clone(),
             sess.cwd.clone(),
             sess.session_id.clone(),
+            sess.created_by.clone(),
         )
     };
     // The fork gets its own agent loop — sharing the parent's loop would let
@@ -958,6 +959,14 @@ pub(crate) fn cmd_fork(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
+    // Provenance: the forking client owns the child (cmd.created_by), else
+    // inherit the parent's — a desktop fork of an imported TUI session must
+    // still announce itself as desktop so the GUI skips its own push import.
+    new_sess.created_by = if !cmd.created_by.is_empty() {
+        cmd.created_by.clone()
+    } else {
+        parent_created_by
+    };
     let supports_images = state
         .model_registry
         .read()
@@ -992,7 +1001,7 @@ pub(crate) fn cmd_clone(
     id: &str,
 ) -> String {
     // Extract needed data from session
-    let (session_manager, broadcaster, _cwd, session_id) = {
+    let (session_manager, broadcaster, _cwd, session_id, parent_created_by) = {
         let sess = session.read();
         if sess.messages.read().is_empty() {
             return RpcResponse::build_fail(
@@ -1006,6 +1015,7 @@ pub(crate) fn cmd_clone(
             sess.broadcaster.clone(),
             sess.cwd.clone(),
             sess.session_id.clone(),
+            sess.created_by.clone(),
         )
     };
     // Own agent loop for the clone (same reasoning as fork).
@@ -1064,6 +1074,9 @@ pub(crate) fn cmd_clone(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
+    // Provenance: clones inherit the parent's creator — keeps the
+    // session_created announcement accurate for the cloning client.
+    new_sess.created_by = parent_created_by;
     let supports_images = state
         .model_registry
         .read()

--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -401,6 +401,7 @@ pub(crate) fn cmd_new_session(state: &AppState, cmd: &RpcCommand, id: &str) -> S
     if !cmd.created_by.is_empty() {
         new_sess.created_by = cmd.created_by.clone();
     }
+    new_sess.creator_id = cmd.creator_id.clone();
     if !cmd.source_meta.is_empty() {
         if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&cmd.source_meta) {
             new_sess.source_meta = meta;
@@ -932,7 +933,13 @@ pub(crate) fn cmd_fork(
     };
 
     // Fork a new session
-    let forked = crate::session::fork_session(&parent, entry_id);
+    let child_created_by = if cmd.created_by.is_empty() {
+        parent_created_by.as_str()
+    } else {
+        cmd.created_by.as_str()
+    };
+    let mut forked = crate::session::fork_session(&parent, entry_id);
+    crate::session::set_creation_provenance(&mut forked, child_created_by, &cmd.creator_id);
     let forked_id = forked.id.clone();
 
     // Save the forked session
@@ -959,14 +966,13 @@ pub(crate) fn cmd_fork(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
-    // Provenance: the forking client owns the child (cmd.created_by), else
-    // inherit the parent's — a desktop fork of an imported TUI session must
-    // still announce itself as desktop so the GUI skips its own push import.
-    new_sess.created_by = if !cmd.created_by.is_empty() {
-        cmd.created_by.clone()
-    } else {
-        parent_created_by
-    };
+    // Category provenance may fall back for legacy callers; creator_id never
+    // inherits because it identifies the client that performed this fork.
+    new_sess.created_by = child_created_by.to_string();
+    // creator_id identifies the client that performed this fork. Never inherit
+    // it from the parent: a TUI/CLI fork of a Desktop session is not owned by
+    // the original Desktop installation.
+    new_sess.creator_id = cmd.creator_id.clone();
     let supports_images = state
         .model_registry
         .read()
@@ -998,6 +1004,7 @@ pub(crate) fn cmd_fork(
 pub(crate) fn cmd_clone(
     state: &AppState,
     session: &Arc<parking_lot::RwLock<ServerSession>>,
+    cmd: &RpcCommand,
     id: &str,
 ) -> String {
     // Extract needed data from session
@@ -1049,7 +1056,13 @@ pub(crate) fn cmd_clone(
     }
 
     // Fork from leaf
-    let forked = crate::session::fork_session(&parent, &leaf_id);
+    let child_created_by = if cmd.created_by.is_empty() {
+        parent_created_by.as_str()
+    } else {
+        cmd.created_by.as_str()
+    };
+    let mut forked = crate::session::fork_session(&parent, &leaf_id);
+    crate::session::set_creation_provenance(&mut forked, child_created_by, &cmd.creator_id);
     let forked_id = forked.id.clone();
 
     // Save the forked session
@@ -1074,9 +1087,10 @@ pub(crate) fn cmd_clone(
         state.model_registry.clone(),
         state.queue_budget.clone(),
     );
-    // Provenance: clones inherit the parent's creator — keeps the
-    // session_created announcement accurate for the cloning client.
-    new_sess.created_by = parent_created_by;
+    // Match fork provenance: category fallback is legacy compatibility while
+    // creator_id identifies only the client performing this clone.
+    new_sess.created_by = child_created_by.to_string();
+    new_sess.creator_id = cmd.creator_id.clone();
     let supports_images = state
         .model_registry
         .read()

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -882,6 +882,75 @@ fn fork_from_explicit_parent_session() {
 }
 
 #[test]
+fn fork_propagates_created_by_from_the_forking_client() {
+    let state = make_app_state();
+    let user = crate::session::SessionEntry::new_user("user", serde_json::json!("fork me"));
+    let entry_id = user.id.clone();
+    save_via(&state, "default", "mock", vec![user]);
+    // The parent is a desktop-owned session (created via the GUI's
+    // new_session): the fork must announce itself as desktop so the GUI skips
+    // its own push import of the session it is about to link itself.
+    state.get_session("default").unwrap().write().created_by = "desktop".to_string();
+
+    // Inheritance when the command carries no provenance.
+    let mut cmd = make_cmd("fork");
+    cmd.entry_id = entry_id.clone();
+    let resp = parse_response(&handle_command_internal(&state, cmd));
+    assert_eq!(resp["success"], true);
+    let fork_id = resp["data"]["sessionId"].as_str().unwrap();
+    assert_eq!(
+        state.get_session(fork_id).unwrap().read().created_by,
+        "desktop"
+    );
+
+    // The command's explicit provenance wins (e.g. a CLI forking a GUI session).
+    let mut cmd = make_cmd("fork");
+    cmd.entry_id = entry_id;
+    cmd.created_by = "cli".to_string();
+    let resp = parse_response(&handle_command_internal(&state, cmd));
+    assert_eq!(resp["success"], true);
+    let fork_id = resp["data"]["sessionId"].as_str().unwrap();
+    assert_eq!(state.get_session(fork_id).unwrap().read().created_by, "cli");
+}
+
+#[test]
+fn clone_propagates_the_parent_created_by() {
+    let state = make_app_state();
+    let user = crate::session::SessionEntry::new_user("user", serde_json::json!("clone me"));
+    save_via(&state, "default", "mock", vec![user]);
+    // cmd_clone's guard requires in-memory messages on the live session.
+    {
+        let session = state.get_session("default").unwrap();
+        session
+            .read()
+            .messages
+            .write()
+            .push(crate::types::AgentMessage::new_user(
+                "user",
+                serde_json::json!("clone me"),
+            ));
+        session.write().created_by = "tui".to_string();
+    }
+
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("clone")));
+    assert_eq!(resp["success"], true);
+    assert_eq!(resp["data"]["cancelled"], false);
+    // The clone response carries no id — find the newly registered session
+    // (make_app_state starts with only "default").
+    let clone_id = state
+        .sessions
+        .read()
+        .keys()
+        .find(|id| id.as_str() != "default")
+        .cloned()
+        .expect("clone registered a new session");
+    assert_eq!(
+        state.get_session(&clone_id).unwrap().read().created_by,
+        "tui"
+    );
+}
+
+#[test]
 fn clone_rejects_empty_session() {
     let state = make_app_state();
     let resp = parse_response(&handle_command_internal(&state, make_cmd("clone")));

--- a/agent/src/rpc/commands/session_lifecycle_tests.rs
+++ b/agent/src/rpc/commands/session_lifecycle_tests.rs
@@ -426,6 +426,7 @@ fn new_session_honors_explicit_id_cwd_model_level_and_provenance() {
     cmd.model_id = "explicit/model".to_string();
     cmd.level = "low".to_string();
     cmd.created_by = "gui".to_string();
+    cmd.creator_id = "desktop-creator-1".to_string();
     cmd.source_meta = "{\"thread\":\"t1\"}".to_string();
     cmd.parent_session = "parent-1".to_string();
     let resp = parse_response(&handle_command_internal(&state, cmd));
@@ -434,6 +435,7 @@ fn new_session_honors_explicit_id_cwd_model_level_and_provenance() {
     let session = state.get_session("ns-explicit").unwrap();
     let sess = session.read();
     assert_eq!(sess.created_by, "gui");
+    assert_eq!(sess.creator_id, "desktop-creator-1");
     assert_eq!(sess.source_meta, serde_json::json!({"thread": "t1"}));
     assert_eq!(sess.parent_session_id, "parent-1");
     assert_eq!(sess.model, "explicit/model");
@@ -887,10 +889,10 @@ fn fork_propagates_created_by_from_the_forking_client() {
     let user = crate::session::SessionEntry::new_user("user", serde_json::json!("fork me"));
     let entry_id = user.id.clone();
     save_via(&state, "default", "mock", vec![user]);
-    // The parent is a desktop-owned session (created via the GUI's
-    // new_session): the fork must announce itself as desktop so the GUI skips
-    // its own push import of the session it is about to link itself.
+    // The parent is a desktop-created session. Category provenance may be
+    // inherited by an old client, but creator identity never is.
     state.get_session("default").unwrap().write().created_by = "desktop".to_string();
+    state.get_session("default").unwrap().write().creator_id = "desktop-parent".to_string();
 
     // Inheritance when the command carries no provenance.
     let mut cmd = make_cmd("fork");
@@ -902,15 +904,30 @@ fn fork_propagates_created_by_from_the_forking_client() {
         state.get_session(fork_id).unwrap().read().created_by,
         "desktop"
     );
+    assert!(state
+        .get_session(fork_id)
+        .unwrap()
+        .read()
+        .creator_id
+        .is_empty());
 
     // The command's explicit provenance wins (e.g. a CLI forking a GUI session).
     let mut cmd = make_cmd("fork");
     cmd.entry_id = entry_id;
     cmd.created_by = "cli".to_string();
+    cmd.creator_id = "cli-creator".to_string();
     let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], true);
     let fork_id = resp["data"]["sessionId"].as_str().unwrap();
     assert_eq!(state.get_session(fork_id).unwrap().read().created_by, "cli");
+    assert_eq!(
+        state.get_session(fork_id).unwrap().read().creator_id,
+        "cli-creator"
+    );
+    let persisted = state.session_manager.load(fork_id).expect("persisted fork");
+    let info = persisted.get_session_info().expect("fork session_info");
+    assert_eq!(info["created_by"], "cli");
+    assert_eq!(info["creator_id"], "cli-creator");
 }
 
 #[test]
@@ -932,7 +949,9 @@ fn clone_propagates_the_parent_created_by() {
         session.write().created_by = "tui".to_string();
     }
 
-    let resp = parse_response(&handle_command_internal(&state, make_cmd("clone")));
+    let mut cmd = make_cmd("clone");
+    cmd.creator_id = "tui-creator".to_string();
+    let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], true);
     assert_eq!(resp["data"]["cancelled"], false);
     // The clone response carries no id — find the newly registered session
@@ -947,6 +966,10 @@ fn clone_propagates_the_parent_created_by() {
     assert_eq!(
         state.get_session(&clone_id).unwrap().read().created_by,
         "tui"
+    );
+    assert_eq!(
+        state.get_session(&clone_id).unwrap().read().creator_id,
+        "tui-creator"
     );
 }
 

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -33,6 +33,13 @@ pub fn global_events_broadcaster() -> Arc<SseBroadcaster> {
     GLOBAL_EVENTS_BROADCASTER.clone()
 }
 
+/// Backward-compatible name retained for Rust callers compiled against the
+/// config-only version of the global stream.
+#[deprecated(note = "use global_events_broadcaster")]
+pub fn global_config_broadcaster() -> Arc<SseBroadcaster> {
+    global_events_broadcaster()
+}
+
 pub fn current_config_revision() -> i64 {
     CONFIG_REVISION.load(Ordering::Acquire)
 }
@@ -64,11 +71,23 @@ pub fn publish_provider_config_changed(
 /// immediately instead of waiting for their discovery polls. An idempotent
 /// hint: consumers reconcile against their own state, so no revision counter.
 pub fn publish_session_created(session_id: &str, created_by: &str, cwd: &str) {
+    publish_session_created_with_creator(session_id, created_by, "", cwd);
+}
+
+/// Creator-aware session announcement. The three-argument wrapper remains for
+/// source compatibility and emits an empty creator id (legacy semantics).
+pub fn publish_session_created_with_creator(
+    session_id: &str,
+    created_by: &str,
+    creator_id: &str,
+    cwd: &str,
+) {
     GLOBAL_EVENTS_BROADCASTER.broadcast(SseEvent::new(
         "session_created",
         serde_json::json!({
             "sessionId": session_id,
             "createdBy": created_by,
+            "creatorId": creator_id,
             "cwd": cwd,
         }),
     ));
@@ -258,6 +277,7 @@ impl AppState {
     pub fn create_session(&self, mut session: ServerSession) -> String {
         let id = session.session_id.clone();
         let created_by = session.created_by.clone();
+        let creator_id = session.creator_id.clone();
         let cwd = session.cwd.clone();
         session.broadcaster = Arc::new(SseBroadcaster::new());
         if let Err(error) = session
@@ -271,7 +291,7 @@ impl AppState {
         ServerSession::ensure_scheduler_worker(&session);
         // Announce after the map insert so subscribers can resolve the
         // session (e.g. get_state) the moment they see the event.
-        publish_session_created(&id, &created_by, &cwd);
+        publish_session_created_with_creator(&id, &created_by, &creator_id, &cwd);
         id
     }
 
@@ -1126,6 +1146,7 @@ mod tests {
             state.queue_budget.clone(),
         );
         session.created_by = "tui".to_string();
+        session.creator_id = "tui-creator".to_string();
         state.create_session(session);
 
         // Other tests broadcast on the same global stream concurrently —
@@ -1139,6 +1160,7 @@ mod tests {
                     let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
                     assert_eq!(data["sessionId"], "announce-me");
                     assert_eq!(data["createdBy"], "tui");
+                    assert_eq!(data["creatorId"], "tui-creator");
                     assert_eq!(data["cwd"], "/tmp/project");
                     return;
                 }

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -22,14 +22,15 @@ pub use commands::handle_command_internal;
 pub use protocol::{RpcCommand, RpcResponse, SseBroadcaster, SseEvent, BROADCAST_RING_CAPACITY};
 pub use session::ServerSession;
 
-/// Provider/auth configuration is process-wide Agent state, not chat state.
-/// This broadcaster gives every client one authoritative completion stream.
-static GLOBAL_CONFIG_BROADCASTER: LazyLock<Arc<SseBroadcaster>> =
+/// Process-wide control-plane events (not chat state): provider/auth config
+/// completions and session lifecycle signals. This broadcaster gives every
+/// client one authoritative stream.
+static GLOBAL_EVENTS_BROADCASTER: LazyLock<Arc<SseBroadcaster>> =
     LazyLock::new(|| Arc::new(SseBroadcaster::new()));
 static CONFIG_REVISION: AtomicI64 = AtomicI64::new(0);
 
-pub fn global_config_broadcaster() -> Arc<SseBroadcaster> {
-    GLOBAL_CONFIG_BROADCASTER.clone()
+pub fn global_events_broadcaster() -> Arc<SseBroadcaster> {
+    GLOBAL_EVENTS_BROADCASTER.clone()
 }
 
 pub fn current_config_revision() -> i64 {
@@ -44,7 +45,7 @@ pub fn publish_provider_config_changed(
     models_changed: bool,
 ) -> i64 {
     let revision = CONFIG_REVISION.fetch_add(1, Ordering::AcqRel) + 1;
-    GLOBAL_CONFIG_BROADCASTER.broadcast(SseEvent::new(
+    GLOBAL_EVENTS_BROADCASTER.broadcast(SseEvent::new(
         "provider_config_changed",
         serde_json::json!({
             "revision": revision,
@@ -55,6 +56,22 @@ pub fn publish_provider_config_changed(
         }),
     ));
     revision
+}
+
+/// Announce a newly minted session on the global control-plane stream. Fired
+/// by `AppState::create_session` (new_session / fork / clone — never disk
+/// hydration) so other clients (e.g. the desktop) can surface the session
+/// immediately instead of waiting for their discovery polls. An idempotent
+/// hint: consumers reconcile against their own state, so no revision counter.
+pub fn publish_session_created(session_id: &str, created_by: &str, cwd: &str) {
+    GLOBAL_EVENTS_BROADCASTER.broadcast(SseEvent::new(
+        "session_created",
+        serde_json::json!({
+            "sessionId": session_id,
+            "createdBy": created_by,
+            "cwd": cwd,
+        }),
+    ));
 }
 
 /// Map one broadcaster/journal event into its replay payload carrier. The
@@ -240,6 +257,8 @@ impl AppState {
     /// an unbound broadcaster silently holds events in memory only.
     pub fn create_session(&self, mut session: ServerSession) -> String {
         let id = session.session_id.clone();
+        let created_by = session.created_by.clone();
+        let cwd = session.cwd.clone();
         session.broadcaster = Arc::new(SseBroadcaster::new());
         if let Err(error) = session
             .broadcaster
@@ -250,6 +269,9 @@ impl AppState {
         let session = Arc::new(RwLock::new(session));
         self.sessions.write().insert(id.clone(), session.clone());
         ServerSession::ensure_scheduler_worker(&session);
+        // Announce after the map insert so subscribers can resolve the
+        // session (e.g. get_state) the moment they see the event.
+        publish_session_created(&id, &created_by, &cwd);
         id
     }
 
@@ -1078,6 +1100,59 @@ mod tests {
         let id = state.create_session(session);
         assert_eq!(id, "journal-fail");
         assert!(state.get_session("journal-fail").is_some());
+    }
+
+    #[test]
+    fn create_session_publishes_global_session_created() {
+        let _sink = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_writer(std::io::sink)
+                .with_ansi(false)
+                .finish(),
+        );
+        let (_dir, state) = bare_app_state();
+        let mut rx = global_events_broadcaster().subscribe();
+        let mut session = crate::rpc::ServerSession::new_with_queue_budget(
+            "announce-me".to_string(),
+            std::sync::Arc::new(tokio::sync::RwLock::new(crate::agent::Loop::new(
+                std::sync::Arc::new(crate::test_support::EmptyProvider),
+                "mock",
+            ))),
+            state.session_manager.clone(),
+            "/tmp/project",
+            std::sync::Arc::new(SseBroadcaster::new()),
+            state.approval_gate.clone(),
+            state.model_registry.clone(),
+            state.queue_budget.clone(),
+        );
+        session.created_by = "tui".to_string();
+        state.create_session(session);
+
+        // Other tests broadcast on the same global stream concurrently —
+        // drain until THIS session's announcement arrives.
+        for _ in 0..64 {
+            match rx.try_recv() {
+                Ok(event)
+                    if event.event_type == "session_created"
+                        && event.data.contains("announce-me") =>
+                {
+                    let data: serde_json::Value = serde_json::from_str(&event.data).unwrap();
+                    assert_eq!(data["sessionId"], "announce-me");
+                    assert_eq!(data["createdBy"], "tui");
+                    assert_eq!(data["cwd"], "/tmp/project");
+                    return;
+                }
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => panic!(
+                    "session_created was not published: create_session must announce new sessions"
+                ),
+                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Closed) => {
+                    panic!("global broadcaster channel closed before session_created arrived")
+                }
+            }
+        }
+        panic!("session_created for announce-me never arrived on the global stream");
     }
 
     #[test]

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -46,6 +46,8 @@ pub struct RpcCommand {
     pub created_by: String,
     #[serde(default)]
     pub source_meta: String,
+    #[serde(default)]
+    pub creator_id: String,
 
     // set_auto_compaction / set_auto_retry
     #[serde(default)]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -85,6 +85,9 @@ pub struct ServerSession {
     pub session_name: String,
     /// Source that created this session: "desktop", "tui", "fork", "feishu", "dingtalk", etc.
     pub created_by: String,
+    /// Stable identity of the creator installation/account. This intentionally
+    /// does not identify a particular process or transport connection.
+    pub creator_id: String,
     /// Arbitrary metadata from the source side (JSON). Free-form.
     pub source_meta: serde_json::Value,
     /// Per-session SSE broadcaster.  Each subscriber (`StreamEvents` call)
@@ -223,6 +226,7 @@ impl ServerSession {
             session_name: String::new(),
             parent_session_id: String::new(),
             created_by: String::new(),
+            creator_id: String::new(),
             source_meta: serde_json::Value::Null,
             broadcaster,
             ephemeral: false,
@@ -890,6 +894,15 @@ impl ServerSession {
                 // applied it (the old inner fallback arm was unreachable).
                 if let Some(v) = info.get("auto_compaction").and_then(|v| v.as_bool()) {
                     self.auto_compaction = v;
+                }
+                if let Some(value) = info.get("created_by").and_then(|value| value.as_str()) {
+                    self.created_by = value.to_string();
+                }
+                if let Some(value) = info.get("creator_id").and_then(|value| value.as_str()) {
+                    self.creator_id = value.to_string();
+                }
+                if let Some(value) = info.get("source_meta") {
+                    self.source_meta = value.clone();
                 }
                 // Restore cwd from session_info (previously lost after agent restart)
                 if let Some(saved_cwd) = info.get("cwd").and_then(|v| v.as_str()) {
@@ -2495,6 +2508,9 @@ mod tests {
                 "cwd": cwd,
                 "model": "deepseek/deepseek-chat",
                 "session_name": "restored name",
+                "created_by": "desktop",
+                "creator_id": "desktop-device-1",
+                "source_meta": {"threadId": "thread-1"},
                 "thinking_level": "low",
                 "auto_compaction": false,
                 "tokens_in": 111,
@@ -2536,6 +2552,9 @@ mod tests {
         assert_eq!(session.model, "deepseek/deepseek-chat");
         assert_eq!(session.session_name, "restored name");
         assert_eq!(session.thinking_level, "low");
+        assert_eq!(session.created_by, "desktop");
+        assert_eq!(session.creator_id, "desktop-device-1");
+        assert_eq!(session.source_meta["threadId"], "thread-1");
         assert!(!session.auto_compaction);
         assert_eq!(
             session.tokens_in.load(std::sync::atomic::Ordering::Relaxed),

--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -661,6 +661,7 @@ impl ServerSession {
         let last_prompt = self.last_prompt_tokens.clone();
         let session_name = self.session_name.clone();
         let created_by = self.created_by.clone();
+        let creator_id = self.creator_id.clone();
         let source_meta = self.source_meta.clone();
         let auto_compaction = self.auto_compaction;
         let approval_gate = self.approval_gate.clone();
@@ -971,6 +972,9 @@ impl ServerSession {
                 });
                 if !created_by.is_empty() {
                     info["created_by"] = serde_json::Value::String(created_by);
+                }
+                if !creator_id.is_empty() {
+                    info["creator_id"] = serde_json::Value::String(creator_id);
                 }
                 if !source_meta.is_null() {
                     info["source_meta"] = source_meta;
@@ -1339,6 +1343,9 @@ impl ServerSession {
             });
             if !self.created_by.is_empty() {
                 info["created_by"] = serde_json::Value::String(self.created_by.clone());
+            }
+            if !self.creator_id.is_empty() {
+                info["creator_id"] = serde_json::Value::String(self.creator_id.clone());
             }
             if !self.source_meta.is_null() {
                 info["source_meta"] = self.source_meta.clone();

--- a/agent/src/session/fork.rs
+++ b/agent/src/session/fork.rs
@@ -154,6 +154,34 @@ pub fn fork_session(parent: &Session, from_entry_id: &str) -> Session {
     }
 }
 
+/// Replace the inherited provenance snapshot on a freshly forked session.
+/// Forking copies history, but the child is created by the client performing
+/// the fork; its durable creator identity must therefore not come from the
+/// parent session.
+pub fn set_creation_provenance(session: &mut Session, created_by: &str, creator_id: &str) {
+    let Some(info) = session
+        .entries
+        .iter_mut()
+        .find(|entry| entry.entry_type == ENTRY_TYPE_SESSION_INFO)
+        .and_then(|entry| entry.content.as_mut())
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    info.insert(
+        "created_by".to_string(),
+        serde_json::Value::String(created_by.to_string()),
+    );
+    if creator_id.is_empty() {
+        info.remove("creator_id");
+    } else {
+        info.insert(
+            "creator_id".to_string(),
+            serde_json::Value::String(creator_id.to_string()),
+        );
+    }
+}
+
 fn for_each_entry<'a>(entries: &'a [SessionEntry], from_id: &str) -> Vec<&'a SessionEntry> {
     // Include all entries from the beginning up to and including from_id,
     // skipping the original session_info (fork_session prepends its own) and

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -32,7 +32,7 @@ pub use entry::{
     ENTRY_TYPE_RUN_TERMINAL, ENTRY_TYPE_SESSION_INFO, ENTRY_TYPE_SYSTEM,
     ENTRY_TYPE_THINKING_LEVEL_CHANGE, ENTRY_TYPE_TOOL, ENTRY_TYPE_USER,
 };
-pub use fork::fork_session;
+pub use fork::{fork_session, set_creation_provenance};
 pub use manager::Manager;
 pub use model::{Session, SessionSummary, CURRENT_SESSION_VERSION};
 pub use persistence::SessionPersistence;

--- a/desktop/DEV_MD/ER.md
+++ b/desktop/DEV_MD/ER.md
@@ -114,7 +114,7 @@ Thread 表示用户可恢复、可继续、可管理的一段对话。
 | `status` | `active`、`archived`、`deleted` |
 | `pinned` | 是否置顶 |
 | `readonly` | 是否只读 |
-| `agent_session_id` | GUI Thread ↔ Agent 会话映射；解析 Agent 侧 sessions JSONL、远程控制查会话时用（`store/schema.rs`） |
+| `agent_session_id` | GUI Thread ↔ Agent 会话映射；非空值全局唯一，一个 Agent session 只能绑定一个 Desktop Thread；解析 Agent 侧 sessions JSONL、远程控制查会话时用（`store/schema.rs`） |
 | `last_message_at` | 最近消息时间 |
 | `last_opened_at` | 最近打开时间 |
 | `created_at` | 创建时间 |
@@ -131,6 +131,8 @@ Thread 表示用户可恢复、可继续、可管理的一段对话。
 - 一个 Thread 可以产生多个 Approval Request。
 - 一个 Thread 可以产生多个 Review Changeset。
 - 一个 Thread 可以由另一个 Thread 分叉（fork）产生。
+- 一个 Agent session 最多映射到一个 Thread；数据库唯一索引是并发导入时的最终约束，通知、事件流重连与低频完整 reconciliation 复用同一个 get-or-create 语义。
+- Desktop 的安装级 `device_id` 是 `session_created.creatorId` 的来源；它独立于远程配对并在 Debug Reset 后保留。`createdBy` 只表示客户端类别，未来的 `clientId` 应表示进程或连接实例。
 
 说明：
 

--- a/desktop/src-tauri/src/agent_bridge/client.rs
+++ b/desktop/src-tauri/src/agent_bridge/client.rs
@@ -211,6 +211,7 @@ pub(super) fn fork_command(
     session_id: String,
     entry_id: String,
     parent_session: String,
+    creator_id: String,
 ) -> RpcCommand {
     RpcCommand {
         entry_id,
@@ -219,6 +220,7 @@ pub(super) fn fork_command(
         // the forked session's provenance, so the session_created push skips
         // it (the GUI creates its own thread row for the fork).
         created_by: "desktop".to_string(),
+        creator_id,
         ..base_command("fork", session_id)
     }
 }
@@ -279,6 +281,7 @@ pub fn new_session_command(
     session_id: String,
     cwd: String,
     created_by: &str,
+    creator_id: String,
     source_meta: serde_json::Value,
     model_id: Option<String>,
     thinking_level: Option<String>,
@@ -288,6 +291,7 @@ pub fn new_session_command(
         // Typed provenance fields (proto created_by/source_meta) — no longer
         // smuggled through custom_instructions, which belongs to compact.
         created_by: created_by.to_string(),
+        creator_id,
         source_meta: source_meta.to_string(),
         model_id: model_id.unwrap_or_default(),
         level: thinking_level.unwrap_or_default(),
@@ -432,6 +436,7 @@ pub(super) fn base_command(command_type: &str, session_id: String) -> RpcCommand
         mode: String::new(),
         custom_instructions: String::new(),
         created_by: String::new(),
+        creator_id: String::new(),
         source_meta: String::new(),
         enabled: false,
         command: String::new(),
@@ -641,10 +646,12 @@ mod tests {
             "sess".to_string(),
             "entry-1".to_string(),
             "parent".to_string(),
+            "desktop-test".to_string(),
         );
         assert_eq!(cmd.r#type, "fork");
         assert_eq!(cmd.entry_id, "entry-1");
         assert_eq!(cmd.parent_session, "parent");
+        assert_eq!(cmd.creator_id, "desktop-test");
 
         assert_eq!(
             delete_session_command("sess".to_string()).r#type,
@@ -677,6 +684,7 @@ mod tests {
             "sess".to_string(),
             "/tmp/ws".to_string(),
             "desktop",
+            "desktop-test".to_string(),
             serde_json::json!({"source": "test"}),
             Some("future/k3".to_string()),
             Some("high".to_string()),
@@ -684,6 +692,7 @@ mod tests {
         assert_eq!(cmd.r#type, "new_session");
         assert_eq!(cmd.cwd, "/tmp/ws");
         assert_eq!(cmd.created_by, "desktop");
+        assert_eq!(cmd.creator_id, "desktop-test");
         assert_eq!(cmd.source_meta, r#"{"source":"test"}"#);
         assert_eq!(cmd.model_id, "future/k3");
         assert_eq!(cmd.level, "high");
@@ -692,6 +701,7 @@ mod tests {
             String::new(),
             String::new(),
             "desktop",
+            String::new(),
             serde_json::Value::Null,
             None,
             None,

--- a/desktop/src-tauri/src/agent_bridge/client.rs
+++ b/desktop/src-tauri/src/agent_bridge/client.rs
@@ -215,6 +215,10 @@ pub(super) fn fork_command(
     RpcCommand {
         entry_id,
         parent_session,
+        // Declare the GUI as the forking client: the agent propagates this to
+        // the forked session's provenance, so the session_created push skips
+        // it (the GUI creates its own thread row for the fork).
+        created_by: "desktop".to_string(),
         ..base_command("fork", session_id)
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/import.rs
+++ b/desktop/src-tauri/src/agent_bridge/import.rs
@@ -3,14 +3,35 @@
 //! records + per-reply run records so they appear in the thread list and right
 //! panel immediately.
 
-use std::sync::Arc;
-use tokio::sync::Semaphore;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex, Weak};
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 
 use super::client::{
     connect_agent, get_state_command, list_session_ids_command, list_sessions_command,
     map_rpc_error, set_session_name_command, RpcResponseExt,
 };
 use crate::store;
+
+/// Serialize the complete import lifecycle per Agent session. The database
+/// unique index prevents duplicate thread rows, while this lock also prevents
+/// a push observer from starting against a row whose full-history import is
+/// still synthesizing run projections.
+static SESSION_IMPORT_LOCKS: LazyLock<Mutex<HashMap<String, Weak<AsyncMutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn session_import_lock(session_id: &str) -> Arc<AsyncMutex<()>> {
+    let mut locks = SESSION_IMPORT_LOCKS
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(session_id).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(session_id.to_string(), Arc::downgrade(&lock));
+    lock
+}
 
 // ─── agent RPC types ────────────────────────────────────────────────────────
 
@@ -285,6 +306,7 @@ async fn write_back_cwd(session_id: &str, cwd: &str) -> Result<(), String> {
         session_id.to_string(),
         cwd.to_string(),
         "desktop",
+        crate::device_identity::device_id_or_empty(),
         serde_json::Value::Null,
         None, // keep existing model
         None, // keep existing thinking level
@@ -313,6 +335,8 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
     if summary.id == "cov-test-import-panic" {
         panic!("cov test seam: simulated import panic");
     }
+    let import_lock = session_import_lock(&summary.id);
+    let _import_guard = import_lock.lock().await;
     if store::is_agent_session_tombstoned(&summary.id)? {
         return Ok(0);
     }
@@ -377,14 +401,18 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
     let title = best_title;
     let (mode, workspace_id, workspace_path, workspace_name) = thread_mode(summary, &title);
 
-    let thread = store::create_thread(store::CreateThreadInput {
-        mode,
-        title: Some(title.clone()),
-        workspace_id,
-        workspace_path: workspace_path.clone(),
-        workspace_name,
-        agent_session_id: Some(summary.id.clone()),
-    })?;
+    let (thread, created) =
+        store::get_or_create_thread_for_agent_session(store::CreateThreadInput {
+            mode,
+            title: Some(title.clone()),
+            workspace_id,
+            workspace_path: workspace_path.clone(),
+            workspace_name,
+            agent_session_id: Some(summary.id.clone()),
+        })?;
+    if !created {
+        return Ok(0);
+    }
 
     // Sync the agent's session_name to the newly-derived title so the sidebar
     // and agent state stay consistent — the agent may have a stale session_name
@@ -435,14 +463,16 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
 }
 
 /// Runtime discovery import for a session reported by another client
-/// (TUI/CLI/channels/another machine) — via the 1s streaming poll or the
-/// `session_created` push. Creates only the thread stub: for a streaming
+/// (TUI/CLI/channels/another machine) via the `session_created` push. Creates
+/// only the thread stub: for a streaming
 /// session the observer mints run rows live as events arrive, so minting
 /// synthetic historical runs here (as `import_one` does) would duplicate the
 /// live run. Title/model heal on the next full `import_missing_sessions`
 /// pass, which has richer summaries. Returns `true` when a stub was created,
 /// `false` when the session was already known (or tombstoned).
 pub(crate) async fn import_discovered_session(session_id: &str) -> Result<bool, crate::AppError> {
+    let import_lock = session_import_lock(session_id);
+    let _import_guard = import_lock.lock().await;
     if store::is_agent_session_tombstoned(session_id)? {
         return Ok(false);
     }
@@ -484,7 +514,7 @@ pub(crate) async fn import_discovered_session(session_id: &str) -> Result<bool, 
     };
     let title = session_title(&summary);
     let (mode, workspace_id, workspace_path, workspace_name) = thread_mode(&summary, &title);
-    store::create_thread(store::CreateThreadInput {
+    let (_, created) = store::get_or_create_thread_for_agent_session(store::CreateThreadInput {
         mode,
         title: Some(title),
         workspace_id,
@@ -492,7 +522,7 @@ pub(crate) async fn import_discovered_session(session_id: &str) -> Result<bool, 
         workspace_name,
         agent_session_id: Some(session_id.to_string()),
     })?;
-    Ok(true)
+    Ok(created)
 }
 
 /// Discover agent sessions not yet in the GUI DB and import them. Runs in the
@@ -545,6 +575,11 @@ pub async fn import_missing_sessions() {
         eprintln!(
             "FutureOS: imported {imported} session(s) ({total_runs} runs) out of {total} agent session(s)"
         );
+        // Full discovery also finds idle sessions, which never appear in the
+        // 1s streaming poll. Arm their passive observers now so later runs and
+        // session metadata changes are projected without requiring a click or
+        // an app restart.
+        super::observer::seed_observers_from_store();
         // New threads landed in the store — let the sidebar know.
         crate::emit_threads_updated();
     }
@@ -1211,6 +1246,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_discovery_creates_one_thread_for_the_agent_session() {
+        let _home = super::super::test_support::TestHome::new("import-disc-concurrent");
+        let mock = super::super::test_support::mock_agent();
+        // The per-session lock makes the loser observe the stored winner before
+        // issuing get_state, so one scripted response is sufficient.
+        mock.push_data(
+            "get_state",
+            serde_json::json!({
+                "sessionId": "sess-race",
+                "sessionName": "Race",
+                "cwd": "",
+                "model": "future/k3"
+            }),
+        );
+
+        let (left, right) = tokio::join!(
+            import_discovered_session("sess-race"),
+            import_discovered_session("sess-race")
+        );
+        let mut outcomes = vec![left.expect("left"), right.expect("right")];
+        outcomes.sort_unstable();
+        assert_eq!(outcomes, vec![false, true]);
+        assert_eq!(
+            crate::store::list_threads()
+                .expect("list")
+                .into_iter()
+                .filter(|thread| thread.agent_session_id.as_deref() == Some("sess-race"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn import_missing_sessions_imports_and_logs_errors() {
         let _home = super::super::test_support::TestHome::new("import-missing");
         let mock = super::super::test_support::mock_agent();
@@ -1244,5 +1312,11 @@ mod tests {
         assert!(crate::store::find_thread_by_agent_session("sess-m2")
             .expect("find")
             .is_some());
+        let observers = super::super::observer::OBSERVERS.lock().unwrap();
+        assert!(observers.contains_key("sess-m1"));
+        assert!(observers.contains_key("sess-m2"));
+        drop(observers);
+        super::super::observer::drop_observer("sess-m1");
+        super::super::observer::drop_observer("sess-m2");
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/import.rs
+++ b/desktop/src-tauri/src/agent_bridge/import.rs
@@ -434,15 +434,20 @@ async fn import_one(summary: &AgentSessionSummary) -> Result<usize, crate::AppEr
     Ok(run_count)
 }
 
-/// Runtime discovery import for a session that is streaming RIGHT NOW
-/// (created by another client — TUI/CLI/another machine). Creates only the
-/// thread stub: the session observer mints run rows live as events arrive, so
-/// minting synthetic historical runs here (as `import_one` does) would
-/// duplicate the live run. Title/model heal on the next full
-/// `import_missing_sessions` pass, which has richer summaries.
-pub(crate) async fn import_streaming_session(session_id: &str) -> Result<(), crate::AppError> {
+/// Runtime discovery import for a session reported by another client
+/// (TUI/CLI/channels/another machine) — via the 1s streaming poll or the
+/// `session_created` push. Creates only the thread stub: for a streaming
+/// session the observer mints run rows live as events arrive, so minting
+/// synthetic historical runs here (as `import_one` does) would duplicate the
+/// live run. Title/model heal on the next full `import_missing_sessions`
+/// pass, which has richer summaries. Returns `true` when a stub was created,
+/// `false` when the session was already known (or tombstoned).
+pub(crate) async fn import_discovered_session(session_id: &str) -> Result<bool, crate::AppError> {
+    if store::is_agent_session_tombstoned(session_id)? {
+        return Ok(false);
+    }
     if store::find_thread_by_agent_session(session_id)?.is_some() {
-        return Ok(());
+        return Ok(false);
     }
     let mut client = connect_agent().await?;
     let response = client
@@ -487,7 +492,7 @@ pub(crate) async fn import_streaming_session(session_id: &str) -> Result<(), cra
         workspace_name,
         agent_session_id: Some(session_id.to_string()),
     })?;
-    Ok(())
+    Ok(true)
 }
 
 /// Discover agent sessions not yet in the GUI DB and import them. Runs in the
@@ -540,6 +545,8 @@ pub async fn import_missing_sessions() {
         eprintln!(
             "FutureOS: imported {imported} session(s) ({total_runs} runs) out of {total} agent session(s)"
         );
+        // New threads landed in the store — let the sidebar know.
+        crate::emit_threads_updated();
     }
 }
 
@@ -1149,7 +1156,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn import_streaming_session_variants() {
+    async fn import_discovered_session_variants() {
         let _home = super::super::test_support::TestHome::new("import-streaming");
         let mock = super::super::test_support::mock_agent();
 
@@ -1158,7 +1165,7 @@ mod tests {
             "get_state",
             super::super::test_support::Reply::Reject("gone".into()),
         );
-        let err = import_streaming_session("sess-live")
+        let err = import_discovered_session("sess-live")
             .await
             .expect_err("reject");
         assert!(err.to_string().contains("get_state"), "{err}");
@@ -1173,16 +1180,34 @@ mod tests {
                 "model": "future/k3"
             }),
         );
-        import_streaming_session("sess-live").await.expect("import");
+        assert!(import_discovered_session("sess-live")
+            .await
+            .expect("import"));
         let thread = crate::store::find_thread_by_agent_session("sess-live")
             .expect("find")
             .expect("some");
         assert_eq!(thread.title, "Live Session");
 
-        // Already-known session → no-op Ok.
-        import_streaming_session("sess-live")
+        // Already-known session → no-op Ok(false).
+        assert!(!import_discovered_session("sess-live")
             .await
-            .expect("idempotent");
+            .expect("idempotent"));
+    }
+
+    #[tokio::test]
+    async fn import_discovered_session_skips_tombstoned_sessions() {
+        let home = super::super::test_support::TestHome::new("import-disc-tomb");
+        let workspace = super::super::test_support::seed_workspace(home.path(), "ws");
+        let thread = super::super::test_support::seed_thread(&workspace.id, Some("sess-tomb2"));
+        crate::store::delete_thread(&thread.id).expect("delete");
+
+        let _mock = super::super::test_support::mock_agent();
+        // No get_state reply is scripted: a tombstoned session must bail
+        // before any RPC, so an unserved command would fail the test.
+        assert!(!import_discovered_session("sess-tomb2").await.expect("skip"));
+        assert!(crate::store::find_thread_by_agent_session("sess-tomb2")
+            .expect("find")
+            .is_none());
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -11,6 +11,7 @@ mod replica;
 mod review;
 mod run_control;
 mod session;
+mod session_events;
 mod skills;
 mod stream;
 #[cfg(test)]
@@ -38,6 +39,7 @@ pub use self::observer::{
 pub use self::run_control::abort_run;
 pub(crate) use self::run_control::{abort_session, wait_for_agent_idle};
 pub use self::session::fork_agent_session;
+pub use self::session_events::spawn_session_events_observer;
 pub use self::skills::{list_installed_skills, refresh_skills, InstalledSkill};
 #[cfg(test)]
 pub use review::capture_before;

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -263,11 +263,14 @@ pub fn seed_observers_from_store() {
 }
 
 /// Background discovery of conversations created outside the GUI (TUI, CLI,
-/// channels, another machine). Two cadences: a 1s pass over the agent's
-/// streaming sessions — a run started by another client appears in the
-/// sidebar within ~1s — and a 60s full import for idle sessions plus
-/// observer import. Idle observers are not re-touched here: opening a thread,
-/// a prompt, or a newly streaming session wakes it instead.
+/// channels, another machine). The `session_created` push observer
+/// (`session_events.rs`) imports most sessions within milliseconds; this poll
+/// remains the backstop for missed events and agents too old to emit the
+/// event. Two cadences: a 1s pass over the agent's streaming sessions — a run
+/// started by another client appears in the sidebar within ~1s — and a 60s
+/// full import for idle sessions plus observer import. Idle observers are not
+/// re-touched here: opening a thread, a prompt, or a newly streaming session
+/// wakes it instead.
 #[cfg(test)]
 static TEST_DISCOVERY_STOP: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
@@ -342,10 +345,11 @@ async fn discover_streaming_sessions() {
             .flatten()
             .is_some();
         if !known {
-            match super::import::import_streaming_session(&session_id).await {
-                Ok(()) => eprintln!(
+            match super::import::import_discovered_session(&session_id).await {
+                Ok(true) => eprintln!(
                     "FutureOS discovered streaming session {session_id} (created by another client)"
                 ),
+                Ok(false) => {}
                 Err(error) => {
                     eprintln!("FutureOS could not import discovered session {session_id}: {error}")
                 }

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -166,10 +166,9 @@ fn now_millis() -> i64 {
         .unwrap_or(0)
 }
 
-/// Register (or refresh) the sole observer for an Agent session, bound to one
-/// immutable GUI-thread owner for its lifetime. A legacy database may contain
-/// more than one thread referencing the same Agent session; that data remains
-/// readable, but a second thread cannot silently take over the live observer.
+/// Register (or refresh) the sole observer for an Agent session, bound to its
+/// one immutable GUI-thread owner for the observer's lifetime. The store's
+/// unique binding index prevents a second thread from claiming the session.
 pub fn ensure_observer_for_thread(session_id: &str, thread_id: &str) -> Result<(), String> {
     ensure_observer_inner(session_id, thread_id, true)
 }
@@ -262,30 +261,23 @@ pub fn seed_observers_from_store() {
     }
 }
 
-/// Background discovery of conversations created outside the GUI (TUI, CLI,
-/// channels, another machine). The `session_created` push observer
-/// (`session_events.rs`) imports most sessions within milliseconds; this poll
-/// remains the backstop for missed events and agents too old to emit the
-/// event. Two cadences: a 1s pass over the agent's streaming sessions — a run
-/// started by another client appears in the sidebar within ~1s — and a 60s
-/// full import for idle sessions plus observer import. Idle observers are not
-/// re-touched here: opening a thread, a prompt, or a newly streaming session
-/// wakes it instead.
+/// Low-frequency reconciliation for conversations created outside the GUI.
+/// The `session_created` stream is the realtime path and also reconciles once
+/// after every attach/reconnect. This 60-second pass is only the final backstop
+/// for an Agent too old to emit notifications or an unusually long outage.
 #[cfg(test)]
 static TEST_DISCOVERY_STOP: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 pub fn spawn_session_discovery() {
     tauri::async_runtime::spawn(async move {
-        let mut ticks = 0u64;
         loop {
             tokio::time::sleep(discovery_interval()).await;
             #[cfg(test)]
             if TEST_DISCOVERY_STOP.swap(false, std::sync::atomic::Ordering::Relaxed) {
                 return;
             }
-            ticks += 1;
-            discovery_tick(ticks).await;
+            super::import::import_missing_sessions().await;
         }
     });
 }
@@ -299,68 +291,33 @@ fn discovery_interval() -> std::time::Duration {
     {
         return std::time::Duration::from_millis(ms);
     }
-    std::time::Duration::from_secs(1)
+    std::time::Duration::from_secs(60)
 }
 
-/// One discovery tick: the fast streaming-session pass, plus the full
-/// idle-session import every 60 ticks.
-async fn discovery_tick(ticks: u64) {
-    discover_streaming_sessions().await;
-    if ticks.is_multiple_of(60) {
-        super::import::import_missing_sessions().await;
+/// Reconcile one externally-created Agent session into Desktop exactly once,
+/// arm its observer immediately, and invalidate the sidebar when a row landed.
+/// Push notification handling uses this path; full reconciliation uses the
+/// same database get-or-create primitive through `import_missing_sessions`.
+pub(super) async fn reconcile_discovered_session(
+    session_id: &str,
+) -> Result<bool, crate::AppError> {
+    let created = super::import::import_discovered_session(session_id).await?;
+    ensure_discovered_session_observer(session_id).map_err(crate::AppError::Message)?;
+    if created {
+        crate::emit_threads_updated();
     }
+    Ok(created)
 }
 
-/// The fast discovery pass: sessions the agent reports as streaming that have
-/// no local thread get a thread stub plus an observer.
-async fn discover_streaming_sessions() {
-    let Ok(mut client) = connect_agent().await else {
-        return;
+fn ensure_discovered_session_observer(session_id: &str) -> Result<(), String> {
+    let Some(thread) = crate::store::find_thread_by_agent_session(session_id)
+        .map_err(|error| error.to_string())?
+    else {
+        // A tombstone intentionally prevents import and therefore has no
+        // Desktop owner to observe.
+        return Ok(());
     };
-    let response = match client
-        .execute_command(super::client::list_streaming_sessions_command())
-        .await
-    {
-        Ok(response) => response.into_inner(),
-        Err(_) => return,
-    };
-    if !response.success {
-        return;
-    }
-    let session_ids: Vec<String> = future_rpc::decode::response_data(&response)
-        .get("sessionIds")
-        .and_then(|value| value.as_array().cloned())
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|value| {
-            value
-                .as_str()
-                .filter(|id| !id.is_empty())
-                .map(str::to_string)
-        })
-        .collect();
-    for session_id in session_ids {
-        let known = crate::store::find_thread_by_agent_session(&session_id)
-            .ok()
-            .flatten()
-            .is_some();
-        if !known {
-            match super::import::import_discovered_session(&session_id).await {
-                Ok(true) => eprintln!(
-                    "FutureOS discovered streaming session {session_id} (created by another client)"
-                ),
-                Ok(false) => {}
-                Err(error) => {
-                    eprintln!("FutureOS could not import discovered session {session_id}: {error}")
-                }
-            }
-        }
-        if let Ok(Some(thread)) = crate::store::find_thread_by_agent_session(&session_id) {
-            if let Err(error) = ensure_observer_for_thread(&session_id, &thread.id) {
-                eprintln!("FutureOS could not observe discovered session {session_id}: {error}");
-            }
-        }
-    }
+    ensure_observer_for_thread(session_id, &thread.id)
 }
 
 /// Drop the observer for a session going away (thread/session deleted).
@@ -1430,16 +1387,21 @@ mod tests {
     }
 
     #[test]
-    fn seed_observers_creates_and_logs_conflicts() {
-        let home = TestHome::new("observer-seed-conflict");
+    fn seed_observers_creates_one_observer_per_unique_session() {
+        let home = TestHome::new("observer-seed-unique");
         let _mock = mock_agent();
         let workspace = seed_workspace(home.path(), "ws");
-        let t1 = seed_thread(&workspace.id, Some("sess-shared"));
-        let _t2 = seed_thread(&workspace.id, Some("sess-shared"));
+        let _t1 = seed_thread(&workspace.id, Some("sess-one"));
+        let _t2 = seed_thread(&workspace.id, Some("sess-two"));
+
         seed_observers_from_store();
-        assert!(OBSERVERS.lock().unwrap().contains_key("sess-shared"));
-        drop_observer("sess-shared");
-        let _ = t1;
+
+        let observers = OBSERVERS.lock().unwrap();
+        assert!(observers.contains_key("sess-one"));
+        assert!(observers.contains_key("sess-two"));
+        drop(observers);
+        drop_observer("sess-one");
+        drop_observer("sess-two");
     }
 
     #[tokio::test]
@@ -1699,60 +1661,6 @@ mod tests {
 
         // Malformed JSON → None.
         assert!(settings_event_payload("s", "t", "e", "not json").is_none());
-    }
-
-    #[tokio::test]
-    async fn discover_streaming_sessions_paths() {
-        let home = TestHome::new("observer-discover");
-        let mock = mock_agent();
-        let workspace = seed_workspace(home.path(), "ws");
-        seed_thread(&workspace.id, Some("sess-known"));
-
-        // Empty sessionIds → no-op.
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": []}),
-        );
-        discover_streaming_sessions().await;
-
-        // A known session → only ensure_observer.
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": ["sess-known"]}),
-        );
-        discover_streaming_sessions().await;
-        assert!(OBSERVERS.lock().unwrap().contains_key("sess-known"));
-        drop_observer("sess-known");
-
-        // An unknown session → import + observe.
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": ["sess-new"]}),
-        );
-        mock.push_data(
-            "get_state",
-            serde_json::json!({"sessionId": "sess-new", "sessionName": "New", "cwd": "", "model": "future/k3"}),
-        );
-        discover_streaming_sessions().await;
-        assert!(OBSERVERS.lock().unwrap().contains_key("sess-new"));
-        drop_observer("sess-new");
-
-        // Reject (success=false) → return.
-        mock.push("list_streaming_sessions", Reply::Reject("nope".to_string()));
-        discover_streaming_sessions().await;
-
-        // Transport error → return.
-        mock.push(
-            "list_streaming_sessions",
-            Reply::Status(tonic::Code::Internal, "down"),
-        );
-        discover_streaming_sessions().await;
-
-        // Connect failure → return.
-        let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock addr");
-        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
-        discover_streaming_sessions().await;
-        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
     }
 
     #[tokio::test]
@@ -2091,69 +1999,23 @@ mod tests {
         assert_eq!(state.last_settled_run.as_deref(), Some("run-owned-term"));
     }
 
-    /// Discovery logs import and observe failures without surfacing them.
-    #[tokio::test]
-    async fn discover_streaming_sessions_logs_import_and_observe_errors() {
-        let home = TestHome::new("observer-discover-err");
-        let mock = mock_agent();
-        let workspace = seed_workspace(home.path(), "ws");
-        let thread = seed_thread(&workspace.id, Some("sess-conflict"));
-
-        // Unknown session whose import fails (get_state reject).
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": ["sess-bad"]}),
-        );
-        mock.push("get_state", Reply::Reject("gone".to_string()));
-        discover_streaming_sessions().await;
-
-        // Known session already observed by a phantom thread → owner conflict.
-        let (cancel, _rx) = oneshot::channel();
-        let shared = Arc::new(ObserverShared::new("ghost-thread"));
-        OBSERVERS.lock().unwrap().insert(
-            "sess-conflict".to_string(),
-            ObserverHandle { cancel, shared },
-        );
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": ["sess-conflict"]}),
-        );
-        discover_streaming_sessions().await;
-        OBSERVERS.lock().unwrap().remove("sess-conflict");
-        let _ = thread;
-    }
-
-    /// The discovery loop ticks, then stops on the test seam; the default
-    /// (unseamed) interval is 1s.
+    /// The low-frequency reconciliation loop ticks, then stops on the test
+    /// seam; the production interval is 60 seconds.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn discovery_loop_ticks_and_stops() {
         let _home = TestHome::new("observer-discovery-loop");
         let mock = mock_agent();
+        for _ in 0..8 {
+            mock.push_typed_data("list_sessions", serde_json::json!({"sessions": []}));
+        }
         std::env::set_var("FUTURE_TEST_DISCOVERY_INTERVAL_MS", "10");
         spawn_session_discovery();
         tokio::time::sleep(Duration::from_millis(60)).await;
         TEST_DISCOVERY_STOP.store(true, std::sync::atomic::Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(30)).await;
         std::env::remove_var("FUTURE_TEST_DISCOVERY_INTERVAL_MS");
-        assert_eq!(discovery_interval(), Duration::from_secs(1));
+        assert_eq!(discovery_interval(), Duration::from_secs(60));
         let _ = mock;
-    }
-
-    /// The 60th discovery tick runs the full import; other ticks do not.
-    #[tokio::test]
-    async fn discovery_tick_imports_on_the_60th_tick() {
-        let _home = TestHome::new("observer-discovery-tick");
-        let mock = mock_agent();
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": []}),
-        );
-        discovery_tick(1).await;
-        mock.push_data(
-            "list_streaming_sessions",
-            serde_json::json!({"sessionIds": []}),
-        );
-        discovery_tick(60).await;
     }
 
     // ── run_observer self-heal paths ─────────────────────────────────

--- a/desktop/src-tauri/src/agent_bridge/session.rs
+++ b/desktop/src-tauri/src/agent_bridge/session.rs
@@ -68,6 +68,7 @@ pub(super) async fn ensure_agent_session(
             String::new(),
             cwd.to_string(),
             "desktop",
+            crate::device_identity::device_id_or_empty(),
             serde_json::Value::Null,
             model_id.map(str::to_string),
             thinking_level.map(str::to_string),
@@ -239,6 +240,7 @@ pub async fn fork_agent_session(
             session_id.clone(),
             entry_id.to_string(),
             session_id.clone(),
+            crate::device_identity::device_id_or_empty(),
         ))
         .await
         .map_err(|error| format!("Unable to fork session: {error}"))?

--- a/desktop/src-tauri/src/agent_bridge/session_events.rs
+++ b/desktop/src-tauri/src/agent_bridge/session_events.rs
@@ -1,0 +1,209 @@
+//! Process-wide session lifecycle observer.
+//!
+//! Subscribes to the Agent's global control-plane stream for
+//! `session_created` announcements and imports sessions minted by other
+//! clients (TUI/CLI/channels) within milliseconds — the discovery polls in
+//! `observer.rs` remain the backstop for missed events and agents too old to
+//! emit the event.
+//!
+//! Sessions the GUI itself created (`createdBy: "desktop"`) are skipped: the
+//! GUI manages those threads and their session links itself, and importing a
+//! stub here would race the prompt pipeline's own thread-row update.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use super::connect_agent;
+
+static STARTED: AtomicBool = AtomicBool::new(false);
+
+pub fn spawn_session_events_observer() {
+    if STARTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    tauri::async_runtime::spawn(run());
+}
+
+async fn run() {
+    let mut backoff = Duration::from_millis(250);
+    loop {
+        let result = observe_once(&mut backoff).await;
+        if let Err(error) = result {
+            eprintln!("FutureOS session events observer reconnecting: {error}");
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(5));
+    }
+}
+
+async fn observe_once(backoff: &mut Duration) -> Result<(), crate::AppError> {
+    let mut client = connect_agent().await?;
+    let mut stream = client
+        .stream_events(crate::agent_proto::StreamRequest {
+            event_types: vec!["session_created".to_string()],
+            global_events: true,
+            ..Default::default()
+        })
+        .await
+        .map_err(|error| format!("global session events stream failed: {error}"))?
+        .into_inner();
+    // A successful attachment proves the Agent is healthy again; if this
+    // stream later closes, reconnect promptly instead of retaining the
+    // maximum delay accumulated during an earlier outage.
+    *backoff = Duration::from_millis(250);
+
+    while let Some(event) = stream
+        .message()
+        .await
+        .map_err(|error| format!("global session events stream closed: {error}"))?
+    {
+        if event.r#type != "session_created" {
+            continue;
+        }
+        handle_session_created(&event.data).await;
+    }
+    Err(crate::AppError::Message(
+        "global session events stream ended".to_string(),
+    ))
+}
+
+/// Parse one `session_created` payload and import the session when it was
+/// created by another client. Failures are logged, never propagated — one bad
+/// event must not tear down the whole stream.
+async fn handle_session_created(data: &str) {
+    let payload: serde_json::Value = match serde_json::from_str(data) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("FutureOS: malformed session_created payload: {error}");
+            return;
+        }
+    };
+    let Some(session_id) = payload
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+        .filter(|id| !id.is_empty())
+    else {
+        eprintln!("FutureOS: session_created payload omitted sessionId");
+        return;
+    };
+    let created_by = payload
+        .get("createdBy")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if created_by == "desktop" {
+        // The GUI creates its own thread rows for its sessions; a push import
+        // here would race the prompt pipeline linking the session to a thread.
+        return;
+    }
+    match super::import::import_discovered_session(session_id).await {
+        Ok(true) => {
+            eprintln!("FutureOS imported session {session_id} announced by client {created_by:?}");
+            crate::emit_threads_updated();
+        }
+        Ok(false) => {}
+        Err(error) => {
+            eprintln!("FutureOS could not import announced session {session_id}: {error}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{mock_agent, stream_event, TestHome};
+    use super::*;
+
+    #[tokio::test]
+    async fn handle_session_created_skips_desktop_and_malformed_payloads() {
+        let _home = TestHome::new("session-events-skip");
+        let _mock = mock_agent();
+
+        // GUI-created sessions are the GUI's own bookkeeping — no import, and
+        // no get_state RPC (an unserved command would fail the test).
+        handle_session_created(r#"{"sessionId":"s-mine","createdBy":"desktop","cwd":"/ws"}"#).await;
+        assert!(crate::store::find_thread_by_agent_session("s-mine")
+            .expect("find")
+            .is_none());
+
+        // Malformed payloads and missing session ids are logged and skipped.
+        handle_session_created("not json").await;
+        handle_session_created(r#"{"createdBy":"tui"}"#).await;
+    }
+
+    #[tokio::test]
+    async fn handle_session_created_imports_external_sessions() {
+        let _home = TestHome::new("session-events-import");
+        let mock = mock_agent();
+
+        mock.push_data(
+            "get_state",
+            serde_json::json!({
+                "sessionId": "s-tui",
+                "sessionName": "From TUI",
+                "cwd": "",
+                "model": "future/k3"
+            }),
+        );
+        handle_session_created(r#"{"sessionId":"s-tui","createdBy":"tui","cwd":"/tmp"}"#).await;
+        let thread = crate::store::find_thread_by_agent_session("s-tui")
+            .expect("find")
+            .expect("imported stub");
+        assert_eq!(thread.title, "From TUI");
+
+        // A repeat announcement is a no-op (import_discovered_session is
+        // idempotent), and no additional RPC is scripted.
+        handle_session_created(r#"{"sessionId":"s-tui","createdBy":"tui","cwd":"/tmp"}"#).await;
+    }
+
+    #[tokio::test]
+    async fn observe_once_consumes_the_stream_until_it_ends() {
+        let _home = TestHome::new("session-events-stream");
+        let mock = mock_agent();
+        mock.push_data(
+            "get_state",
+            serde_json::json!({
+                "sessionId": "s-live",
+                "sessionName": "Live",
+                "cwd": "",
+                "model": "future/k3"
+            }),
+        );
+        mock.push_plain_stream(super::super::test_support::StreamScript::Events(
+            vec![
+                stream_event(
+                    "",
+                    0,
+                    "session_created",
+                    r#"{"sessionId":"s-live","createdBy":"tui"}"#,
+                ),
+                // Unknown types are ignored; the stream must survive them.
+                stream_event("", 1, "ping", r#"{"configRevision":3}"#),
+            ],
+            None,
+        ));
+        let mut backoff = Duration::from_secs(5);
+        let result = observe_once(&mut backoff).await;
+        assert!(result.is_err(), "stream ends → Err");
+        assert_eq!(backoff, Duration::from_millis(250));
+        assert!(crate::store::find_thread_by_agent_session("s-live")
+            .expect("find")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn observe_once_surfaces_attach_failure() {
+        let _mock = mock_agent();
+        let prev = std::env::var("FUTURE_AGENT_GRPC_ADDR").expect("mock sets the endpoint");
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", "http://[::1");
+        let mut backoff = Duration::from_millis(250);
+        let result = observe_once(&mut backoff).await;
+        std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn spawn_session_events_observer_runs_once() {
+        let _mock = mock_agent();
+        spawn_session_events_observer();
+        spawn_session_events_observer();
+    }
+}

--- a/desktop/src-tauri/src/agent_bridge/session_events.rs
+++ b/desktop/src-tauri/src/agent_bridge/session_events.rs
@@ -6,9 +6,11 @@
 //! `observer.rs` remain the backstop for missed events and agents too old to
 //! emit the event.
 //!
-//! Sessions the GUI itself created (`createdBy: "desktop"`) are skipped: the
-//! GUI manages those threads and their session links itself, and importing a
-//! stub here would race the prompt pipeline's own thread-row update.
+//! Sessions created by this Desktop installation (`creatorId == deviceId`) are
+//! skipped: the GUI manages those threads and their session links itself, and
+//! importing a stub here would race the prompt pipeline's own thread-row
+//! update. Another Desktop has the same `createdBy` category but a different
+//! creator id, so its sessions are imported normally.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -47,6 +49,11 @@ async fn observe_once(backoff: &mut Duration) -> Result<(), crate::AppError> {
         .await
         .map_err(|error| format!("global session events stream failed: {error}"))?
         .into_inner();
+    // The global stream is an in-memory notification channel, not a durable
+    // log. Once the subscription exists, reconcile the Agent's authoritative
+    // session list before consuming queued notifications. This closes startup
+    // and reconnect gaps without a one-second streaming-session poll.
+    super::import::import_missing_sessions().await;
     // A successful attachment proves the Agent is healthy again; if this
     // stream later closes, reconnect promptly instead of retaining the
     // maximum delay accumulated during an earlier outage.
@@ -90,15 +97,40 @@ async fn handle_session_created(data: &str) {
         .get("createdBy")
         .and_then(|value| value.as_str())
         .unwrap_or_default();
-    if created_by == "desktop" {
-        // The GUI creates its own thread rows for its sessions; a push import
-        // here would race the prompt pipeline linking the session to a thread.
+    let creator_id = payload
+        .get("creatorId")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    // Compatibility with a pre-creatorId Agent: conservatively preserve the
+    // old self-import guard. New Agents never take this branch, so two current
+    // Desktop installations with distinct device ids still discover each
+    // other correctly.
+    if creator_id.is_empty() && created_by == "desktop" {
         return;
     }
-    match super::import::import_discovered_session(session_id).await {
+    if !creator_id.is_empty() {
+        match crate::device_identity::device_id() {
+            Ok(device_id) if creator_id == device_id => {
+                return; // This installation's prompt/fork path owns the local row.
+            }
+            Ok(_) => {}
+            Err(error) => {
+                // Importing while identity is unknown could steal the unique
+                // binding from this installation's in-flight create. The
+                // reconnect/periodic reconciliation will retry after the
+                // original thread has had a chance to persist its binding.
+                eprintln!(
+                    "FutureOS deferred session {session_id} while device identity is unavailable: {error}"
+                );
+                return;
+            }
+        }
+    }
+    match super::observer::reconcile_discovered_session(session_id).await {
         Ok(true) => {
-            eprintln!("FutureOS imported session {session_id} announced by client {created_by:?}");
-            crate::emit_threads_updated();
+            eprintln!(
+                "FutureOS imported session {session_id} announced by client {created_by:?} creator {creator_id:?}"
+            );
         }
         Ok(false) => {}
         Err(error) => {
@@ -113,13 +145,23 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn handle_session_created_skips_desktop_and_malformed_payloads() {
+    async fn handle_session_created_skips_own_creator_and_malformed_payloads() {
         let _home = TestHome::new("session-events-skip");
         let _mock = mock_agent();
+        let creator_id = crate::device_identity::device_id().expect("device id");
 
-        // GUI-created sessions are the GUI's own bookkeeping — no import, and
-        // no get_state RPC (an unserved command would fail the test).
-        handle_session_created(r#"{"sessionId":"s-mine","createdBy":"desktop","cwd":"/ws"}"#).await;
+        // This installation's sessions are its own bookkeeping — no import,
+        // and no get_state RPC (an unserved command would fail the test).
+        handle_session_created(
+            &serde_json::json!({
+                "sessionId": "s-mine",
+                "createdBy": "desktop",
+                "creatorId": creator_id,
+                "cwd": "/ws"
+            })
+            .to_string(),
+        )
+        .await;
         assert!(crate::store::find_thread_by_agent_session("s-mine")
             .expect("find")
             .is_none());
@@ -143,21 +185,32 @@ mod tests {
                 "model": "future/k3"
             }),
         );
-        handle_session_created(r#"{"sessionId":"s-tui","createdBy":"tui","cwd":"/tmp"}"#).await;
+        handle_session_created(
+            r#"{"sessionId":"s-tui","createdBy":"desktop","creatorId":"desktop_other","cwd":"/tmp"}"#,
+        )
+        .await;
         let thread = crate::store::find_thread_by_agent_session("s-tui")
             .expect("find")
             .expect("imported stub");
         assert_eq!(thread.title, "From TUI");
+        assert!(super::super::observer::OBSERVERS
+            .lock()
+            .unwrap()
+            .contains_key("s-tui"));
 
         // A repeat announcement is a no-op (import_discovered_session is
         // idempotent), and no additional RPC is scripted.
-        handle_session_created(r#"{"sessionId":"s-tui","createdBy":"tui","cwd":"/tmp"}"#).await;
+        handle_session_created(
+            r#"{"sessionId":"s-tui","createdBy":"desktop","creatorId":"desktop_other","cwd":"/tmp"}"#,
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn observe_once_consumes_the_stream_until_it_ends() {
         let _home = TestHome::new("session-events-stream");
         let mock = mock_agent();
+        mock.push_typed_data("list_sessions", serde_json::json!({"sessions": []}));
         mock.push_data(
             "get_state",
             serde_json::json!({
@@ -198,12 +251,5 @@ mod tests {
         let result = observe_once(&mut backoff).await;
         std::env::set_var("FUTURE_AGENT_GRPC_ADDR", prev);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn spawn_session_events_observer_runs_once() {
-        let _mock = mock_agent();
-        spawn_session_events_observer();
-        spawn_session_events_observer();
     }
 }

--- a/desktop/src-tauri/src/agent_bridge/stream.rs
+++ b/desktop/src-tauri/src/agent_bridge/stream.rs
@@ -636,7 +636,11 @@ mod tests {
         assert_eq!(response.content, "hello world");
         assert!(response.complete);
         // The collector attaches atomically from the start.
-        let attaches = mock.stream_requests();
+        let attaches: Vec<_> = mock
+            .stream_requests()
+            .into_iter()
+            .filter(|request| request.atomic_attach)
+            .collect();
         assert_eq!(attaches.len(), 1);
         assert!(attaches[0].atomic_attach);
         assert_eq!(attaches[0].after_idx, -1);
@@ -977,7 +981,12 @@ mod tests {
             .expect("collect");
         std::env::remove_var("FUTURE_TEST_AGENT_STREAM_TIMEOUT_MS");
         assert!(response.complete);
-        assert_eq!(mock.stream_requests().len(), 2);
+        let atomic_attaches = mock
+            .stream_requests()
+            .into_iter()
+            .filter(|request| request.atomic_attach)
+            .count();
+        assert_eq!(atomic_attaches, 2);
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/device_identity.rs
+++ b/desktop/src-tauri/src/device_identity.rs
@@ -1,0 +1,102 @@
+//! Stable identity of this Desktop installation.
+//!
+//! `device_id` is intentionally broader than remote pairing: Agent session
+//! provenance, remote control, and future device-scoped features all refer to
+//! the same installation identity. It survives app-data reset and pairing
+//! revocation. A future `client_id` should identify one process/connection and
+//! must not replace this durable value.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
+
+static DEVICE_IDS: LazyLock<Mutex<HashMap<PathBuf, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Return the durable Desktop installation id, creating it exactly once.
+///
+/// Before this component existed the id lived only inside
+/// `remote_pairing.json`. Seed from that legacy location when present so an
+/// upgraded, already-paired installation keeps its platform identity.
+pub fn device_id() -> Result<String, crate::AppError> {
+    let identity_root = PathBuf::from(crate::home_dir().ok_or_else(|| {
+        crate::AppError::Message("HOME/USERPROFILE environment variable is not set.".to_string())
+    })?)
+    .join(".future");
+    if let Some(device_id) = DEVICE_IDS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&identity_root)
+        .cloned()
+    {
+        return Ok(device_id);
+    }
+    let legacy_id = legacy_pairing_device_id();
+    let candidate = legacy_id.unwrap_or_else(new_device_id);
+    let device_id = crate::store::get_or_create_device_id(&candidate)?;
+    DEVICE_IDS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(identity_root, device_id.clone());
+    Ok(device_id)
+}
+
+/// Best-effort identity for non-critical lifecycle metadata.
+///
+/// Creating or forking an Agent session must not fail merely because the local
+/// identity store is momentarily locked. An empty creator id activates the
+/// conservative legacy `createdBy == desktop` filter; later reconciliation
+/// converges through the unique agent-session binding.
+pub fn device_id_or_empty() -> String {
+    device_id().unwrap_or_default()
+}
+
+fn legacy_pairing_device_id() -> Option<String> {
+    let home = crate::home_dir()?;
+    let path = PathBuf::from(home)
+        .join(".future")
+        .join("remote_pairing.json");
+    crate::config_io::read_json_object(&path)
+        .ok()?
+        .get("desktopId")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+fn new_device_id() -> String {
+    let key = nkeys::KeyPair::new_user().public_key();
+    format!("desktop_{}", &key[1..17])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_id_is_stable_and_keeps_the_desktop_namespace() {
+        let _home = crate::store::test_schema_home("device_identity_stable");
+        let first = device_id().expect("first id");
+        let second = device_id().expect("second id");
+        assert_eq!(first, second);
+        assert!(first.starts_with("desktop_"));
+    }
+
+    #[test]
+    fn legacy_pairing_id_seeds_the_common_identity() {
+        let _home = crate::store::test_schema_home("device_identity_legacy");
+        let home_path = std::env::var("HOME").expect("test HOME");
+        let path = std::path::Path::new(&home_path)
+            .join(".future")
+            .join("remote_pairing.json");
+        crate::config_io::write_json_atomic(
+            &path,
+            &serde_json::json!({"desktopId": "desktop_legacy"}),
+            true,
+        )
+        .expect("legacy creds");
+
+        assert_eq!(device_id().expect("migrated id"), "desktop_legacy");
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -298,6 +298,16 @@ fn emit_remote_activity_on<R: tauri::Runtime>(handle: &tauri::AppHandle<R>, thre
     let _ = handle.emit("remote-activity", thread_id.to_string());
 }
 
+/// Notify the frontend that the thread list changed behind its back — sessions
+/// created outside the GUI (TUI/CLI/channels) were imported into the store —
+/// so the sidebar re-lists threads. No payload: a bare invalidation signal.
+pub(crate) fn emit_threads_updated() {
+    if let Some(handle) = APP_HANDLE.get() {
+        use tauri::Emitter;
+        let _ = handle.emit("threads-updated", ());
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ThreadRuntimeUpdate {
@@ -707,6 +717,10 @@ pub fn run() {
             // Global provider/auth completion stream. This is independent of
             // chat observers and fans committed revisions to WebView + Mobile.
             agent_bridge::spawn_provider_config_observer();
+            // Global session lifecycle stream: sessions created by other
+            // clients (TUI/CLI/channels) are imported within milliseconds of
+            // the agent's session_created announcement.
+            agent_bridge::spawn_session_events_observer();
             // Discovery: conversations created by other clients (TUI/CLI) get
             // a thread stub + an observer — streaming ones within ~1s, idle
             // ones on the 60s import pass.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod auth_store;
 mod build_info;
 mod commands;
 mod config_io;
+mod device_identity;
 mod error;
 mod future_login;
 mod future_platform;
@@ -721,9 +722,9 @@ pub fn run() {
             // clients (TUI/CLI/channels) are imported within milliseconds of
             // the agent's session_created announcement.
             agent_bridge::spawn_session_events_observer();
-            // Discovery: conversations created by other clients (TUI/CLI) get
-            // a thread stub + an observer — streaming ones within ~1s, idle
-            // ones on the 60s import pass.
+            // Low-frequency safety reconciliation for lifecycle notifications
+            // missed during outages or emitted by an older Agent. The global
+            // stream is the realtime path and reconciles on every reconnect.
             agent_bridge::spawn_session_discovery();
             // Continuously flush local deletion tombstones. This is independent
             // of the current UI route and makes offline GUI deletes converge.

--- a/desktop/src-tauri/src/remote/pairing.rs
+++ b/desktop/src-tauri/src/remote/pairing.rs
@@ -1,7 +1,9 @@
-//! Persisted desktop identity and the platform pairing/JWT control plane.
+//! Platform pairing/JWT control plane.
 //!
 //! The NKey seed never leaves this desktop. The platform receives only the
-//! public user key and returns a short-lived, pair-scoped NATS user JWT.
+//! public user key and returns a short-lived, pair-scoped NATS user JWT. The
+//! installation-wide device id is owned by `device_identity`; pairing stores a
+//! copy because the server credential is bound to that exact identity.
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
@@ -134,9 +136,7 @@ pub async fn create_pairing() -> Result<(PairingCreds, String, Option<i64>), cra
     let nkey_seed = key_pair
         .seed()
         .map_err(|error| crate::AppError::Message(format!("generate desktop NKey: {error}")))?;
-    let desktop_id = load_creds()
-        .map(|creds| creds.desktop_id)
-        .unwrap_or_else(new_device_id);
+    let desktop_id = crate::device_identity::device_id()?;
     let platform = crate::future_platform::current_platform_url();
     let response = http_client()?
         .post(format!("{platform}/client/v1/remote/pair/code"))
@@ -214,11 +214,6 @@ pub async fn revoke_pairing(creds: &PairingCreds) -> Result<(), crate::AppError>
         return Ok(());
     }
     Err(response_error(response, "revoke remote pairing").await)
-}
-
-pub fn new_device_id() -> String {
-    let key = nkeys::KeyPair::new_user().public_key();
-    format!("desktop_{}", &key[1..17])
 }
 
 pub fn refresh_delay(creds: &PairingCreds) -> std::time::Duration {
@@ -641,13 +636,6 @@ mod http_tests {
         // Already expired → the 5s floor.
         creds.jwt_expires_at = now_secs() - 10;
         assert_eq!(refresh_delay(&creds).as_secs(), 5);
-    }
-
-    #[test]
-    fn new_device_id_format() {
-        let id = new_device_id();
-        assert!(id.starts_with("desktop_"));
-        assert_eq!(id.len(), "desktop_".len() + 16);
     }
 
     #[test]

--- a/desktop/src-tauri/src/store.rs
+++ b/desktop/src-tauri/src/store.rs
@@ -21,7 +21,8 @@ mod workspaces;
 use db::*;
 
 pub use app_settings::{
-    get_app_settings, update_app_settings, AppSettings, UpdateAppSettingsInput,
+    get_app_settings, get_or_create_device_id, update_app_settings, AppSettings,
+    UpdateAppSettingsInput,
 };
 pub use approvals::{
     decide_approval_request, ensure_approval_request, list_approval_requests,
@@ -62,10 +63,10 @@ pub use runs::{
 pub(crate) use runs::{append_run_event, flush_run_event_log_for_test};
 pub use threads::{
     archive_thread, batch_delete_threads, create_thread, delete_thread, delete_thread_with_files,
-    find_thread_by_agent_session, get_recent_thread, get_thread, list_threads, mark_thread_opened,
-    move_thread_to_workspace, pin_thread, purge_soft_deleted_threads, rename_thread,
-    restore_thread, sync_thread_title, update_thread_model, update_thread_session_id,
-    update_thread_thinking_level, ThreadRecord,
+    find_thread_by_agent_session, get_or_create_thread_for_agent_session, get_recent_thread,
+    get_thread, list_threads, mark_thread_opened, move_thread_to_workspace, pin_thread,
+    purge_soft_deleted_threads, rename_thread, restore_thread, sync_thread_title,
+    update_thread_model, update_thread_session_id, update_thread_thinking_level, ThreadRecord,
 };
 pub use util::{create_id, now_millis, take_catalog_dirty};
 pub use workspace_files::{search_workspace_files, WorkspaceFileResult, WorkspaceFileSearchInput};
@@ -153,6 +154,10 @@ fn log_reconcile(result: Result<usize, crate::AppError>, op: &str) {
 /// by Settings ▸ Debug ▸ Reset.
 pub fn clear_all_data() -> Result<(), crate::AppError> {
     let conn = connect()?;
+    // Device identity is installation-scoped control-plane state, not a UI
+    // preference or projection. Preserve it when Debug ▸ Reset clears app
+    // data so creatorId and remote pairing do not silently change identity.
+    let device_id = app_settings::read_device_id(&conn)?;
     // Retain a durable deletion intent even though all display/projection data
     // is being reset. The table is deliberately control-plane state, not user
     // history, and startup will retry it against the Agent.
@@ -174,6 +179,7 @@ pub fn clear_all_data() -> Result<(), crate::AppError> {
     }
     conn.execute_batch("PRAGMA foreign_keys = ON;")?;
     apply_schema(&conn)?;
+    app_settings::restore_device_id(&conn, device_id.as_deref())?;
     drop(conn);
 
     // Best effort: remove GUI-managed file trees; they're recreated on demand.
@@ -265,7 +271,12 @@ mod tests {
     fn clear_all_data_rebuilds_pristine_schema() {
         let _home = HomeGuard::new("store-clear");
         initialize_app_store().unwrap();
+        let device_id = get_or_create_device_id("desktop-reset-stable").unwrap();
         clear_all_data().unwrap();
+        assert_eq!(
+            get_or_create_device_id("desktop-should-not-win").unwrap(),
+            device_id
+        );
         // The reset re-applies the schema: a fresh query against the core table
         // must succeed and be empty.
         let conn = connect().unwrap();

--- a/desktop/src-tauri/src/store/app_settings.rs
+++ b/desktop/src-tauri/src/store/app_settings.rs
@@ -56,6 +56,53 @@ const KEY_AUTO_CONNECT_REMOTE: &str = "auto_connect_remote";
 const KEY_SKILL_GUIDE_DISMISSED: &str = "skill_guide_dismissed";
 const KEY_SKILL_INTRO_DISMISSED: &str = "skill_intro_dismissed";
 const KEY_BELL_ON_COMPLETE: &str = "bell_on_complete";
+const KEY_DEVICE_ID: &str = "device_id";
+
+/// Atomically install the Desktop-wide device identity. The caller supplies a
+/// legacy or freshly generated candidate, but SQLite decides the winner when
+/// multiple Desktop processes start for the first time concurrently.
+pub fn get_or_create_device_id(candidate: &str) -> Result<String, crate::AppError> {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return Err("device id cannot be empty".to_string().into());
+    }
+    let mut conn = connect()?;
+    // Device identity is needed by early control-plane paths (including remote
+    // pairing tests and reconnects), so do not require the full application
+    // schema initializer to have won the startup race first.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS app_settings (
+             key TEXT PRIMARY KEY,
+             value TEXT NOT NULL,
+             updated_at INTEGER NOT NULL
+         )",
+    )?;
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    if let Some(existing) = read_value(&tx, KEY_DEVICE_ID)?
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        tx.commit()?;
+        return Ok(existing);
+    }
+    write_value(&tx, KEY_DEVICE_ID, candidate, now_millis())?;
+    tx.commit()?;
+    Ok(candidate.to_string())
+}
+
+pub(super) fn read_device_id(conn: &Connection) -> Result<Option<String>, crate::AppError> {
+    read_value(conn, KEY_DEVICE_ID)
+}
+
+pub(super) fn restore_device_id(
+    conn: &Connection,
+    device_id: Option<&str>,
+) -> Result<(), crate::AppError> {
+    if let Some(device_id) = device_id {
+        write_value(conn, KEY_DEVICE_ID, device_id, now_millis())?;
+    }
+    Ok(())
+}
 
 pub fn get_app_settings() -> Result<AppSettings, crate::AppError> {
     let conn = connect()?;
@@ -210,6 +257,21 @@ mod tests {
         assert!(!settings.auto_connect_remote);
         assert!(!settings.skill_guide_dismissed);
         assert!(!settings.skill_intro_dismissed);
+    }
+
+    #[test]
+    fn device_identity_is_installed_once_and_reused() {
+        let (_home, conn) = guarded_conn("settings_device_id");
+        drop(conn);
+        assert_eq!(
+            get_or_create_device_id("desktop_first").expect("first"),
+            "desktop_first"
+        );
+        assert_eq!(
+            get_or_create_device_id("desktop_second").expect("reuse"),
+            "desktop_first"
+        );
+        assert!(get_or_create_device_id("   ").is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/store/db.rs
+++ b/desktop/src-tauri/src/store/db.rs
@@ -10,8 +10,8 @@ use super::approvals::{
 };
 use super::runs::{run_from_row, RunRecord};
 use super::schema::{
-    ADDED_COLUMNS, ADDED_INDEXES, DROPPED_COLUMNS, DROPPED_TABLES, RENAMED_COLUMNS, SCHEMA,
-    VERSIONED_MIGRATIONS,
+    ADDED_COLUMNS, ADDED_INDEXES, AGENT_SESSION_BINDING_MIGRATION_VERSION, DROPPED_COLUMNS,
+    DROPPED_TABLES, RENAMED_COLUMNS, SCHEMA, UNIQUE_AGENT_SESSION_INDEX, VERSIONED_MIGRATIONS,
 };
 use super::util::now_millis;
 
@@ -167,6 +167,10 @@ pub(super) fn connect() -> Result<PooledConnection, crate::AppError> {
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {
     conn.execute_batch(SCHEMA)?;
+    // This is a required identity invariant: one Agent session may back only
+    // one Desktop thread. Repair legacy duplicate bindings before installing
+    // the unique index, otherwise an upgraded database could not start.
+    apply_agent_session_binding_migration(conn)?;
     // Run archiving is optional UI metadata. A failed upgrade must not block
     // the Agent/file-tool main flow; read paths project its missing column as
     // NULL and the archive action reports its own unavailable error.
@@ -220,6 +224,72 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), crate::AppError> {
                 // or is the last column — log and continue.
                 eprintln!("FutureOS migration: failed to drop {table}.{column}: {error}");
             }
+        }
+    }
+    Ok(())
+}
+
+/// Install the one-Agent-session-to-one-Desktop-thread invariant.
+///
+/// Older databases could contain duplicate bindings because discovery used a
+/// check-then-insert sequence without a database constraint. Preserve every
+/// thread row, but detach all except the most recently active owner. Detached
+/// rows become ordinary local threads and can mint a fresh Agent session if
+/// the user continues them. Normalize the surviving id before adding the
+/// unique index so whitespace variants cannot bypass the invariant.
+fn apply_agent_session_binding_migration(conn: &Connection) -> Result<(), crate::AppError> {
+    let applied = conn
+        .query_row(
+            "SELECT 1 FROM schema_migrations WHERE version = ?1",
+            [AGENT_SESSION_BINDING_MIGRATION_VERSION],
+            |_| Ok(()),
+        )
+        .optional()?;
+    if applied.is_some() {
+        return Ok(());
+    }
+
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = (|| {
+        conn.execute(
+            "WITH ranked AS (
+                 SELECT rowid,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY TRIM(agent_session_id)
+                            ORDER BY
+                                CASE WHEN status != 'deleted' THEN 0 ELSE 1 END,
+                                COALESCE(last_message_at, updated_at, created_at) DESC,
+                                rowid DESC
+                        ) AS binding_rank
+                 FROM threads
+                 WHERE agent_session_id IS NOT NULL
+                   AND TRIM(agent_session_id) != ''
+             )
+             UPDATE threads
+             SET agent_session_id = NULL
+             WHERE rowid IN (
+                 SELECT rowid FROM ranked WHERE binding_rank > 1
+             )",
+            [],
+        )?;
+        conn.execute(
+            "UPDATE threads
+             SET agent_session_id = TRIM(agent_session_id)
+             WHERE agent_session_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(UNIQUE_AGENT_SESSION_INDEX, [])?;
+        conn.execute(
+            "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, ?2)",
+            params![AGENT_SESSION_BINDING_MIGRATION_VERSION, now_millis()],
+        )?;
+        Ok::<(), crate::AppError>(())
+    })();
+    match result {
+        Ok(()) => conn.execute_batch("COMMIT")?,
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(error);
         }
     }
     Ok(())
@@ -396,6 +466,70 @@ mod tests {
     fn apply_schema_on_fresh_db_succeeds() {
         let conn = Connection::open_in_memory().unwrap();
         apply_schema(&conn).unwrap();
+    }
+
+    #[test]
+    fn apply_schema_dedupes_and_enforces_unique_agent_session_bindings() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_schema(&conn).unwrap();
+        // Recreate the pre-v1.1.5 state: no index/marker and two bindings that
+        // differ only by surrounding whitespace.
+        conn.execute("DROP INDEX idx_threads_agent_session_unique", [])
+            .unwrap();
+        conn.execute(
+            "DELETE FROM schema_migrations WHERE version = ?1",
+            [AGENT_SESSION_BINDING_MIGRATION_VERSION],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "INSERT INTO workspaces (id, name, kind, path, created_at, updated_at)
+                 VALUES ('ws-bind', 'W', 'user', '/tmp/ws-bind', 1, 1);
+             INSERT INTO threads (
+                 id, workspace_id, mode, title, status, agent_session_id,
+                 created_at, updated_at
+             ) VALUES
+                 ('thread-old', 'ws-bind', 'chat', 'Old', 'active', ' session-1 ', 1, 1),
+                 ('thread-new', 'ws-bind', 'chat', 'New', 'active', 'session-1', 2, 2);",
+        )
+        .unwrap();
+
+        apply_schema(&conn).unwrap();
+        apply_schema(&conn).unwrap();
+
+        let old_binding: Option<String> = conn
+            .query_row(
+                "SELECT agent_session_id FROM threads WHERE id = 'thread-old'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let new_binding: String = conn
+            .query_row(
+                "SELECT agent_session_id FROM threads WHERE id = 'thread-new'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            old_binding, None,
+            "older duplicate is preserved but detached"
+        );
+        assert_eq!(new_binding, "session-1", "survivor id is normalized");
+        assert!(conn
+            .execute(
+                "UPDATE threads SET agent_session_id = 'session-1' WHERE id = 'thread-old'",
+                [],
+            )
+            .is_err());
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM schema_migrations WHERE version = ?1",
+                [AGENT_SESSION_BINDING_MIGRATION_VERSION],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -700,7 +834,9 @@ mod tests {
                  workspace_id TEXT,
                  status TEXT,
                  pinned INTEGER,
+                 agent_session_id TEXT,
                  last_message_at INTEGER,
+                 created_at INTEGER,
                  updated_at INTEGER,
                  model_provider TEXT,
                  model_id TEXT,

--- a/desktop/src-tauri/src/store/deletions.rs
+++ b/desktop/src-tauri/src/store/deletions.rs
@@ -153,7 +153,7 @@ mod tests {
                  id, workspace_id, mode, title, agent_session_id, created_at, updated_at
              ) VALUES
                  ('t1', 'ws1', 'chat', 'T1', 'sess_1', 1, 1),
-                 ('t2', 'ws1', 'chat', 'T2', 'sess_1', 1, 1),
+                 ('t2', 'ws1', 'chat', 'T2', 'sess_2', 1, 1),
                  ('t3', 'ws1', 'chat', 'T3', '  ', 1, 1),
                  ('t4', 'ws1', 'chat', 'T4', NULL, 1, 1);",
         )
@@ -169,8 +169,8 @@ mod tests {
             .expect("query")
             .collect::<Result<Vec<_>, _>>()
             .expect("collect");
-        // sess_1 deduped across t1/t2; blank and NULL session ids fall back to
-        // the thread id.
-        assert_eq!(ids, vec!["sess_1", "t3", "t4"]);
+        // Bound session ids are unique; blank and NULL ids fall back to the
+        // owning thread id.
+        assert_eq!(ids, vec!["sess_1", "sess_2", "t3", "t4"]);
     }
 }

--- a/desktop/src-tauri/src/store/schema.rs
+++ b/desktop/src-tauri/src/store/schema.rs
@@ -236,6 +236,9 @@ CREATE TABLE IF NOT EXISTS agent_delete_outbox (
 
 CREATE INDEX IF NOT EXISTS idx_threads_workspace ON threads(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_threads_recent ON threads(status, pinned, last_message_at, updated_at);
+-- idx_threads_agent_session_unique is applied by a versioned migration after
+-- duplicate legacy bindings are detached; creating it here would make SCHEMA
+-- fail before that repair can run on an upgraded database.
 -- idx_messages_thread removed with messages table
 CREATE INDEX IF NOT EXISTS idx_runs_thread ON runs(thread_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_trigger_message ON runs(trigger_message_id);
@@ -316,6 +319,17 @@ pub(super) const VERSIONED_MIGRATIONS: &[(&str, &str, &str, &str)] = &[(
     "archived_at",
     "ALTER TABLE runs ADD COLUMN archived_at INTEGER",
 )];
+
+/// A Desktop thread is a projection owner for at most one Agent session, and
+/// an Agent session has at most one Desktop projection owner. This index is
+/// installed by a dedicated migration after legacy duplicate bindings have
+/// been detached.
+pub(super) const AGENT_SESSION_BINDING_MIGRATION_VERSION: &str =
+    "v1.1.5-unique-agent-session-binding";
+pub(super) const UNIQUE_AGENT_SESSION_INDEX: &str =
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_threads_agent_session_unique \
+     ON threads(agent_session_id) \
+     WHERE agent_session_id IS NOT NULL AND agent_session_id != ''";
 
 /// Columns renamed after their table's initial creation (N-3 aligned the DB
 /// `type` columns with the Rust `*_type` fields). `CREATE TABLE IF NOT EXISTS`

--- a/desktop/src-tauri/src/store/threads.rs
+++ b/desktop/src-tauri/src/store/threads.rs
@@ -91,7 +91,10 @@ pub fn create_thread(input: CreateThreadInput) -> Result<ThreadRecord, crate::Ap
     // Only use a pre-existing agent session ID (e.g. from fork). For normal
     // threads leave it empty — the agent generates the ID on first prompt
     // and it's persisted back via update_thread_session_id.
-    let agent_session_id = input.agent_session_id.filter(|id| !id.is_empty());
+    let agent_session_id = input
+        .agent_session_id
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
     let title = input.title.unwrap_or_else(|| {
         if mode == "chat" {
             "New Chat".to_string()
@@ -137,6 +140,36 @@ pub fn create_thread(input: CreateThreadInput) -> Result<ThreadRecord, crate::Ap
     tx.commit()?;
     mark_catalog_dirty();
     Ok(thread)
+}
+
+/// Create the sole Desktop projection for an Agent session.
+///
+/// The unique index is the concurrency authority. The optimistic lookup keeps
+/// the common path cheap; if another discovery task wins between that lookup
+/// and the insert, the losing insert rolls back and returns the winner instead
+/// of creating a duplicate thread/workspace pair.
+pub fn get_or_create_thread_for_agent_session(
+    mut input: CreateThreadInput,
+) -> Result<(ThreadRecord, bool), crate::AppError> {
+    let session_id = input
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| "agentSessionId is required for an Agent-backed thread.".to_string())?
+        .to_string();
+    input.agent_session_id = Some(session_id.clone());
+
+    if let Some(thread) = find_thread_by_agent_session(&session_id)? {
+        return Ok((thread, false));
+    }
+    match create_thread(input) {
+        Ok(thread) => Ok((thread, true)),
+        Err(error) => match find_thread_by_agent_session(&session_id)? {
+            Some(thread) => Ok((thread, false)),
+            None => Err(error),
+        },
+    }
 }
 
 pub fn get_thread(thread_id: &str) -> Result<Option<ThreadRecord>, crate::AppError> {
@@ -219,6 +252,10 @@ pub fn update_thread_thinking_level(
 
 /// Persist the agent-generated session id after the first prompt creates it.
 pub fn update_thread_session_id(thread_id: &str, session_id: &str) -> Result<(), crate::AppError> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Err("agentSessionId cannot be empty.".to_string().into());
+    }
     let now = now_millis();
     const SQL: &str = "UPDATE threads SET agent_session_id = ?1, updated_at = ?2
          WHERE id = ?3 AND status != 'deleted'";
@@ -402,9 +439,10 @@ pub(crate) fn delete_thread_inner(
         .map(str::trim)
         .filter(|id| !id.is_empty())
         .unwrap_or(&thread.id);
-    // A session can be represented by more than one GUI thread during import
-    // or migration. Only the last owner is allowed to tombstone its canonical
-    // Agent session.
+    // Non-empty Agent session bindings are unique. Keep the count guard for
+    // the unbound-thread-id fallback: a legacy Agent id could theoretically
+    // equal another local thread id, and only the final effective owner may
+    // tombstone that source session.
     const OWNER_SQL: &str = "SELECT COUNT(*) FROM threads
          WHERE COALESCE(NULLIF(TRIM(agent_session_id), ''), id) = ?1";
     let owner_count: i64 = tx.query_row(OWNER_SQL, [session_id], |row| row.get(0))?;
@@ -818,6 +856,28 @@ mod tests {
     }
 
     #[test]
+    fn agent_session_binding_is_normalized_and_get_or_create_is_idempotent() {
+        let (_home, _conn) = guarded_conn("threads_unique_agent_session");
+        let mut first = chat_input();
+        first.agent_session_id = Some("  sess-one  ".to_string());
+        let (created, was_created) =
+            get_or_create_thread_for_agent_session(first).expect("create binding");
+        assert!(was_created);
+        assert_eq!(created.agent_session_id.as_deref(), Some("sess-one"));
+
+        let mut repeated = chat_input();
+        repeated.agent_session_id = Some("sess-one".to_string());
+        let (existing, was_created) =
+            get_or_create_thread_for_agent_session(repeated).expect("reuse binding");
+        assert!(!was_created);
+        assert_eq!(existing.id, created.id);
+
+        let other = create_thread(chat_input()).expect("create unbound thread");
+        assert!(update_thread_session_id(&other.id, "sess-one").is_err());
+        assert!(update_thread_session_id(&other.id, "   ").is_err());
+    }
+
+    #[test]
     fn thread_field_updates_round_trip() {
         let (_home, conn) = guarded_conn("threads_updates");
         seed_two_threads(&conn);
@@ -947,28 +1007,22 @@ mod tests {
     }
 
     #[test]
-    fn delete_tombstones_only_the_last_owner_of_a_session() {
-        let (_home, conn) = guarded_conn("threads_delete_shared");
+    fn deleting_a_bound_thread_tombstones_its_unique_session() {
+        let (_home, conn) = guarded_conn("threads_delete_bound");
         conn.execute_batch(
             "INSERT INTO workspaces (id, name, kind, path, created_at, updated_at)
                  VALUES ('ws1', 'W', 'user', '/tmp/ws1', 1, 1);
              INSERT INTO threads (id, workspace_id, mode, title, agent_session_id,
                  created_at, updated_at)
-                 VALUES ('ta', 'ws1', 'chat', 'A', 'sess_shared', 1, 1),
-                        ('tb', 'ws1', 'chat', 'B', 'sess_shared', 1, 1);",
+                 VALUES ('ta', 'ws1', 'chat', 'A', 'sess_unique', 1, 1);",
         )
         .expect("seed");
         drop(conn);
 
-        delete_thread("ta").expect("delete first");
+        delete_thread("ta").expect("delete");
         assert!(
-            !crate::store::is_agent_session_tombstoned("sess_shared").expect("check"),
-            "a surviving owner keeps the session untombstoned"
-        );
-        delete_thread("tb").expect("delete last");
-        assert!(
-            crate::store::is_agent_session_tombstoned("sess_shared").expect("check"),
-            "the last owner tombstones the session"
+            crate::store::is_agent_session_tombstoned("sess_unique").expect("check"),
+            "the sole owner tombstones the session"
         );
     }
 

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -315,6 +315,13 @@ export function AppShell() {
     void refreshStore();
   });
 
+  // Sessions created outside the GUI (TUI/CLI/channels) were imported into the
+  // store by the backend — refresh the thread list so they appear in the
+  // sidebar without a user action.
+  useTauriEvent("threads-updated", () => {
+    void refreshStore();
+  });
+
   function handleSectionChange(nextSection: ActivitySection) {
     if (nextSection === "settings") {
       setSettingsTab("general");

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -216,6 +216,12 @@ message RpcCommand {
   // per-client data, not part of the typed contract.
   string source_meta = 162;
 
+  // Stable device identity of the creator installation. Unlike a future
+  // client_id this does not identify one process or transport connection.
+  // Consumers use it to distinguish their own lifecycle announcements from
+  // sessions created by another instance of the same client type.
+  string creator_id = 163;
+
   // ── set_auth ───────────────────────────────────────────────────────────
   // One auth.json entry mutation (typed sub-message, not JSON-in-string).
   // Read when type == "set_auth".
@@ -1164,7 +1170,9 @@ message StreamEvent {
   //   provider_config_changed  global provider/auth configuration committed
 //   session_created          global control-plane signal: a session was minted
 //                            (new_session / fork / clone, never disk hydration)
-//                            — carries {sessionId, createdBy, cwd}; subscribe
+//                            — carries {sessionId, createdBy, creatorId, cwd};
+//                            creatorId is the durable creator installation,
+//                            not a per-connection client id; subscribe
 //                            via global_events
   //
   // Provider-specific aliases are normalized inside the Agent and never cross

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -1118,7 +1118,8 @@ message StreamRequest {
   // Optional list of event types to receive.  Empty = all events.
   // Valid types: "ping", "agent_start", "agent_end", "text_chunk",
   // "thinking_start", "thinking_delta", "thinking_end", "tool_start",
-  // "tool_delta", "tool_end", "approval_request", "error", "stop".
+  // "tool_delta", "tool_end", "approval_request", "error", "stop",
+  // plus "session_created" on the global control-plane stream.
   repeated string event_types = 1;
 
   // Scope events to a specific session.  Required so the agent
@@ -1133,7 +1134,8 @@ message StreamRequest {
 
   // Subscribe to process-wide Agent control-plane events instead of one
   // session. When true, session_id/run_id must be empty and atomic_attach
-  // false. The initial ping carries the current config revision.
+  // false. The initial ping carries the current config revision. Carries
+  // "provider_config_changed" and "session_created".
   bool global_events = 6;
 }
 
@@ -1160,6 +1162,10 @@ message StreamEvent {
   //   compaction_started / compaction_committed /
   //   compaction_failed                                     sideband signals
   //   provider_config_changed  global provider/auth configuration committed
+//   session_created          global control-plane signal: a session was minted
+//                            (new_session / fork / clone, never disk hydration)
+//                            — carries {sessionId, createdBy, cwd}; subscribe
+//                            via global_events
   //
   // Provider-specific aliases are normalized inside the Agent and never cross
   // this RPC boundary.

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -142,7 +142,7 @@ pub struct RpcCommand {
     /// per-client data, not part of the typed contract.
     #[prost(string, tag = "162")]
     pub source_meta: ::prost::alloc::string::String,
-    /// Stable identity of the creator installation/account. Unlike a future
+    /// Stable device identity of the creator installation. Unlike a future
     /// client_id this does not identify one process or transport connection.
     /// Consumers use it to distinguish their own lifecycle announcements from
     /// sessions created by another instance of the same client type.

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -1209,7 +1209,8 @@ pub struct StreamRequest {
     /// Optional list of event types to receive.  Empty = all events.
     /// Valid types: "ping", "agent_start", "agent_end", "text_chunk",
     /// "thinking_start", "thinking_delta", "thinking_end", "tool_start",
-    /// "tool_delta", "tool_end", "approval_request", "error", "stop".
+    /// "tool_delta", "tool_end", "approval_request", "error", "stop",
+    /// plus "session_created" on the global control-plane stream.
     #[prost(string, repeated, tag = "1")]
     pub event_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Scope events to a specific session.  Required so the agent
@@ -1226,7 +1227,8 @@ pub struct StreamRequest {
     pub atomic_attach: bool,
     /// Subscribe to process-wide Agent control-plane events instead of one
     /// session. When true, session_id/run_id must be empty and atomic_attach
-    /// false. The initial ping carries the current config revision.
+    /// false. The initial ping carries the current config revision. Carries
+    /// "provider_config_changed" and "session_created".
     #[prost(bool, tag = "6")]
     pub global_events: bool,
 }
@@ -1252,6 +1254,10 @@ pub struct StreamEvent {
     ///    compaction_started / compaction_committed /
     ///    compaction_failed                                     sideband signals
     ///    provider_config_changed  global provider/auth configuration committed
+    ///    session_created          global control-plane signal: a session was minted
+    ///                             (new_session / fork / clone, never disk hydration)
+    ///                             — carries {sessionId, createdBy, cwd}; subscribe
+    ///                             via global_events
     ///
     /// Provider-specific aliases are normalized inside the Agent and never cross
     /// this RPC boundary.

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -142,6 +142,12 @@ pub struct RpcCommand {
     /// per-client data, not part of the typed contract.
     #[prost(string, tag = "162")]
     pub source_meta: ::prost::alloc::string::String,
+    /// Stable identity of the creator installation/account. Unlike a future
+    /// client_id this does not identify one process or transport connection.
+    /// Consumers use it to distinguish their own lifecycle announcements from
+    /// sessions created by another instance of the same client type.
+    #[prost(string, tag = "163")]
+    pub creator_id: ::prost::alloc::string::String,
     /// ── set_auth ───────────────────────────────────────────────────────────
     /// One auth.json entry mutation (typed sub-message, not JSON-in-string).
     /// Read when type == "set_auth".
@@ -1256,7 +1262,9 @@ pub struct StreamEvent {
     ///    provider_config_changed  global provider/auth configuration committed
     ///    session_created          global control-plane signal: a session was minted
     ///                             (new_session / fork / clone, never disk hydration)
-    ///                             — carries {sessionId, createdBy, cwd}; subscribe
+    ///                             — carries {sessionId, createdBy, creatorId, cwd};
+    ///                             creatorId is the durable creator installation,
+    ///                             not a per-connection client id; subscribe
     ///                             via global_events
     ///
     /// Provider-specific aliases are normalized inside the Agent and never cross


### PR DESCRIPTION
## Summary

- publish global `session_created` notifications after create/fork responses, carrying a stable `creatorId` without letting broadcast failures affect the lifecycle command
- give Desktop a shared, persisted device identity and reconcile externally created Agent sessions immediately while avoiding re-import of sessions created by the same installation
- enforce one-to-one `agent_session_id` bindings in SQLite, reuse one concurrency-safe get-or-create import path, and replace the 1-second streaming poll with event-driven reconciliation plus a 60-second recovery pass
- keep the existing broadcaster and publisher entry points as deprecated compatibility aliases; TUI behavior is unchanged

## Validation

- `make generate-proto`
- `cargo fmt --all -- --check`
- `cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo clippy -p future-agent --all-targets -- -D warnings`
- `cargo clippy --all-targets --manifest-path desktop/src-tauri/Cargo.toml -- -D warnings`
- `npm --prefix desktop run lint`
- `git diff --check origin/main...HEAD`

Full test suites were not rerun after merging the latest `main`; GitHub Actions owns final test execution.
