### PR TITLE
fix(loop): reliable steering, bounded validation and event-driven supervision

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -47,12 +47,12 @@ agent executes one bounded turn (gRPC) → writes evidence → kernel decides th
 | Concept | Command | What it does |
 |---|---|---|
 | Goal | `goal init` | Project-local state at `<cwd>/.future/loop/`, event-sourced and replayable |
-| Todo | `todo add/update/complete/supersede` | Five classes: advancement / user-gate / user-action / monitor (external-state watch) / blocker; `--blocks` dependency chains; `--priority` |
+| Todo | `todo add/update/complete/supersede` | Classes: advancement / user-gate / user-action / monitor / blocker / coordination; `--blocks` dependency chains; `--priority` |
 | Evidence | `todo complete --evidence` | **Non-empty, enforced**: closing a todo must state what actually landed (paths, attempt ids, measurements); `--force` is the explicit operator override |
 | Acceptance contract | `todo add --acceptance "tok1,tok2"` | Completion evidence must contain every token (case-insensitive) — the hard form of "done ≠ delivered" |
 | Verifier | `todo add --verify "cmd"` | The kernel runs the command after each **run turn boundary**; only exit 0 lets that turn's todo complete (bounded by `--max-validation-attempts`). A machine-checkable gate for deterministic deliverables. **Not** for exploratory todos (research/report) whose correctness the kernel cannot judge — the orchestrator judges those by reading the artifact, and a manual `todo complete` deliberately does not re-run `--verify` |
 | Lease | `lease claim/renew/release/status` | Who holds a todo and until when. **Lease liveness**: the holder's pid is recorded; a dead process's leases are auto-reclaimed — no manual cleanup after killing a worker |
-| Gate | `gate resolve` | Any open user gate freezes all work until resolved. Gates are decision points, not work items: `todo complete` on a gate **bails and points at `gate resolve`** (the decision is recorded, never silently marked "done"). user-actions (non-blocking human to-dos) surface to the user without freezing the agent |
+| Gate | `gate resolve` | An open gate blocks its dependents; independent work can run and complete. `--global-gate` explicitly freezes all work. Gates are decision points, not work items: `todo complete` on a gate **bails and points at `gate resolve`** (the decision is recorded, never silently marked "done"). user-actions (non-blocking human to-dos) surface to the user without freezing the agent |
 | Delivery closure | `delivery status/record` | Completion lands in a pending `delivered` state; an operator resolves it as `verified/failed/rework`; unverified deliveries auto-derive a follow-up after 3 turns |
 | Terminal | `frontier show` | Validated closure: todos done/superseded + closure intent + no acceptance gaps + no pending deferred work; `frontier` gives the terminal judgement with gap detail |
 | Dashboard | `ui` | Local read-only web dashboard on 127.0.0.1: goal cards, attention queue, kernel decision, todo DAG, workers/cost, run/event ledgers — live over SSE; mutations stay in the CLI |
@@ -71,20 +71,20 @@ and let the agent drive**:
 You say "/future-loop keep an eye on X for a week"
    │
    ▼
-Agent loads the future-loop skill (v3.x driving manual)
+Agent loads the future-loop skill (v4 driving manual)
    ├─ 1. `future loop status` first — continue an existing goal, never duplicate it
    ├─ 2. Confirm the plan with you (steps/model/thinking level) — unless your message already carries the full objective + constraints
    ├─ 3. `goal init` + decompose todos (dependencies via --blocks, hard checks via --verify/--acceptance)
-   ├─ 4. Drive turns: `run --max-turns 1 --agent-id <unique>`, relaunching the moment a turn exits
+   ├─ 4. Dispatch detached turns; watchdog notifications trigger evidence/budget review before relaunch
    ├─ 5. Correct a drifting worker via `todo update --text` (picked up at the next turn)
-   ├─ 6. Interrupt a stuck worker mid-turn via `supervisor steer --goal G --instruction "..."`
-   ├─ 7. Irreversible/expensive/user-only decisions → open a user gate and wait (gates freeze everything)
+   ├─ 6. Routine steer waits for a boundary; add `--interrupt` only for urgent correction
+   ├─ 7. Irreversible/expensive/user-only decisions → open a user gate and wait (scoped gates freeze dependents; global gates freeze everything)
    └─ 8. Close out: acceptance todo copies artifacts to the project root → validated closure (terminal)
 ```
 
 **Skill vs CLI**: the skill owns "what to do when, how to decompose, how to
 drive" (the orchestration layer); the CLI is the underlying mechanism (state
-kernel + hard checks + decisions). The skill is a maintained v3.x manual, kept
+kernel + hard checks + decisions). The skill is a maintained v4 manual, kept
 in sync with this page. Its source of truth lives in the **`skills` git
 submodule** at `skills/builtin/future-loop/SKILL.md` (repo
 [future-skills](https://github.com/futuregene/future-skills)); editing the
@@ -95,15 +95,16 @@ to ship a doc change.
 ## User workflow (zero to closure)
 
 ```bash
-# 1. Create the goal
-future loop goal init --objective "..." --cwd DIR
+# 1. Run from the project directory (or set FUTURE_LOOP_ROOT), then create
+future loop goal init --objective "..."
+future loop supervisor register --goal G --session-id YOUR_CURRENT_SESSION_ID
 
 # 2. Decompose — dependencies and hard checks together
 future loop todo add --goal G --text "..." --priority P0 --verify "cargo check -p X"
 future loop todo add --goal G --text "..." --blocks T1 --acceptance "attempt,scored"
 future loop todo add --goal G --role user --class user_gate --text "Release gate" --gate-question "Ship it?"
 
-# 3. Drive turns (one worker per --agent-id; relaunch as soon as a turn exits)
+# 3. Dispatch (one unique --agent-id per concurrent worker; review before relaunch)
 future loop run --goal G --agent-id mac-worker --model M --thinking-level L --max-turns 1
 
 # 4. Human decisions
@@ -150,7 +151,9 @@ root, and only GET endpoints exist (any other method is a 405). Mutations
 - `--acceptance` turns "accepted by an external observable" into a hard check
 - Lease liveness self-heals: dead-process leases are reclaimed automatically — relaunching workers needs no manual release
 - Workspace guard: multi-agent write conflicts degrade to serial automatically
-- Idle turns (1 hour without writes) are ledgered; correct the worker via `todo update --text` (applies at the next turn)
+- Missing `write/edit` activity is advisory, not proof of no progress; shell calls and provider input phases do not inflate this proxy. Inspect artifacts and validation before intervening.
+- Validators are asynchronous, drain both pipes, retain bounded diagnostic tails and time out independently (120s default; positive `FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS` override). Unix uses `sh -c`, Windows uses `cmd.exe /D /S /C`.
+- Manual completion records `completion_basis` in the delivery note: manual review or explicit operator override, never an implied machine pass.
 
 ## Bidirectional messaging (supervisor ↔ worker)
 
@@ -163,29 +166,32 @@ channel. Both directions ride the same event-sourced state:
   This binds the supervisor's agent session id to the goal; workers read it on
   `replay` and target their reports at it.
 
-- **Down (supervisor → worker, an interrupt):**
-  `future loop supervisor steer --goal G [--agent-id A] --instruction "..."`
-  A `WorkerSteered` event lands in the ledger; the running worker's watch task
-  sees it and aborts the in-flight run (a real interrupt, `supersede_session`
-  semantics — not a system-prompt note). The next turn drains the instruction
-  into its envelope and follows it.
+- **Down (supervisor → worker, durable guidance):**
+  `future loop supervisor steer --goal G [--agent-id A] [--interrupt] --instruction "..."`.
+  Routine guidance waits for a boundary; `--interrupt` additionally aborts the
+  in-flight session. `ControlIssued` UUIDs and recipient-specific acknowledgments
+  prevent cross-worker overwrite and broadcast loss. Acknowledgment follows
+  durable completed-turn writeback; interrupted guidance may replay, so make it
+  idempotent. Legacy single-slot steer events remain readable.
 
-- **Up (worker → supervisor, a report):**
-  At a turn boundary the worker enqueues a report (`enqueue_if_busy`, so it
-  never interrupts the supervisor) to the registered session for exactly three
-  state transitions: a user gate opens (①), a todo completes (②), or a todo
-  fails on a science/hard error (③). Each report is idempotent-keyed on the
-  transition, so re-sends across runs dedup. The durable user gate remains the
-  authoritative intervention channel if no supervisor is registered.
+- **Up (worker → supervisor, persistent batched reports):**
+  Gate/completion/failure/infra notes are ledgered first, including while the agent
+  is offline. An independent watchdog coalesces up to 32 notes into an immutable
+  batch and sends with `enqueue_if_busy`. Failed pushes retry the same request key
+  and payload. Queue acceptance is not proof of supervisor action; reconcile current
+  state before reacting to old notifications. `supervisor events` includes delivery
+  pending state and control/batch receipts.
 
 - **Infra stops + dead workers:** a worker that exits before reaching a
   turn-boundary writeback (gRPC transport loss, incomplete-retry budget
   exhaustion) also reports an `infra_stopped` note.
   A worker that dies outright (SIGKILL / crash / host failure) executes no
-  code, so the periodic `scheduler tick` detects the orphaned lease (dead
-  holder pid) and pushes a `host_died` note to the registered supervisor,
-  prompting the orchestrator to relaunch rather than only discovering the dead
-  worker on its next `status` poll.
+  code. The independent watchdog started by detached run/registration detects
+  dead lease holders even when the last worker dies. It also flags verification
+  pending for five minutes without requiring more paid turns. `scheduler tick`
+  remains a supplemental check. After host restart, re-register or run
+  `supervisor watch --goal G` under the host service manager (`--once` for one
+  reconciliation); this is not an automatically installed boot service.
 
 - **Watch a worker mid-turn:** the messaging above is turn-boundary driven.
   To see what a worker is doing *right now* (which tools it is calling, its
@@ -231,7 +237,7 @@ parsing a merged top-level line.
 
 - **Agent service** (`future agent`, per-user local IPC by default, `--grpc-addr` to switch to TCP): `run` executes every turn through it, discovered socket-first like the TUI/CLI clients (`FUTURE_LOOP_AGENT_ADDR` overrides with an explicit TCP address)
 - **Any client through the skill** (TUI, desktop, mobile, Feishu / DingTalk): loop goals are driven by the `/future-loop` skill orchestrating `future loop` commands — there is no native bridge↔loop integration; gates surface as agent messages asking one concrete question
-- **The `/future-loop` skill**: the driving manual for agents (v3.x, kept in sync with this doc)
+- **The `/future-loop` skill**: the driving manual for agents (v4, kept in sync with this doc)
 - **State location**: `<cwd>/.future/loop/` (add to the project `.gitignore`)
 
 ## Further reading

--- a/docs/loop-control-plane.zh-CN.md
+++ b/docs/loop-control-plane.zh-CN.md
@@ -32,12 +32,12 @@ Agent 执行一个有界回合（gRPC）→ 写证据 → 内核据此决定下�
 | 概念 | 命令 | 说明 |
 |---|---|---|
 | 目标 goal | `goal init` | 项目本地状态 `<cwd>/.future/loop/`，事件溯源 + 可重放 |
-| 任务 todo | `todo add/update/complete/supersede` | 五类：advancement（推进）/ user-gate（人工门禁）/ user-action（不冻结的人待办）/ monitor（监视外部状态）/ blocker（外部阻塞）；`--blocks` 依赖链；`--priority` |
+| 任务 todo | `todo add/update/complete/supersede` | 类别：advancement（推进）/ user-gate（人工门禁）/ user-action（不冻结的人待办）/ monitor（监视）/ blocker（阻塞）/ coordination（编排记账）；`--blocks` 依赖链；`--priority` |
 | 证据 evidence | `todo complete --evidence` | **非空强制**：关单必须写明实际落地了什么（路径、attempt id、测量结果），`--force` 是操作者显式覆盖 |
 | 验收契约 acceptance | `todo add --acceptance "tok1,tok2"` | 关单证据必须包含全部 token（大小写不敏感）——"done ≠ delivered" 的硬形式 |
 | 验证器 verify | `todo add --verify "cmd"` | 每个 **run 回合边界**后内核执行命令，exit 0 才算完成；上限 `--max-validation-attempts`。用于机器可判的确定性交付物。**不适用于探索性任务**（检索/报告）——内核判不了其正确性，正确性由编排 agent 读工件判断；手动 `todo complete` 也刻意不重跑 `--verify` |
 | 租约 lease | `lease claim/renew/release/status` | 任务被谁租用、多久过期。**租约活性自愈**：记录持有进程 pid，进程死了自动回收——杀掉 worker 后无需手动清理 |
-| 门禁 gate | `gate resolve` | 任何打开的用户门禁冻结全部工作直到解决。门禁是决策点不是工作项：对 gate 用 `todo complete` 会**报错并指向 `gate resolve`**（决策被记录，绝不默默标 done）；user-action（不冻结的人待办）展示给用户但不阻塞 agent |
+| 门禁 gate | `gate resolve` | 普通门禁只阻塞依赖它的任务，无关工作可继续执行和完成；`--global-gate` 才全局冻结。门禁是决策点不是工作项：对 gate 用 `todo complete` 会**报错并指向 `gate resolve`**（决策被记录，绝不默默标 done）；user-action（不冻结的人待办）展示给用户但不阻塞 agent |
 | 交付闭环 delivery | `delivery status/record` | 完成 = `delivered` 待验证态；操作者用 `verified/failed/rework` 结案；3 回合未验证自动派生跟进任务 |
 | 终局 terminal | `frontier show` | 验证式闭环：todos 完成/被取代 + 闭环意图 + 无验收缺口 + 无待决 deferred 工作；`frontier` 给出终局判定与缺口明细 |
 | 配额 quota | `quota should-run/usage/spend/decisions` | 确定性 should-run 内核：每个回合的调度、拒绝原因、花费全部可审计 |
@@ -54,18 +54,18 @@ Agent 执行一个有界回合（gRPC）→ 写证据 → 内核据此决定下�
 你（用户）说 "/future-loop 帮我盯着 X 一周"
    │
    ▼
-Agent 加载 future-loop 技能（v3.x 驾驶手册）
+Agent 加载 future-loop 技能（v4 驾驶手册）
    ├─ 1. 先 `future loop status` 查是否已有同类目标（有则续做，不重复建）
    ├─ 2. 与你确认计划（步骤/模型/thinking level）——除非你的指令已含完整目标与约束
    ├─ 3. `goal init` + 拆 todos（依赖 --blocks、硬校验 --verify/--acceptance 一起挂）
-   ├─ 4. 逐回合驱动：`run --max-turns 1 --agent-id <唯一名>`，回合结束立即重启
+   ├─ 4. detached 派发；watchdog 通知唤醒后，核对证据与预算再决定下一轮
    ├─ 5. 用 `todo update --text` 纠正跑偏的 worker（下一回合生效）
-   ├─ 6. 遇到不可逆/昂贵/用户专属决策 → 挂 user gate 等你拍板（gate 冻结一切）
+   ├─ 6. 遇到不可逆/昂贵/用户专属决策 → 挂 user gate 等你拍板（普通 gate 只冻结下游；global gate 冻结全部）
    └─ 7. 收尾：验收 todo 拷贝交付物到项目根 → validated closure（terminal）
 ```
 
 **技能与 CLI 的分工**：技能负责"何时该做什么、如何拆解、如何驾驶"（编排层）；
-CLI 是底层机制（状态内核 + 硬校验 + 决策）。技能是 v3.x 持续维护的驾驶手册，
+CLI 是底层机制（状态内核 + 硬校验 + 决策）。技能是 v4 持续维护的驾驶手册，
 与本页同步更新。其内容源头在 **`skills` git submodule** 的
 `skills/builtin/future-loop/SKILL.md`（仓库 [future-skills](https://github.com/futuregene/future-skills)）；
 改 `~/.future/agent/skills/` 的安装副本只对本地机器生效——要随仓库分发文档改动，
@@ -74,15 +74,16 @@ CLI 是底层机制（状态内核 + 硬校验 + 决策）。技能是 v3.x 持�
 ## 用户工作流（从零到闭环）
 
 ```bash
-# 1. 创建目标
-future loop goal init --objective "..." --cwd DIR
+# 1. 从项目目录执行（或设置 FUTURE_LOOP_ROOT），创建并注册
+future loop goal init --objective "..."
+future loop supervisor register --goal G --session-id YOUR_CURRENT_SESSION_ID
 
 # 2. 拆任务（依赖 + 硬校验一起挂上）
 future loop todo add --goal G --text "..." --priority P0 --verify "cargo check -p X"
 future loop todo add --goal G --text "..." --blocks T1 --acceptance "attempt,scored"
 future loop todo add --goal G --role user --class user_gate --text "发布门禁" --gate-question "是否发布？"
 
-# 3. 驱动回合（一个 worker 一个 --agent-id；回合结束立即重启）
+# 3. 派发回合（每个并行 worker 独立 --agent-id；检查证据后再决定重启）
 future loop run --goal G --agent-id mac-worker --model M --thinking-level L --max-turns 1
 
 # 4. 人工拍板
@@ -124,7 +125,9 @@ resolve、goal cancel 等）仍留在 CLI——页面只显示对应的 `future 
 - `--acceptance` 把"验收以外部可观测信号为准"变成硬校验
 - 租约活性自愈：死进程的租约自动回收，重启 worker 不再需要手动 release
 - 工作区守卫：多 agent 写冲突自动降级串行
-- 空转回合（15 分钟无写入）会记账；用 `todo update --text` 纠正（下一回合生效）
+- 缺少 write/edit 活动只作提示，不等于没有进展；shell 调用不自动算写入，provider input/execution 不重复计数。先读产物、验证和里程碑，再决定干预。
+- 验证器异步执行、排空双管道、保留有界诊断尾部，独立默认 120 秒超时（正数 `FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS` 可配置）。Unix 用 `sh -c`，Windows 用 `cmd.exe /D /S /C`。
+- 手动完成在 delivery note 标记 `completion_basis`：人工审阅或显式覆盖，不伪装机器验证通过。
 
 ## 双向消息（supervisor ↔ worker）
 
@@ -136,24 +139,24 @@ supervisor（运行 `/future-loop` 技能的编排 agent）与其 worker 通过�
   这把 supervisor 的 agent 会话 id 绑定到目标；worker 在 `replay` 时读到它，并把报告
   定向到它。
 
-- **下行（supervisor → worker，一次中断）：**
-  `future loop supervisor steer --goal G [--agent-id A] --instruction "..."`
-  一条 `WorkerSteered` 事件落入账本；运行中 worker 的 watch 任务看到它，并中止进行中的
-  运行（真正的 `supersede_session` 中断，不是 system-prompt 提示）。下一回合把这条指令
-  排入它的 envelope 并执行。
+- **下行（supervisor → worker，持久指导）：**
+  `future loop supervisor steer --goal G [--agent-id A] [--interrupt] --instruction "..."`。
+  默认下一回合边界注入；`--interrupt` 才额外中断当前会话。`ControlIssued` 使用 UUID，
+  按接收者确认，避免跨 worker 覆盖和广播被第一个消费者清空。完成回合持久写回后才确认；
+  崩溃可重投，因此指导必须幂等。旧单槽 steer 账本保留兼容读取。
 
-- **上行（worker → supervisor，一次报告）：**
-  在回合边界，worker 把报告入队（`enqueue_if_busy`，因此绝不打断 supervisor）到已注册
-  会话，且恰好针对三种状态迁移：用户闸门打开（①）、todo 完成（②）、或 todo 因科学/
-  硬错误失败（③）。每条报告按迁移幂等键控，因此跨运行的重发会去重。若未注册
-  supervisor，持久化用户闸门仍是权威的干预通道。
+- **上行（worker → supervisor，持久合批报告）：**
+  gate/完成/失败/基础设施通知先落账，Agent 离线也不丢。独立 watchdog 每批合并最多
+  32 条，固定请求 key 和正文后以 `enqueue_if_busy` 推送，失败恢复重试。队列接收不代表
+  supervisor 已行动；旧通知只触发当前状态核对。`supervisor events` 展示待送状态和控制/
+  合批回执。
 
 - **基础设施停止 + 死 worker：** 在到达回合边界写回之前退出的 worker（gRPC 传输丢失、
   不完整重试预算耗尽）也会上报一条 `infra_stopped` 备注。
-  直接死掉的 worker（SIGKILL / 崩溃 / 宿主机故障）不执行任何代码，因此周期性的
-  `scheduler tick` 会检测到孤儿租约（持有者 pid 已死），并向已注册的 supervisor 推送
-  一条 `host_died` 备注，促使编排者重启，而不是只在下次 `status` 轮询时才发现有 worker
-  死了。
+  直接死掉的 worker 不执行代码。detached run / supervisor 注册启动的独立 watchdog
+  即使在最后一个 worker 死亡后也会检查死租约，且会提醒超过五分钟未验证的交付，
+  不依赖新的付费回合。`scheduler tick` 保留为补充。宿主重启后重新注册，或用系统服务
+  管理器运行 `supervisor watch --goal G`（`--once` 单次核对）；它不是自动安装的开机服务。
 
 - **回合中观察 worker：** 上述消息都是回合边界驱动的。要看 worker *此刻*在做什么
   （在调哪些工具、token/成本消耗），用 `future loop worker tail --goal G [--agent-id A]
@@ -193,7 +196,7 @@ usage 即可发现参数。
 
 - **Agent 服务**（`future agent`，默认按用户隔离的本地 IPC，`--grpc-addr` 可切 TCP）：`run` 通过它执行每个回合
 - **任何客户端都可经技能驱动**（TUI、桌面、移动端、飞书 / 钉钉）：loop 目标由 `/future-loop` 技能编排 `future loop` 命令驱动——桥与 loop 之间没有原生集成；门禁以 agent 消息形式提出一个具体问题
-- **技能 `/future-loop`**：编排 Agent 使用本控制面的驾驶手册（v3.x 与本文档同步维护）
+- **技能 `/future-loop`**：编排 Agent 使用本控制面的驾驶手册（v4 与本文档同步维护）
 - **状态位置**：`<cwd>/.future/loop/`（加入项目 `.gitignore`）
 
 ## 更多

--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -1,448 +1,165 @@
-# Loop Architecture: a kanban tool, not a rule engine
-
-This document states the design principles of the loop control plane. For the
-operational model (concepts, commands, multi-agent), see
-`docs/loop-control-plane.md`; for the agent-facing driving manual, see the
-`future-loop` SKILL.md.
-
-## Design principles
-
-1. **Kanban, not a rule engine.** The kernel offers deterministic tools —
-   todo state, verify gates, acceptance contracts, evidence, leases — and
-   never decides "you're stuck, stop and replan" on the agent's behalf. It
-   computes signals (outcome floor, oscillation, repair count, monitor stall,
-   no-progress turns) and surfaces them as **advisories** in the turn
-   envelope; what to do about them is a decision, and decisions do not live
-   in the kernel.
-
-2. **The agent is the orchestrator — with observability and control
-   levers.** The decision-maker is the model, not the kernel. The kernel
-   enforces only the **correctness floor** — the hard constraints that keep
-   goal state legal (verify gates, acceptance contracts, terminal closure,
-   leases) — and never judges whether an *exploratory* result is
-   *right*. But "the agent decides" is only meaningful if the agent can
-   *see* and *act*. So the loop hands the orchestrator levers, not just
-   state:
-
-   - **observe** — four faces, not just `tail`:
-     - **behavior (the process)** — `worker tail` streams a worker's live
-       turn log (a condensed tool/usage view): watch the worker's *hands*;
-     - **artifacts (the results)** — read the files the evidence points at
-       (the report, the data): this is how the orchestrator judges an
-       *exploratory* result — not by tailing the process but by reading the
-       *work*;
-     - **the ledger (state & history)** — `status` / `diagnose` expose todo
-       state, signals, gates, and leases on demand: the authoritative board;
-     - **pushes (events)** — supervisor notifications deliver state
-       transitions (see "Run lifecycle & orchestrator notification");
-   - **steer** — `supervisor steer` interrupts/corrects a running worker,
-     `todo update` reshapes the kanban mid-flight;
-   - **stop** — `worker stop` halts a worker on the orchestrator's judgement;
-   - **close** — manual `todo complete` deliberately does **not** re-run the
-     machine `--verify` gate: for exploratory deliverables the orchestrator's
-     reading of the artifact is the judgement, and the kernel does not
-     second-guess it.
-
-   Observability and steerability are therefore part of the architecture,
-   not conveniences: they are what makes the orchestrator real.
-
-   **Workers escalate; they never decide whether a human is needed.** A
-   worker that hits something it can't resolve does not open a "user gate"
-   or judge "this one is for a human" — it **escalates to the orchestrator**
-   (a signal/message, not a freeze) and keeps its lane otherwise. *Whether*
-   the question needs a human at all is the orchestrator's call: it may
-   answer directly, reshape the todo, change strategy, or — only then —
-   take it to the person. How the orchestrator reaches the person (and
-   whether that freezes anything) is **not constrained by the loop** — it is
-   orchestration-layer behavior, outside the kernel. So the kernel has no
-   `blocked_by: human` concept and no worker-opened gate: only dependency
-   edges (`--blocks`, work must wait) and a reliable worker→orchestrator
-   escalation channel. The human sits at the top of the supervision stack
-   (see "Supervision layers"), reached *through* the orchestrator, never
-   addressed by a worker directly.
-
-3. **The user drives through the skill.** Users do not script the kernel
-   directly; they state a goal (`/future-loop <task>`) and the agent — guided
-   by the `future-loop` SKILL.md — decomposes it, drives runs, reads signals,
-   and escalates decision points. SKILL.md owns "what to do when, how to
-   decompose, how to steer" (the orchestration layer); the CLI/kernel is the
-   underlying mechanism (state + hard checks). Decision guidance lives in
-   SKILL.md precisely because that is where the decision-maker reads.
-
-4. **All capabilities are exposed through the CLI.** `future loop <cmd>` is
-   the single machine interface to the control plane: every state change —
-   goal/todo mutation, gate resolution, lease, steer, stop, completion — is
-   a CLI invocation, deterministic and auditable in the event ledger. The
-   skill drives the CLI on the agent's behalf; a human operator types the
-   same commands; the dashboard (`ui`) is deliberately **read-only**
-   (mutations stay in the CLI). One interface, no side doors: anything the
-   loop can do, the CLI can express.
-
-5. **State is durable; context is replayable.** Goals, todos, evidence, and
-   signals persist outside the chat (event-sourced, replayable). The ledger
-   (with evidence) is the **authority** on state and history; session
-   continuity is a valuable **cache**, refreshed from the ledger when the
-   world moved while the session was parked (see "Worker session lifecycle"
-   below). Whether to resume a session at all is the caller's choice, not
-   the kernel's.
-
-## The two categories of kernel behavior
-
-The kernel does exactly two kinds of things, distinguished by a single
-question: **if it is violated, is the goal's state now illegal?**
-
-- **Floors** — enforced; a violation puts the goal into an illegal state.
-  The kernel's only coercive power.
-- **Gauges** — computed and handed to the agent; *what to do about them is
-  never the kernel's business*. Some inform strategy, some cut off budget,
-  but all are information, not coercion.
-
-### A. Floors (enforced — deterministic kanban semantics)
-
-These are state-consistency hard constraints. Weakening them would put the
-goal into an illegal state:
-
-| Floor | Why it must stay |
-|---|---|
-| succession closure missing | completion must declare a successor / no-follow-up, or the goal can never close |
-| acceptance gap | hard contract: the acceptance token must be satisfied |
-| terminal judgement | deterministic kanban state: all todos done + gaps satisfied |
-| blocker | a blocker |
-| work leased to others | concurrency correctness |
-| verify gate | correctness: exit 0 before complete |
-| lease | concurrency mutual exclusion |
-
-Machine verification has a deliberate complement: **orchestrator judgement,
-recorded through the delivery closure**. A completion lands as `delivered`;
-the orchestrator (or operator) resolves it as `verified / failed / rework`
-by reading the artifact — the kernel records the judgement, never
-second-guesses it (a manual `todo complete` does not re-run `--verify`).
-
-### B. Gauges (information — never a forced replan)
-
-Everything the kernel computes and surfaces, the agent reads and acts on —
-or ignores. Both strategy hints and spend caps are kernel-computed
-quantities handed over, differing only in how the agent uses them, not in
-kind. None of them decides "you are stuck → replan".
-
-*Soft gauges (strategy hints)* — surfaced as advisories in the turn
-envelope, queryable via `status` / `diagnose`:
-
-| Gauge | Detection | What the agent sees |
-|---|---|---|
-| outcome floor | `surface_streak >= threshold` | N consecutive turns without a material outcome |
-| oscillation | A→V→A→V alternation | deliveries flip-flop accept/reject |
-| repair budget | `failed_attempts > MAX` | failed todos stay runnable (no filtering); "failed N times" |
-| monitor stall | `consecutive_no_change >= 3` | quiet wait + "consider expiring the watch lane" |
-| no-progress | `no_progress_turns >= 2` | "consider restarting with a fresh session" |
-
-*Hard gauges (spend caps)* — they bound consumption; when one trips, the
-goal waits and the orchestrator (or user) decides what next — still never a
-kernel-forced replan:
-
-| Gauge | What it caps |
-|---|---|
-| validation budget | a `--verify` gate that keeps failing still bounds the run loop |
-| quota | should-run decisions, scheduling refusals, spend |
-| turn timeout | one bounded turn at a time |
-
-The single distinction that matters: a floor says *this state is illegal*;
-a gauge says *here is a number* — and the response to a number is always a
-decision, which lives with the agent, not the kernel.
-
-## Run lifecycle & orchestrator notification
-
-How a run is launched, and how a worker reaches the orchestrator session,
-are architectural decisions (mechanisms of the principles above), fixed here:
-
-1. **Runs are detached (async).** The orchestrator never blocks on a run:
-   it dispatches the run as an independent process, immediately regains
-   control, and keeps watching other workers, reading signals, and answering
-   gates. A synchronous run would demote the orchestrator to "just another
-   worker" for the run's whole lifetime.
-
-   **This is a caller-side contract, not a kernel mechanism.** `run` is a
-   foreground CLI invocation; the kernel offers no server-side spawn or job
-   handle. Detachment is achieved by how the orchestrator launches it
-   (shell background / nohup / setsid / scheduler) and is enforced by
-   discipline: **the orchestrating agent must never run `future loop run`
-   synchronously and wait for a todo to complete** — while it blocks, no
-   worker is watched, no gate is answered, no signal is read, and the goal's
-   dead time is the orchestrator's fault (see the skill's drive playbook).
-   The liveness path below (lease + pid + scheduler tick) exists precisely
-   because detached runs cannot rely on a blocked caller noticing anything.
-
-2. **The ledger is the authoritative state.** Every worker writeback lands
-   in the event ledger — replayable, auditable, crash-safe. The ledger never
-   loses "what happened", even when every other channel fails.
-
-3. **Orchestrator awareness = push triggers + ledger pulls.** Because the
-   orchestrator is an LLM session (it has polling, not interrupts), state
-   *transitions* — completion, failure, a gate opening, a dead worker, a
-   signal escalating after N unacknowledged turns — are pushed to the
-   supervisor session as messages. Pushes are **volatile
-   triggers, not the record**: they are idempotent (dedup-keyed on the
-   transition, so re-sends are no-ops) and droppable (no supervisor
-   registered or agent unreachable → dropped, the ledger remains
-   authoritative). The orchestrator's ledger reads (`status`, `worker tail`,
-   the next turn envelope) always converge on the truth, so a lost message
-   costs latency, never correctness. Two push paths exist: the worker's own
-   transition reports, and the scheduler's dead-holder sweep for workers
-   that died too abruptly to report.
-
-4. **Detached runs are supervised by lease + pid liveness, not by a parent
-   process.** A synchronous run gets crash-supervision for free (the blocked
-   caller notices when the run dies). Detaching removes that implicit
-   supervision, so it is taken over formally: the scheduler's dead-holder
-   check (`notify_dead_holders`) notices a lease whose holder pid is gone
-   and pushes a relaunch prompt to the supervisor. Detach as default
-   therefore depends on this liveness path being reliable — it is the
-   primary supervision, not a fallback.
-
-### Supervision layers: the human supervises the orchestrator
-
-Supervision is a stack, and it tops out at a person:
-
-- **the orchestrator (supervisor) watches workers** — via the lease + pid
-  liveness above, plus `worker tail` for live inspection;
-- **the human watches the orchestrator.** The orchestrator is the top of the
-  automated supervision chain; nothing in the loop supervises it. When it
-  stalls, goes wrong, or decides a question needs a person, the human is
-  the escalation target. Workers reach the person only *through* the
-  orchestrator (they escalate, never address the human directly); how the
-  orchestrator then involves the person — and whether that freezes any work
-  — is orchestration-layer behavior the kernel does not constrain. The
-  person may also step in directly at any time (`todo update`, `worker
-  stop`, manual `todo complete`): automation below, a person at the top.
-
-## The kanban's structure: todos, dependencies, workers
-
-Three relations define how multi-worker work is laid out on the board, and
-— crucially — how information flows without any worker-to-worker messaging.
-
-**Todo↔todo: the dependency DAG is the board's skeleton.** `--blocks` edges
-are the *only* ordering mechanism — there is no global priority queue and
-no worker-level sequencing, only edges between todos. A fan-out is one todo
-blocking several downstream todos; a fan-in (synthesis) is one todo blocked
-by several upstream ones. The graph says *what must precede what*, nothing
-more.
-
-**Todo↔worker: weak, runtime-brokered binding.** A todo is not owned by any
-worker — it sits on the board for anyone to claim. Who actually does which
-todo is brokered at runtime in two steps: the orchestrator's intent when it
-spawns a worker (it knows which model should probe which direction), and
-the worker's claim when it matches (specialization, free lease). The
-relation is many-to-many and resolved dynamically; a **lease** is the
-"currently held" snapshot of it, giving mutual exclusion and liveness, not
-assignment. The kernel does not assign todos to workers — the orchestrator
-shapes the board, workers claim from it.
-
-**Worker↔worker: no direct messages — the board is the shared state.**
-Workers never talk to each other. Information moves only through three
-carriers, all mediated by the ledger: **evidence** (the durable declaration
-of what landed), the **artifact files** it points at (the report, the
-data), and the **turn envelope's context layer** (recomputed from the
-ledger into the next turn). A worker that "looks at upstream results and
-summarizes" is not receiving messages — that *is* its todo: it is ordered
-after the upstream todos by `--blocks`, its envelope injects their evidence
-and artifact paths, and it reads those artifacts.
-
-**Fan-out → synthesize → fan-out, in these terms.** Spawn several workers
-on different models along different directions (parallel todos, no mutual
-edges); a synthesis todo `--blocks` them all, so a downstream worker reads
-their artifacts and summarizes; a second wave of todos `--blocks` the
-synthesis. Grouping, model choice, direction assignment, and round
-progression are all **orchestration-layer** decisions (the orchestrator
-shapes the todo texts, `--blocks` wiring, and spawn configurations); the
-board only guarantees order (edges) and mutual exclusion (leases), and does
-not model *which artifact flows into which todo* — that wiring the
-orchestrator writes into the todo text and acceptance contract.
-
-## Steering vs. reconfiguring a running worker
-
-The orchestrator can change two different things about a worker mid-goal,
-and they take different mechanisms because they differ in whether the
-session survives:
-
-- **Change *what* it does (instruction / objective) → steer.** A
-  `supervisor steer` records a `WorkerSteered` event (latest wins) and the
-  worker's steer-watch aborts the current turn so the next turn drains the
-  instruction into its envelope. This is the *interrupt* form — not a silent
-  note-append: the in-flight reasoning is abandoned and the worker resumes
-  under the new instruction. The session (its accumulated context) survives.
-
-- **Change *what it runs on* (model / thinking level) → retire + respawn.**
-  Model and thinking level are properties of a session, fixed at spawn;
-  they are not hot-updatable through steer. Changing them means the
-  worker's *configuration* changed, and configuration is identity: retire
-  the session and spawn a fresh one on the new configuration, cold-starting
-  its context from the ledger (this is exactly what "context limit /
-  direction change" retirement already does). So reconfiguration is not a
-  third channel — it is the ordinary retire-and-respawn transition applied
-  to a config change.
-
-The rule of thumb: **steer changes the task; respawn changes the worker.**
-Both are orchestrator decisions; the kernel only records the events.
-
-## Worker session lifecycle
-
-A worker session is a **first-class lifecycle object**, not an appendage of
-a run: the orchestrator spawns it, attaches work to it, parks it, resumes
-it, and retires it. Resume-vs-fresh is one transition inside this
-lifecycle, not the whole story.
-
-### States and transitions
-
-```
-   spawn ──► ACTIVE (on duty, holds a lease, executing turns)
-                │   ▲
-     interrupt  │   │ resume (InfraRecoverable → back to the
-                ▼   │   pre-interruption state)
-           INTERRUPTED (FailureKind recorded)
-                │
-                ├── InfraRecoverable → resume
-                ├── ContextCorrupted → RETIRE + spawn fresh
-                └── HardError        → RETIRE + spawn fresh
-
-   ACTIVE ──park──► PARKED (no matching work / cost / quota; context sealed)
-   ACTIVE ◄─resume + delta── PARKED
-
-   any state ──► RETIRE: goal done / direction changed (mass supersede) /
-                context limit / explicit fresh. Retired ≠ deleted — the
-                ledger keeps everything.
-```
-
-A session in **either** ACTIVE or PARKED can be interrupted (a parked
-session cannot hit a 429, but its host can die) — INTERRUPTED records the
-interruption, and an `InfraRecoverable` resume returns to the state the
-session was in.
-
-**When to park**:
-
-- no runnable todo matches this worker's specialization (model, thinking
-  level, accumulated todo context) — don't let it spin polling;
-- cost control: keeping a session alive while waiting on a monitor/gate is
-  not worth it;
-- quota pressure: yield session capacity to a higher-priority goal.
-
-**What a resumed session needs** — a parked session's *reasoning chain* (why
-it chose an approach, what it tried that failed) is its real value and is
-kept as-is; but the *world* changed while it slept, and resuming on a stale
-world model is the biggest resume pitfall. The refresh is just the ordinary
-turn envelope, recomputed from the ledger on the resume turn (see "The turn
-envelope" below): because the envelope's context layer is always derived
-live from the ledger, a resumed session automatically sees the world as it
-is now — new todos, fresh evidence, current gauges, gate verdicts.
-
-**When fresh is mandatory (RETIRE + spawn, never resume)**:
-
-- `ContextCorrupted`: the verify gate rejected the output — the reasoning
-  chain is polluted and would carry a false premise forward;
-- direction change: after a mass supersede / replan, the old context is
-  residue of dead routes;
-- context limit: retire *before* hitting the token ceiling, with a handoff —
-  the outgoing worker writes "what I learned, where the pits are" into the
-  ledger (this is exactly why evidence is enforced non-empty), and the fresh
-  session cold-starts from the ledger.
-
-### FailureKind: classifying the interruption
-
-`FailureKind` classifies an interruption to decide the INTERRUPTED →
-(resume | RETIRE) branch:
-
-- `InfraRecoverable` — the accident was *outside* (429 / rate-limit /
-  connection reset / agent crash / stream gap); the reasoning state is
-  intact: **resume**.
-- `ContextCorrupted` — the accident was *in the reasoning*: the verify gate
-  rejected the output, so the reasoning state is polluted: **fresh**.
-- `HardError` — the turn errored without a recoverable infra cause: **fresh**.
-
-The kernel only provides this classification (observation data); the caller
-decides resume-vs-fresh explicitly. **Fresh is the default — there is no
-`--session-policy` flag.** The only resume path is an explicit pin
-(`--resume-session <id>`), because the goal-level retention holds a single id
-and is ambiguous with parallel workers. The kernel stays a pure tool: it
-provides state and signals, but never makes the decision.
-
-Two scoping rules keep the lifecycle simple: parking happens at **turn
-boundaries** (no preemptive mid-turn suspension or checkpoints), and a
-session is bound to **one goal** (no cross-goal reuse — context
-contamination outweighs the savings).
-
-**How the states map to the kernel's actual surface.** The lifecycle above is
-the model; the kernel implements it with fewer moving parts, and the mapping
-matters when reasoning about behavior:
-
-- **ACTIVE / INTERRUPTED** are explicit: a run is a live process holding
-  leases; the writeback stamps a `FailureKind` per turn and `cmd_run` records
-  a `SessionRetention` (id + classification + resumable advisory) when the
-  run exits.
-- **PARKED has no dedicated state.** A quiet-wait exit (monitor not due,
-  blocker with no fallback, work leased to others, gated with no fallback)
-  retains the session and stops — the *effect* of parking, derivable from
-  the goal's frontier. Resuming "with delta" is just the ordinary turn
-  envelope recomputed from the ledger on the next `run`.
-- **RETIRE has no dedicated state either.** `worker stop --delete` and a
-  non-resumable retention (`HardError` / `ScienceVerifyFailed`) are the
-  retire transition: the next run cold-starts fresh from the ledger. A
-  context-limit hit classifies as `HardError`, so it retires by the same
-  rule — there is no separate pre-emptive "retire before the ceiling with a
-  handoff todo" mechanism; write the handoff into evidence before the
-  context runs out.
-- **spawn** is `run`'s session creation; there is no orchestrator-side
-  session registry beyond the ledger's `worker_session_bound` events.
-
-## The turn envelope: what the orchestrator injects into a worker
-
-The turn envelope is the single information interface between the
-orchestrator/kernel and a worker — the per-turn prompt the worker executes.
-It carries **two layers**, and deliberately not a third:
-
-- **Instruction layer (every turn)** — the TODO text and the completion
-  contract ("report what you did; declare the successor or
-  `--no-follow-up`"). Without these the worker has neither a task nor a
-  definition of done.
-- **Context layer (recomputed from the ledger every turn)** — the goal and
-  objective, the previous turn's evidence, this todo's failure history
-  (classified), recent semantic history, and resolved gate verdicts. This
-  is what stops the worker re-doing work and re-stepping into known pits —
-  it is where "durable artifacts, not session memory" actually lands.
-
-**Not in the envelope: the kernel's scheduling internals.** The should-run
-verdict, mode, and arbitration disposition are the kernel's *own* decision
-state, addressed to the orchestrator and the operator — not to the worker.
-Putting them in the worker's prompt would leak the scheduler's hesitation into
-the executor (a worker's job is how to do the work, not whether the kernel
-thought it should run) and blur the observe/decide split. The envelope tells
-the worker *what to do and the context to do it well*; it does not tell the
-worker what the kernel was thinking.
-
-**In the envelope: the observable signals.** Signals (outcome floor,
-oscillation, failure count, no-progress) are a different kind of quantity:
-observations about the *work*, recomputed from the ledger — not the kernel's
-hesitation. Principle 1 promises them as advisories "in the turn envelope",
-and that is where they live: the envelope's context layer carries a `signals`
-block recomputed by the same kernel detectors that render the delivery
-reason's advisories (one detector set, two consumers — the orchestrator reads
-them in the packet reason, the worker reads them in the envelope). What to do
-about a signal is, as everywhere, a decision — never a kernel directive.
-
-**One envelope, no special cases.** A first turn, a resumed turn, and an
-ordinary turn all use the same envelope; the differences fall out of
-whatever the ledger currently holds. A first turn's envelope is naturally
-short (no failure history, no previous evidence); a resumed turn's envelope
-naturally reads as "the world since you parked" — because the context layer
-is always computed live from the ledger.
-
-## Trust & authorization boundary
-
-A worker runs **with the user's full trust domain**: it executes arbitrary
-shell (a `--verify` gate is a command), writes its workspace, and a steer
-message injects instructions into it. There is no sandboxing layer in the
-loop itself; containment is the **workspace boundary** (a worker stays in
-its workspace unless `--force-workspace` says otherwise). When a worker
-reaches something at or beyond that edge — irreversible, expensive,
-credential-bound — it does not decide "this needs a human"; it escalates to
-the orchestrator, which decides whether to proceed, reroute, or involve the
-person. Autonomy inside the trust domain, the orchestrator as the gate at
-its edge.
+# Loop architecture: durable kanban, reliable controls, evidence-driven agents
+
+Operational commands: [control plane guide](../../docs/loop-control-plane.md).
+Agent driving policy: `skills/builtin/future-loop/SKILL.md`; research methodology:
+`skills/builtin/future-research/SKILL.md` (the skills submodule).
+
+## Boundaries
+
+The model chooses strategies, interprets scientific evidence, and asks people for
+judgment. The kernel supplies deterministic state, dependencies, leases, evidence,
+validation, and advisory signals. It does not force a replan because a heuristic
+says a worker is stuck. More rules are not a substitute for giving the agent the
+right evidence.
+
+The event ledger is authoritative. Sessions are useful caches, not durable task
+memory. All control capabilities are exposed through the CLI; the dashboard remains
+strictly read-only. The human supervises the orchestrator's judgment. A non-LLM
+watchdog supervises process liveness and notification transport, not reasoning.
+
+## Floors, signals, and budgets
+
+- **Floors:** legal task transitions, explicit completion intent, acceptance gaps,
+  dependency constraints, leases, and validated terminal closure.
+- **Signals:** unsuccessful attempts, outcome streaks, oscillation, missing artifact
+  activity, monitor state, reported milestones. These describe observations, not
+  mandatory strategy changes.
+- **Bounds:** outer run iteration limits, validation attempt limits and independent
+  validator wall time. Do not confuse `--max-turns` with a token/currency cap or
+  a timeout for the agent's entire inner reasoning/tool loop.
+
+Manual completion intentionally differs from machine verification: it records a
+manual review (or explicit operator override), never a fabricated validator pass.
+A delivery is initially pending. `delivery record` records the reviewer's judgment;
+the kernel cannot establish the truth of a scientific claim by checking tokens or
+file existence. Changes to acceptance standards need explicit justification.
+
+## Task graph and ownership
+
+Advancement tasks declare incoming prerequisites using `--blocks`; gates/blockers
+can declare outgoing dependents. Both edge directions are honored by scheduling
+and manual completion. An open scoped gate blocks its dependents, not unrelated
+work. `--global-gate` is the explicit global freeze. Resolve decisions with
+`gate resolve`, not `todo complete`.
+
+`--owner` is a durable assignment; lease expiry does not remove it. Unowned todos
+form an intentionally shared pool. Unique worker IDs are required for parallel
+runs; sharing an ID defeats own-lease exclusion. Coordination todos belong to the
+orchestrator and never enter a worker's advancement frontier. Workspace guards
+remain mandatory unless a caller has established non-conflicting write sets.
+
+Dependencies determine eligibility; priority only orders eligible offers. Workers
+exchange knowledge through evidence and artifacts, not an additional negotiation
+protocol. Fan-out, synthesis and a subsequent fan-out are expressed as ordinary
+todos and dependency edges.
+
+## Durable steering
+
+New steering uses `ControlIssued` with a UUID, target (worker or broadcast), text
+and interrupt flag. Routine guidance waits for a turn boundary; `--interrupt`
+additionally aborts the in-flight session. Latest-wins is restricted to the SAME
+scope. A target-specific instruction cannot erase another worker's instruction;
+broadcast and target-specific guidance can both appear, in ledger order.
+
+`ControlAcknowledged` is recipient-specific and written only after a completed
+turn's durable run record. One recipient does not consume a broadcast for everyone.
+A failed transport or interrupted turn leaves instructions pending. This is
+**at-least-once guidance**, not exactly-once external side effects: a crash after
+execution but before acknowledgment can replay an instruction. Guidance must be
+idempotent; irreversible operations still need their own approval/idempotency.
+
+The interrupt watcher does not advance over incomplete JSONL lines or failed
+interrupt delivery. Legacy `WorkerSteered` / `SteerConsumed` events remain readable
+for old ledgers, but new CLI instructions never use their single-slot projection.
+Model/thinking configuration changes require an appropriately configured new
+session, not a steering message.
+
+## Detached execution and independent liveness
+
+Production `run` re-executes into a detached child and checks for immediate startup
+failure. `--detach` marks the internal foreground child;
+`FUTURE_LOOP_NO_DETACH=1` is the foreground embedding/test escape hatch. The unified
+`future` binary retains its `loop` dispatch prefix when re-executing.
+
+A successful detached dispatch or supervisor registration also ensures an
+independent `supervisor watch --goal G` process exists. An OS file lock allows
+only one watcher per goal. Every two seconds it observes dead lease holders,
+flags deliveries awaiting verification for five minutes, and services the outbox.
+It remains alive when the last worker dies and does not require another paid run
+or an LLM polling session to discover the failure. `scheduler tick` and post-run
+sweeps remain supplemental reconciliation triggers.
+
+The watcher exits when the goal is deleted/cancelled or terminal with no pending
+notification. It is not an OS boot service: after host restart, launch the same
+CLI under a service manager or re-register/resume the goal. No local process can
+guarantee progress through host power loss without a host restart mechanism.
+
+Lifecycle commands stop invalidated workers before removing their state. Late
+completion cannot resurrect superseded tasks. This is distinct from interrupting
+for new guidance, where the task remains resumable.
+
+## Durable, batched supervisor outbox
+
+1. Persist `SupervisorNote` before connecting to the agent, even with no supervisor.
+   Deduplicate by episode key.
+2. Prepare an immutable `SupervisorBatchPrepared`: target session, note keys,
+   bounded message, UUID. A batch contains at most 32 notes and points to full
+   ledger evidence. The watchdog coalesces notes arriving between ticks.
+3. Push with `enqueue_if_busy`, never interrupting the supervisor. A retry uses
+   exactly the same request key AND message, including after an ambiguous reply.
+4. Record `SupervisorBatchDelivered` only after remote acceptance. This receipt
+   means accepted by the agent queue, not that the supervisor acted on it.
+
+The ledger, prepared batches, receipts and OS lock prevent concurrent flushers
+from independently delivering the same pending notes. If transport fails, retain
+and retry. A new registered supervisor can recover notes from the ledger. Treat
+old notifications as prompts to reconcile CURRENT status, not unconditional orders
+to restart a worker. Foreground embedders without a watchdog may flush immediately;
+the same persistence and replay rules apply.
+
+## Bounded validators
+
+Validators run asynchronously with independent wall time (120 seconds default;
+positive `FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS` override). Both output pipes are
+continuously drained; only bounded diagnostic tails are retained. Hung validators
+or inherited pipes time out. Cancellation/timeout cleans up the subprocess tree
+(Unix process groups; Windows process-tree termination).
+
+Commands use `sh -c` on Unix and `cmd.exe /D /S /C` on Windows. Shell language is
+therefore platform-specific; portable tasks should invoke a portable checker.
+A failed command returns diagnostics for repair; a spawn/timeout failure is
+inconclusive rather than a passed check. Receipt metadata must not hide manual
+review behind a machine-pass label.
+
+## Turn envelope and evidence handoff
+
+Every turn includes the objective, todo, explicit acceptance/validator contract,
+resolved decisions, upstream evidence, prior evidence, relevant failures, a small
+recent-history window and advisory signals. Recent reported milestones are also
+fed back as claims to verify, not proven results.
+
+For fan-in, every resolved predecessor gets an index entry. Summary bytes are
+shared fairly; an early verbose source cannot consume the entire budget. The
+index is O(fan-in), while summaries remain bounded. Full evidence is available via
+`status --format json`. Superseded sources are labeled, not treated as verified.
+The orchestrator must name artifact paths in downstream task text; summaries are
+not a substitute for reading reports and reproducing decisive measurements.
+
+Separate **liveness**, **activity** and **progress**. `write/edit` execution starts
+are artifact-activity proxies; shell calls are not automatically writes. Provider
+input/execution phases are not double-counted. Actual progress requires evidence:
+new artifacts, validation, measured improvements or falsified hypotheses. Neither
+file churn nor uninterrupted thinking proves progress or lack of it.
+
+## Proportional orchestration and honest stopping
+
+Use light, standard or heavy workflows according to uncertainty/risk. A code
+review does not require a fixed citation count or a worker swarm. Parallelize
+meaningfully different methods only when the expected benefit exceeds overhead.
+Confirm worker configuration and resource limits; do not silently override them.
+
+At checkpoints, compare new evidence and remaining gap with expected next-step
+cost. Stop as achieved, bounded infeasible, budget-limited, low-return, or blocked.
+Only achieved work satisfies successful closure. Preserve partial artifacts and
+acceptance gaps; ask before expanding budget. Proving all conceivable methods
+impossible is not required to stop an open-ended investigation honestly.

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -1,337 +1,114 @@
-# Loop 架构：一个 kanban 工具，不是一个规则引擎
-
-本文档阐述 loop 控制平面的设计原则。运维模型（概念、命令、多 agent 编排）见
-`docs/loop-control-plane.zh-CN.md`；面向 agent 的驾驶手册见 `future-loop`
-SKILL.md。
-
-## 设计原则
-
-1. **kanban，不是规则引擎。** 内核提供确定性工具——todo 状态、verify 门、
-   acceptance 契约、evidence、lease——从不替 agent 判断「你卡住了，停下来重新
-   规划」。它计算信号（outcome floor、振荡、失败次数、monitor 停滞、无进展回合），
-   并以 **advisory（提示）** 的形式放进 turn envelope（回合信封）；如何处理信号是决策，
-   而决策不留在内核里。
-
-2. **agent 是编排者——要有可观测性和控制杆。** 决策者是大模型，不是内核。
-   内核只守住**正确性底线**——保证 goal 状态合法的硬约束（verify 门、
-   acceptance 契约、终局判定、lease）——从不判断一个*探索性*
-   结果*对不对*。但「agent 决策」只有当 agent 能*看见*、能*动手*时才有意义。
-   所以 loop 交给编排者的不只是状态，还有控制杆：
-
-   - **观测** — 四个面，不只是 `tail`：
-     - **行为流（过程）** — `worker tail` 实时流式查看 worker 的回合日志
-       （压缩的工具/用量视图）：看 worker 的*手*；
-     - **产物（结果）** — 读 evidence 指向的文件（报告、数据）：这是编排者
-       判断*探索性*结果的方式——不是盯过程，而是读*活*；
-     - **账本（状态与历史）** — `status` / `diagnose` 按需暴露 todo 状态、
-       信号、gate、lease：权威看板；
-     - **推送（事件）** — supervisor 通知送达状态转换点（见「run 生命周期与
-       编排者通知」）；
-   - **steer** — `supervisor steer` 打断/纠正正在运行的 worker，
-     `todo update` 在看板上中途调整；
-   - **停止** — `worker stop` 由编排者判断后停下 worker；
-   - **关闭** — 手动 `todo complete` **有意不**重跑机器 `--verify` 门：
-     对探索性交付物，编排者读产物就是判定，内核不做二次猜测。
-
-   因此可观测性和可 steer 性是架构的一部分，不是便利功能：它们让「编排者」
-   真正成立。
-
-   **worker 只上浮，从不判断要不要找人。** worker 遇到自己解决不了的事，
-   不会去开一个「user gate」、也不判断「这事该人来做」——它**上浮给编排者**
-   （一个信号/消息，不是冻结），自己那条道照常。*这件事到底要不要人*，是
-   编排者的判断：它可以直接答、调整 todo、换策略，或者——只有到这一步——
-   才提给那个人。编排者怎么找到人（以及那要不要冻结什么）**loop 不约束**——
-   那是编排层行为，在内核之外。所以内核没有 `blocked_by: human` 概念、也没有
-   worker 开启的 gate：只有依赖边（`--blocks`，工作必须等待）和一条可靠的
-   worker→编排者上浮通道。人位于监督栈的顶端（见「监督的层级」），*经由*
-   编排者触达，worker 从不直接找人。
-
-3. **用户通过 skill 使用 loop。** 用户不直接编排内核；他们说出目标
-   （`/future-loop <任务>`），由 agent——在 `future-loop` SKILL.md 的指导下——
-   拆解目标、驱动 run、读取信号、上浮决策点。SKILL.md 负责「什么时候做什么、
-   怎么拆解、怎么 steer」（编排层）；CLI/内核是底层机制（状态 + 硬检查）。决策
-   指引放在 SKILL.md，正因为那才是决策者（大模型）会读的地方。
-
-4. **一切能力经 CLI 暴露。** `future loop <cmd>` 是控制平面唯一的机器接口：
-   每一次状态变更——goal/todo 变更、gate 裁决、lease、steer、停止、完成——都是
-   一次 CLI 调用，确定性、可在事件账本中审计。skill 代表 agent 驱动 CLI；人类
-   operator 敲同样的命令；dashboard（`ui`）**有意只读**（变更留在 CLI）。一个
-   接口，没有旁门：loop 能做的任何事，CLI 都能表达。
-
-5. **状态持久化，上下文可重放。** goal、todo、evidence、信号都持久化在对话之外
-   （event-sourced、可重放）。**账本（含 evidence）是状态与历史的权威**；session
-   连续性是有价值的**缓存**，当封存期间世界变了、缓存失效时，以账本为准、经增量
-   信封刷新（见下文「worker 会话生命周期」）。是否 resume 一个会话，始终是调用方
-   的选择，不是内核的。
-
-## 内核行为的两类划分
-
-内核只做两类事，用一个问题区分：**违反它，goal 的状态是否就非法了？**
-
-- **底线（floors）** —— 强制执行；违反就让 goal 陷入非法状态。内核唯一
-  的强制力。
-- **仪表（gauges）** —— 算好递给 agent；*拿它怎么办从来不是内核的事*。
-  有的供策略参考、有的掐断预算，但都是信息，不是强制。
-
-### A. 底线（强制：kanban 的确定性语义）
-
-这些是状态一致性的硬约束，弱化它们会让 goal 陷入非法状态：
-
-| 底线 | 为什么必须保留 |
-|---|---|
-| succession closure missing | 完成必须声明 successor / no-follow-up，否则 goal 永远无法关闭 |
-| acceptance gap | 硬契约：acceptance token 必须满足 |
-| 终局判定 | kanban 确定性状态：所有 todo done + gaps 满足才关闭 |
-| blocker | 阻塞器 |
-| work leased to others | 并发正确性 |
-| verify 门 | 正确性：exit 0 才 complete |
-| lease | 并发互斥 |
-
-机器验证有一个有意的互补面：**编排者判断，经交付闭环记录**。完成先落到
-`delivered` 待决态；编排者（或 operator）读产物后裁决为
-`verified / failed / rework`——内核记录这个判断，不做二次猜测（手动
-`todo complete` 不重跑 `--verify`）。
-
-### B. 仪表（信息：永远不强制 replan）
-
-内核算出并浮现的一切，agent 读了自行处置——或忽略。策略提示与花费封顶
-都是内核算好递出的量，区别只在 agent 怎么用，不在种类。没有一个决定
-「你卡住了 → replan」。
-
-*软仪表（策略提示）* —— 以 advisory 形式浮现在 turn envelope，也可经
-`status` / `diagnose` 查询：
-
-| 仪表 | 检测条件 | agent 看到的提示 |
-|---|---|---|
-| outcome floor | `surface_streak >= threshold` | 连续 N 个回合无实质产出 |
-| 振荡（oscillation） | A→V→A→V 交替 | 交付在 accept/reject 之间反复 |
-| repair budget | `failed_attempts > MAX` | 失败 todo 仍 runnable（不再过滤），提示「已失败 N 次」 |
-| monitor 停滞 | `consecutive_no_change >= 3` | quiet wait + 「考虑让 watch lane 过期」 |
-| 无进展（no-progress） | `no_progress_turns >= 2` | 「考虑用全新会话重启」 |
-
-*硬仪表（花费封顶）* —— 封顶消耗；某个触发后 goal 等待，接下来怎么办
-由编排者（或用户）决定——同样永远不是内核强制的 replan：
-
-| 仪表 | 封顶什么 |
-|---|---|
-| validation budget | `--verify` 门一直失败仍限制 run loop 的回合数 |
-| quota（配额） | should-run 判定、调度拒绝、花费 |
-| turn 超时 | 一次一个有界回合 |
-
-唯一重要的区分：底线说*这个状态非法*；仪表说*这有个数*——而对一个数
-的回应永远是决策，决策在 agent，不在内核。
-
-## run 生命周期与编排者通知
-
-run 如何发起、worker 如何触达编排会话，属于架构决策（上述原则的实现
-机制），在此固定：
-
-1. **run 是 detached（异步）的。** 编排者从不被 run 阻塞：它把 run
-   作为独立进程派发出去，立即拿回控制权，继续盯其他 worker、读信号、
-   响应 gate。同步 run 会把编排者在 run 的整个生命周期内降级成「又一个
-   worker」。
-
-   **这是调用方契约，不是内核机制。** `run` 是一个前台 CLI 调用；内核不
-   提供服务端 spawn 或 job handle。分离靠编排者怎么启动它（shell 后台 /
-   nohup / setsid / 调度器）达成，靠纪律维持：**编排 agent 绝不能同步地
-   跑 `future loop run` 并原地等某个 todo 完成**——阻塞期间没有 worker
-   被盯、没有 gate 被应答、没有信号被读，goal 的死时间就是编排者的过错
-   （见 skill 的 drive playbook）。下文的 liveness 路径（lease + pid +
-   scheduler tick）之所以存在，正是因为 detached run 不能指望一个阻塞的
-   调用者会注意到什么。
-
-2. **账本是权威状态。** worker 每次 writeback 落在事件账本里——可重放、
-   可审计、崩溃不丢。即使其他所有通道都失败，账本也永远不会丢「发生过
-   什么」。
-
-3. **编排者感知 = push 触发 + 账本拉取。** 因为编排者是 LLM 会话（只有
-   轮询、没有中断），状态*转换点*——完成、失败、gate 打开、worker 死亡——
-   以及信号在连续 N 个回合未被响应后的升级——
-   以消息形式 push 给 supervisor 会话。push 是**易失的触发器，不是记录**：
-   幂等（按转换去重，重发即 no-op）、可丢弃（未注册 supervisor 或 agent
-   不可达 → 丢弃，账本仍是权威）。编排者的账本读取（`status`、
-   `worker tail`、下一个 turn envelope）总会收敛到真相，所以丢消息只损失
-   延迟，永不损失正确性。push 有两条路径：worker 自己的转换报告，以及
-   scheduler 对死得来不及报告的 worker 的 dead-holder 清扫。
-
-4. **detached run 由 lease + pid 活性监督，而不是父进程。** 同步 run 免费
-   获得崩溃监督（被阻塞的调用方会在 run 死掉时立刻感知）。detach 拿掉了
-   这层隐式监督，所以要正式接管：scheduler 的 dead-holder 检查
-   （`notify_dead_holders`）发现持有进程 pid 已消失的 lease，向 supervisor
-   push 重启提示。因此 detach 成为默认的前提是这条活性路径可靠——它是
-   主监督，不是兜底。
-
-### 监督的层级：人来监督编排者
-
-监督是一个栈，顶端是人：
-
-- **编排者（supervisor）监督 worker** —— 通过上面的 lease + pid 活性，
-  以及 `worker tail` 做实时查看；
-- **人监督编排者。** 编排者是自动化监督链的顶端；loop 里没有任何东西
-  监督它。当它停滞、走错、或判断某事需要人时，人是上浮的终点。worker
-  只能*经由*编排者触达人（它上浮，从不直接找人）；编排者之后如何让人
-  参与——以及那要不要冻结任何工作——是编排层行为，内核不约束。人也可以
-  随时直接介入（`todo update`、`worker stop`、手动 `todo complete`）：
-  下层自动化，顶端是一个人。
-
-## 看板的结构：todo、依赖、worker
-
-三种关系定义了多 worker 工作如何在看板上铺开——关键在于，信息如何在不
-存在 worker 间直接消息的情况下流动。
-
-**todo↔todo：依赖 DAG 是看板的骨架。** `--blocks` 边是*唯一*的排序机制——
-没有全局优先级队列，也没有 worker 层面的先后，只有 todo 之间的边。扇出
-是一个 todo 阻塞多个下游 todo；汇总（综合）是一个 todo 被多个上游 todo
-阻塞。图只表达*什么必须先于什么*，别无其它。
-
-**todo↔worker：弱绑定、运行时撮合。** todo 不专属于任何 worker——它摆在
-看板上谁都能认领（lease）。实际「谁干哪个」在运行时两步撮合：编排者
-spawn worker 时的意图（它知道该让哪个模型探哪个方向），以及 worker 认领
-时的匹配（专精、lease 空闲）。关系是多对多、动态解析的；**lease** 是它的
-「当前占用」快照，提供互斥与活性，而不是指派。内核不把 todo 指派给
-worker——编排者塑形看板，worker 从看板认领。
-
-**worker↔worker：没有直接消息——看板即共享状态。** worker 之间从不互相
-说话。信息只经由三个载体流动，全部由账本中转：**evidence**（落地什么的
-持久声明）、它指向的**产物文件**（报告、数据）、以及 **turn envelope 的
-上下文层**（下一回合从账本重算注入）。一个「查看上游结果并总结」的
-worker 并不是在收消息——那*就是*它的 todo：它被 `--blocks` 排在上游 todo
-之后，它的信封注入上游的 evidence 和产物路径，它去读那些产物。
-
-**扇出 → 汇总 → 扇出，用这些概念说。** 用不同模型沿不同方向 spawn 若干
-worker（并行 todo，互无边）；一个汇总 todo `--blocks` 它们全部，于是下游
-worker 读它们的产物做综合；第二轮 todo `--blocks` 这个汇总。编组、选模型、
-分方向、定轮次，全是**编排层**的决策（编排者塑形 todo 文本、`--blocks`
-接线与 spawn 配置）；看板只保证顺序（边）与互斥（lease），并不建模*哪个
-产物流向哪个 todo*——这部分接线由编排者写进 todo 文本和 acceptance 契约。
-
-## steer 与重配一个运行中的 worker
-
-编排者可以在 goal 中途改变 worker 的两类东西，它们走不同机制，因为区别
-在于会话是否存活：
-
-- **改「做什么」（指令/目标）→ steer。** `supervisor steer` 记录一个
-  `WorkerSteered` 事件（latest wins），worker 的 steer 监听中止当前回合，
-  让下一回合把该指令排进信封。这是*打断*式——不是悄悄附加：进行中的推理
-  被放弃，worker 在新指令下继续。会话（它积累的上下文）存活。
-
-- **改「用什么跑」（模型/思考等级）→ 退役 + 重开。** 模型和思考等级是会话
-  的属性，spawn 时固定，不能经 steer 热更新。改它们意味着 worker 的*配置*
-  变了，而配置即身份：退役该会话、用新配置 spawn 一个全新会话，上下文从
-  账本冷启动（这正是「上下文超限/方向调整」退役本就在做的事）。所以重配
-  不是第三条通道——它就是普通的退役-重开转移，应用到配置变更上。
-
-经验法则：**steer 改任务，respawn 改 worker。** 两者都是编排者的决策，
-内核只记录事件。
-
-## worker 会话生命周期
-
-worker 会话是一个**一等生命周期对象**，不是 run 的附属物：编排者创建它、
-往它身上挂工作、泊车它、恢复它、最终退役它。resume-vs-fresh 只是这个
-生命周期里的一个转移，不是全部。
-
-### 状态与转移
-
-```
-   spawn ──► ACTIVE（在岗，持 lease 执行 turn）
-                │   ▲
-        中断    │   │ resume（InfraRecoverable → 回到中断前状态）
-                ▼   │
-           INTERRUPTED（FailureKind 已记录）
-                │
-                ├── InfraRecoverable → resume
-                ├── ContextCorrupted → RETIRE + spawn fresh
-                └── HardError        → RETIRE + spawn fresh
-
-   ACTIVE ──泊车──► PARKED（无匹配工作/成本/配额；上下文封存）
-   ACTIVE ◄─resume + 增量── PARKED
-
-   任意状态 ──► RETIRE（退役）：goal 完成 / 方向调整（大面积 supersede）/
-              上下文超限 / 显式 fresh。退役 ≠ 删除——账本永存。
-```
-
-ACTIVE 或 PARKED 中的会话都可能被中断（parked 会话不会撞 429，但它的
-宿主会死）——INTERRUPTED 记录中断，`InfraRecoverable` 的 resume 回到
-会话中断前所处的状态。
-
-**何时泊车（PARKED）**：
-
-- 没有 runnable todo 匹配这个 worker 的专精（model、thinking level、已
-  积累的 todo 上下文）——不让它空转轮询；
-- 成本控制：等 monitor/gate 期间保活一个会话不值得；
-- 配额压力：把会话资源让给更高优先级的 goal。
-
-**恢复的会话需要什么** —— 泊车会话的*推理链*（为什么选这条路、试过什么
-失败了）是它真正的价值，原样保留；但封存期间*世界*变了，带着陈旧的世界
-模型继续干活是 resume 最大的坑。刷新就是 resume 那个回合从账本重算的
-普通 turn envelope（见下文「turn envelope」）：因为信封的上下文层永远从
-账本实时推导，恢复的会话自动看到此刻的世界——新 todo、新 evidence、当前
-仪表、gate 裁决。
-
-**何时必须 fresh（RETIRE + spawn，绝不 resume）**：
-
-- `ContextCorrupted`：verify 门拒绝了输出——推理链已被污染，续它会带着
-  错误前提继续；
-- 方向调整：大面积 supersede / replan 后，旧上下文全是作废路线的残留；
-- 上下文超限：在撞到 token 上限*之前*退役，安排一次交接——旧 worker 把
-  「学到什么、坑在哪」写进账本（这正是 evidence 强制非空的价值），fresh
-  会话从账本冷启动。
-
-### FailureKind：中断的分类
-
-`FailureKind` 对中断分类，决定 INTERRUPTED →（resume | RETIRE）的分支：
-
-- `InfraRecoverable` — 事故在*外面*（429 / 限流 / 连接重置 / agent 崩溃 /
-  流间隙），推理状态完好：**可 resume**。
-- `ContextCorrupted` — 事故在*推理里*：verify 门拒绝了输出，推理状态已
-  污染：**应 fresh**。
-- `HardError` — 回合出错且无可恢复的基础设施原因：**应 fresh**。
-
-内核只提供这个分类（观察数据）；resume-vs-fresh 由调用方显式决策。
-**默认即 fresh —— 没有 `--session-policy` 标志。** 唯一恢复路径是显式 pin
-（`--resume-session <id>`），因为 goal 级 retention 只存单个 id，并行 worker
-下有歧义。内核依然是纯工具——提供状态和信号，但**从不替 agent 做决策**。
-
-两条界定让生命周期保持简单：泊车发生在 **turn 边界**（不做 turn 中途的
-抢占式挂起或检查点），会话绑定**一个 goal**（不跨 goal 复用——上下文
-污染风险大于收益）。
-
-## turn envelope：编排者给 worker 注入什么
-
-turn envelope 是编排者/内核与 worker 之间唯一的信息接口——worker 执行的
-每回合 prompt。它携带**两层**，并有意不含第三层：
-
-- **指令层（每回合）** —— TODO 文本和完成契约（「报告你做了什么、观察
-  到什么；声明 successor 或 `--no-follow-up`」）。没有这两个，worker 既
-  不知道干什么、也不知道什么叫完成。
-- **上下文层（每回合从账本重算）** —— goal 与 objective、上一回合的
-  evidence、本 todo 的失败史（已分类）、近期语义历史、已裁决的 gate。这
-  让 worker 不重复劳动、不再踩已知的坑——「持久产物而非 session 记忆」
-  正落在这里。
-
-**不在信封里：内核的调度内部状态。** should-run 判定、mode、arbitration
-处置是内核*自己的*决策状态，是给编排者和 operator 看的——不是给 worker
-的。把它们放进 worker 的 prompt，等于把调度器的犹豫泄漏进执行者（worker
-该关心的是怎么干活，不是内核觉得该不该跑），也模糊了观察/决策的分离。信封
-告诉 worker *做什么、以及做好它所需的上下文*；不告诉 worker 内核在想什么。
-
-**在信封里：可观察信号。** 信号（outcome floor、oscillation、失败计数、
-无进展）是另一类量：它们是对*工作本身*的观察、从账本重算——不是调度器的
-犹豫。原则 1 承诺信号以 advisory 形式进 turn envelope，它们确实在那里：
-信封的上下文层携带一个 `signals` 块，由与 delivery reason 的 advisory
-相同的内核检测器重算（一套检测器、两个消费者——编排者从 packet reason 读，
-worker 从信封读）。对信号如何处置，一如全程，是决策而非内核指令。
-
-**一个信封，没有特例。** 第一回合、resume 的回合、普通回合用同一个信封，
-差异完全由账本此刻装着什么自然产生。第一回合的信封自然短（没有失败史、
-没有上一回合 evidence）；resume 回合的信封自然读起来像「你泊车以来的
-世界」——因为上下文层永远从账本实时算。
-
-## 信任与授权边界
-
-worker 以**用户的完整信任域**运行：它执行任意 shell（一个 `--verify` 门就是
-一条命令）、写它的 workspace，steer 消息能向它注入指令。loop 本身没有沙箱层；
-隔离靠 **workspace 边界**（worker 留在自己的 workspace，除非 `--force-workspace`
-另有指定）。当 worker 碰到处于或超出这条边界的事——不可逆、昂贵、需凭据——
-它不判断「这要找人」，而是上浮给编排者，由编排者决定是继续、换路、还是让人
-参与。信任域内自主，编排者就是边界处的那道门。
+# Loop 架构：持久看板、可靠控制、基于证据的 Agent
+
+操作指南：[Loop 控制面](../../docs/loop-control-plane.zh-CN.md)。编排驾驶手册：
+`skills/builtin/future-loop/SKILL.md`；研究方法：`skills/builtin/future-research/SKILL.md`。
+两份 skill 都由 skills 子模块分发。英文详细契约见 [ARCHITECTURE.md](ARCHITECTURE.md)。
+
+## 边界
+
+模型选择策略、解释科学证据、向人请求判断。内核提供确定性的状态、依赖、租约、证据、
+验证器和提示信号，不因为启发式认为“卡住了”就强制重规划。智能的主要增益来自正确投喂
+证据，而不是继续增加规则。
+
+账本是权威，session 是缓存。能力统一经 CLI 暴露，仪表盘严格只读。人监督编排者的判断；
+无需 LLM 的 watchdog 监督进程活性和通知传输，不监督科学推理、更不自动选模型或重规划。
+
+## 底线、信号、预算
+
+- **底线**：合法状态转移、完成意图、验收缺口、依赖约束、租约、验证式终局。
+- **信号**：失败次数、成果连续段、振荡、缺少产物活动、monitor 状态、worker 里程碑。
+  信号描述事实，不替 Agent 做策略判断。
+- **预算**：外层回合数、验证尝试次数、验证命令独立墙钟上限。`--max-turns` 不是
+  token/金额上限，也不是 Agent 内层推理和工具调用的总超时。
+
+手动完成有意不重跑机器验证，但记录其依据为人工审阅或显式覆盖，不伪造机器通过。
+`delivered` 不等于 verified；`delivery record` 记录审阅者的判断。token 出现、文件存在、
+脚本 exit 0 都不能单独证明探索性结论正确。修改验收标准必须有明确理由。
+
+## 依赖与归属
+
+推进任务的 `--blocks` 指向前置；gate/blocker 的 `--blocks` 指向下游。调度与手动完成
+采用相同依赖语义。普通 gate 只阻塞相关任务，`--global-gate` 才全局冻结；无关工作可以
+继续执行和完成。决策用 `gate resolve`，不能用 `todo complete` 代替。
+
+`--owner` 是持久指派，租约到期不会取消归属。无 owner 才进入共享池。并行 run 必须使用
+不同 agent ID；coordination 任务属于编排者，不进入 worker 前沿。工作区守卫避免写冲突。
+依赖决定可执行性，priority 只排序可执行候选。
+
+worker 通过账本 evidence 和产物文件交接，不引入额外协商协议。扇出、汇总、下一轮扇出
+由普通 todo 和依赖边表达。
+
+## 可靠 steer
+
+新指令用 `ControlIssued`：UUID、目标 worker/广播、文本、interrupt 标志。
+普通指导在下一回合边界注入，`--interrupt` 才额外中断当前会话。latest-wins 仅限同一
+目标范围；A 的新指令不覆盖 B 的，广播与定向指导可同时按账本顺序注入。
+
+`ControlAcknowledged` 按接收者落账，且必须晚于完成回合的持久写回。一个 worker 不会替
+其他 worker 消费广播。传输失败、中断不会提前消费；崩溃可能导致重投，因此这是
+**至少一次指导**，不是外部副作用“恰好一次”。指导必须幂等，不可逆操作另行审批。
+
+中断 watcher 不越过不完整 JSONL 行，也不把失败的中断当送达。旧 `WorkerSteered` /
+`SteerConsumed` 账本仍兼容，但新 CLI 不再写单槽指令。模型/思考级改变需要新配置的
+会话，不能靠 steer 热切换。
+
+## 异步执行与独立活性监督
+
+生产 `run` 默认 re-exec detached child，检测立即退出的启动失败。`--detach` 是内部
+前台子进程标记，`FUTURE_LOOP_NO_DETACH=1` 用于前台嵌入/测试。统一 `future` 二进制
+重启自身时保留 `loop` 分组前缀。
+
+detached 派发或 supervisor 注册会确保独立 `supervisor watch --goal G` 进程存在。
+每个 goal 的 OS 文件锁保证单实例。它每两秒检查死租约持有者、超过五分钟仍未验证的交付、
+待送通知；即使最后一个 worker 死亡，也不依赖下一次付费 run 或 LLM 轮询来发现。
+`scheduler tick` 和回合结束检查保留为补充。
+
+goal 删除/取消，或终局且无待送通知时 watcher 退出。它不是开机服务；宿主重启后需重新
+运行该 CLI、重新注册 supervisor，或由操作系统服务管理器托管。没有宿主重启机制就不能
+承诺跨断电自动恢复。
+
+生命周期命令先停止失效 worker，再删状态；晚到完成不能复活 superseded 任务。
+这与指导性中断不同，后者保留任务以继续工作。
+
+## 持久、合批的通知队列
+
+1. **先记录** `SupervisorNote`，不依赖 Agent 可达或 supervisor 已注册；同 episode 去重。
+2. **准备不可变批次** `SupervisorBatchPrepared`：会话、note keys、消息、UUID。
+   每批最多 32 条，每条有界并指向完整账本；watchdog 自然合并两个 tick 之间的消息。
+3. **推送**使用 `enqueue_if_busy`，不打断编排者。失败重试使用相同请求 key 和相同正文。
+4. **送达回执** `SupervisorBatchDelivered` 只在远端接收后写入。接收不代表编排者已执行。
+
+OS 锁串行化并发 flusher。掉线保留批次，恢复补送；换 supervisor 可从账本恢复通知。
+旧通知只触发当前状态核对，不能直接变成“重启这个 worker”的命令。无 watcher 的前台
+嵌入者可立即 flush，但同样遵守持久化和重放语义。
+
+## 有界验证器
+
+验证器异步执行，独立默认 120 秒超时，可用正数 `FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS`
+配置。stdout/stderr 持续排空，仅保留有界诊断尾部；命令或继承管道挂住都会超时。
+取消/超时清理子进程树（Unix process group；Windows process-tree termination）。
+
+Unix 用 `sh -c`，Windows 用 `cmd.exe /D /S /C`，不是跨平台通用 shell 语言；可移植
+任务应调用可移植校验程序。失败附带诊断，启动失败/超时记 inconclusive，不伪装通过。
+
+## 投喂与真实进展
+
+每轮信封包含目标、todo、验收/验证器契约、已决 gate、上游 evidence、上一轮 evidence、
+相关失败、少量近期历史、提示信号。近期里程碑报告也会注入，但明确标为待核实声明。
+
+fan-in 为每个已结束前置保留索引，摘要预算公平分配，不让第一个长报告吞掉后面的来源。
+索引随前置数量增长，摘要总量仍受限；完整 evidence 用 `status --format json` 读取。
+superseded 来源有明确标记。编排者仍须在下游 todo 写出产物路径，不把摘要当完整知识交接。
+
+区分 **存活、活动、进展**。`write/edit` 执行开始只是产物活动代理；shell 不自动算写入，
+provider input/execution 阶段不重复计数。真实进展来自新产物、验证结果、指标改善或假设
+被排除。读论文可能有进展，反复写进度文件也可能没有。
+
+## 适度编排与诚实停止
+
+根据不确定性和风险选择轻量、标准、重型流程。一次代码复盘不强制固定引用数量或多 worker。
+仅在预期收益超过通信成本时并行不同方法族。确认配置、预算，不擅自改变用户约束。
+
+检查点比较新增证据、剩余差距与下一步成本。允许达标、限定不可行、预算耗尽、低收益停止、
+受阻等结果；只有达标才能称成功闭环。保留阶段成果和验收缺口，扩预算先问人。开放研究
+不需要“证明所有可能方法都失败”才允许诚实停止。

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -52,10 +52,11 @@ pub struct SessionTotals {
     pub cost: f64,
 }
 
-/// O3: write-class tools — a `tool_start` of any of these resets the idle
-/// clock. Everything else (read, grep, todo, …) is observation-only.
+/// Artifact-activity proxy: write/edit execution resets the idle clock. Shell
+/// may mutate files OR merely poll; do not infer material progress from its name.
+/// Reading and computation may be productive without invoking these tools.
 pub fn is_write_class_tool(name: &str) -> bool {
-    matches!(name, "write" | "edit" | "shell")
+    matches!(name, "write" | "edit")
 }
 
 /// O3: per-turn progress signals observed on the event stream. Shared between
@@ -566,7 +567,8 @@ async fn consume_run_stream(
         }
         // O3: fold tool_start into the progress tracker (write-class
         // starts reset the idle clock; all starts count).
-        if ev.r#type == "tool_start" {
+        if ev.r#type == "tool_start" && data.get("phase").and_then(|p| p.as_str()) != Some("input")
+        {
             if let (Some(progress), Some(name)) =
                 (progress, data.get("tool_name").and_then(|v| v.as_str()))
             {
@@ -574,7 +576,7 @@ async fn consume_run_stream(
             }
         }
         match ev.r#type.as_str() {
-            "tool_start" => {
+            "tool_start" if data.get("phase").and_then(|p| p.as_str()) != Some("input") => {
                 if let Some(name) = data.get("tool_name").and_then(|v| v.as_str()) {
                     summary.tools.push(name.to_string());
                 }

--- a/orchestration/loop/src/agents/control.rs
+++ b/orchestration/loop/src/agents/control.rs
@@ -1,0 +1,101 @@
+//! Durable, recipient-scoped steering. Acknowledgement means a successful
+//! turn writeback, not merely assembling a prompt. Retrying after an ambiguous
+//! disconnect is deliberately at-least-once; instructions must be idempotent.
+use crate::store::{Event, Store};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Instruction {
+    pub id: String,
+    pub agent_id: Option<String>,
+    pub text: String,
+    /// Ordinary guidance waits for the next boundary. Urgent corrections abort.
+    pub interrupt: bool,
+}
+
+/// Latest instruction per scope (broadcast and this recipient), in ledger
+/// order. Acknowledgements by other recipients never consume a broadcast.
+pub fn pending(store: &Store, goal: &str, agent: Option<&str>) -> anyhow::Result<Vec<Instruction>> {
+    let events = store.events(goal)?;
+    let mut instructions: Vec<Instruction> = Vec::new();
+    let mut acknowledged = std::collections::HashSet::new();
+    for entry in events {
+        match entry.event {
+            Event::ControlIssued { instruction, .. }
+                if instruction.agent_id.is_none() || instruction.agent_id.as_deref() == agent =>
+            {
+                instructions.retain(|old| old.agent_id != instruction.agent_id);
+                instructions.push(instruction);
+            }
+            Event::ControlAcknowledged {
+                instruction_id,
+                agent_id,
+                ..
+            } if agent_id.as_deref() == agent => {
+                acknowledged.insert(instruction_id);
+            }
+            _ => {}
+        }
+    }
+    instructions.retain(|instruction| !acknowledged.contains(&instruction.id));
+    Ok(instructions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Goal;
+
+    #[test]
+    fn targeted_broadcast_same_second_and_restart_are_recipient_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Store::open(dir.path().to_str().unwrap()).unwrap();
+        store.register(&Goal::new("g", "goal", ".")).unwrap();
+        for (id, target) in [
+            ("a1", Some("a")),
+            ("b1", Some("b")),
+            ("all", None),
+            ("a2", Some("a")),
+        ] {
+            store
+                .append(Event::ControlIssued {
+                    goal_id: "g".into(),
+                    instruction: Instruction {
+                        id: id.into(),
+                        agent_id: target.map(str::to_owned),
+                        text: id.into(),
+                        interrupt: true,
+                    },
+                    ts: 1,
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            pending(&store, "g", Some("a"))
+                .unwrap()
+                .iter()
+                .map(|i| i.id.as_str())
+                .collect::<Vec<_>>(),
+            ["all", "a2"]
+        );
+        store
+            .append(Event::ControlAcknowledged {
+                goal_id: "g".into(),
+                instruction_id: "all".into(),
+                agent_id: Some("a".into()),
+                ts: 2,
+            })
+            .unwrap();
+        drop(store);
+        let store = Store::open(dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(pending(&store, "g", Some("a")).unwrap()[0].id, "a2");
+        assert_eq!(
+            pending(&store, "g", Some("b"))
+                .unwrap()
+                .iter()
+                .map(|i| i.id.as_str())
+                .collect::<Vec<_>>(),
+            ["b1", "all"]
+        );
+    }
+}

--- a/orchestration/loop/src/agents/mod.rs
+++ b/orchestration/loop/src/agents/mod.rs
@@ -3,7 +3,9 @@
 //! supervisor event projection (supervisor), and the workspace guard
 //! against shared-workspace write conflicts (workspace_guard).
 
+pub mod control;
 pub mod lane;
 pub mod scope;
+pub mod supervision;
 pub mod supervisor;
 pub mod workspace_guard;

--- a/orchestration/loop/src/agents/supervision.rs
+++ b/orchestration/loop/src/agents/supervision.rs
@@ -1,0 +1,344 @@
+//! Loop-owned, non-LLM watchdog and durable supervisor outbox. The watchdog
+//! only observes and delivers; retry/replan/model selection remain agent policy.
+use crate::{
+    agent_client::AgentClient,
+    state::now_epoch,
+    store::{Event, Store},
+};
+use anyhow::Result;
+use fs2::FileExt;
+use std::{collections::HashSet, fs::File, time::Duration};
+
+const TICK: Duration = Duration::from_secs(2);
+const MAX_BATCH_NOTES: usize = 32;
+
+fn lock_file(store: &Store, goal: &str, suffix: &str) -> Result<File> {
+    // IDs are not paths (also safe for legacy/user-selected goal IDs).
+    use sha2::{Digest, Sha256};
+    let name = format!("{:x}.{suffix}", Sha256::digest(goal.as_bytes()));
+    let dir = std::path::PathBuf::from(store.root_path()).join("supervision");
+    std::fs::create_dir_all(&dir)?;
+    Ok(std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(dir.join(name))?)
+}
+
+pub fn running(store: &Store, goal: &str) -> bool {
+    lock_file(store, goal, "watch.lock").is_ok_and(|file| file.try_lock_exclusive().is_err())
+}
+
+/// Persist even without a reachable agent or registered supervisor. Retry of
+/// the same episode is a no-op, not another ledger row / paid wakeup.
+pub fn queue(
+    store: &mut Store,
+    goal: &str,
+    kind: &str,
+    todo: &str,
+    message: &str,
+    key: &str,
+) -> Result<()> {
+    let lock = lock_file(store, goal, "notes.lock")?;
+    lock.lock_exclusive()?;
+    if !store
+        .events(goal)?
+        .iter()
+        .any(|e| matches!(&e.event, Event::SupervisorNote { dedup_key, .. } if dedup_key == key))
+    {
+        store.append(Event::SupervisorNote {
+            goal_id: goal.into(),
+            todo_id: todo.into(),
+            note_kind: kind.into(),
+            message: message.into(),
+            dedup_key: key.into(),
+            ts: now_epoch(),
+        })?;
+    }
+    Ok(())
+}
+
+/// Prepare a fixed-size immutable batch or retry an unacknowledged one. A
+/// crash after remote acceptance reuses its key AND payload on the next tick.
+pub async fn flush(store: &mut Store, goal_id: &str, client: &mut AgentClient) -> Result<()> {
+    let lock = lock_file(store, goal_id, "outbox.lock")?;
+    if lock.try_lock_exclusive().is_err() {
+        return Ok(());
+    }
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(());
+    };
+    let Some(session) = goal.supervisor_session_id else {
+        return Ok(());
+    };
+    let events = store.events(goal_id)?;
+    let delivered: HashSet<&str> = events
+        .iter()
+        .filter_map(|e| match &e.event {
+            Event::SupervisorBatchDelivered { batch_id, .. } => Some(batch_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    let delivered_keys: HashSet<&str> = events
+        .iter()
+        .flat_map(|entry| match &entry.event {
+            Event::SupervisorBatchPrepared {
+                batch_id,
+                note_keys,
+                ..
+            } if delivered.contains(batch_id.as_str()) => {
+                note_keys.iter().map(String::as_str).collect()
+            }
+            _ => Vec::new(),
+        })
+        .collect();
+    let mut assigned = HashSet::new();
+    let mut pending = None;
+    for event in &events {
+        if let Event::SupervisorBatchPrepared {
+            batch_id,
+            session_id,
+            note_keys,
+            message,
+            ..
+        } = &event.event
+        {
+            // A supervisor change re-targets undelivered work, not every
+            // historical notification already accepted by an earlier session.
+            if session_id == &session || delivered.contains(batch_id.as_str()) {
+                assigned.extend(note_keys.iter().cloned());
+            }
+            if session_id == &session
+                && pending.is_none()
+                && !delivered.contains(batch_id.as_str())
+                && !note_keys
+                    .iter()
+                    .all(|key| delivered_keys.contains(key.as_str()))
+            {
+                pending = Some((batch_id.clone(), message.clone()));
+            }
+        }
+    }
+    if pending.is_none() {
+        let mut keys = Vec::new();
+        let mut lines = Vec::new();
+        for event in &events {
+            if let Event::SupervisorNote {
+                dedup_key, message, ..
+            } = &event.event
+            {
+                if !assigned.contains(dedup_key) {
+                    assigned.insert(dedup_key.clone());
+                    keys.push(dedup_key.clone());
+                    lines.push(crate::decision::truncate(message, 800));
+                    if keys.len() == MAX_BATCH_NOTES {
+                        break;
+                    }
+                }
+            }
+        }
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let batch_id = uuid::Uuid::new_v4().to_string();
+        let message = format!("[future-loop] goal {goal_id}: {} event(s). Reconcile current status before acting; events may be stale. Read `future loop supervisor events --goal {goal_id}` for full evidence.\n{}", keys.len(), lines.join("\n"));
+        store.append(Event::SupervisorBatchPrepared {
+            goal_id: goal_id.into(),
+            batch_id: batch_id.clone(),
+            session_id: session.clone(),
+            note_keys: keys,
+            message: message.clone(),
+            ts: now_epoch(),
+        })?;
+        pending = Some((batch_id, message));
+    }
+    if let Some((id, message)) = pending {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            client.prompt(&session, &message, &format!("loop-batch:{id}")),
+        )
+        .await??;
+        store.append(Event::SupervisorBatchDelivered {
+            goal_id: goal_id.into(),
+            batch_id: id,
+            ts: now_epoch(),
+        })?;
+    }
+    Ok(())
+}
+
+pub fn pending_delivery(store: &Store, goal_id: &str) -> Result<bool> {
+    if store.replay(goal_id)?.is_none() {
+        return Ok(false);
+    }
+    let events = store.events(goal_id)?;
+    let receipts: HashSet<&str> = events
+        .iter()
+        .filter_map(|e| match &e.event {
+            Event::SupervisorBatchDelivered { batch_id, .. } => Some(batch_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    let delivered: HashSet<&str> = events
+        .iter()
+        .flat_map(|e| match &e.event {
+            Event::SupervisorBatchPrepared {
+                batch_id,
+                note_keys,
+                ..
+            } if receipts.contains(batch_id.as_str()) => {
+                note_keys.iter().map(String::as_str).collect()
+            }
+            _ => Vec::new(),
+        })
+        .collect();
+    Ok(events.iter().any(|e| matches!(&e.event, Event::SupervisorNote { dedup_key, .. } if !delivered.contains(dedup_key.as_str()))))
+}
+
+pub fn record_dead_holders(store: &mut Store, goal_id: &str) -> Result<()> {
+    let Some(goal) = store.replay(goal_id)? else {
+        return Ok(());
+    };
+    for todo in crate::work_items::task_lease::dead_holder_todos(&goal) {
+        if let Some(pid) = todo.holder_pid {
+            queue(store, goal_id, "host_died", &todo.id,
+                &format!("[future-loop] goal {goal_id}: todo {} stopped before completion (host_died) — holder pid {pid} is gone; inspect then relaunch if appropriate", todo.id),
+                &format!("host_died:{}:{pid}:{}", todo.id, todo.lease_expires_at.unwrap_or(0)))?;
+        }
+    }
+    // Wall-clock follow-up still works when no further paid turns happen.
+    for delivery in &goal.delivery_states {
+        if delivery.outcome == "delivered" && now_epoch().saturating_sub(delivery.updated_at) >= 300
+        {
+            queue(store, goal_id, "verification_due", &delivery.todo_id,
+                &format!("Delivery {} is awaiting verification; read its artifacts and record verified/failed/rework, not another blind retry.", delivery.todo_id),
+                &format!("verification_due:{}:{}", delivery.todo_id, delivery.seq))?;
+        }
+    }
+    Ok(())
+}
+
+/// Foreground service entry point. Its lifetime is independent of every run;
+/// an OS lock prevents duplicate watchers. Restart via this same CLI after a
+/// host restart (no claim of surviving power loss without an OS service).
+pub async fn watch(store: &mut Store, goal_id: &str, once: bool) -> Result<()> {
+    let lock = lock_file(store, goal_id, "watch.lock")?;
+    if lock.try_lock_exclusive().is_err() {
+        return Ok(());
+    }
+    loop {
+        let Some(goal) = store.replay(goal_id)? else {
+            return Ok(());
+        };
+        if goal.status == "cancelled"
+            || (goal.is_terminal()
+                && (goal.supervisor_session_id.is_none() || !pending_delivery(store, goal_id)?))
+        {
+            return Ok(());
+        }
+        record_dead_holders(store, goal_id)?;
+        if goal.supervisor_session_id.is_some() && pending_delivery(store, goal_id)? {
+            let connected = tokio::time::timeout(
+                Duration::from_secs(5),
+                AgentClient::connect(&crate::agent_client::agent_addr()),
+            )
+            .await;
+            if let Ok(Ok(mut client)) = connected {
+                if let Err(error) = flush(store, goal_id, &mut client).await {
+                    eprintln!("supervisor outbox retained for retry: {error}");
+                } else if goal.is_terminal() && !pending_delivery(store, goal_id)? {
+                    return Ok(());
+                }
+            }
+        }
+        if once {
+            return Ok(());
+        }
+        tokio::time::sleep(TICK).await;
+    }
+}
+
+/// Dispatch a separate watcher from production binaries only. Test harnesses
+/// and foreground embedders opt in with `supervisor watch` explicitly.
+pub fn ensure_watchdog(store: &Store, goal: &str) -> Result<()> {
+    if running(store, goal) || std::env::var("FUTURE_LOOP_NO_DETACH").ok().as_deref() == Some("1") {
+        return Ok(());
+    }
+    let exe = std::env::current_exe()?;
+    let stem = exe.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if !matches!(stem, "future" | "future-loop") {
+        return Ok(());
+    }
+    let mut cmd = std::process::Command::new(&exe);
+    if stem == "future" {
+        cmd.arg("loop");
+    }
+    cmd.args(["supervisor", "watch", "--goal", goal]);
+    cmd.env("FUTURE_LOOP_ROOT", store.root_path());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0000_0200 | 0x0000_0008);
+    }
+    let log = lock_file(store, goal, "watch.log")?;
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(log.try_clone()?)
+        .stderr(log);
+    let mut child = cmd.spawn()?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if running(store, goal) {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            let closed = store
+                .replay(goal)?
+                .is_none_or(|g| g.status == "cancelled" || g.is_terminal());
+            if status.success() && closed {
+                return Ok(());
+            }
+            anyhow::bail!("supervisor watchdog exited before acquiring its lock: {status}");
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("supervisor watchdog did not become ready within 3 seconds");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Goal;
+    #[test]
+    fn notes_persist_without_supervisor_and_deduplicate() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Store::open(dir.path().to_str().unwrap()).unwrap();
+        store.register(&Goal::new("g", "goal", ".")).unwrap();
+        for _ in 0..3 {
+            queue(&mut store, "g", "host_died", "t", "offline", "episode").unwrap();
+        }
+        assert_eq!(
+            store
+                .events("g")
+                .unwrap()
+                .iter()
+                .filter(|e| matches!(e.event, Event::SupervisorNote { .. }))
+                .count(),
+            1
+        );
+        let lock = lock_file(&store, "g", "watch.lock").unwrap();
+        lock.lock_exclusive().unwrap();
+        assert!(running(&store, "g"));
+        drop(lock);
+        assert!(!running(&store, "g"));
+    }
+}

--- a/orchestration/loop/src/agents/supervisor.rs
+++ b/orchestration/loop/src/agents/supervisor.rs
@@ -85,6 +85,11 @@ pub fn build_supervisor_event_projection(
         "progress": progress_items,
         "note_count": note_items.len(),
         "notes": note_items,
+        "delivery_pending": crate::agents::supervision::pending_delivery(store, goal_id)?,
+        "control_events": events.iter().filter(|e| matches!(e.event,
+            Event::ControlIssued { .. } | Event::ControlAcknowledged { .. }
+            | Event::SupervisorBatchPrepared { .. } | Event::SupervisorBatchDelivered { .. }
+        )).map(|e| &e.event).collect::<Vec<_>>(),
     }))
 }
 

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -181,7 +181,7 @@ async fn main_from_args(prog: &str, args: Vec<String>) -> Result<()> {
         // ── P3 commands ──────────────────────────────────────────────────
         "scope" => cmd_scope(&store, &args[1..]),
         "lane" => cmd_lane(&store, &args[1..]),
-        "supervisor" => cmd_supervisor(&mut store, &args[1..]),
+        "supervisor" => cmd_supervisor(&mut store, &args[1..]).await,
         "report" => cmd_report(&mut store, &args[1..]),
         "worker" => cmd_worker(&mut store, &args[1..]).await,
         "task-graph" => cmd_task_graph(&store, &args[1..]),
@@ -388,8 +388,8 @@ fn build_cli_registry() -> CommandRegistry {
     r.command(
         agent,
         "supervisor",
-        "supervisor register|steer|events (G-16)",
-        "supervisor register|steer|events --goal G ...",
+        "supervisor register|steer|events|watch (G-16)",
+        "supervisor register|steer|events|watch --goal G ...",
     );
     r.subcommand(
         "supervisor",
@@ -400,14 +400,32 @@ fn build_cli_registry() -> CommandRegistry {
     r.subcommand(
         "supervisor",
         "steer",
-        "interrupt the in-flight worker turn and inject an instruction",
-        "steer --goal G [--agent-id A] --instruction \"...\"",
+        "durable next-boundary guidance; --interrupt for urgent redirection",
+        "steer --goal G [--agent-id A] [--interrupt] --instruction \"...\"",
     );
     r.subcommand(
         "supervisor",
         "events",
         "read the supervisor event projection (gates / completions / failures / progress)",
         "events --goal G [--format json]",
+    );
+    r.subcommand(
+        "supervisor",
+        "watch",
+        "non-LLM watchdog: death detection and durable batched notification delivery",
+        "watch --goal G [--once]",
+    );
+    r.subcommand_flags(
+        "supervisor",
+        "watch",
+        &[
+            ("--goal G", "goal id", "required"),
+            (
+                "--once",
+                "one reconciliation instead of a persistent watcher",
+                "boolean",
+            ),
+        ],
     );
     r.command(
         agent,
@@ -956,8 +974,13 @@ fn build_cli_registry() -> CommandRegistry {
             ),
             (
                 "--instruction TEXT",
-                "the mid-turn redirect",
-                "required; interrupts the in-flight turn and injects the instruction",
+                "idempotent guidance",
+                "required; delivered at next boundary, acknowledged after writeback",
+            ),
+            (
+                "--interrupt",
+                "abort in-flight turn for urgent guidance",
+                "boolean; default false",
             ),
         ],
     );
@@ -2547,7 +2570,11 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     // closes the manual `todo complete` bypass. Resolving the gate itself is
     // the gate's own path (`gate resolve`) — gates are never completed here.
     if t.class != TaskClass::UserGate && t.class != TaskClass::Blocker {
-        let open_gates: Vec<String> = goal.open_gates().map(|g| g.id.clone()).collect();
+        let open_gates: Vec<String> = if goal.is_blocked(t) {
+            goal.open_gates().map(|g| g.id.clone()).collect()
+        } else {
+            Vec::new()
+        };
         if !open_gates.is_empty() {
             bail!(
                 "todo {todo_id} cannot be completed while open gate(s) [{}] are pending — \
@@ -2557,6 +2584,13 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
     let is_advancement = t.class == TaskClass::Advancement;
+    let completion_basis = if force {
+        "operator_override"
+    } else if t.validator.is_some() {
+        "manual_review; machine validator NOT executed"
+    } else {
+        "manual_review"
+    };
     // O6: completion evidence contract (retrospective: 11/33 completions
     // shipped <60-char evidence, several fully empty, and every one of those
     // todos had to be reopened by hand). Advancement todos must carry real,
@@ -2618,7 +2652,7 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
             goal_id: goal_id.clone(),
             todo_id: todo_id.clone(),
             outcome: crate::work_items::delivery_outcome::OUTCOME_DELIVERED.to_string(),
-            note: None,
+            note: Some(format!("completion_basis={completion_basis}")),
             delivered_turn,
             seq,
             ts: now_epoch(),
@@ -4192,6 +4226,7 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         let goal_for_dir = goal_id
             .clone()
             .ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+        crate::agents::supervision::ensure_watchdog(store, &goal_for_dir)?;
         let run_log_dir = std::path::PathBuf::from(store.root_path())
             .join("detached")
             .join(&goal_for_dir);
@@ -4501,24 +4536,18 @@ pub async fn notify_supervisor(
     message: &str,
     dedup_key: &str,
 ) {
-    // ① Durable ledger note — authoritative intervention channel; survives a
-    // lost/delayed push and a busy supervisor.
-    if let Err(e) = store.append(crate::store::Event::SupervisorNote {
-        goal_id: goal_id.to_string(),
-        todo_id: todo_id.to_string(),
-        note_kind: kind.to_string(),
-        message: message.to_string(),
-        dedup_key: dedup_key.to_string(),
-        ts: crate::state::now_epoch(),
-    }) {
-        println!("   ⚠ supervisor note ledger append failed: {e}");
-    }
-    // ② Best-effort push — wakes an idle supervisor only.
-    let Some(sid) = supervisor_session_id else {
+    if let Err(e) =
+        crate::agents::supervision::queue(store, goal_id, kind, todo_id, message, dedup_key)
+    {
+        eprintln!("supervisor note persistence failed: {e}");
         return;
-    };
-    if let Err(e) = client.prompt(sid, message, dedup_key).await {
-        println!("   ⚠ supervisor notify failed (best-effort): {e}");
+    }
+    // A production watchdog coalesces concurrent notes. Foreground embedders
+    // without one retain immediate delivery, with the same durable retry path.
+    if supervisor_session_id.is_some() && !crate::agents::supervision::running(store, goal_id) {
+        if let Err(e) = crate::agents::supervision::flush(store, goal_id, client).await {
+            eprintln!("supervisor outbox retained for retry: {e}");
+        }
     }
 }
 
@@ -4547,7 +4576,7 @@ pub async fn notify_infra_stop(
         &format!(
             "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion ({kind}) — {detail}"
         ),
-        &format!("infra_stopped:{todo_id}:{kind}"),
+        &format!("infra_stopped:{todo_id}:{kind}:{}", std::process::id()),
     )
     .await;
 }
@@ -4563,36 +4592,15 @@ pub async fn notify_infra_stop(
 /// no-op (the tick itself never fails over a lost notification).
 #[doc(hidden)] // test-visible seam
 pub async fn notify_dead_holders(store: &mut Store, goal_id: &str) -> Result<()> {
-    let Some(goal) = store.replay(goal_id)? else {
-        return Ok(());
-    };
-    let supervisor = goal.supervisor_session_id.clone();
-    let dead: Vec<(String, u32)> = crate::work_items::task_lease::dead_holder_todos(&goal)
-        .into_iter()
-        .filter_map(|t| t.holder_pid.map(|pid| (t.id.clone(), pid)))
-        .collect();
-    if dead.is_empty() {
-        return Ok(());
-    }
-    let Ok(mut client) =
-        crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await
-    else {
-        return Ok(());
-    };
-    for (todo_id, pid) in dead {
-        notify_supervisor(
-            store,
-            &mut client,
-            goal_id,
-            supervisor.as_deref(),
-            "host_died",
-            &todo_id,
-            &format!(
-                "[future-loop] goal {goal_id}: todo {todo_id} stopped before completion (host_died) — holder pid {pid} is gone (no release); relaunch to reclaim the lease"
-            ),
-            &format!("infra_stopped:{todo_id}:host_died:{pid}"),
-        )
-        .await;
+    // Persist before attempting any connection: agent downtime must not erase
+    // the very observation needed to recover once it comes back.
+    crate::agents::supervision::record_dead_holders(store, goal_id)?;
+    if !crate::agents::supervision::running(store, goal_id) {
+        if let Ok(mut client) =
+            crate::agent_client::AgentClient::connect(&crate::agent_client::agent_addr()).await
+        {
+            let _ = crate::agents::supervision::flush(store, goal_id, &mut client).await;
+        }
     }
     Ok(())
 }
@@ -4846,24 +4854,34 @@ async fn run_turns(
                 s.instruction
             ))
         });
-        // Persist the consumption BEFORE the turn runs: if this run dies
-        // mid-turn, the next run still must not re-inject the stale steer.
-        if let Some(steer) = goal.pending_steer.as_ref() {
-            if steer_note
-                .as_ref()
-                .is_some_and(|n| n.contains(steer.instruction.as_str()))
-            {
-                store.append(Event::SteerConsumed {
-                    goal_id: goal_id.to_string(),
-                    agent_id: steer.agent_id.clone(),
-                    steer_ts: steer.ts,
-                    ts: now_epoch(),
-                })?;
-                last_steer_ts = steer.ts;
-            }
-        }
-        let continue_note = next_continue_note.take();
-        let turn_note = steer_note.or(continue_note);
+        let controls = crate::agents::control::pending(store, goal_id, agent_id)?;
+        let mut notes: Vec<String> = steer_note.into_iter().collect();
+        notes.extend(controls.iter().map(|c| {
+            format!(
+                "SUPERVISOR STEERING [{}] (idempotent guidance; a retry may repeat it):\n{}",
+                c.id, c.text
+            )
+        }));
+        notes.extend(
+            store
+                .events(goal_id)?
+                .iter()
+                .rev()
+                .filter_map(|entry| match &entry.event {
+                    Event::ProgressReported {
+                        todo_id: reported,
+                        message,
+                        ..
+                    } if reported == &todo_id => Some(format!(
+                        "Reported milestone (claim, verify against artifacts): {}",
+                        crate::decision::truncate(message, 600)
+                    )),
+                    _ => None,
+                })
+                .take(2),
+        );
+        notes.extend(next_continue_note.take());
+        let turn_note = (!notes.is_empty()).then(|| notes.join("\n\n"));
         let turn_future = execute_turn(
             client,
             session_id,
@@ -4983,6 +5001,28 @@ async fn run_turns(
             record: record.clone(),
             ts: now_epoch(),
         })?;
+        // Ack only after durable writeback. A transport failure/crash before
+        // this point must leave the instruction available to a restarted run.
+        if record.terminal_state == "completed" {
+            for instruction in &controls {
+                store.append(Event::ControlAcknowledged {
+                    goal_id: goal_id.to_string(),
+                    instruction_id: instruction.id.clone(),
+                    agent_id: agent_id.map(str::to_owned),
+                    ts: now_epoch(),
+                })?;
+            }
+            if let Some(steer) = &goal.pending_steer {
+                if steer.ts == last_steer_ts {
+                    store.append(Event::SteerConsumed {
+                        goal_id: goal_id.to_string(),
+                        agent_id: steer.agent_id.clone(),
+                        steer_ts: steer.ts,
+                        ts: now_epoch(),
+                    })?;
+                }
+            }
+        }
         // O3: normal turn end — evaluate the no-progress window and ledger
         // the breach (detection + bookkeeping; no auto-injection).
         record_no_progress_if_idle(store, goal_id, &todo_id, agent_id, &progress)?;
@@ -5261,17 +5301,32 @@ pub async fn steer_worker_poll_once(
     if read.is_err() {
         return offset;
     }
-    let new_offset = meta.len();
-    for line in buf.lines() {
+    let Some(complete_bytes) = buf.rfind('\n').map(|i| i + 1) else {
+        return offset;
+    };
+    let new_offset = offset + complete_bytes as u64;
+    for line in buf[..complete_bytes].lines() {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
         };
-        if v.get("kind").and_then(|k| k.as_str()) != Some("worker_steered") {
+        let kind = v.get("kind").and_then(|k| k.as_str());
+        let instruction = if kind == Some("control_issued") {
+            let instruction = &v["instruction"];
+            if instruction["interrupt"] != true {
+                continue;
+            }
+            instruction
+        } else if kind == Some("worker_steered") {
+            &v
+        } else {
             continue;
-        }
+        };
         // Broadcast (agent_id absent) targets every worker; a specific
         // agent_id targets only the matching worker.
-        let targets_this_worker = match (agent_id, v.get("agent_id").and_then(|a| a.as_str())) {
+        let targets_this_worker = match (
+            agent_id,
+            instruction.get("agent_id").and_then(|a| a.as_str()),
+        ) {
             (Some(me), Some(target)) => me == target,
             (_, None) => true,
             (None, Some(_)) => false,
@@ -5286,8 +5341,11 @@ pub async fn steer_worker_poll_once(
         }
         if let Some(c) = client.as_mut() {
             if c.abort(session_id).await.is_err() {
-                *client = None; // reconnect on the next event
+                *client = None;
+                return offset; // retry undelivered interrupt; never lose the event
             }
+        } else {
+            return offset;
         }
     }
     new_offset
@@ -6176,6 +6234,8 @@ fn parse_pairs(args: &[String], mut f: impl FnMut(&str, String)) {
                 "--no-follow-up"
                     | "--anonymous"
                     | "--detach"
+                    | "--interrupt"
+                    | "--once"
                     | "--force-workspace"
                     | "--help"
                     | "-h"
@@ -6851,9 +6911,21 @@ fn cmd_lane(store: &Store, args: &[String]) -> Result<()> {
 /// supervisor proposal/receipt events (projection-only) plus the bidirectional
 /// messaging primitives: `register` binds the supervisor's session id (the
 /// up-channel target), `steer` issues a mid-turn interrupt (the down-channel).
-fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
+async fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
     let sub = args.first().map(|s| s.as_str()).unwrap_or("");
     match sub {
+        "watch" => {
+            reject_unknown_flags(&args[1..], &["--goal", "--once"])?;
+            let mut goal = None;
+            parse_pairs(&args[1..], |k, v| {
+                if k == "--goal" {
+                    goal = Some(v);
+                }
+            });
+            let goal = goal.ok_or_else(|| anyhow::anyhow!("--goal required"))?;
+            crate::agents::supervision::watch(store, &goal, args.iter().any(|a| a == "--once"))
+                .await?;
+        }
         "events" => {
             let mut goal_id = None;
             reject_unknown_flags(&args[1..], &["--goal"])?;
@@ -6888,6 +6960,7 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
                 session_id: session_id.to_string(),
                 ts: now_epoch(),
             })?;
+            crate::agents::supervision::ensure_watchdog(store, &goal_id)?;
             println!("supervisor registered (session {session_id})");
         }
         // `supervisor steer --goal G [--agent-id A] --instruction <text>` —
@@ -6897,7 +6970,11 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
             let mut goal_id = None;
             let mut agent_id = None;
             let mut instruction = None;
-            reject_unknown_flags(&args[1..], &["--agent-id", "--goal", "--instruction"])?;
+            reject_unknown_flags(
+                &args[1..],
+                &["--agent-id", "--goal", "--instruction", "--interrupt"],
+            )?;
+            let interrupt = args.iter().any(|a| a == "--interrupt");
             parse_pairs(&args[1..], |k, v| {
                 if k == "--goal" {
                     goal_id = Some(v);
@@ -6911,16 +6988,20 @@ fn cmd_supervisor(store: &mut Store, args: &[String]) -> Result<()> {
             let instruction =
                 instruction.ok_or_else(|| anyhow::anyhow!("--instruction required"))?;
             let target = agent_id.clone();
-            store.append(Event::WorkerSteered {
+            store.append(Event::ControlIssued {
                 goal_id: goal_id.clone(),
-                agent_id: target.clone(),
-                instruction: instruction.to_string(),
+                instruction: crate::agents::control::Instruction {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    agent_id: target.clone(),
+                    text: instruction.clone(),
+                    interrupt,
+                },
                 ts: now_epoch(),
             })?;
             let target = target.as_deref().unwrap_or("all workers");
             println!("steer issued → {target}: {instruction}");
         }
-        _ => bail!("supervisor subcommand must be events|register|steer"),
+        _ => bail!("supervisor subcommand must be events|register|steer|watch"),
     }
     Ok(())
 }
@@ -7906,6 +7987,10 @@ fn describe_event(event: &crate::store::Event) -> String {
     let kind = match event {
         Event::GoalStarted { .. } => "goal_started",
         Event::SteerConsumed { .. } => "steer_consumed",
+        Event::ControlIssued { .. } => "control_issued",
+        Event::ControlAcknowledged { .. } => "control_acknowledged",
+        Event::SupervisorBatchPrepared { .. } => "supervisor_batch_prepared",
+        Event::SupervisorBatchDelivered { .. } => "supervisor_batch_delivered",
         Event::TodoAdded { .. } => "todo_added",
         Event::TodoCompleted {
             todo_id,

--- a/orchestration/loop/src/decision/stall.rs
+++ b/orchestration/loop/src/decision/stall.rs
@@ -53,7 +53,7 @@ pub fn todo_signals(goal: &Goal, todo: &Todo) -> Vec<String> {
     }
     if let Some(signal) = oscillation_replan_reason(goal) {
         advisories.push(format!(
-            "[signal: {signal} — consider a different validator or splitting the todo]"
+            "[signal: {signal} — inspect artifacts and split work if useful; do not weaken acceptance criteria to obtain a pass]"
         ));
     }
     if todo.failed_attempts > 0 {
@@ -72,7 +72,7 @@ pub fn todo_signals(goal: &Goal, todo: &Todo) -> Vec<String> {
         .count() as u32;
     if no_progress_turns >= LLM_ZOMBIE_TURN_THRESHOLD {
         advisories.push(format!(
-            "[signal: {no_progress_turns} turns with no write-class tool (write/edit/shell) — the worker may be stuck; consider restarting with a fresh session]"
+            "[signal: {no_progress_turns} turns with no write-class tool (write/edit) — activity is not progress; shell/read-only research may be productive. Inspect evidence, validation and reported milestones before deciding whether to restart]"
         ));
     }
     advisories

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -8,10 +8,7 @@ use anyhow::{Context, Result};
 
 use crate::agent_client::{AgentClient, RunSummary, TurnProgressTracker};
 use crate::decision::{compose_goal_boundary, compose_turn_envelope};
-use crate::state::{
-    now_epoch, task_validation_receipt, Goal, RecoveryKind, RunRecord, TaskValidation, Todo,
-    ValidationStatus,
-};
+use crate::state::{now_epoch, Goal, RunRecord, TaskValidation, Todo};
 
 /// Evidence is a summary the orchestrator reads to decide what a worker
 /// actually landed — it is NOT a full transcript. Truncating head-only loses
@@ -118,8 +115,14 @@ pub fn classify_failure(record: &crate::state::RunRecord) -> crate::state::Failu
     use crate::state::{FailureKind, ValidationStatus};
     // A verify-gate failure is the science failure regardless of terminal_state.
     if let Some(v) = &record.validation {
-        if v.status == ValidationStatus::Failed && !v.ok {
-            return FailureKind::ScienceVerifyFailed;
+        if !v.ok {
+            return if v.status == ValidationStatus::Failed {
+                FailureKind::ScienceVerifyFailed
+            } else {
+                // A checker timeout/spawn failure says nothing about the
+                // scientific validity of the artifact, but it is not success.
+                FailureKind::InfraRecoverable
+            };
         }
     }
     if record.terminal_state == "error" {
@@ -144,7 +147,7 @@ pub fn turn_succeeded(record: &RunRecord) -> bool {
 }
 
 /// O3: evaluate turn-end progress. Returns `Some(idle_secs)` when the last
-/// write-class tool (write/edit/shell) start — or the turn start when no
+/// artifact-tool (write/edit) execution start — or the turn start when no
 /// write-class tool started at all — is at least `threshold_secs` before
 /// `now`; `None` otherwise. Pure so tests exercise it without wall-clock
 /// waits.
@@ -195,44 +198,15 @@ pub fn validator_tautology(cmd: &str) -> Option<&'static str> {
 /// `todo add --verify "cmd"` attaches a validator; the kernel runs it in the
 /// goal cwd and only completes the todo when it exits 0. No validator ⇒
 /// `None` (validation not required ⇒ material results default to ok).
-fn run_validator(goal: &Goal, todo: &Todo) -> Option<TaskValidation> {
+async fn run_validator(goal: &Goal, todo: &Todo) -> Option<TaskValidation> {
     let cmd = todo.validator.as_deref()?;
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .current_dir(&goal.cwd)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .status();
-    match status {
-        Ok(s) => {
-            let code = s.code().unwrap_or(-1);
-            if code == 0 {
-                Some(task_validation_receipt(
-                    ValidationStatus::Passed,
-                    cmd,
-                    "validator passed (exit 0)",
-                    None,
-                    Some(code),
-                ))
-            } else {
-                Some(task_validation_receipt(
-                    ValidationStatus::Failed,
-                    cmd,
-                    &format!("validator exited {code} — repair required"),
-                    Some(RecoveryKind::RepairRequired),
-                    Some(code),
-                ))
-            }
-        }
-        Err(e) => Some(task_validation_receipt(
-            ValidationStatus::Inconclusive,
-            cmd,
-            &format!("validator failed to run: {e}"),
-            Some(RecoveryKind::RepairRequired),
-            None,
-        )),
-    }
+    let timeout = std::env::var("FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(crate::validator::DEFAULT_TIMEOUT);
+    Some(crate::validator::validate(std::path::Path::new(&goal.cwd), cmd, timeout).await)
 }
 
 /// Consecutive trailing `incomplete` records for `todo_id` (the just-written
@@ -388,7 +362,7 @@ pub async fn execute_turn(
     // Independent validator (if any) runs after a completed turn; a failed or
     // interrupted turn never runs the validator (no material result to check).
     record.validation = if terminal_state == "completed" {
-        run_validator(goal, todo)
+        run_validator(goal, todo).await
     } else {
         None
     };

--- a/orchestration/loop/src/lib.rs
+++ b/orchestration/loop/src/lib.rs
@@ -30,6 +30,7 @@ pub mod scheduler;
 pub mod state;
 pub mod store;
 pub mod turn_envelope;
+pub mod validator;
 pub mod webui;
 pub mod work_items;
 pub mod worker_bridge;

--- a/orchestration/loop/src/state.rs
+++ b/orchestration/loop/src/state.rs
@@ -1123,6 +1123,18 @@ impl Goal {
     /// Unknown predecessor ids do NOT block here (liveness); the
     /// `task-graph` projection fails closed on them instead.
     pub fn is_blocked(&self, t: &Todo) -> bool {
+        // Gates/blockers may declare outgoing edges; advancement todos declare
+        // incoming edges. Honor both forms, consistently with task-graph.
+        if self.open_blocking_sources().any(|source| {
+            source.id != t.id
+                && (source.global_gate
+                    || source
+                        .blocked_by_gate
+                        .as_deref()
+                        .is_some_and(|ids| ids.split(',').any(|id| id.trim() == t.id)))
+        }) {
+            return true;
+        }
         let Some(ids) = t.blocked_by_gate.as_deref() else {
             return false;
         };

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -571,6 +571,32 @@ pub enum Event {
         steer_ts: u64,
         ts: u64,
     },
+    /// Recipient-scoped steering, replacing the legacy single-slot projection.
+    ControlIssued {
+        goal_id: String,
+        instruction: crate::agents::control::Instruction,
+        ts: u64,
+    },
+    ControlAcknowledged {
+        goal_id: String,
+        instruction_id: String,
+        agent_id: Option<String>,
+        ts: u64,
+    },
+    /// Immutable outbox batch: retries reuse exactly the same key and payload.
+    SupervisorBatchPrepared {
+        goal_id: String,
+        batch_id: String,
+        session_id: String,
+        note_keys: Vec<String>,
+        message: String,
+        ts: u64,
+    },
+    SupervisorBatchDelivered {
+        goal_id: String,
+        batch_id: String,
+        ts: u64,
+    },
     /// An operator asked a worker to STOP: interrupt any in-flight turn and
     /// exit the run loop at the next turn boundary (unlike `WorkerSteered`,
     /// which drains an instruction and keeps running). `agent_id` `None`
@@ -625,6 +651,10 @@ impl Event {
             | Event::SupervisorRegistered { goal_id, .. }
             | Event::WorkerSteered { goal_id, .. }
             | Event::SteerConsumed { goal_id, .. }
+            | Event::ControlIssued { goal_id, .. }
+            | Event::ControlAcknowledged { goal_id, .. }
+            | Event::SupervisorBatchPrepared { goal_id, .. }
+            | Event::SupervisorBatchDelivered { goal_id, .. }
             | Event::WorkerStopped { goal_id, .. }
             | Event::WorkerSessionBound { goal_id, .. } => goal_id,
         }
@@ -1980,7 +2010,11 @@ fn apply(goal: &mut Goal, event: Event) {
         // Projection-only: a supervisor note is already folded into the
         // supervisor projection (and pushed to the supervisor session); it
         // never mutates the kanban.
-        Event::SupervisorNote { .. } => {}
+        Event::SupervisorNote { .. }
+        | Event::ControlIssued { .. }
+        | Event::ControlAcknowledged { .. }
+        | Event::SupervisorBatchPrepared { .. }
+        | Event::SupervisorBatchDelivered { .. } => {}
     }
 }
 

--- a/orchestration/loop/src/turn_envelope.rs
+++ b/orchestration/loop/src/turn_envelope.rs
@@ -4,7 +4,8 @@
 //! implement the minimal deterministic core the host needs).
 //!
 //! The envelope is a plain-text prompt for a policy-free agent: one bounded
-//! turn, no loop policy embedded (all policy stays in the decision kernel).
+//! turn, with evidence/contracts/signals but no strategy policy (strategy is
+//! the agent's responsibility; the kernel only enforces consistency floors).
 //! [`compose_turn_message`] keeps the P0 signature used by the gRPC executor
 //! and delegates to [`compose_turn_envelope`]. The kernel's scheduling
 //! internals (the should-run verdict, mode, reason, arbitration) are
@@ -29,8 +30,8 @@ pub const TURN_ENVELOPE_SCHEMA_VERSION: &str = "future_loop_turn_envelope_v0";
 const GOAL_MEMORY_SEMANTIC_EVENTS: usize = 5;
 /// Cap the failure-cause text so a runaway error never bloats the prompt.
 const GOAL_MEMORY_ERROR_CHARS: usize = 200;
-/// Cap the combined upstream-evidence summary a fan-in todo's envelope
-/// injects (a wide fan-in must not bloat the prompt).
+/// Summary byte budget shared across all upstream sources. Source index entries
+/// are retained separately, even when a wide fan-in exhausts summary space.
 const UPSTREAM_EVIDENCE_CHARS: usize = 1_200;
 
 /// Compose the goal-memory block fed to the orchestrating agent every turn.
@@ -68,9 +69,10 @@ pub fn compose_goal_memory(goal: &Goal, todo: &Todo) -> String {
         } else if let Some(v) = &last.validation {
             if !v.ok {
                 line.push_str(&format!(
-                    ": verify gate {} rejected (exit {})",
+                    ": verify gate {} rejected (exit {}): {}",
                     v.validator_kind,
-                    v.exit_code.unwrap_or(-1)
+                    v.exit_code.unwrap_or(-1),
+                    crate::executor::truncate_evidence(&v.summary, 1600)
                 ));
             }
         }
@@ -165,6 +167,14 @@ pub fn compose_turn_envelope(goal: &Goal, todo: &Todo, prev: Option<&RunRecord>)
     // Instruction.
     out.push_str(&format!("TODO {}: {}\n", todo.id, todo.text));
 
+    if let Some(acceptance) = &todo.acceptance {
+        out.push_str(&format!(
+            "Acceptance contract (do not silently weaken): {acceptance}\n"
+        ));
+    }
+    if let Some(validator) = &todo.validator {
+        out.push_str(&format!("Machine verification: {validator}\nA manual completion is a reviewed override, not a machine pass.\n"));
+    }
     // Context: resolved gate decisions flow into blocked todos' packets.
     if let Some(gate_ids) = todo.blocked_by_gate.as_deref() {
         let decisions: Vec<String> = gate_ids
@@ -209,6 +219,7 @@ pub fn compose_turn_envelope(goal: &Goal, todo: &Todo, prev: Option<&RunRecord>)
     // Completion contract footer (LoopX: completion must declare closure intent).
     out.push_str("\n\nComplete the todo and report what you did and observed.");
     out.push_str("\nOn completion, declare the successor todo or --no-follow-up.");
+    out.push_str("\nHandoff: identify artifacts and paths, new evidence versus the previous attempt, rejected approaches, uncertainties and the next useful check. Activity alone is not progress; budget exhaustion is not successful completion.");
     out
 }
 
@@ -226,35 +237,38 @@ pub fn compose_upstream_evidence(goal: &Goal, todo: &Todo) -> String {
     let Some(ids) = todo.blocked_by_gate.as_deref() else {
         return String::new();
     };
+    let predecessors: Vec<&Todo> = ids
+        .split(',')
+        .map(str::trim)
+        .filter_map(|id| goal.todo(id))
+        .filter(|pred| matches!(pred.status, TodoStatus::Done | TodoStatus::Superseded))
+        .collect();
+    // Every predecessor gets an index entry; summaries share the budget fairly.
+    // The index is O(fan-in), intentionally never silently dropping a source.
+    let per_source = UPSTREAM_EVIDENCE_CHARS / predecessors.len().max(1);
     let mut entries: Vec<String> = Vec::new();
-    let mut used = 0usize;
-    for gid in ids.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-        let Some(pred) = goal.todo(gid) else {
-            continue;
+    for pred in predecessors {
+        let evidence = pred
+            .evidence
+            .as_deref()
+            .unwrap_or("[no evidence recorded]")
+            .trim();
+        let snippet = if per_source >= 12 {
+            crate::executor::truncate_evidence(evidence, per_source)
+        } else {
+            String::new()
         };
-        if !matches!(pred.status, TodoStatus::Done | TodoStatus::Superseded) {
-            continue;
-        }
-        let Some(evidence) = pred.evidence.as_deref() else {
-            continue;
-        };
-        let evidence = evidence.trim();
-        if evidence.is_empty() {
-            continue;
-        }
-        let remaining = UPSTREAM_EVIDENCE_CHARS.saturating_sub(used);
-        if remaining == 0 {
-            break;
-        }
-        let snippet = truncate(evidence, remaining);
-        used += snippet.chars().count();
-        entries.push(format!("upstream {}: {}", pred.id, snippet));
+        entries.push(format!(
+            "upstream {}: {} [status={:?}]",
+            pred.id, snippet, pred.status
+        ));
     }
     if entries.is_empty() {
         return String::new();
     }
     let mut out = String::new();
-    out.push_str("\nUpstream evidence:\n");
+    out.push_str("\nUpstream evidence: (summaries only; read referenced artifacts, not just these snippets)\n");
+    out.push_str(&format!("Full source evidence: future loop status --goal {} --format json (source IDs below). Superseded sources are not verified results.\n", goal.goal_id));
     for e in entries {
         out.push_str(&e);
         out.push('\n');

--- a/orchestration/loop/src/validator.rs
+++ b/orchestration/loop/src/validator.rs
@@ -1,0 +1,212 @@
+//! Bounded validator subprocesses. Drain both pipes even after the retained
+//! diagnostic budget is exhausted. Cancellation kills the whole process tree.
+use std::{path::Path, process::Stdio, time::Duration};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const OUTPUT_BYTES: usize = 16_384;
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+struct ProcessTree(u32);
+impl Drop for ProcessTree {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: the child creates its own process group, whose id is its pid.
+        unsafe {
+            libc::kill(-(self.0 as i32), libc::SIGKILL);
+        }
+        #[cfg(windows)]
+        {
+            let _ = std::process::Command::new("taskkill")
+                .args(["/PID", &self.0.to_string(), "/T", "/F"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+    }
+}
+
+async fn drain(mut pipe: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut retained = Vec::new();
+    let mut chunk = [0; 4096];
+    loop {
+        let n = pipe.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        retained.extend_from_slice(&chunk[..n]);
+        if retained.len() > OUTPUT_BYTES {
+            retained.drain(..retained.len() - OUTPUT_BYTES);
+        }
+    }
+    Ok(retained)
+}
+
+pub async fn validate(
+    cwd: &Path,
+    command: &str,
+    timeout: Duration,
+) -> crate::state::TaskValidation {
+    use crate::state::{task_validation_receipt, RecoveryKind, ValidationStatus};
+    let result = execute(cwd, command, timeout).await;
+    let (status, summary, exit) = match result {
+        Ok((code, output)) if code == Some(0) => (
+            ValidationStatus::Passed,
+            format!("validator passed (exit 0)\n{output}"),
+            code,
+        ),
+        Ok((code, output)) => (
+            ValidationStatus::Failed,
+            format!(
+                "validator exited {} — repair output, not acceptance criteria\n{output}",
+                code.unwrap_or(-1)
+            ),
+            code,
+        ),
+        Err(error) => (
+            ValidationStatus::Inconclusive,
+            format!("validator failed to run: {error}"),
+            None,
+        ),
+    };
+    let recovery = (status != ValidationStatus::Passed).then_some(RecoveryKind::RepairRequired);
+    task_validation_receipt(status, command, &summary, recovery, exit)
+}
+
+async fn execute(
+    cwd: &Path,
+    command: &str,
+    timeout: Duration,
+) -> anyhow::Result<(Option<i32>, String)> {
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.args(["/D", "/S", "/C", command]);
+        c
+    };
+    #[cfg(not(windows))]
+    let mut cmd = {
+        let mut c = tokio::process::Command::new("sh");
+        c.args(["-c", command]);
+        c
+    };
+    #[cfg(unix)]
+    cmd.process_group(0);
+    cmd.current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = cmd.spawn()?;
+    let tree = ProcessTree(
+        child
+            .id()
+            .ok_or_else(|| anyhow::anyhow!("validator has no pid"))?,
+    );
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    // One timeout covers execution AND pipe draining (a descendant can inherit
+    // a pipe after its parent exits). Dropping these futures closes the pipes.
+    let result = tokio::time::timeout(timeout, async {
+        let (status, out, err) = tokio::try_join!(child.wait(), drain(stdout), drain(stderr))?;
+        Ok::<_, std::io::Error>((
+            status.code(),
+            format!(
+                "stdout (tail):\n{}\nstderr (tail):\n{}",
+                String::from_utf8_lossy(&out),
+                String::from_utf8_lossy(&err)
+            ),
+        ))
+    })
+    .await;
+    drop(tree);
+    match result {
+        Ok(result) => Ok(result?),
+        Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            anyhow::bail!(
+                "timeout after {}ms; process tree terminated",
+                timeout.as_millis()
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn failure_carries_diagnostics() {
+        let dir = tempfile::tempdir().unwrap();
+        let receipt = validate(
+            dir.path(),
+            "echo diagnostic 1>&2 & exit 7",
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(!receipt.ok);
+        assert_eq!(receipt.exit_code, Some(7));
+        assert!(receipt.summary.contains("diagnostic"));
+    }
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn large_stderr_is_drained_and_retention_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let receipt = validate(
+            dir.path(),
+            "i=0; while [ $i -lt 20000 ]; do echo error-message >&2; i=$((i+1)); done; exit 2",
+            Duration::from_secs(10),
+        )
+        .await;
+        assert_eq!(receipt.exit_code, Some(2));
+        assert!(receipt.summary.contains("error-message"));
+        assert!(receipt.summary.len() < OUTPUT_BYTES + 1000);
+    }
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelling_validation_reaps_the_owned_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().to_path_buf();
+        let task = tokio::spawn(async move {
+            validate(
+                &cwd,
+                "echo $$ > validator.pid; sleep 60",
+                Duration::from_secs(60),
+            )
+            .await
+        });
+        let pid = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(pid) = std::fs::read_to_string(dir.path().join("validator.pid"))
+                    .ok()
+                    .and_then(|text| text.trim().parse::<u32>().ok())
+                {
+                    break pid;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while crate::compat::pid_alive(pid) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cancelled validator process must be killed and reaped");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hung_child_and_inherited_pipe_are_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        for command in ["sleep 60", "sleep 60 & exit 0"] {
+            let receipt = validate(dir.path(), command, Duration::from_millis(50)).await;
+            assert!(!receipt.ok);
+            assert!(receipt.summary.contains("timeout"), "{}", receipt.summary);
+        }
+    }
+}

--- a/orchestration/loop/src/webui/server.rs
+++ b/orchestration/loop/src/webui/server.rs
@@ -775,7 +775,7 @@ mod tests {
         assert!(run_server(root, port, false).await.is_err());
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn run_server_serves_and_broadcaster_ticks() {
         let (root, _dir) = store_root();
         let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -803,6 +803,11 @@ mod tests {
         client.read_to_end(&mut buf).await.unwrap();
         assert!(String::from_utf8_lossy(&buf).contains("200 OK"));
 
+        // Keep real time for the TCP exchange above: auto-advancing a paused
+        // clock can expire the server's header-read timeout before the OS
+        // reports client bytes ready (ConnectionReset on Linux CI). Only the
+        // deterministic broadcaster assertions below need a paused clock.
+        tokio::time::pause();
         // First broadcaster tick: computes the initial fingerprint.
         tokio::time::advance(std::time::Duration::from_millis(1300)).await;
         // Append a todo → the projection changes → the next tick's fingerprint

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -542,7 +542,7 @@ fn todo_complete_contract() {
         assert_eq!(t.successor_ids, vec![s.clone()]);
         assert_eq!(t.evidence.as_deref(), Some("did the thing"));
     }
-    // Gate freeze: an open user gate blocks completing other todos.
+    // An explicitly global gate blocks completion of every work item.
     cli_ok(&[
         "todo",
         "add",
@@ -552,6 +552,7 @@ fn todo_complete_contract() {
         "approval",
         "--class",
         "user_gate",
+        "--global-gate",
         "--gate-question",
         "ok?",
     ]);

--- a/orchestration/loop/tests/console_drive_g12.rs
+++ b/orchestration/loop/tests/console_drive_g12.rs
@@ -156,8 +156,12 @@ fn supervisor_steer_records_and_renders() {
         "re-check",
     ]);
     let store = open_store(&cr);
-    let g = store.replay(&gid).unwrap().unwrap();
-    assert_eq!(g.pending_steer.as_ref().unwrap().instruction, "re-check");
+    let controls = future_loop::agents::control::pending(&store, &gid, Some("worker-a")).unwrap();
+    assert_eq!(controls[0].text, "re-check");
+    assert!(
+        !controls[0].interrupt,
+        "ordinary guidance waits for a boundary"
+    );
 }
 
 // ── remaining error arms ───────────────────────────────────────────────────

--- a/orchestration/loop/tests/console_sweep.rs
+++ b/orchestration/loop/tests/console_sweep.rs
@@ -558,6 +558,14 @@ fn notify_supervisor_enqueues_to_registered_session_only() {
         .await;
         assert!(shared.lock().unwrap().prompt_calls.is_empty());
 
+        // The ledger, not a stale caller parameter, is registration authority.
+        store
+            .append(future_loop::store::Event::SupervisorRegistered {
+                goal_id: gid.clone(),
+                session_id: "sup-sess".into(),
+                ts: 1,
+            })
+            .unwrap();
         // Registered → ledgered AND enqueued to that session (enqueue_if_busy).
         future_loop::console::notify_supervisor(
             &mut store,

--- a/orchestration/loop/tests/console_sweep2.rs
+++ b/orchestration/loop/tests/console_sweep2.rs
@@ -7,7 +7,7 @@
 mod common;
 
 use common::mock_agent::{completed_events, spawn_mock, MockState};
-use common::{cli, cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
+use common::{cli_err, cli_ok, cli_root, first_todo_id, init_goal, open_store};
 use future_loop::state::now_epoch;
 use future_loop::store::{Event, Store};
 
@@ -369,12 +369,24 @@ fn run_validator_inconclusive_print() {
         "--max-validation-attempts",
         "1",
     ]);
-    // With an empty PATH the validator's `sh` cannot spawn → Inconclusive.
-    let saved = std::env::var_os("PATH");
-    std::env::set_var("PATH", "/nonexistent-dir-xyz");
-    let result = cli(&["run", "--goal", &gid, "--anonymous", "--max-turns", "2"]);
-    if let Some(p) = saved {
-        std::env::set_var("PATH", p);
-    }
-    result.unwrap();
+    // Missing cwd makes either platform's checker fail to spawn. This is
+    // inconclusive infrastructure, not a science failure or successful closure.
+    std::fs::remove_dir_all(&cr.cwd).unwrap();
+    let error = cli_err(&["run", "--goal", &gid, "--anonymous", "--max-turns", "1"]);
+    assert!(error.contains("max-turns"), "{error}");
+    let goal = open_store(&cr).replay(&gid).unwrap().unwrap();
+    assert_eq!(
+        goal.history.last().unwrap().failure_kind,
+        Some(future_loop::state::FailureKind::InfraRecoverable)
+    );
+    assert_eq!(
+        goal.history
+            .last()
+            .unwrap()
+            .validation
+            .as_ref()
+            .unwrap()
+            .status,
+        future_loop::state::ValidationStatus::Inconclusive
+    );
 }

--- a/orchestration/loop/tests/no_progress_drive.rs
+++ b/orchestration/loop/tests/no_progress_drive.rs
@@ -66,10 +66,10 @@ fn no_progress_pure_boundary_and_skew() {
 
 #[test]
 fn write_class_tool_matrix() {
-    for t in ["write", "edit", "shell"] {
+    for t in ["write", "edit"] {
         assert!(is_write_class_tool(t), "{t} is write-class");
     }
-    for t in ["read", "grep", "todo_update", "list", ""] {
+    for t in ["shell", "read", "grep", "todo_update", "list", ""] {
         assert!(!is_write_class_tool(t), "{t} is not write-class");
     }
 }
@@ -122,7 +122,10 @@ fn run_turn_folds_tool_starts_into_tracker() {
         assert_eq!(summary.terminal_state, "completed");
         let snap = progress.snapshot();
         assert_eq!(snap.tool_calls_total, 2);
-        assert!(snap.last_write_tool_at.is_some(), "shell is write-class");
+        assert!(
+            snap.last_write_tool_at.is_none(),
+            "shell activity alone is not a known artifact write"
+        );
     });
 }
 

--- a/orchestration/loop/tests/reliability_contract.rs
+++ b/orchestration/loop/tests/reliability_contract.rs
@@ -1,0 +1,397 @@
+//! Fault-oriented contracts: delivery survives disconnects, steering is scoped,
+//! and observation does not silently become a correctness claim.
+mod common;
+use common::mock_agent::*;
+use common::*;
+use future_loop::{
+    agents::{control, supervision},
+    store::Event,
+};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+fn mock_env(state: MockState) -> (tokio::runtime::Runtime, SharedState) {
+    let rt = rt();
+    let (addr, shared) = rt.block_on(spawn_mock(state));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", addr);
+    (rt, shared)
+}
+
+#[test]
+fn outbox_batches_and_retries_an_immutable_payload_after_disconnect() {
+    let cr = cli_root();
+    let goal = init_goal(&cr, "outbox");
+    let mut store = open_store(&cr);
+    store
+        .append(Event::SupervisorRegistered {
+            goal_id: goal.clone(),
+            session_id: "supervisor".into(),
+            ts: 1,
+        })
+        .unwrap();
+    for n in 0..3 {
+        supervision::queue(
+            &mut store,
+            &goal,
+            "completed",
+            "t",
+            &format!("result {n}"),
+            &format!("key-{n}"),
+        )
+        .unwrap();
+    }
+    rt().block_on(async {
+        let (addr, shared) = spawn_mock(MockState::fail("prompt")).await;
+        let mut client = future_loop::agent_client::AgentClient::connect(&addr)
+            .await
+            .unwrap();
+        assert!(supervision::flush(&mut store, &goal, &mut client)
+            .await
+            .is_err());
+        let batches: Vec<_> = store
+            .events(&goal)
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| match e.event {
+                Event::SupervisorBatchPrepared {
+                    batch_id, message, ..
+                } => Some((batch_id, message)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(batches.len(), 1);
+        assert!(supervision::pending_delivery(&store, &goal).unwrap());
+        // New input while disconnected must NOT mutate the in-flight batch.
+        supervision::queue(&mut store, &goal, "completed", "t", "new result", "key-new").unwrap();
+        drop(store);
+        let mut store = open_store(&cr);
+        shared.lock().unwrap().fail_commands.clear();
+        supervision::flush(&mut store, &goal, &mut client)
+            .await
+            .unwrap();
+        assert_eq!(
+            shared.lock().unwrap().prompt_messages,
+            vec![batches[0].1.clone()]
+        );
+        assert!(supervision::pending_delivery(&store, &goal).unwrap());
+        supervision::flush(&mut store, &goal, &mut client)
+            .await
+            .unwrap();
+        supervision::flush(&mut store, &goal, &mut client)
+            .await
+            .unwrap();
+        assert_eq!(
+            shared.lock().unwrap().prompt_calls.len(),
+            2,
+            "no duplicate wakeups"
+        );
+        assert!(!supervision::pending_delivery(&store, &goal).unwrap());
+    });
+}
+
+#[test]
+fn steer_is_acknowledged_only_after_completed_writeback() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        stream_error: true,
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "steering restart");
+    cli_ok(&[
+        "supervisor",
+        "steer",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "a",
+        "--instruction",
+        "preserve this correction",
+    ]);
+    let _ = cli_err(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "a",
+        "--max-turns",
+        "1",
+    ]);
+    assert_eq!(
+        control::pending(&open_store(&cr), &goal, Some("a"))
+            .unwrap()
+            .len(),
+        1
+    );
+    {
+        let mut mock = shared.lock().unwrap();
+        mock.stream_error = false;
+        mock.events = completed_events("mock-run-2");
+    }
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "a",
+        "--max-turns",
+        "3",
+    ]);
+    assert!(control::pending(&open_store(&cr), &goal, Some("a"))
+        .unwrap()
+        .is_empty());
+    let messages = shared.lock().unwrap().prompt_messages.clone();
+    assert!(messages
+        .iter()
+        .all(|m| m.contains("preserve this correction")));
+}
+
+#[test]
+fn independent_work_completes_but_reverse_and_global_gate_edges_block() {
+    let cr = cli_root();
+    let goal = init_goal(&cr, "gate scope");
+    let blocked = add_todo(&cr, &goal, "blocked work");
+    let independent = add_todo(&cr, &goal, "independent work");
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "approve",
+        "--class",
+        "user_gate",
+        "--blocks",
+        &blocked,
+    ]);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &independent,
+        "--no-follow-up",
+        "--evidence",
+        "reviewed independent artifact",
+    ]);
+    let store = open_store(&cr);
+    let state = store.replay(&goal).unwrap().unwrap();
+    assert!(state.is_blocked(state.todo(&blocked).unwrap()));
+    assert!(!state.runnable_advancement().any(|t| t.id == blocked));
+    assert!(cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &blocked,
+        "--no-follow-up",
+        "--evidence",
+        "not approved"
+    ])
+    .contains("open gate"));
+}
+
+#[test]
+fn fan_in_never_hides_late_sources_and_contract_is_always_visible() {
+    use future_loop::state::{Goal, Todo, TodoStatus};
+    let mut goal = Goal::new("g", "synthesize", ".");
+    let ids: Vec<String> = (0..40).map(|n| format!("source-{n}")).collect();
+    for id in &ids {
+        let mut todo = Todo::advancement(id, "source");
+        todo.status = TodoStatus::Done;
+        todo.evidence = Some("evidence ".repeat(600));
+        goal.add(todo);
+    }
+    let mut synthesis = Todo::advancement("synthesis", "read upstream artifacts")
+        .blocking(&ids.iter().map(String::as_str).collect::<Vec<_>>());
+    synthesis.validator = Some("python validate.py".into());
+    synthesis.acceptance = Some("measured,replicated".into());
+    let envelope = future_loop::turn_envelope::compose_turn_envelope(&goal, &synthesis, None);
+    for id in ids {
+        assert!(envelope.contains(&format!("upstream {id}:")));
+    }
+    assert!(envelope.contains("python validate.py"));
+    assert!(envelope.contains("measured,replicated"));
+    assert!(
+        envelope.len() < 6000,
+        "summaries are bounded, not copied wholesale"
+    );
+}
+
+#[test]
+fn input_phase_does_not_count_twice_and_shell_is_only_activity() {
+    rt().block_on(async {
+        let events = vec![
+            ev(
+                "r",
+                0,
+                "tool_start",
+                r#"{"tool_name":"write","phase":"input"}"#,
+            ),
+            ev(
+                "r",
+                1,
+                "tool_start",
+                r#"{"tool_name":"write","phase":"execution"}"#,
+            ),
+            ev(
+                "r",
+                2,
+                "tool_start",
+                r#"{"tool_name":"shell","phase":"execution"}"#,
+            ),
+            ev("r", 3, "agent_end", r#"{"state":"completed"}"#),
+        ];
+        let (addr, _) = spawn_mock(MockState {
+            events,
+            ..Default::default()
+        })
+        .await;
+        let mut client = future_loop::agent_client::AgentClient::connect(&addr)
+            .await
+            .unwrap();
+        let progress = future_loop::agent_client::TurnProgressTracker::new(1);
+        let summary = client
+            .run_turn("s", "r", None, Some(&progress))
+            .await
+            .unwrap();
+        assert_eq!(progress.snapshot().tool_calls_total, 2);
+        assert_eq!(summary.tools, ["write", "shell"]);
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn detached_watchdog_reports_death_of_the_only_worker() {
+    let cr = cli_root();
+    let (_rt, shared) = mock_env(MockState {
+        hang_stream: true,
+        ..Default::default()
+    });
+    let goal = init_goal(&cr, "sole worker liveness");
+    let mut store = open_store(&cr);
+    store
+        .append(Event::SupervisorRegistered {
+            goal_id: goal.clone(),
+            session_id: "supervisor".into(),
+            ts: 1,
+        })
+        .unwrap();
+    // Always cancel the test goal, including on an assertion panic. This also
+    // lets the independent watchdog exit before its temporary root is removed.
+    struct Cleanup {
+        root: String,
+        goal: String,
+    }
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            if let Ok(mut store) = future_loop::store::Store::open(&self.root) {
+                let _ = store.append(Event::GoalCancelled {
+                    goal_id: self.goal.clone(),
+                    reason: "test cleanup".into(),
+                    ts: 2,
+                });
+            }
+        }
+    }
+    let cleanup = Cleanup {
+        root: cr.root.clone(),
+        goal: goal.clone(),
+    };
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_future-loop"))
+        .args([
+            "run",
+            "--goal",
+            &goal,
+            "--agent-id",
+            "sole",
+            "--max-turns",
+            "1",
+        ])
+        .env_remove("FUTURE_LOOP_NO_DETACH")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let pid = loop {
+        if let Some(pid) = store
+            .replay(&goal)
+            .unwrap()
+            .unwrap()
+            .todos
+            .iter()
+            .find_map(|t| t.holder_pid)
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "worker never acquired its lease"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
+    // SAFETY: this pid belongs to the detached worker created by this test.
+    assert_eq!(unsafe { libc::kill(pid as i32, libc::SIGKILL) }, 0);
+    loop {
+        if shared
+            .lock()
+            .unwrap()
+            .prompt_messages
+            .iter()
+            .any(|m| m.contains("host_died"))
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "last-worker death was not delivered by the independent watchdog"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    drop(cleanup);
+    while supervision::running(&store, &goal) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "watchdog did not exit on cancellation"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn dead_holder_is_recorded_without_any_agent_connection() {
+    let cr = cli_root();
+    let goal = init_goal(&cr, "dead worker offline");
+    let todo = first_todo_id(&cr.root, &goal);
+    // A PID obtained from our own reaped child, not an arbitrary real process.
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_future-loop"))
+        .arg("version")
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    child.wait().unwrap();
+    let mut store = open_store(&cr);
+    store
+        .append(Event::TodoClaimed {
+            goal_id: goal.clone(),
+            todo_id: todo.clone(),
+            agent_id: "dead".into(),
+            lease_expires_at: future_loop::state::now_epoch() + 300,
+            holder_pid: Some(pid),
+            ts: 1,
+        })
+        .unwrap();
+    supervision::record_dead_holders(&mut store, &goal).unwrap();
+    supervision::record_dead_holders(&mut store, &goal).unwrap();
+    assert_eq!(store.events(&goal).unwrap().iter().filter(|e| matches!(&e.event, Event::SupervisorNote { note_kind, .. } if note_kind == "host_died")).count(), 1);
+}


### PR DESCRIPTION
## Summary
- Replace new single-slot steering writes with UUID instructions and recipient-scoped, post-writeback acknowledgements; routine guidance waits for the next boundary and `--interrupt` is explicit. Preserve legacy event replay.
- Run validators asynchronously with independent timeouts, drained/bounded diagnostics, cancellation cleanup, platform-appropriate shells, and inconclusive infrastructure classification. Mark manual completion provenance.
- Add an independently detached, non-LLM watchdog and durable immutable notification batches with retry/deduplication. Detect death of the last worker and wall-clock-overdue verification without paid polling.
- Preserve every upstream source in fan-in envelopes, expose acceptance/validation contracts and milestone claims, distinguish activity from progress, and honor reverse/global gate edges consistently.
- Align English/Chinese architecture and operating docs; ship proportional loop/research skills with explicit budgets, evidence handoffs and honest non-success stop states.

## Skills / single-PR integration
The skills source is a separate repository. To retain the requested single PR, this PR pins the published `future-skills` feature commit `799c9b8` rather than opening another PR or modifying its main branch directly. Keep its source branch reachable while this gitlink is used.
[Full skills diff](https://github.com/futuregene/future-skills/compare/78df9446ff2373e6080649023b108adf4d551f8e...799c9b8)

## Validation
- `cargo fmt -p future-loop --check`
- `cargo clippy -p future-loop --all-targets -- -D warnings`
- `cargo test -p future-loop`: **955 passed**
- `cargo clippy -p future-loop --target x86_64-pc-windows-msvc --all-targets -- -D warnings` (cross-compilation, not Windows runtime testing)
- Skill frontmatter/metadata and `git diff --check`
- Fault coverage includes sole-worker SIGKILL notification, durable batch retry across reconnect/reopen, steering acknowledgement after successful writeback, wide fan-in, gate scope, output-pipe saturation, inherited-pipe timeout and validator cancellation.

## Operational notes
- Existing callers wanting immediate interruption must add `supervisor steer --interrupt`; update the executable together with the skills.
- Watchdog is an independent local process, not an automatically installed boot service. Host reboot recovery requires re-registration or a service manager running `supervisor watch`.
- Steering is at-least-once guidance, not exactly-once external effects. Notification receipt means queue acceptance, not supervisor action.
- No new hard token/currency cap is claimed; budgets and evidence-driven stopping remain explicit orchestration policy.