### PR TITLE
loop: align agent transport with TUI/CLI socket-first discovery

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -229,7 +229,7 @@ parsing a merged top-level line.
 
 ## How it fits FutureOS
 
-- **Agent service** (`future agent`, gRPC 127.0.0.1:50051): `run` executes every turn through it
+- **Agent service** (`future agent`, per-user local IPC by default, `--grpc-addr` to switch to TCP): `run` executes every turn through it, discovered socket-first like the TUI/CLI clients (`FUTURE_LOOP_AGENT_ADDR` overrides with an explicit TCP address)
 - **Any client through the skill** (TUI, desktop, mobile, Feishu / DingTalk): loop goals are driven by the `/future-loop` skill orchestrating `future loop` commands — there is no native bridge↔loop integration; gates surface as agent messages asking one concrete question
 - **The `/future-loop` skill**: the driving manual for agents (v3.x, kept in sync with this doc)
 - **State location**: `<cwd>/.future/loop/` (add to the project `.gitignore`)

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -11,11 +11,13 @@ use future_rpc::proto::future_agent_client::FutureAgentClient;
 use future_rpc::proto::{RpcCommand, StreamEvent, StreamRequest};
 use serde_json::Value;
 
-/// Agent gRPC address (`host:port`). Defaults to the local agent; overridable
-/// via FUTURE_LOOP_AGENT_ADDR so tests can point the control plane at a mock
-/// server (mirrors the BROWSER_LAUNCHER_OVERRIDE test-hook precedent in cli).
+/// Agent transport selector, mirroring the TUI/CLI clients: the per-user local
+/// IPC endpoint by default (the `auto` sentinel), or an explicit TCP address
+/// via FUTURE_LOOP_AGENT_ADDR — which tests use to point the control plane at
+/// a mock server (mirrors the BROWSER_LAUNCHER_OVERRIDE test-hook precedent).
 pub fn agent_addr() -> String {
-    std::env::var("FUTURE_LOOP_AGENT_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string())
+    std::env::var("FUTURE_LOOP_AGENT_ADDR")
+        .unwrap_or_else(|_| future_rpc::transport::AUTO_ENDPOINT.to_string())
 }
 
 /// What the agent reported at the end of one bounded turn (agent_end).
@@ -115,21 +117,20 @@ pub struct AgentClient {
 }
 
 impl AgentClient {
+    /// Connect through the shared per-user transport discovery: an explicit
+    /// TCP address (FUTURE_LOOP_AGENT_ADDR, or a test mock addr) is tried
+    /// first with local IPC as fallback; the `auto` sentinel selects only the
+    /// local endpoint. Same socket-first boundary as the TUI/CLI clients.
     pub async fn connect(addr: &str) -> Result<Self> {
-        let addr = format!(
-            "http://{}",
-            addr.trim_start_matches("http://")
-                .trim_start_matches("https://")
-        );
-        let endpoint = tonic::transport::Endpoint::new(addr.clone())?
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(120));
-        let channel = endpoint
-            .connect()
-            .await
-            .map_err(|e| anyhow!("Failed to connect to agent at {addr}: {e}"))?;
+        let connected = future_rpc::transport::connect_channel(
+            Some(addr),
+            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(120),
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to connect to agent: {e}"))?;
         Ok(Self {
-            inner: FutureAgentClient::new(channel),
+            inner: FutureAgentClient::new(connected.channel),
         })
     }
 

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -48,6 +48,12 @@ fn sample_record(state: &str) -> RunRecord {
 #[test]
 fn connect_failure_is_wrapped() {
     rt().block_on(async {
+        // Point local-IPC discovery at a path that never resolves so the
+        // fallback after the TCP dial fails too — an ambient agent socket
+        // would otherwise make the port-1 dial succeed via fallback.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("nonexistent/agent.sock");
+        std::env::set_var("FUTURE_AGENT_SOCKET", &socket);
         // Port 1 is never listenable.
         let err = match AgentClient::connect("127.0.0.1:1").await {
             Ok(_) => panic!("connect to port 1 should fail"),
@@ -60,6 +66,8 @@ fn connect_failure_is_wrapped() {
             Err(e) => e,
         };
         assert!(format!("{err:#}").contains("Failed to connect"));
+        std::env::remove_var("FUTURE_AGENT_SOCKET");
+        drop(dir);
     });
 }
 

--- a/orchestration/loop/tests/common/mod.rs
+++ b/orchestration/loop/tests/common/mod.rs
@@ -36,6 +36,11 @@ pub fn cli_root() -> CliRoot {
     let cwd = dir.path().join("cwd");
     std::fs::create_dir_all(&cwd).unwrap();
     std::env::set_var("FUTURE_LOOP_ROOT", &root);
+    // Isolate local-IPC discovery too: "unreachable agent" tests would
+    // otherwise fall back to an ambient ~/.future/run/agent.sock on a
+    // developer machine and connect to a real agent instead of failing.
+    let socket = dir.path().join("agent.sock");
+    std::env::set_var("FUTURE_AGENT_SOCKET", &socket);
     CliRoot {
         _guard: guard,
         _dir: dir,


### PR DESCRIPTION
## Summary

`future loop run` hardcoded its agent connection to TCP `127.0.0.1:50051`, while the TUI/CLI clients discover the agent **socket-first** via the per-user local IPC boundary (see `future_rpc::transport`). This meant the loop control plane could not reach an agent started the default way (socket-only, no `--grpc-addr`), and required a separately-flagged TCP agent.

This PR routes the loop's agent client through the shared `transport::connect_channel` discovery so it behaves like every other client.

## Changes

- `agent_addr()` now defaults to the `auto` sentinel (local IPC) instead of `127.0.0.1:50051`; `FUTURE_LOOP_AGENT_ADDR` still overrides with an explicit TCP address (tests keep using it to point at mock servers).
- `AgentClient::connect()` reuses `future_rpc::transport::connect_channel`: explicit TCP first with local IPC fallback; `auto` selects local-only.
- Test isolation: `cli_root()` and `connect_failure_is_wrapped` set `FUTURE_AGENT_SOCKET` to a tempdir so "unreachable agent" tests never fall back to an ambient dev-machine socket.
- Docs: `docs/loop-control-plane.md` agent-service line now matches the zh doc (per-user local IPC by default).

## Verification

- `cargo fmt -p future-loop --check` ✅
- `cargo clippy -p future-loop --all-targets -- -D warnings` ✅
- `cargo test -p future-loop` ✅ (all green)
- Manual: with nothing listening on 50051, `future loop models` still succeeds against the socket-only agent.