### PR TITLE
Improve cross-platform Chinese font fallback

### DIFF
--- a/desktop/src/i18n/i18n.test.ts
+++ b/desktop/src/i18n/i18n.test.ts
@@ -12,6 +12,7 @@ describe("i18n language helpers", () => {
     localStorage.setItem("future.language", "en");
     const mod = await import("./index");
     expect(mod.getLanguage()).toBe("en");
+    expect(document.documentElement.lang).toBe("en");
   });
 
   it("follows the OS language when no preference is stored (first run)", async () => {
@@ -40,6 +41,7 @@ describe("i18n language helpers", () => {
     vi.stubGlobal("navigator", { language: "zh-CN" });
     const mod = await import("./index");
     expect(mod.getLanguage()).toBe("zh");
+    expect(document.documentElement.lang).toBe("zh-CN");
   });
 
   it("falls back to the system language for an unrecognized stored value", async () => {
@@ -55,7 +57,9 @@ describe("i18n language helpers", () => {
     mod.setLanguage("en");
     expect(localStorage.getItem("future.language")).toBe("en");
     expect(mod.getLanguage()).toBe("en");
+    expect(document.documentElement.lang).toBe("en");
     mod.setLanguage("zh");
     expect(mod.getLanguage()).toBe("zh");
+    expect(document.documentElement.lang).toBe("zh-CN");
   });
 });

--- a/desktop/src/i18n/index.ts
+++ b/desktop/src/i18n/index.ts
@@ -59,10 +59,19 @@ function readStoredLanguage(): Language {
 }
 
 const namespaces = Object.keys(resources[DEFAULT_LANGUAGE] ?? {});
+const initialLanguage = readStoredLanguage();
+
+function syncDocumentLanguage(language: string): void {
+  if (typeof document !== "undefined")
+    document.documentElement.lang = language === "en" ? "en" : "zh-CN";
+}
+
+syncDocumentLanguage(initialLanguage);
+i18n.on("languageChanged", syncDocumentLanguage);
 
 void i18n.use(initReactI18next).init({
   resources,
-  lng: readStoredLanguage(),
+  lng: initialLanguage,
   fallbackLng: "en",
   ns: namespaces.length > 0 ? namespaces : ["common"],
   defaultNS: "common",

--- a/desktop/src/styles/globals.css
+++ b/desktop/src/styles/globals.css
@@ -45,8 +45,10 @@
   color: theme(colors.ink);
   background: theme(colors.canvas);
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+    -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB",
+    "Segoe UI", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans CJK SC",
+    "Noto Sans SC", "Source Han Sans SC", "WenQuanYi Micro Hei", ui-sans-serif,
+    system-ui, sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary
- synchronize the document language with the active Chinese or English locale
- prefer platform-native Apple and Windows UI fonts before Linux CJK fallbacks
- add explicit Simplified Chinese fallbacks for PingFang, Microsoft YaHei, Noto, Source Han Sans, and WenQuanYi Micro Hei

## Validation
- npm run lint (desktop)
- npm run stylelint (desktop)
- Prettier check for the changed test and CSS files
- git diff --cached --check

Full local test suites were not run; GitHub Actions owns test execution.