### PR TITLE
Fix mobile camera permission review flow

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -16,6 +16,8 @@ const bundleVersion = version.split(/[-+]/)[0];
 // local dev builds just use a constant — TestFlight/Play enforce monotonicity
 // only, not that the number corresponds to any git commit.
 const buildNumber = process.env.FUTURE_BUILD_NUMBER || "1";
+const cameraPermission =
+  "FutureOS uses the camera to scan desktop pairing QR codes and take photos you choose to attach to conversations.";
 
 const config: ExpoConfig = {
   name: "FutureOS",
@@ -31,14 +33,14 @@ const config: ExpoConfig = {
     [
       "expo-camera",
       {
-        cameraPermission: "Allow FutureOS to scan the desktop pairing QR code.",
+        cameraPermission,
         recordAudioAndroid: false,
       },
     ],
     [
       "expo-image-picker",
       {
-        cameraPermission: "Allow FutureOS to take photos for conversation attachments.",
+        cameraPermission,
         photosPermission: "Allow FutureOS to select photos for conversation attachments.",
         microphonePermission: false,
       },

--- a/mobile/src/i18n/locales.ts
+++ b/mobile/src/i18n/locales.ts
@@ -7,8 +7,12 @@ export const resources = {
         title: "Connect to your desktop",
         description:
           "Open Phone Control in FutureOS Desktop, choose Pair & start, then scan the QR code.",
-        permission: "Camera access is required to scan the desktop pairing code.",
-        grant: "Allow camera",
+        permission:
+          "Scan the one-time QR code shown in FutureOS Desktop to connect this device. This scanner does not capture or save photos.",
+        continue: "Continue",
+        permissionDenied:
+          "Camera access is off. Enable it in Settings to scan the QR code, or paste the pairing code below.",
+        openSettings: "Open Settings",
         scanning: "Point the camera at the QR code",
         claiming: "Pairing securely…",
         invalid: "The pairing code has expired. Scan a new code. (PA002)",
@@ -278,8 +282,11 @@ export const resources = {
       pairing: {
         title: "连接桌面端",
         description: "在 FutureOS 桌面端打开“手机遥控”，点击“配对并启动”，然后扫描二维码。",
-        permission: "需要相机权限来扫描桌面端配对二维码。",
-        grant: "允许相机",
+        permission:
+          "扫描 FutureOS 桌面端显示的一次性二维码以连接此设备。扫码过程不会拍摄或保存照片。",
+        continue: "继续",
+        permissionDenied: "相机权限已关闭。你可以前往系统设置开启权限，或在下方粘贴配对码。",
+        openSettings: "打开设置",
         scanning: "将二维码放入取景框",
         claiming: "正在安全配对…",
         invalid: "配对码已失效，请重新扫码（PA002）",

--- a/mobile/src/screens/PairingScreen.tsx
+++ b/mobile/src/screens/PairingScreen.tsx
@@ -5,8 +5,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
+  AppState,
   Keyboard,
   KeyboardAvoidingView,
+  Linking,
   Modal,
   Platform,
   Pressable,
@@ -61,7 +63,7 @@ function pairingErrorMessage(error: unknown, t: TFunction): string {
 export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
   const { t } = useTranslation();
   const remote = useRemote();
-  const [permission, requestPermission] = useCameraPermissions();
+  const [permission, requestPermission, getPermission] = useCameraPermissions();
   const scanLocked = useRef(false);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [manualOpen, setManualOpen] = useState(false);
@@ -75,6 +77,13 @@ export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
     },
     [],
   );
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", state => {
+      if (state === "active") void getPermission();
+    });
+    return () => subscription.remove();
+  }, [getPermission]);
 
   const showToast = useCallback((message: string) => {
     if (toastTimer.current) clearTimeout(toastTimer.current);
@@ -170,8 +179,15 @@ export function PairingScreen({ revoked = false }: { revoked?: boolean }) {
             ) : !permission.granted ? (
               <View style={styles.permission}>
                 <ScanLine color={colors.inkSoft} size={40} />
-                <Text style={styles.permissionText}>{t("pairing.permission")}</Text>
-                <Button label={t("pairing.grant")} onPress={() => void requestPermission()} />
+                <Text style={styles.permissionText}>
+                  {t(permission.canAskAgain ? "pairing.permission" : "pairing.permissionDenied")}
+                </Text>
+                <Button
+                  label={t(permission.canAskAgain ? "pairing.continue" : "pairing.openSettings")}
+                  onPress={() =>
+                    void (permission.canAskAgain ? requestPermission() : Linking.openSettings())
+                  }
+                />
               </View>
             ) : (
               <>

--- a/scripts/reset-ios-simulator-permissions.sh
+++ b/scripts/reset-ios-simulator-permissions.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+simulator="${FUTURE_IOS_SIMULATOR:-booted}"
+bundle_id="${FUTURE_IOS_BUNDLE_ID:-cn.futureos.mobile}"
+
+# `terminate` also fails when the app is already stopped; that is safe to ignore.
+xcrun simctl terminate "$simulator" "$bundle_id" >/dev/null 2>&1 || true
+xcrun simctl privacy "$simulator" reset all "$bundle_id"
+
+echo "Reset simulator permissions for $bundle_id on $simulator."


### PR DESCRIPTION
Summary
- replace the custom Allow camera action with neutral Continue copy
- route denied camera permission to system Settings and refresh on app foreground
- unify the iOS camera purpose string and add a simulator permission reset helper

Validation
- mobile TypeScript typecheck
- mobile ESLint
- mobile Prettier check
- bash syntax check
- Expo iOS permission configuration introspection
- git diff checks

Tests
- Not run during PR delivery; GitHub Actions owns test execution.