### PR TITLE
fix(loop): harden CLI surface — drop session-policy + ghost flags, per-flag help, dead-worker sweep on run exit

### DIFF
--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -364,9 +364,10 @@ is now — new todos, fresh evidence, current gauges, gate verdicts.
 - `HardError` — the turn errored without a recoverable infra cause: **fresh**.
 
 The kernel only provides this classification (observation data); the caller
-decides resume-vs-fresh explicitly via `--session-policy` /
-`--resume-session`, and the default `auto` resumes only sessions the kernel
-judged resumable (`InfraRecoverable`). The kernel stays a pure tool: it
+decides resume-vs-fresh explicitly. **Fresh is the default — there is no
+`--session-policy` flag.** The only resume path is an explicit pin
+(`--resume-session <id>`), because the goal-level retention holds a single id
+and is ambiguous with parallel workers. The kernel stays a pure tool: it
 provides state and signals, but never makes the decision.
 
 Two scoping rules keep the lifecycle simple: parking happens at **turn

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -292,10 +292,10 @@ ACTIVE 或 PARKED 中的会话都可能被中断（parked 会话不会撞 429，
   污染：**应 fresh**。
 - `HardError` — 回合出错且无可恢复的基础设施原因：**应 fresh**。
 
-内核只提供这个分类（观察数据）；resume-vs-fresh 由调用方经
-`--session-policy` / `--resume-session` 显式决策，默认 `auto` 只 resume
-内核判定「可恢复」（`InfraRecoverable`）的会话。内核依然是纯工具——
-提供状态和信号，但**从不替 agent 做决策**。
+内核只提供这个分类（观察数据）；resume-vs-fresh 由调用方显式决策。
+**默认即 fresh —— 没有 `--session-policy` 标志。** 唯一恢复路径是显式 pin
+（`--resume-session <id>`），因为 goal 级 retention 只存单个 id，并行 worker
+下有歧义。内核依然是纯工具——提供状态和信号，但**从不替 agent 做决策**。
 
 两条界定让生命周期保持简单：泊车发生在 **turn 边界**（不做 turn 中途的
 抢占式挂起或检查点），会话绑定**一个 goal**（不跨 goal 复用——上下文

--- a/orchestration/loop/src/cli/registry.rs
+++ b/orchestration/loop/src/cli/registry.rs
@@ -73,12 +73,26 @@ impl Journey {
     }
 }
 
+/// One flag's help entry. `flag` is the exact token (value placeholder
+/// included, e.g. `--max-turns N`); `what` describes what the flag does;
+/// `notes` carries defaults / constraints / gotchas (empty string when none).
+#[derive(Debug, Clone)]
+pub struct FlagHelp {
+    pub flag: String,
+    pub what: String,
+    pub notes: String,
+}
+
 /// One registered command.
 #[derive(Debug, Clone)]
 pub struct CommandDef {
     pub name: String,
     pub summary: String,
     pub usage: String,
+    /// Per-flag help (defaults / constraints / gotchas) rendered by
+    /// `<command> --help` so a caller understands each flag without reading
+    /// the source. Empty when the command has no flags.
+    pub flags: Vec<FlagHelp>,
     /// True for commands surfaced only with `--include-experimental`.
     pub experimental: bool,
     /// Operator journey (P1-9). Defaults to maintainer; the CLI builder
@@ -164,6 +178,7 @@ impl CommandRegistry {
                     name: name.to_string(),
                     summary: summary.to_string(),
                     usage: usage.to_string(),
+                    flags: Vec::new(),
                     experimental,
                     journey: Journey::Maintainer,
                     subcommands: Vec::new(),
@@ -190,10 +205,57 @@ impl CommandRegistry {
                     name: name.to_string(),
                     summary: summary.to_string(),
                     usage: usage.to_string(),
+                    flags: Vec::new(),
                     experimental: false,
                     journey: Journey::Maintainer,
                     subcommands: Vec::new(),
                 });
+            }
+        }
+        self
+    }
+
+    /// Attach per-flag help to an already-registered command. Each entry is
+    /// `(flag, what, notes)`; `notes` may be empty. No-op for unknown command
+    /// names. Replaces any previously attached flags for that command.
+    pub fn flags(&mut self, command: &str, flags: &[(&str, &str, &str)]) -> &mut Self {
+        for (_, c) in &mut self.commands {
+            if c.name == command {
+                c.flags = flags
+                    .iter()
+                    .map(|(f, w, n)| FlagHelp {
+                        flag: f.to_string(),
+                        what: w.to_string(),
+                        notes: n.to_string(),
+                    })
+                    .collect();
+            }
+        }
+        self
+    }
+
+    /// Attach per-flag help to a subcommand (verb) under an already-
+    /// registered command. No-op for unknown parent/sub names.
+    pub fn subcommand_flags(
+        &mut self,
+        command: &str,
+        sub: &str,
+        flags: &[(&str, &str, &str)],
+    ) -> &mut Self {
+        for (_, c) in &mut self.commands {
+            if c.name == command {
+                for s in &mut c.subcommands {
+                    if s.name == sub {
+                        s.flags = flags
+                            .iter()
+                            .map(|(f, w, n)| FlagHelp {
+                                flag: f.to_string(),
+                                what: w.to_string(),
+                                notes: n.to_string(),
+                            })
+                            .collect();
+                    }
+                }
             }
         }
         self
@@ -408,6 +470,45 @@ mod tests {
         assert!(r.find_subcommand("goal", "cancel", false).is_some());
         assert!(r.find_subcommand("goal", "missing", false).is_none());
         assert!(r.find_subcommand("backup", "init", false).is_none());
+    }
+
+    #[test]
+    fn flags_and_subcommand_flags_attach_and_replace() {
+        let mut r = sample();
+        r.flags(
+            "backup",
+            &[
+                ("--goal G", "goal id", "required"),
+                ("--list", "list backups", "optional"),
+            ],
+        );
+        // command-level flags are findable through find()
+        let (_, c) = r.find("backup", false).unwrap();
+        assert_eq!(c.flags.len(), 2);
+        assert_eq!(c.flags[0].flag, "--goal G");
+        assert_eq!(c.flags[0].what, "goal id");
+        assert_eq!(c.flags[0].notes, "required");
+        // re-attaching replaces (no accumulation)
+        r.flags("backup", &[("--goal G", "goal id", "required")]);
+        let (_, c) = r.find("backup", false).unwrap();
+        assert_eq!(c.flags.len(), 1);
+        // unknown command → no-op
+        r.flags("nope", &[("--x", "y", "z")]);
+        assert!(r.find("nope", false).is_none());
+
+        // subcommand flags
+        r.subcommand("goal", "init", "create a goal", "init --objective");
+        r.subcommand_flags(
+            "goal",
+            "init",
+            &[("--objective TEXT", "goal objective", "required")],
+        );
+        let (_, _, sub) = r.find_subcommand("goal", "init", false).unwrap();
+        assert_eq!(sub.flags.len(), 1);
+        assert_eq!(sub.flags[0].flag, "--objective TEXT");
+        // unknown subcommand → no-op
+        r.subcommand_flags("goal", "missing", &[("--x", "y", "z")]);
+        assert!(r.find_subcommand("goal", "missing", false).is_none());
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use crate::agent_client::TurnProgressTracker;
-use crate::cli::registry::{CommandRegistry, Journey};
+use crate::cli::registry::{CommandRegistry, FlagHelp, Journey};
 use crate::decision::{complete_todo, decide_for};
 use crate::executor::{execute_turn, writeback};
 use crate::state::{now_epoch, Goal, TaskClass, Todo, TodoStatus};
@@ -361,6 +361,42 @@ fn build_cli_registry() -> CommandRegistry {
         "register/onboard agents + multi-agent contract/recipe/succession/collective surface (G12)",
         "agent onboard --goal G --agent-id A [--recipe N] | list|contract|recipe|succession|collective --goal G",
     );
+    r.subcommand(
+        "agent",
+        "onboard",
+        "register a peer + apply an optional recipe",
+        "onboard --goal G --agent-id A [--workspace p1,p2] [--recipe N]",
+    );
+    r.subcommand(
+        "agent",
+        "list",
+        "registered agents + live lease status",
+        "list --goal G [--format json]",
+    );
+    r.subcommand(
+        "agent",
+        "contract",
+        "multi-agent topology (set/show)",
+        "contract set --goal G --contract '<json>' | --contract-file PATH | contract show --goal G [--format json]",
+    );
+    r.subcommand(
+        "agent",
+        "recipe",
+        "named G12 recipe (add/show)",
+        "recipe add --goal G --name N [--capabilities c1,c2] [--workspace p] [--priority P0] | recipe show --goal G [--name N]",
+    );
+    r.subcommand(
+        "agent",
+        "succession",
+        "role-succession (show/apply)",
+        "succession show|apply --goal G [--primary P] [--reason R] [--format json]",
+    );
+    r.subcommand(
+        "agent",
+        "collective",
+        "collective turn ledger (show)",
+        "collective show --goal G [--collective NAME] [--format json]",
+    );
     r.command(
         agent,
         "scope",
@@ -542,7 +578,7 @@ fn build_cli_registry() -> CommandRegistry {
         ops,
         "run",
         "drive one bounded gRPC turn (--agent-id for lease coordination, or --anonymous; auto-registers)",
-        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-incomplete-retries N] [--lease-secs N] [--force-workspace] [--session-policy auto|fresh|resume] [--resume-session ID] [--anonymous]",
+        "run --goal G --agent-id A [--model M] [--thinking-level L] [--max-turns N] [--max-incomplete-retries N] [--lease-secs N] [--force-workspace] [--resume-session ID] [--anonymous]",
     );
 
     let work_items = r.group(
@@ -590,6 +626,990 @@ fn build_cli_registry() -> CommandRegistry {
         "canary smoke [--profile core-control-plane|release-gate|premerge] [--json] | canary premerge [--json]",
     );
 
+    // ── per-flag help (rendered by `<command> --help` / `<command> <sub>
+    //    --help`) — defaults, constraints, and gotchas sourced from each
+    //    handler so the help text can never drift from the code. ──────────
+
+    r.flags(
+        "goal",
+        &[
+            (
+                "--objective TEXT",
+                "goal objective",
+                "required; this is the durable goal statement",
+            ),
+            (
+                "--cwd DIR",
+                "working directory for the goal",
+                "defaults to the process cwd",
+            ),
+            (
+                "--goal-doc TEXT",
+                "seed the GOAL.md workbench",
+                "written to <cwd>/GOAL.md when given",
+            ),
+            (
+                "--goal-id ID",
+                "pin the goal id",
+                "defaults to an auto-generated id; re-init with the same id is idempotent",
+            ),
+        ],
+    );
+
+    r.flags(
+        "status",
+        &[
+            (
+                "--goal G",
+                "limit the projection to one goal",
+                "omitted → every registered goal",
+            ),
+            (
+                "--format json",
+                "machine-readable projection",
+                "goal + todos with priority/class/status/blocks + terminal flag",
+            ),
+        ],
+    );
+
+    r.flags(
+        "ui",
+        &[
+            (
+                "--port N",
+                "listen port",
+                "default 7717; 0 picks a free port",
+            ),
+            (
+                "--root DIR",
+                "state root to serve",
+                "defaults to the loop state root",
+            ),
+            (
+                "--no-open",
+                "do not open the browser",
+                "the dashboard is strictly read-only (GET only)",
+            ),
+        ],
+    );
+
+    r.flags(
+        "models",
+        &[(
+            "--format json",
+            "machine-readable model list",
+            "auth.json/models.json merged with the built-in catalog",
+        )],
+    );
+
+    r.flags(
+        "diagnose",
+        &[
+            ("--goal G", "goal to diagnose", "required"),
+            (
+                "--format json",
+                "machine-readable diagnostic",
+                "decision + open todos/gates + projection gap + recent runs",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "todo",
+        "add",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--text TEXT", "todo text", "required; must be non-empty"),
+            ("--priority P0|P1|P2", "priority (P0 urgent)", "defaults to P1; also prefixes the text with [P0]/[P1]/[P2]"),
+            ("--blocks T", "blocking todo ids", "comma-separated; a bare `--blocks` reads as `true` and is rejected"),
+            ("--verify CMD", "validator command", "e.g. `cargo check -p ...`; advisory for code-like todos so uncompilable work can't be marked done"),
+            ("--acceptance a,b", "completion contract tokens", "evidence must contain every token (case-insensitive) before `todo complete` accepts"),
+            ("--owner A", "pin the todo to agent A", "absent → shared pool any worker may claim"),
+            ("--class C", "task class", "see --role; combo is validated (advancement|monitor|blocker|coordination|user_gate|user_action)"),
+            ("--role R", "actor role", "agent|user; valid combos: agent+advancement/monitor/blocker/coordination, any+user_gate, user+user_action"),
+            ("--gate-question Q", "gate question", "for user_gate; defaults to the text"),
+            ("--action-kind K", "free-form action tag", "optional"),
+            ("--defer-secs N", "defer N seconds from now", "marks the todo Deferred with a real resume_when deadline"),
+            ("--resume-when N", "defer N seconds or text hint", "numeric N = real deadline (same as --defer-secs); non-numeric = text hint with a 1h placeholder"),
+            ("--title T", "short title", "optional"),
+            ("--task-repository R", "task repository label", "optional"),
+            ("--continuation-policy P", "continuation policy", "optional"),
+            ("--required-write-scope P", "write scopes", "comma-separated"),
+            ("--goal-bound", "goal-bound flag", "boolean"),
+            ("--global-gate", "global gate flag", "boolean; a user_gate + global_gate implies goal_bound"),
+            ("--note TEXT", "free-form note", "optional"),
+            ("--monitor-target T", "monitor target", "G-12 monitor metadata"),
+            ("--monitor-policy P", "monitor policy", "G-12 monitor metadata"),
+            ("--cadence C", "monitor cadence", "e.g. 15m/1h/2d; drives the first due time"),
+            ("--max-validation-attempts N", "validation retry cap", "clamped to >= 1"),
+        ],
+    );
+
+    r.subcommand_flags(
+        "todo",
+        "update",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "required"),
+            ("--text TEXT", "replace the text", "optional"),
+            (
+                "--status S",
+                "status",
+                "open|blocked|deferred|superseded; `done` is rejected (use `todo complete`)",
+            ),
+            (
+                "--priority P0|P1|P2",
+                "priority",
+                "validated against P0|P1|P2",
+            ),
+            (
+                "--blocks T",
+                "replace the blocking set",
+                "comma-separated; `--blocks \"\"` clears it; absent → untouched",
+            ),
+            (
+                "--acceptance a,b",
+                "replace the acceptance contract",
+                "optional",
+            ),
+            ("--owner A", "reassign the owner", "optional"),
+            ("--evidence E", "attach evidence", "optional"),
+            ("--note TEXT", "note", "optional"),
+            (
+                "--resume-when N",
+                "defer or text hint",
+                "numeric N = defer N seconds; non-numeric = text hint (no deadline) with a warning",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "todo",
+        "complete",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "required"),
+            (
+                "--no-follow-up",
+                "declare no successor",
+                "advancement todos need this OR --successor",
+            ),
+            (
+                "--successor T2",
+                "declare the successor todo",
+                "alternative to --no-follow-up",
+            ),
+            (
+                "--evidence E",
+                "what actually landed",
+                "advancement todos require non-empty evidence unless --force",
+            ),
+            (
+                "--force",
+                "override evidence/acceptance/gate checks",
+                "explicit operator closeout only",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "todo",
+        "supersede",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--todo-id T",
+                "todo id",
+                "required; must be unfinished (done todos refuse)",
+            ),
+            (
+                "--reason R",
+                "why it is obsolete",
+                "optional; also stops any detached run holding this todo",
+            ),
+        ],
+    );
+
+    r.flags(
+        "gate",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--todo-id G1",
+                "the user_gate todo id",
+                "required; fails closed on non-gate todos",
+            ),
+            (
+                "--decision D",
+                "the operator decision",
+                "required; recorded and flows into blocked todos' packets",
+            ),
+            ("--note N", "decision note", "optional"),
+        ],
+    );
+
+    r.flags(
+        "replan",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--delta-kind K", "frontier-changing delta kind", "ack requires at least one frontier-changing kind (vision_patch|no_followup|successor_or_supersede|runnable_todo_set|...)"),
+            ("--format json", "machine-readable output", "for `replan obligations` / `replan rules show`"),
+            ("--rule-ids R1,R2", "explicit rule set for `replan rules set`", "full replace; `--rule-ids \"\"` resets to the default set"),
+        ],
+    );
+
+    r.flags(
+        "frontier",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable frontier projection",
+                "outcome segments + replan rule + terminal judgement + semantic history",
+            ),
+        ],
+    );
+
+    r.flags(
+        "lease",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "required"),
+            ("--agent-id A", "agent id", "defaults to `default-agent`"),
+            (
+                "--lease-secs N",
+                "lease length in seconds",
+                "claim/renew only",
+            ),
+            (
+                "--force",
+                "override the workspace conflict guard",
+                "claim only; degrades parallel claims to serial",
+            ),
+            (
+                "--format json",
+                "machine-readable status",
+                "for `lease status`",
+            ),
+        ],
+    );
+
+    r.flags(
+        "task-graph",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable graph",
+                "nodes + edges + topological order; cycles fail closed",
+            ),
+        ],
+    );
+
+    r.flags(
+        "agent",
+        &[
+            ("--goal G", "goal id", "required for `agent register`"),
+            (
+                "--agent-id A",
+                "agent id",
+                "required; auto-registered on first `run` use",
+            ),
+            (
+                "--workspace P",
+                "declared write set",
+                "comma-separated paths; drives the P0-1 workspace guard",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "onboard",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "required"),
+            (
+                "--workspace P",
+                "declared write set",
+                "comma-separated paths",
+            ),
+            (
+                "--recipe N",
+                "apply a recorded recipe",
+                "conflicts with an explicit --workspace (the recipe owns the profile)",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "list",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable agent list",
+                "agent → status + workspaces + capabilities + last-active",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "contract",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--contract JSON",
+                "inline contract JSON",
+                "set only; alternative to --contract-file",
+            ),
+            ("--contract-file PATH", "contract JSON file", "set only"),
+            (
+                "--format json",
+                "machine-readable contract projection",
+                "show only",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "recipe",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--name N",
+                "recipe name",
+                "add: required; show: optional filter",
+            ),
+            (
+                "--capabilities c1,c2",
+                "capabilities",
+                "add only; comma-separated",
+            ),
+            (
+                "--workspace P",
+                "workspace",
+                "add only; comma-separated paths",
+            ),
+            (
+                "--priority P0",
+                "default priority",
+                "add only; P0|P1|P2 (default P1)",
+            ),
+            ("--format json", "machine-readable recipes", "show only"),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "succession",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--primary P", "filter by primary", "optional"),
+            ("--reason R", "filter by reason", "optional"),
+            (
+                "--format json",
+                "machine-readable succession projection",
+                "show only",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "agent",
+        "collective",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--collective NAME",
+                "one collective",
+                "omitted → every collective in the contract",
+            ),
+            (
+                "--format json",
+                "machine-readable collective ledger",
+                "per-agent turns + wake roster",
+            ),
+        ],
+    );
+
+    r.flags(
+        "scope",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "required"),
+            ("--exclude X", "todo ids to exclude", "comma-separated"),
+        ],
+    );
+
+    r.flags(
+        "lane",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "required"),
+        ],
+    );
+
+    r.subcommand_flags(
+        "supervisor",
+        "register",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--session-id S",
+                "supervisor agent session id",
+                "required; the up-channel target workers push intervention reports to",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "supervisor",
+        "steer",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--agent-id A",
+                "target worker",
+                "omitted → broadcast to all workers",
+            ),
+            (
+                "--instruction TEXT",
+                "the mid-turn redirect",
+                "required; interrupts the in-flight turn and injects the instruction",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "supervisor",
+        "propose",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "supervisor id", "required"),
+            ("--decision-id D", "decision id", "required"),
+            ("--target-agent-id T", "target agent", "required"),
+            ("--kind K", "observe|execute", "default observe"),
+            (
+                "--capabilities c1,c2",
+                "capabilities",
+                "for execute decisions",
+            ),
+            ("--summary S", "decision summary", "optional"),
+        ],
+    );
+
+    r.subcommand_flags(
+        "supervisor",
+        "receipt",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--decision-id D", "decision id", "required"),
+            ("--receipt-id R", "receipt id", "required"),
+            ("--adapter-id A", "adapter id", "required"),
+            (
+                "--outcome O",
+                "executed|failed|rejected",
+                "default rejected",
+            ),
+            ("--authority-ref REF", "authority reference", "optional"),
+            (
+                "--host-capabilities c1,c2",
+                "host capabilities",
+                "comma-separated",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "supervisor",
+        "events",
+        &[("--goal G", "goal id", "required")],
+    );
+
+    r.flags(
+        "report",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--agent-id A",
+                "reporting worker",
+                "optional; truncated to 128 chars",
+            ),
+            (
+                "--todo-id T",
+                "related todo",
+                "optional; truncated to 128 chars",
+            ),
+            (
+                "--message TEXT",
+                "the milestone note",
+                "required; truncated to 500 chars; projection-only (never a push)",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "worker",
+        "list",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable worker list",
+                "agent → backing session + running/ended/idle status",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "worker",
+        "stop",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--agent-id A",
+                "one worker to stop",
+                "either --agent-id or --all is required",
+            ),
+            (
+                "--all",
+                "stop every worker with a live session",
+                "broadcast stop signal",
+            ),
+            (
+                "--delete",
+                "also reclaim the backing agent session",
+                "a later `run` then starts fresh",
+            ),
+        ],
+    );
+
+    r.subcommand_flags(
+        "worker",
+        "tail",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--agent-id A",
+                "one worker's latest run",
+                "omitted → latest run across all workers",
+            ),
+            ("--lines N", "how many events to show", "default 20"),
+            (
+                "--raw",
+                "dump the .live.jsonl verbatim",
+                "condensed tool/usage view is the default",
+            ),
+            ("--format json", "machine-readable", "same as --raw"),
+        ],
+    );
+
+    r.flags(
+        "doctor",
+        &[
+            (
+                "--goal G",
+                "limit ledger/decision checks to one goal",
+                "omitted → every registered goal",
+            ),
+            (
+                "--agent-addr ADDR",
+                "probe agent gRPC reachability",
+                "omitted → the agent probe is skipped",
+            ),
+        ],
+    );
+
+    r.flags(
+        "history",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable run history",
+                "ledger-derived RunRecord list",
+            ),
+        ],
+    );
+
+    r.flags(
+        "turn",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "required"),
+            ("--agent-id A", "agent id", "optional; scopes the decision"),
+        ],
+    );
+
+    r.flags(
+        "todo-event",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "required"),
+            (
+                "--format json",
+                "machine-readable event history",
+                "events touching this todo",
+            ),
+        ],
+    );
+
+    r.flags(
+        "evidence-log",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "limit to one todo", "omitted → all todos"),
+            (
+                "--format json",
+                "machine-readable evidence trail",
+                "attached + run + completion evidence",
+            ),
+        ],
+    );
+
+    r.flags(
+        "backup",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--list",
+                "list existing backups",
+                "mutually exclusive with --restore",
+            ),
+            (
+                "--restore DIR",
+                "restore a point-in-time snapshot",
+                "replaces current state",
+            ),
+        ],
+    );
+
+    r.flags(
+        "authority",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--write-scope P",
+                "declared write scope",
+                "comma-separated paths",
+            ),
+            (
+                "--require-approval K",
+                "approval-gated action kinds",
+                "comma-separated",
+            ),
+        ],
+    );
+
+    r.flags(
+        "profile",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--outcome-floor N",
+                "outcome floor streak threshold",
+                "must be a number",
+            ),
+        ],
+    );
+
+    r.flags(
+        "quota",
+        &[
+            (
+                "--goal G",
+                "goal id",
+                "required for should-run/usage/spend/decisions",
+            ),
+            (
+                "--agent-id A",
+                "scope the decision",
+                "`quota should-run` only",
+            ),
+            (
+                "--all",
+                "aggregate across every goal",
+                "`quota usage` only; alternative to --goal",
+            ),
+            (
+                "--limit N",
+                "how many decisions to show",
+                "`quota decisions` only; default 10",
+            ),
+            (
+                "--format json",
+                "machine-readable output",
+                "should-run/usage/decisions",
+            ),
+        ],
+    );
+
+    r.flags(
+        "scheduler",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "defaults to `codex-app`"),
+            (
+                "--progression 15,30,60",
+                "backoff progression minutes",
+                "tick only; bootstrap only — sets the sequence on the FIRST tick, ignored once state exists",
+            ),
+            ("--action A", "tick action", "tick/ack; default tick_next"),
+            (
+                "--threshold-secs N",
+                "liveness threshold",
+                "liveness only; default 2h (7200s)",
+            ),
+            (
+                "--target-rrule R",
+                "target RRULE",
+                "record-host-failure only; required",
+            ),
+            (
+                "--observed-rrule R",
+                "observed host RRULE",
+                "record-host-failure only",
+            ),
+            (
+                "--failure-kind K",
+                "failure kind",
+                "record-host-failure only; required",
+            ),
+            (
+                "--failure-count N",
+                "failure count",
+                "record-host-failure only; default 1",
+            ),
+            ("--rrule R", "RRULE for the ack", "ack only"),
+            (
+                "--source S",
+                "ack source",
+                "ack only; default scheduler_cli",
+            ),
+            ("--format json", "machine-readable output", "show/liveness"),
+        ],
+    );
+
+    r.flags(
+        "store",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--format json",
+                "machine-readable verify report",
+                "verify only",
+            ),
+            (
+                "--repair",
+                "rebuild a drifted run index",
+                "verify only; non-destructive",
+            ),
+        ],
+    );
+
+    r.flags(
+        "backfill",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--from PATH",
+                "source markdown workbench",
+                "omitted → the active state markdown is derived",
+            ),
+            (
+                "--privacy L",
+                "public_safe|local_private|private_pointer",
+                "default local_private",
+            ),
+            (
+                "--dry-run",
+                "print the events without appending",
+                "read-only preview",
+            ),
+        ],
+    );
+
+    r.flags(
+        "privacy",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--level L", "privacy tier", "default public_safe"),
+            (
+                "--format json",
+                "machine-readable projections",
+                "includes the privacy report + public-safe markdown + status cache",
+            ),
+        ],
+    );
+
+    r.flags(
+        "runs",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--keep N",
+                "how many latest runs to keep",
+                "compact/retention; default 50",
+            ),
+            (
+                "--cutoff TS",
+                "archive runs before this epoch",
+                "compact only",
+            ),
+            (
+                "--rebuild",
+                "rebuild the index from run files",
+                "index only",
+            ),
+            ("--format json", "machine-readable output", "history only"),
+        ],
+    );
+
+    r.flags(
+        "heartbeat-prompt",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "optional; scopes the decision"),
+        ],
+    );
+
+    r.flags(
+        "worker-bridge",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "agent id", "optional"),
+            ("--max-turns N", "max turn iterations", "default 6"),
+        ],
+    );
+
+    r.flags(
+        "run",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--agent-id A", "worker identity for lease coordination", "REQUIRED for coordinated runs; auto-registered on first use; use a unique id per concurrent worker"),
+            ("--anonymous", "legacy uncoordinated one-shot", "claims nothing and hides nothing — two agentless runs deterministically race on the same todo"),
+            ("--model M", "model override", "sets the session model before the turn loop"),
+            ("--thinking-level L", "thinking level override", "sets the session thinking level before the turn loop"),
+            ("--max-turns N", "max turn iterations", "default 6"),
+            ("--max-incomplete-retries N", "incomplete retry cap", "default 3"),
+            ("--lease-secs N", "task lease length", "default 4h (14400s)"),
+            ("--force-workspace", "force workspace override", "boolean"),
+            ("--resume-session ID", "resume this exact agent session", "fresh is the default; a dead id falls back to fresh automatically"),
+            ("--detach", "internal: marks the detached child", "the run re-executes itself detached by default; set FUTURE_LOOP_NO_DETACH=1 to run foreground"),
+        ],
+    );
+
+    r.flags(
+        "attention",
+        &[
+            (
+                "--goal G",
+                "one goal's attention item",
+                "alternative to --all",
+            ),
+            ("--all", "every registered goal", "alternative to --goal"),
+            (
+                "--format json",
+                "machine-readable attention queue",
+                "includes role-succession hints",
+            ),
+        ],
+    );
+
+    r.flags(
+        "inbox",
+        &[
+            (
+                "--project DIR",
+                "project directory",
+                "defaults to the process cwd",
+            ),
+            (
+                "--scope S",
+                "addressed_only|configured_chat_all",
+                "default addressed_only",
+            ),
+            ("--name NAME", "operator display name", "default operator"),
+            (
+                "--format json",
+                "machine-readable urgency",
+                "content is never returned",
+            ),
+        ],
+    );
+
+    r.flags(
+        "delivery",
+        &[
+            ("--goal G", "goal id", "required"),
+            ("--todo-id T", "todo id", "record only; required"),
+            (
+                "--outcome O",
+                "delivered|verified|failed|rework",
+                "record only; required; transition validated against current state",
+            ),
+            ("--note N", "outcome note", "record only"),
+            (
+                "--turns N",
+                "follow-through threshold",
+                "followthrough only; default 3",
+            ),
+            ("--format json", "machine-readable output", "status only"),
+        ],
+    );
+
+    r.flags(
+        "registry",
+        &[
+            (
+                "--format json",
+                "machine-readable registry",
+                "groups + commands",
+            ),
+            (
+                "--include-experimental",
+                "include experimental commands",
+                "hidden by default",
+            ),
+        ],
+    );
+
+    r.flags(
+        "commands",
+        &[
+            (
+                "--format json",
+                "machine-readable journey view",
+                "five operator journeys",
+            ),
+            (
+                "--include-experimental",
+                "include experimental commands",
+                "hidden by default",
+            ),
+        ],
+    );
+
+    r.flags(
+        "canary",
+        &[
+            (
+                "--profile P",
+                "smoke profile",
+                "core-control-plane|release-gate|premerge; default release-gate",
+            ),
+            (
+                "--json",
+                "machine-readable result",
+                "fails closed (non-zero exit) on any check failure",
+            ),
+        ],
+    );
+
     // P1-9: journey metadata overlay (presentation only — the registry
     // itself stays the flat machine catalog).
     for (name, journey) in JOURNEY_ASSIGNMENTS {
@@ -615,7 +1635,8 @@ fn cli_help(registry: &CommandRegistry, include_experimental: bool) -> Result<()
 }
 
 /// P0-3②: render the per-command help for `<command> --help` — the command's
-/// summary + usage from the registry (pure, unit-testable; the caller prints).
+/// summary + usage + per-flag details from the registry (pure, unit-testable;
+/// the caller prints).
 fn render_command_help(
     registry: &CommandRegistry,
     command: &str,
@@ -631,6 +1652,10 @@ fn render_command_help(
             "{} — {}{}\n\nusage: {}\n\ngroup: {} — {}\n",
             def.name, def.summary, mark, def.usage, group.name, group.summary
         );
+        if !def.flags.is_empty() {
+            out.push_str("\nflags:\n");
+            out.push_str(&render_flags(&def.flags));
+        }
         if !def.subcommands.is_empty() {
             out.push_str("\nsubcommands:\n");
             for sub in &def.subcommands {
@@ -648,6 +1673,27 @@ fn render_command_help(
     }
 }
 
+/// Render one flag list: `<flag>  what` per line, `notes` (defaults /
+/// constraints / gotchas) indented on the following line. Over-long flag
+/// tokens wrap onto their own line; `what` and `notes` align to the same
+/// column.
+fn render_flags(flags: &[FlagHelp]) -> String {
+    const WIDTH: usize = 24;
+    let mut out = String::new();
+    for f in flags {
+        if f.flag.len() >= WIDTH {
+            out.push_str(&format!("  {}\n", f.flag));
+            out.push_str(&format!("  {:<WIDTH$} {}\n", "", f.what));
+        } else {
+            out.push_str(&format!("  {:<WIDTH$} {}\n", f.flag, f.what));
+        }
+        if !f.notes.is_empty() {
+            out.push_str(&format!("  {:<WIDTH$} {}\n", "", f.notes));
+        }
+    }
+    out
+}
+
 /// Render `<command> <sub> --help` — the exact usage of one verb (steer /
 /// update / stop / …) so an AI orchestrator discovers its flags directly
 /// instead of parsing a merged top-level usage line.
@@ -658,17 +1704,24 @@ fn render_subcommand_help(
     include_experimental: bool,
 ) -> String {
     match registry.find_subcommand(command, sub, include_experimental) {
-        Some((group, parent, def)) => format!(
-            "{} {} — {}\n\nusage: {} {}\n\ngroup: {} — {}\n\nfull command list: {} --help\n",
-            parent.name,
-            def.name,
-            def.summary,
-            parent.name,
-            def.usage,
-            group.name,
-            group.summary,
-            prog()
-        ),
+        Some((group, parent, def)) => {
+            let mut out = format!(
+                "{} {} — {}\n\nusage: {} {}\n\ngroup: {} — {}\n",
+                parent.name,
+                def.name,
+                def.summary,
+                parent.name,
+                def.usage,
+                group.name,
+                group.summary,
+            );
+            if !def.flags.is_empty() {
+                out.push_str("\nflags:\n");
+                out.push_str(&render_flags(&def.flags));
+            }
+            out.push_str(&format!("\nfull command list: {} --help\n", prog()));
+            out
+        }
         None => format!(
             "unknown subcommand `{sub}` for `{command}` (try `{} {command} --help`)\n",
             prog()
@@ -2356,10 +3409,7 @@ fn cmd_replan(store: &mut Store, args: &[String]) -> Result<()> {
     }
     if args.first().map(|s| s.as_str()) == Some("obligations") {
         let mut goal_id = None;
-        reject_unknown_flags(
-            &args[1..],
-            &["--delta-kind", "--format", "--goal", "--json"],
-        )?;
+        reject_unknown_flags(&args[1..], &["--format", "--goal", "--json"])?;
         parse_pairs(&args[1..], |k, v| {
             if k == "--goal" {
                 goal_id = Some(v)
@@ -2386,7 +3436,7 @@ fn cmd_replan(store: &mut Store, args: &[String]) -> Result<()> {
     }
     let mut goal_id = None;
     let mut delta_kinds: Vec<String> = vec![];
-    reject_unknown_flags(args, &["--delta-kind", "--format", "--goal", "--json"])?;
+    reject_unknown_flags(args, &["--delta-kind", "--goal"])?;
     parse_pairs(args, |k, v| {
         if k == "--goal" {
             goal_id = Some(v);
@@ -3173,23 +4223,11 @@ fn scheduler_scope(
 /// P1-3: each tick also lands a `SchedulerTicked` heartbeat (liveness), the
 /// monitor poll plan, and a dead-worker push (see [`notify_dead_holders`]).
 async fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
-    let mut cadence_class = "monitor_backoff".to_string();
     let mut progression: Vec<i64> = vec![];
     let mut action = "tick_next".to_string();
-    reject_unknown_flags(
-        args,
-        &[
-            "--action",
-            "--agent-id",
-            "--cadence-class",
-            "--goal",
-            "--progression",
-        ],
-    )?;
+    reject_unknown_flags(args, &["--action", "--agent-id", "--goal", "--progression"])?;
     parse_pairs(args, |k, v| {
-        if k == "--cadence-class" {
-            cadence_class = v;
-        } else if k == "--progression" {
+        if k == "--progression" {
             progression = v
                 .split(',')
                 .filter_map(|s| s.trim().parse::<i64>().ok())
@@ -3246,6 +4284,15 @@ async fn scheduler_tick(store: &mut Store, args: &[String]) -> Result<()> {
     }
 
     let mut state = state.unwrap();
+    // `--progression` only shapes the bootstrap state (the first tick). Once
+    // state exists the persisted cursor owns the sequence, so a progression
+    // flag here is a silent no-op — warn instead of pretending it applied.
+    if !progression.is_empty() {
+        eprintln!(
+            "note: --progression only applies on the FIRST tick (bootstrap); \
+             scheduler state already exists for {goal_id} — progression unchanged"
+        );
+    }
     let rrule = st::apply_next_progression(&mut state, now);
     st::write_scheduler_state(&goal_dir, &state)?;
     print!("{}", crate::cli_projection::render_scheduler_state(&state));
@@ -3707,13 +4754,12 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let mut lease_secs = DEFAULT_RUN_LEASE_SECS;
     let mut force_workspace = false;
     // Session retention: the CALLER decides resume-vs-fresh, never the kernel.
-    // `--resume-session <id>` pins the exact session to resume;
-    // `--session-policy <auto|fresh|resume>` sets the default policy:
-    //   auto   → resume the retained session only when the kernel marked it
-    //            resumable (InfraRecoverable), else fresh (default);
-    //   fresh  → always start a new session (the pre-retention behavior);
-    //   resume → resume the retained session whenever one exists.
-    let mut session_policy = "auto".to_string();
+    // The default is ALWAYS a fresh session; the ONLY way to resume is an
+    // explicit pin `--resume-session <id>` (goal-level `session_retention` is
+    // a single field written by whichever run finished last, so an implicit
+    // "resume the retained session" would hand one worker's session to
+    // another under parallel workers). A pinned id that is no longer alive
+    // falls back to a fresh session.
     let mut resume_session: Option<String> = None;
     reject_unknown_flags(
         args,
@@ -3728,7 +4774,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             "--max-turns",
             "--model",
             "--resume-session",
-            "--session-policy",
             "--thinking-level",
         ],
     )?;
@@ -3753,8 +4798,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
             anonymous = true;
         } else if k == "--force-workspace" {
             force_workspace = true;
-        } else if k == "--session-policy" {
-            session_policy = v;
         } else if k == "--resume-session" {
             resume_session = Some(v);
         }
@@ -3864,9 +4907,6 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         );
         return Ok(());
     }
-    if !matches!(session_policy.as_str(), "auto" | "fresh" | "resume") {
-        bail!("--session-policy must be auto | fresh | resume");
-    }
     let goal_id = goal_id.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
 
     // Identity gate BEFORE any gRPC/session work — fail fast with a hint
@@ -3880,34 +4920,18 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found"))?;
 
     // ── Session retention: the CALLER decides resume-vs-fresh, never the
-    //    kernel. The kernel only recorded WHY the last session was interrupted
-    //    (`session_retention` on the goal) and kept its id on disk. Resolution
-    //    order:
-    //      1. `--resume-session <id>` (explicit pin) → use it if alive;
-    //      2. `--session-policy resume` → use the retained id if alive;
-    //      3. `--session-policy auto` (default) → use the retained id only
-    //         when the kernel marked it resumable (InfraRecoverable);
-    //      4. `--session-policy fresh` → always new;
-    //      5. a retained id that is no longer alive falls back to new.
-    let retained = goal0.session_retention.clone();
-    let want_session: Option<String> = if let Some(id) = resume_session.clone() {
-        Some(id)
-    } else {
-        match session_policy.as_str() {
-            "resume" => retained.as_ref().map(|r| r.session_id.clone()),
-            "fresh" => None,
-            _ /* auto */ => retained
-                .as_ref()
-                .filter(|r| r.resumable)
-                .map(|r| r.session_id.clone()),
-        }
-    };
+    //    kernel. The kernel records WHY the last run was interrupted
+    //    (`session_retention` on the goal, advisory) and keeps the session id
+    //    on disk. Fresh is the default; the only resume path is an explicit
+    //    `--resume-session <id>` pin, which falls back to fresh when the
+    //    pinned id is no longer alive.
+    let want_session: Option<String> = resume_session.clone();
     // Human-readable session title for agent session lists: the goal
     // objective, bounded so long objectives don't produce unwieldy names.
     let session_title = crate::decision::truncate(&goal0.objective, 60);
     let session_id = match want_session {
         Some(id) if client.session_alive(&id).await => {
-            println!("   ⤺ resuming session {id} (policy {session_policy})");
+            println!("   ⤺ resuming session {id}");
             id
         }
         Some(id) => {
@@ -3941,7 +4965,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     // Run the turn loop. Session lifecycle: the session is never deleted —
     // the kernel records the retention state (id + failure classification +
     // resumable advisory) on the goal and lets the NEXT caller decide
-    // resume-vs-fresh via --session-policy / --resume-session.
+    // resume-vs-fresh via --resume-session.
     let mut last_failure_kind: Option<crate::state::FailureKind> = None;
     // Down-channel steering: watch the ledger for supervisor steering
     // instructions targeting THIS worker and abort the session mid-turn so the
@@ -3966,6 +4990,10 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     )
     .await;
     steer_handle.abort();
+
+    // Post-run supervision: sweep dead holders (best-effort — the run's own
+    // writeback already landed; a lost notification must not fail it).
+    let _ = supervise_after_run(store, &goal_id).await;
 
     // Record the retention state (the kernel's advisory, not a directive).
     let resumable = matches!(
@@ -4002,16 +5030,17 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
 
     // Session retention: never delete the agent session. The session (and its
     // accumulated exploration) stays on the agent; the NEXT caller decides
-    // resume-vs-fresh. A resumable session (infra interruption) is also picked
-    // up by the default `auto` policy; a non-resumable one must be resumed
-    // explicitly.
+    // resume-vs-fresh explicitly. The default is a fresh session; the only
+    // resume path is an explicit pin (`--resume-session <id>`), so this
+    // resumable classification is advisory data for the orchestrator's own
+    // judgment, not a directive.
     if resumable {
         println!(
-            "   ⤺ session {session_id} retained (resumable) — next `run` with default policy will resume it"
+            "   ⤺ session {session_id} retained (resumable) — resume it with --resume-session {session_id}"
         );
     } else {
         println!(
-            "   ⤺ session {session_id} retained — resume it with --session-policy resume or --resume-session"
+            "   ⤺ session {session_id} retained — resume it with --resume-session {session_id}"
         );
     }
     result
@@ -4197,6 +5226,25 @@ pub async fn notify_dead_holders(store: &mut Store, goal_id: &str) -> Result<()>
         )
         .await;
     }
+    Ok(())
+}
+
+/// Best-effort post-run supervision — the run process itself is a live actor,
+/// so its exit is a natural point to run the dead-holder sweep without
+/// depending on an explicit `scheduler tick` (which no orchestrator actually
+/// runs). The single side effect is idempotent and a no-op on failure, so it
+/// can never fail the run's own writeback:
+///
+/// - **Dead-holder sweep** — `notify_dead_holders` pushes `host_died` to the
+///   registered supervisor for any lease whose holder pid is gone (a
+///   SIGKILL'd/crashed worker executes no code, so it cannot self-report).
+///   This is the single supervision signal the single-process model needs:
+///   the orchestrator is the only live actor, and this sweep is what lets a
+///   dead worker surface without a cron.
+async fn supervise_after_run(store: &mut Store, goal_id: &str) -> Result<()> {
+    // Dead-holder sweep is best-effort: a lost notification must never fail
+    // the run that already wrote back.
+    let _ = notify_dead_holders(store, goal_id).await;
     Ok(())
 }
 
@@ -6192,7 +7240,7 @@ async fn cmd_worker_list(store: &Store, args: &[String]) -> Result<()> {
 /// boundary — NOT `pkill`), then aborting any in-flight agent session over
 /// gRPC so the current turn ends promptly instead of running to completion.
 /// The run client exits its loop at the next turn boundary and retains the
-/// session (resumable per `--session-policy`); `--delete` also reclaims the
+/// session (resumable per `--resume-session`); `--delete` also reclaims the
 /// backing agent session afterwards so a later `run` starts fresh. `--all`
 /// broadcasts the stop to every worker with a live session for this goal.
 async fn cmd_worker_stop(store: &mut Store, args: &[String]) -> Result<()> {
@@ -6449,16 +7497,11 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
             reject_unknown_flags(
                 &args[1..],
                 &[
-                    "--adapter-id",
                     "--agent-id",
-                    "--authority-ref",
                     "--capabilities",
                     "--decision-id",
                     "--goal",
-                    "--host-capabilities",
                     "--kind",
-                    "--outcome",
-                    "--receipt-id",
                     "--summary",
                     "--target-agent-id",
                 ],
@@ -6522,17 +7565,12 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
                 &args[1..],
                 &[
                     "--adapter-id",
-                    "--agent-id",
                     "--authority-ref",
-                    "--capabilities",
                     "--decision-id",
                     "--goal",
                     "--host-capabilities",
-                    "--kind",
                     "--outcome",
                     "--receipt-id",
-                    "--summary",
-                    "--target-agent-id",
                 ],
             )?;
             parse_pairs(&args[1..], |k, v| {
@@ -6582,23 +7620,7 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
         }
         "events" => {
             let mut goal_id = None;
-            reject_unknown_flags(
-                &args[1..],
-                &[
-                    "--adapter-id",
-                    "--agent-id",
-                    "--authority-ref",
-                    "--capabilities",
-                    "--decision-id",
-                    "--goal",
-                    "--host-capabilities",
-                    "--kind",
-                    "--outcome",
-                    "--receipt-id",
-                    "--summary",
-                    "--target-agent-id",
-                ],
-            )?;
+            reject_unknown_flags(&args[1..], &["--goal"])?;
             parse_pairs(&args[1..], |k, v| {
                 if k == "--goal" {
                     goal_id = Some(v);
@@ -9124,6 +10146,29 @@ mod cli_quirks_tests {
     }
 
     #[test]
+    fn render_command_help_lists_per_flag_details() {
+        let registry = build_cli_registry();
+        // `run` carries the richest flag surface: defaults + constraints.
+        let help = render_command_help(&registry, "run", false);
+        assert!(help.contains("flags:"), "got: {help}");
+        assert!(help.contains("--max-turns N"), "got: {help}");
+        assert!(help.contains("default 6"), "got: {help}");
+        assert!(help.contains("--resume-session ID"), "got: {help}");
+        // a command without flags (version) renders no `flags:` section.
+        let vhelp = render_command_help(&registry, "version", false);
+        assert!(!vhelp.contains("\nflags:\n"), "got: {vhelp}");
+    }
+
+    #[test]
+    fn render_subcommand_help_lists_per_flag_details() {
+        let registry = build_cli_registry();
+        let help = render_subcommand_help(&registry, "worker", "stop", false);
+        assert!(help.contains("flags:"), "got: {help}");
+        assert!(help.contains("--all"), "got: {help}");
+        assert!(help.contains("--delete"), "got: {help}");
+    }
+
+    #[test]
     fn render_subcommand_help_shows_exact_verb_usage() {
         let registry = build_cli_registry();
         let help = render_subcommand_help(&registry, "supervisor", "steer", false);
@@ -9515,6 +10560,19 @@ mod cli_quirks_tests {
         assert_eq!(todo.status, crate::state::TodoStatus::Deferred);
         let deadline = todo.resume_when.expect("numeric sets a deadline");
         assert!(deadline >= before + std::time::Duration::from_secs(120));
+    }
+
+    #[tokio::test]
+    async fn supervise_after_run_is_best_effort() {
+        let mut store = tmp_store("supervise");
+        open_goal_with_todo(&mut store, "g_sup");
+
+        // A goal with no supervisor and no dead holders is a clean no-op.
+        supervise_after_run(&mut store, "g_sup").await.unwrap();
+
+        // An unknown goal (replay returns None) and an unreachable agent are
+        // both absorbed — the supervision step never fails the run's writeback.
+        supervise_after_run(&mut store, "goal_nope").await.unwrap();
     }
 }
 

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -881,7 +881,7 @@ pub struct Goal {
     /// Session retention: the last run's agent session that MAY be resumable.
     /// The loop kernel never decides resume-vs-fresh itself — it only records
     /// WHY the session was interrupted (the failure classification) and keeps
-    /// the session id on disk; the CALLER (orchestrator / `run --session-policy`)
+    /// the session id on disk; the CALLER (orchestrator / `run --resume-session`)
     /// decides whether to resume it or start fresh. Written at run exit.
     #[serde(default)]
     pub session_retention: Option<SessionRetention>,

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -1433,6 +1433,28 @@ fn replan_ack_and_obligations() {
     .contains("not found"));
     assert!(cli_err(&["replan", "obligations"]).contains("--goal required"));
     assert!(cli_err(&["replan", "obligations", "--goal", "goal_nope"]).contains("not found"));
+    // Ghost flags removed: `replan ack` no longer accepts --format/--json,
+    // `replan obligations` no longer accepts --delta-kind.
+    assert!(cli_err(&[
+        "replan",
+        "ack",
+        "--goal",
+        &gid,
+        "--delta-kind",
+        "vision_patch",
+        "--format",
+        "json"
+    ])
+    .contains("unknown flag `--format`"));
+    assert!(cli_err(&[
+        "replan",
+        "obligations",
+        "--goal",
+        &gid,
+        "--delta-kind",
+        "vision_patch"
+    ])
+    .contains("unknown flag `--delta-kind`"));
 }
 
 // ── top-level dispatch quirks ──────────────────────────────────────────────

--- a/orchestration/loop/tests/console_drive_b.rs
+++ b/orchestration/loop/tests/console_drive_b.rs
@@ -65,7 +65,8 @@ fn scheduler_surface() {
     cli_ok(&["scheduler", "tick", "--goal", &gid]);
     cli_ok(&["scheduler", "show", "--goal", &gid]);
     cli_ok(&["scheduler", "tick", "--goal", &gid]);
-    // custom progression / cadence class / action on a second agent.
+    // custom progression / action on a second agent (cadence-class is not a
+    // tick flag — it was a dead no-op and was removed).
     cli_ok(&[
         "scheduler",
         "tick",
@@ -73,8 +74,6 @@ fn scheduler_surface() {
         &gid,
         "--agent-id",
         "agent-b",
-        "--cadence-class",
-        "hourly",
         "--progression",
         "15,30,60",
         "--action",

--- a/orchestration/loop/tests/console_drive_c.rs
+++ b/orchestration/loop/tests/console_drive_c.rs
@@ -189,6 +189,42 @@ fn supervisor_surface() {
     .contains("--adapter-id"));
     assert!(cli_err(&["supervisor", "events"]).contains("--goal required"));
     assert!(cli_err(&["supervisor", "bogus", "--goal", &gid]).contains("propose|receipt|events"));
+    // Ghost flags removed: flags the reject array accepted but the parse
+    // closure never read are now hard `unknown flag` errors.
+    assert!(cli_err(&[
+        "supervisor",
+        "propose",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "sup",
+        "--decision-id",
+        "d",
+        "--target-agent-id",
+        "w",
+        "--outcome",
+        "x",
+    ])
+    .contains("unknown flag `--outcome`"));
+    assert!(cli_err(&[
+        "supervisor",
+        "receipt",
+        "--goal",
+        &gid,
+        "--decision-id",
+        "d",
+        "--receipt-id",
+        "r",
+        "--adapter-id",
+        "a",
+        "--agent-id",
+        "sup",
+    ])
+    .contains("unknown flag `--agent-id`"));
+    assert!(
+        cli_err(&["supervisor", "events", "--goal", &gid, "--format", "json",])
+            .contains("unknown flag `--format`")
+    );
 }
 
 // ── task-graph / attention ─────────────────────────────────────────────────

--- a/orchestration/loop/tests/console_drive_g12.rs
+++ b/orchestration/loop/tests/console_drive_g12.rs
@@ -761,10 +761,10 @@ fn notify_dead_holders_early_returns() {
     std::env::remove_var("FUTURE_LOOP_AGENT_ADDR");
 }
 
-// ── run session-policy validation + resume-session parsing ─────────────────
+// ── run session-policy removal + resume-session parsing ───────────────────
 
 #[test]
-fn run_rejects_bad_session_policy() {
+fn run_rejects_removed_session_policy_flag() {
     let cr = cli_root();
     let gid = init_goal(&cr, "run session policy");
     let err = cli_err(&[
@@ -774,10 +774,23 @@ fn run_rejects_bad_session_policy() {
         "--agent-id",
         "a1",
         "--session-policy",
-        "bogus",
+        "fresh",
     ]);
-    assert!(
-        err.contains("--session-policy must be auto | fresh | resume"),
-        "{err}"
-    );
+    assert!(err.contains("unknown flag `--session-policy`"), "{err}");
+}
+
+#[test]
+fn run_rejects_resume_policy_value() {
+    let cr = cli_root();
+    let gid = init_goal(&cr, "run resume policy");
+    let err = cli_err(&[
+        "run",
+        "--goal",
+        &gid,
+        "--agent-id",
+        "a1",
+        "--session-policy",
+        "resume",
+    ]);
+    assert!(err.contains("unknown flag `--session-policy`"), "{err}");
 }


### PR DESCRIPTION
## Summary

Loop CLI surface hardening, five changes that all close the gap between what the CLI claims and what it does:

### 1. Remove `--session-policy` (run)
Fresh is now the default; resume only via an explicit `--resume-session <id>` pin. The goal-level `session_retention` is a single field (whichever run wrote back last), so an implicit "resume the retained session" would hand one worker's session to another under parallel workers.

### 2. Delete ghost flags
Flags the `reject_unknown_flags` array accepted but the parse closure never read (silent no-ops):
- `supervisor propose`: `--outcome --receipt-id --adapter-id --authority-ref --host-capabilities`
- `supervisor receipt`: `--agent-id --kind --summary --target-agent-id --capabilities`
- `supervisor events`: all but `--goal`
- `replan ack`: `--format --json`
- `replan obligations`: `--delta-kind`
- `scheduler tick`: `--cadence-class`

### 3. Per-flag help
`<command> --help` / `<command> <sub> --help` now render each flag with its default + constraints, sourced from each handler. `agent` gains subcommand registrations so `agent onboard|list|contract|recipe|succession|collective --help` resolve.

### 4. `scheduler tick --progression` warns
It is bootstrap-only; once state exists it now warns instead of silently ignoring the flag.

### 5. Dead-worker sweep on run exit
`run` now sweeps dead-holder leases (`notify_dead_holders`) on exit, so a SIGKILL'd/crashed worker surfaces to the supervisor without a scheduler-tick cron.

## Verification
- `cargo fmt -p future-loop --check` ✅
- `cargo clippy -p future-loop --all-targets` ✅ (no warnings)
- `cargo test -p future-loop --lib` (392 passed) + integration suites (`console_drive_a/b/c/cov100/g12`, `scheduler_drive/state_contract`, `run_lifecycle/identity`, `agent_run_drive/agent_client_executor`, `cli_registry_contract`) ✅

Companion skills bump: future-skills #41 (v3.11.0).