### PR TITLE
fix(loop): widen TurnNoProgress idle window from 15m to 1h

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -150,7 +150,7 @@ root, and only GET endpoints exist (any other method is a 405). Mutations
 - `--acceptance` turns "accepted by an external observable" into a hard check
 - Lease liveness self-heals: dead-process leases are reclaimed automatically — relaunching workers needs no manual release
 - Workspace guard: multi-agent write conflicts degrade to serial automatically
-- Idle turns (15 minutes without writes) are ledgered; correct the worker via `todo update --text` (applies at the next turn)
+- Idle turns (1 hour without writes) are ledgered; correct the worker via `todo update --text` (applies at the next turn)
 
 ## Bidirectional messaging (supervisor ↔ worker)
 

--- a/docs/verification/errors-outdated-missing.md
+++ b/docs/verification/errors-outdated-missing.md
@@ -342,7 +342,7 @@ README.md L105-118（zh L100-113）列出 12 个命令，源码（tui/src/app.ts
 ### H2. 核验无误（供后继跳过）
 
 - loop 注册表「10 组 43 命令」、`quota should-run/usage/spend/decisions`、`scheduler tick|show|record-host-failure|ack|liveness`、`delivery status|record|followthrough`、`agent onboard|list|contract|recipe|succession|collective`、`lease claim|renew|release|expire|status`、`frontier show`、`run --goal/--agent-id/--model/--thinking-level/--max-turns` 与实测 registry 输出一致。
-- 语义历史 N=50（goal_frontier/semantic_history.rs `SEMANTIC_HISTORY_CAP`）；交付 3 回合未验证派生跟进（work_items/delivery_outcome.rs）；空转 15 分钟记账（state.rs `TURN_NO_PROGRESS_IDLE_SECS_DEFAULT = 15 * 60`）；租约 pid 活性回收（state.rs claim → compat::pid_alive）。
+- 语义历史 N=50（goal_frontier/semantic_history.rs `SEMANTIC_HISTORY_CAP`）；交付 3 回合未验证派生跟进（work_items/delivery_outcome.rs）；空转 1 小时记账（state.rs `TURN_NO_PROGRESS_IDLE_SECS_DEFAULT = 60 * 60`）；租约 pid 活性回收（state.rs claim → compat::pid_alive）。
 - channels-config.md 全部字段与默认值 ↔ channels/src/config.rs 逐字段一致。
 - TUI 斜杠命令 19 个（17 可用 + /export /import stub）与 tui.md/README 一致；9 个快捷键与 help_screen.rs 一致；README 沙箱三档与 future.proto L251 注释一致；Models.md 3826/143 与 README「3800+/140+」一致；`future init` 链接 future + future-agent 到 ~/.future/bin 与 init.rs 一致。
 - wiki CLI.md 命令组与 `future --help` 实测一致（init/auth/account/run/skills/tools/models/session/doctor + agent/tui/channel/loop）。

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -971,14 +971,14 @@ pub struct TurnNoProgressRecord {
     pub ts: u64,
 }
 
-/// O3: default idle-turn no-progress window (15 minutes). A turn that ends
+/// O3: default idle-turn no-progress window (1 hour). A turn that ends
 /// without any write-class tool (write/edit/shell) starting inside this
 /// window is ledgered as `TurnNoProgress`.
-pub const TURN_NO_PROGRESS_IDLE_SECS_DEFAULT: u64 = 15 * 60;
+pub const TURN_NO_PROGRESS_IDLE_SECS_DEFAULT: u64 = 60 * 60;
 
 /// O3: effective no-progress window (secs). The `FUTURE_LOOP_NO_PROGRESS_SECS`
 /// env var shrinks it in tests (mirrors the FUTURE_LOOP_AGENT_ADDR hook);
-/// invalid or non-positive values fall back to the 15-minute default.
+/// invalid or non-positive values fall back to the 1-hour default.
 pub fn no_progress_idle_secs() -> u64 {
     std::env::var("FUTURE_LOOP_NO_PROGRESS_SECS")
         .ok()


### PR DESCRIPTION
## 变更

- `orchestration/loop/src/state.rs`：`TURN_NO_PROGRESS_IDLE_SECS_DEFAULT` 从 `15 * 60` 改为 `60 * 60`（15 分钟 → 1 小时）。turn 结束时若在此窗口内没有任何 write 类工具（`write`/`edit`/`shell`）启动，才记为 `TurnNoProgress`。
- 同步 `docs/loop-control-plane.md` 与 `docs/verification/errors-outdated-missing.md`。
- `skills` 子模块指针 bump 到 `56fb6a2`（future-skills#39），同步 SKILL.md 里 1 小时窗口措辞 + 区分「真死寂 vs write-idle-but-thinking」的处置指引。

## 动机

给长思考模型更宽的「想而不写」容忍窗口：原本 15 分钟无 write 类工具就会在 turn 结束时记账提醒，对深推理任务过于激进。1 小时窗口下，`TurnNoProgress` 仍是**事后记账**信号（不自动干预），真正死寂的 worker 仍应靠 supervisor 主动盯盘在几分钟内 steer/stop。

## 验证

- `cargo fmt -p future-loop --check` ✅
- `cargo clippy -p future-loop --all-targets -- -D warnings` ✅
- `cargo test -p future-loop` ✅（全绿）