### PR TITLE
chore(loop): remove --max-turn-secs wall-clock turn budget

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -179,8 +179,8 @@ channel. Both directions ride the same event-sourced state:
   authoritative intervention channel if no supervisor is registered.
 
 - **Infra stops + dead workers:** a worker that exits before reaching a
-  turn-boundary writeback (gRPC transport loss, `--max-turn-secs` timeout,
-  incomplete-retry budget exhaustion) also reports an `infra_stopped` note.
+  turn-boundary writeback (gRPC transport loss, incomplete-retry budget
+  exhaustion) also reports an `infra_stopped` note.
   A worker that dies outright (SIGKILL / crash / host failure) executes no
   code, so the periodic `scheduler tick` detects the orphaned lease (dead
   holder pid) and pushes a `host_died` note to the registered supervisor,

--- a/docs/loop-control-plane.zh-CN.md
+++ b/docs/loop-control-plane.zh-CN.md
@@ -149,7 +149,7 @@ supervisor（运行 `/future-loop` 技能的编排 agent）与其 worker 通过�
   supervisor，持久化用户闸门仍是权威的干预通道。
 
 - **基础设施停止 + 死 worker：** 在到达回合边界写回之前退出的 worker（gRPC 传输丢失、
-  `--max-turn-secs` 超时、不完整重试预算耗尽）也会上报一条 `infra_stopped` 备注。
+  不完整重试预算耗尽）也会上报一条 `infra_stopped` 备注。
   直接死掉的 worker（SIGKILL / 崩溃 / 宿主机故障）不执行任何代码，因此周期性的
   `scheduler tick` 会检测到孤儿租约（持有者 pid 已死），并向已注册的 supervisor 推送
   一条 `host_died` 备注，促使编排者重启，而不是只在下次 `status` 轮询时才发现有 worker

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -542,7 +542,7 @@ fn build_cli_registry() -> CommandRegistry {
         ops,
         "run",
         "drive one bounded gRPC turn (--agent-id for lease coordination, or --anonymous; auto-registers)",
-        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-turn-secs N] [--max-incomplete-retries N] [--lease-secs N] [--force-workspace] [--session-policy auto|fresh|resume] [--resume-session ID] [--anonymous]",
+        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-incomplete-retries N] [--lease-secs N] [--force-workspace] [--session-policy auto|fresh|resume] [--resume-session ID] [--anonymous]",
     );
 
     let work_items = r.group(
@@ -3701,7 +3701,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut model = None;
     let mut thinking = None;
     let mut max_turns = 6u32;
-    let mut max_turn_secs = 0u64;
     let mut max_incomplete_retries = crate::executor::DEFAULT_MAX_INCOMPLETE_RETRIES;
     let mut agent_id = None;
     let mut anonymous = false;
@@ -3726,7 +3725,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             "--goal",
             "--lease-secs",
             "--max-incomplete-retries",
-            "--max-turn-secs",
             "--max-turns",
             "--model",
             "--resume-session",
@@ -3743,8 +3741,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             thinking = Some(v);
         } else if k == "--max-turns" {
             max_turns = v.parse().unwrap_or(6);
-        } else if k == "--max-turn-secs" {
-            max_turn_secs = v.parse().unwrap_or(0);
         } else if k == "--max-incomplete-retries" {
             max_incomplete_retries = v
                 .parse()
@@ -3964,7 +3960,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         max_turns,
         lease_secs,
         agent_id.as_deref(),
-        max_turn_secs,
         max_incomplete_retries,
         force_workspace,
         &mut last_failure_kind,
@@ -4131,11 +4126,10 @@ pub async fn notify_supervisor(
 }
 
 /// Report a worker stop that never reached a turn-boundary writeback (a
-/// transport failure propagating before writeback, or a wall-clock budget
-/// truncation returning early). Both exits skip the normal ②/③ up-channel
-/// reports, so the supervisor would otherwise be left polling a worker that
-/// already stopped. Idempotency is keyed on `todo_id` + `kind`, so a relaunch
-/// that hits the same stop re-notifies only once.
+/// transport failure propagating before writeback). That exit skips the normal
+/// ②/③ up-channel reports, so the supervisor would otherwise be left polling a
+/// worker that already stopped. Idempotency is keyed on `todo_id` + `kind`, so
+/// a relaunch that hits the same stop re-notifies only once.
 #[doc(hidden)] // test-visible seam
 pub async fn notify_infra_stop(
     store: &mut Store,
@@ -4163,7 +4157,7 @@ pub async fn notify_infra_stop(
 
 /// Dead-worker push (the host-died case the recoverable infra stops above
 /// cannot reach): a worker that died mid-slice (SIGKILL / crash / host
-/// failure) executes no code, so the `transport` / `timeout` /
+/// failure) executes no code, so the `transport` /
 /// `incomplete_budget` reports never fire. The scheduler tick is the periodic
 /// trigger that notices a lease whose holder pid is gone and pushes a report
 /// to the registered supervisor, so the orchestrator is prompted to relaunch
@@ -4215,7 +4209,6 @@ async fn run_turns(
     max_turns: u32,
     lease_secs: u64,
     agent_id: Option<&str>,
-    max_turn_secs: u64,
     max_incomplete_retries: u32,
     force_workspace: bool,
     last_failure_kind: &mut Option<crate::state::FailureKind>,
@@ -4468,80 +4461,26 @@ async fn run_turns(
             Some(&progress),
             turn_note.as_deref(),
         );
-        let record = if max_turn_secs > 0 {
-            // Wall-clock budget per turn: a long turn that never sees new
-            // instructions is an observability hole; bound it so orchestrators
-            // can relaunch on a safe cadence (context replays from the ledger).
-            match tokio::time::timeout(std::time::Duration::from_secs(max_turn_secs), turn_future)
-                .await
-            {
-                Ok(r) => match r {
-                    Ok(rec) => rec,
-                    Err(e) => {
-                        // A gRPC transport failure (h2 reset, stream error,
-                        // connect loss …) never reached a writeback, so the
-                        // ②/③ up-channel reports are skipped. Report the
-                        // infra stop and mark it resumable before
-                        // re-propagating, so the supervisor isn't left
-                        // polling a dead worker.
-                        *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
-                        notify_infra_stop(
-                            store,
-                            client,
-                            goal_id,
-                            goal.supervisor_session_id.as_deref(),
-                            &todo_id,
-                            "transport",
-                            &format!("{e}"),
-                        )
-                        .await;
-                        return Err(e);
-                    }
-                },
-                Err(_) => {
-                    // O3: budget truncation is a turn end — evaluate the
-                    // no-progress window against the observed tool starts
-                    // before stopping the run.
-                    record_no_progress_if_idle(store, goal_id, &todo_id, agent_id, &progress)?;
-                    // A turn that outlives its wall-clock budget is an infra
-                    // stop, not a science result: mark it resumable so the
-                    // session's reasoning state is retained for the next
-                    // launch, and report it up-channel (the early return
-                    // otherwise skips the ②/③ reports).
-                    *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
-                    notify_infra_stop(
-                        store,
-                        client,
-                        goal_id,
-                        goal.supervisor_session_id.as_deref(),
-                        &todo_id,
-                        "timeout",
-                        &format!("turn exceeded --max-turn-secs ({max_turn_secs}s)"),
-                    )
-                    .await;
-                    println!(
-                        "   ⏱ turn exceeded --max-turn-secs ({max_turn_secs}s) — stopping run gracefully; relaunch to continue"
-                    );
-                    return Ok(());
-                }
-            }
-        } else {
-            match turn_future.await {
-                Ok(rec) => rec,
-                Err(e) => {
-                    *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
-                    notify_infra_stop(
-                        store,
-                        client,
-                        goal_id,
-                        goal.supervisor_session_id.as_deref(),
-                        &todo_id,
-                        "transport",
-                        &format!("{e}"),
-                    )
-                    .await;
-                    return Err(e);
-                }
+        let record = match turn_future.await {
+            Ok(rec) => rec,
+            Err(e) => {
+                // A gRPC transport failure (h2 reset, stream error, connect
+                // loss …) never reached a writeback, so the ②/③ up-channel
+                // reports are skipped. Report the infra stop and mark it
+                // resumable before re-propagating, so the supervisor isn't
+                // left polling a dead worker.
+                *last_failure_kind = Some(crate::state::FailureKind::InfraRecoverable);
+                notify_infra_stop(
+                    store,
+                    client,
+                    goal_id,
+                    goal.supervisor_session_id.as_deref(),
+                    &todo_id,
+                    "transport",
+                    &format!("{e}"),
+                )
+                .await;
+                return Err(e);
             }
         };
         println!(

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -561,28 +561,6 @@ fn run_with_model_and_thinking_flags() {
     assert!(recorded.contains(&"set_thinking_level".to_string()));
 }
 
-#[test]
-fn run_max_turn_secs_graceful_timeout() {
-    let cr = cli_root();
-    let st = MockState {
-        hang_stream: true,
-        ..Default::default()
-    };
-    let (_rt, _shared) = mock_env(st);
-    let goal = init_goal(&cr, "hanging turn");
-    // The turn stream never yields; the wall-clock budget stops the run gracefully.
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "1",
-        "--max-turns",
-        "3",
-    ]);
-}
-
 // ── bidirectional messaging: up-channel turn-boundary reports ────────────────
 
 /// A registered supervisor receives an `enqueue_if_busy` report when a todo
@@ -753,56 +731,6 @@ fn run_notifies_supervisor_on_transport_error() {
             .1
             .contains("stopped before completion (transport)"),
         "transport stop reported: {}",
-        reports[0].1
-    );
-}
-
-/// A registered supervisor receives a report when a turn outlives its
-/// wall-clock budget (--max-turn-secs). The early return previously skipped
-/// the ②/③ reports, leaving the supervisor blind to the stop.
-#[test]
-fn run_notifies_supervisor_on_timeout() {
-    let cr = cli_root();
-    let (_rt, shared) = mock_env(MockState {
-        hang_stream: true,
-        ..Default::default()
-    });
-    let goal = init_goal(&cr, "notify on timeout");
-    cli_ok(&[
-        "supervisor",
-        "register",
-        "--goal",
-        &goal,
-        "--session-id",
-        "sup-sess",
-    ]);
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "1",
-        "--max-turns",
-        "3",
-    ]);
-    let st = shared.lock().unwrap();
-    let reports: Vec<_> = st
-        .prompt_calls
-        .iter()
-        .zip(st.prompt_messages.iter())
-        .filter(|((sid, _), _)| sid == "sup-sess")
-        .collect();
-    assert_eq!(
-        reports.len(),
-        1,
-        "one timeout report: {:?}",
-        st.prompt_calls
-    );
-    assert_eq!(reports[0].0 .1, "enqueue_if_busy");
-    assert!(
-        reports[0].1.contains("stopped before completion (timeout)"),
-        "timeout stop reported: {}",
         reports[0].1
     );
 }

--- a/orchestration/loop/tests/common/mock_agent.rs
+++ b/orchestration/loop/tests/common/mock_agent.rs
@@ -2,8 +2,8 @@
 //! StreamEvents — the only two RPCs the loop control plane consumes).
 //!
 //! The mock is scripted through `MockState`: per-command failures, invalid
-//! JSON payloads, a never-yielding event stream (for wall-clock timeout
-//! paths), and a scripted event list for `run_turn`.
+//! JSON payloads, a never-yielding event stream, and a scripted event list for
+//! `run_turn`.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -44,10 +44,10 @@ pub struct MockState {
     pub invalid_json: HashSet<String>,
     /// ExecuteCommand fails at the transport level (tonic::Status error).
     pub grpc_error: bool,
-    /// stream_events returns a stream that never yields (timeout tests).
+    /// stream_events returns a stream that never yields.
     pub hang_stream: bool,
     /// Replays the scripted `events` first, then never yields — the
-    /// budget-truncation path WITH observed tool starts (O3 idle detection).
+    /// no-progress path WITH observed tool starts (O3 idle detection).
     pub events_then_hang: bool,
     /// stream_events fails immediately with a tonic status.
     pub stream_error: bool,

--- a/orchestration/loop/tests/console_drive_cov100c.rs
+++ b/orchestration/loop/tests/console_drive_cov100c.rs
@@ -406,11 +406,11 @@ fn run_falls_back_to_fresh_for_dead_session() {
 }
 
 #[test]
-fn run_transport_error_with_turn_budget() {
+fn run_transport_error_reports_and_returns() {
     let cr = cli_root();
-    let gid = init_goal(&cr, "transport with budget");
-    // A non-DataLoss mid-stream error under a wall-clock turn budget hits the
-    // `Ok(Err(e))` arm of the timeout match (transport stop + resumable mark).
+    let gid = init_goal(&cr, "transport error");
+    // A non-DataLoss mid-stream error hits the transport-failure arm of the
+    // turn await (transport stop + resumable mark, then re-propagates).
     let st = MockState {
         stream_attach_plan: vec![AttachPlan::HardErrorAfter(0)],
         ..Default::default()
@@ -418,16 +418,7 @@ fn run_transport_error_with_turn_budget() {
     let rt = rt();
     let (addr, _shared) = rt.block_on(spawn_mock(st));
     std::env::set_var("FUTURE_LOOP_AGENT_ADDR", &addr);
-    let err = cli_err(&[
-        "run",
-        "--goal",
-        &gid,
-        "--anonymous",
-        "--max-turns",
-        "1",
-        "--max-turn-secs",
-        "5",
-    ]);
+    let err = cli_err(&["run", "--goal", &gid, "--anonymous", "--max-turns", "1"]);
     assert!(err.contains("stream error"), "{err}");
     std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
 }

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -1,7 +1,6 @@
 //! Coverage sweep for console.rs remainder: unknown-flag parse arms across
-//! every command, the monitor claim-race re-decide loop, wall-clock-budget
-//! success arm, session-cleanup warning, and assorted print arms unreachable
-//! through the happy paths.
+//! every command, the monitor claim-race re-decide loop, session-cleanup
+//! warning, and assorted print arms unreachable through the happy paths.
 
 mod common;
 
@@ -357,27 +356,7 @@ fn run_monitor_claim_race_stops_without_selection() {
     assert_ne!(m.status, TodoStatus::Done, "raced monitor never executed");
 }
 
-// ── run: wall-clock budget success arm + session cleanup warning ───────────
-
-#[test]
-fn run_with_time_budget_success_path() {
-    let cr = cli_root();
-    let (_rt, _shared) = mock_env(MockState {
-        events: completed_events("mock-run-1"),
-        ..Default::default()
-    });
-    let goal = init_goal(&cr, "budget success");
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "600",
-        "--max-turns",
-        "3",
-    ]);
-}
+// ── run: session cleanup warning ───────────────────────────────────────────
 
 #[test]
 fn run_retains_session() {

--- a/orchestration/loop/tests/no_progress_drive.rs
+++ b/orchestration/loop/tests/no_progress_drive.rs
@@ -126,89 +126,6 @@ fn run_turn_folds_tool_starts_into_tracker() {
     });
 }
 
-// ── budget truncation → ledger event ───────────────────────────────────────
-
-#[test]
-fn budget_truncation_read_only_turn_records_turn_no_progress() {
-    let cr = cli_root();
-    let events = vec![ev(
-        "mock-run-1",
-        0,
-        "tool_start",
-        "{\"tool_name\":\"read\"}",
-    )];
-    let st = MockState {
-        events,
-        events_then_hang: true,
-        ..Default::default()
-    };
-    let (_rt, _shared) = mock_env(st);
-    // Shrink the idle window to 1s so the 2s budget truncation breaches it
-    // (the env hook mirrors FUTURE_LOOP_AGENT_ADDR; default is 15 min).
-    std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "1");
-    let goal = init_goal(&cr, "read-only hang");
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "2",
-        "--max-turns",
-        "3",
-    ]);
-    std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
-    let store = open_store(&cr);
-    let g = store.replay(&goal).unwrap().unwrap();
-    assert_eq!(g.turn_no_progress.len(), 1, "{:?}", g.turn_no_progress);
-    let np = &g.turn_no_progress[0];
-    assert!(np.idle_secs >= 1, "idle {np:?}");
-    assert_eq!(np.tool_calls_total, 1, "the read tool_start was observed");
-    assert!(np.agent_id.is_none(), "anonymous run");
-    // The ledger carries the real event (replay folds it, so this must hold).
-    let text = std::fs::read_to_string(store.goal_dir(&goal).join("events.jsonl")).unwrap();
-    assert!(text.contains("\"kind\":\"turn_no_progress\""), "{text}");
-    // Status surfaces the breach (recent-last).
-    cli_ok(&["status", "--goal", &goal]);
-}
-
-#[test]
-fn budget_truncation_after_write_tool_no_event() {
-    let cr = cli_root();
-    let events = vec![ev(
-        "mock-run-1",
-        0,
-        "tool_start",
-        "{\"tool_name\":\"write\"}",
-    )];
-    let st = MockState {
-        events,
-        events_then_hang: true,
-        ..Default::default()
-    };
-    let (_rt, _shared) = mock_env(st);
-    // Window 5s: the 2s budget truncation ends well inside it → no breach.
-    std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "5");
-    let goal = init_goal(&cr, "write then hang");
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "2",
-        "--max-turns",
-        "3",
-    ]);
-    std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
-    let store = open_store(&cr);
-    let g = store.replay(&goal).unwrap().unwrap();
-    assert!(g.turn_no_progress.is_empty(), "{:?}", g.turn_no_progress);
-    // Status projections (human + json) render the empty state cleanly.
-    cli_ok(&["status", "--goal", &goal]);
-    cli_ok(&["status", "--format", "json", "--goal", &goal]);
-}
-
 #[test]
 fn normal_completion_inside_window_no_event() {
     let cr = cli_root();
@@ -220,16 +137,7 @@ fn normal_completion_inside_window_no_event() {
     });
     std::env::set_var("FUTURE_LOOP_NO_PROGRESS_SECS", "1");
     let goal = init_goal(&cr, "normal completion");
-    cli_ok(&[
-        "run",
-        "--goal",
-        &goal,
-        "--anonymous",
-        "--max-turn-secs",
-        "600",
-        "--max-turns",
-        "3",
-    ]);
+    cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
     std::env::remove_var("FUTURE_LOOP_NO_PROGRESS_SECS");
     let store = open_store(&cr);
     let g = store.replay(&goal).unwrap().unwrap();


### PR DESCRIPTION
## What

Remove the `--max-turn-secs` flag from `future loop run`.

## Why

The per-turn wall-clock budget conflated **turn duration** with **turn liveness**:

- A healthy xhigh run can legitimately stream reasoning well past any fixed cap (the exact case that triggered the real-world timeout — 1200s exceeded while the model was still thinking).
- A genuinely dead stream is already caught by the agent's own idle timeouts: `STREAM_IDLE_TIMEOUT_SECS=45` (LLM layer) and `idle_timeouts_for` (run_loop layer, high/xhigh = 180s/60s).

Worse, the timeout **never actually aborted the underlying agent run** — `tokio::time::timeout` only drops the loop's stream subscription, while the agent-side run is an independent spawned task that keeps running to completion. So "relaunch to continue" really meant "requeue behind the still-running turn" (`enqueue_if_busy`).

## Change

Kill-time decisions belong to the orchestrator — `monitor_poll` + `worker stop` already expose the observe-then-kill primitives. So the flag is removed rather than fixed:

- Drop the flag from `run`, the `run_turns` signature, and the usage/help text.
- Simplify the turn-await to a direct `turn_future.await` (the transport-error branch is preserved).
- Remove the now-dead timeout tests + mock/doc references.

Default behavior (`0` = unlimited) is unchanged — this removes an opt-in knob, not the default path.

## Checks

- `cargo fmt -p future-loop --check` ✅
- `cargo clippy -p future-loop --all-targets -- -D warnings` ✅
- `cargo test -p future-loop` (affected test targets) ✅