### PR TITLE
fix(loop): enforce completion contracts and preserve final handoffs

### DIFF
--- a/docs/loop-control-plane.md
+++ b/docs/loop-control-plane.md
@@ -145,6 +145,24 @@ root, and only GET endpoints exist (any other method is a 405). Mutations
 - All state is projected from `.future/loop/` on every request; the
   dashboard holds no separate state and writes nothing.
 
+## Completion receipts and contract enforcement
+
+Both manual and automatic advancement completion require nonempty evidence and
+all declared acceptance tokens. Automatic runs also require any configured
+validator to pass. Missing evidence is a rejected handoff, not a successful model
+turn; manual `--force` remains an explicitly recorded override. Tokens alone do
+not establish factual correctness.
+
+Automatic deliveries carry a JSON `task_delivery` receipt: goal/todo/worker/run/
+session identity, validation, recent evidence, full-text journal path and the
+number of other pending todos across all owners/classes. Read the artifacts before
+recording `verified`. Closing a slice does not invent successors or announce global
+completion; use `frontier show` for the latter. New live journals retain complete
+reply `text_chunk.text`; in-memory and ledger summaries are bounded recent tails.
+
+The watchdog delivers loop events; external scoring/compute results require an
+explicit monitor/adapter. A queued external request is not a verified result.
+
 ## Hard checks first (conventions fail, gates hold)
 - Empty-evidence closures are **refused** (fail-closed by default; `--force` opens)
 - `--verify` makes "wrote it" mean "it compiles / the artifact exists" — attach one to every delivery todo

--- a/docs/loop-control-plane.zh-CN.md
+++ b/docs/loop-control-plane.zh-CN.md
@@ -118,6 +118,20 @@ resolve、goal cancel 等）仍留在 CLI——页面只显示对应的 `future 
 - 所有状态在每次请求时都从 `.future/loop/` 投影出来；仪表盘不持有独立状态，也不写入
   任何内容。
 
+## 完成回执与契约执行
+
+手动和自动推进任务关单都要求非空证据及全部 acceptance token；自动 run 还要求已配置的
+验证器通过。缺证据属于交接被拒绝，不因模型正常结束就算成功。手动 `--force` 仍是有明确
+记录的覆盖；token 出现本身不证明事实正确。
+
+自动交付携带 JSON `task_delivery` 回执：goal/todo/worker/run/session 身份、验证结果、
+最近证据、全文日志路径，以及所有 owner/class 中其他未完成任务数。阅读产物后再记录
+`verified`。结束一个切片不自动编造后继关系，也不宣布全局完成；全局状态用 `frontier show`
+检查。新 live 日志保留完整回复 `text_chunk.text`，内存和账本摘要保留有界的最近文字。
+
+watchdog 投递 loop 事件；外部评分和算力结果需显式监控任务／适配器。外部请求已入队
+不等于结果已验证。
+
 ## 硬校验优先（约定靠不住，闸门靠得住）
 
 - 空证据关单会被**拒绝**（默认 fail-closed，`--force` 才放行）

--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -28,6 +28,12 @@ watchdog supervises process liveness and notification transport, not reasoning.
   validator wall time. Do not confuse `--max-turns` with a token/currency cap or
   a timeout for the agent's entire inner reasoning/tool loop.
 
+Automatic and manual completion share the nonempty-evidence and acceptance-token
+checks. A normal model return is not enough: a rejected handoff remains open with
+an explicit error. Automatic completion also checks any configured validator and
+rechecks the current contract before writeback. Other runnable tasks are never
+invented as successors; closing a slice does not close the goal.
+
 Manual completion intentionally differs from machine verification: it records a
 manual review (or explicit operator override), never a fabricated validator pass.
 A delivery is initially pending. `delivery record` records the reviewer's judgment;
@@ -144,6 +150,15 @@ index is O(fan-in), while summaries remain bounded. Full evidence is available v
 `status --format json`. Superseded sources are labeled, not treated as verified.
 The orchestrator must name artifact paths in downstream task text; summaries are
 not a substitute for reading reports and reproducing decisive measurements.
+
+Worker reply text is journaled in full as `text_chunk.text` in the per-run live
+file; bounded summaries keep the latest text rather than the opening plan.
+Completion notifications contain a JSON `task_delivery` receipt with trusted
+worker/session/run IDs, the validation result, the evidence tail and full-text
+journal path. `pending_other_todos` counts all owners/classes, not just the shared
+frontier. `awaiting_review` is not a scientific pass or global terminal verdict.
+External score/resource monitors still require an application-specific adapter;
+the watchdog does not query arbitrary external services.
 
 Separate **liveness**, **activity** and **progress**. `write/edit` execution starts
 are artifact-activity proxies; shell calls are not automatically writes. Provider

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -21,6 +21,11 @@
 - **预算**：外层回合数、验证尝试次数、验证命令独立墙钟上限。`--max-turns` 不是
   token/金额上限，也不是 Agent 内层推理和工具调用的总超时。
 
+自动与手动完成共用非空证据和 acceptance token 检查。模型正常结束回复本身不足以关单：
+交接契约未满足时，任务保持未完成并记录明确错误。自动完成还会检查已配置的验证器，并在
+写回前复核当前契约。其他可执行任务不会被自动编成后继关系；一个任务切片结束不等于
+整个 goal 结束。
+
 手动完成有意不重跑机器验证，但记录其依据为人工审阅或显式覆盖，不伪造机器通过。
 `delivered` 不等于 verified；`delivery record` 记录审阅者的判断。token 出现、文件存在、
 脚本 exit 0 都不能单独证明探索性结论正确。修改验收标准必须有明确理由。
@@ -99,6 +104,12 @@ Unix 用 `sh -c`，Windows 用 `cmd.exe /D /S /C`，不是跨平台通用 shell 
 fan-in 为每个已结束前置保留索引，摘要预算公平分配，不让第一个长报告吞掉后面的来源。
 索引随前置数量增长，摘要总量仍受限；完整 evidence 用 `status --format json` 读取。
 superseded 来源有明确标记。编排者仍须在下游 todo 写出产物路径，不把摘要当完整知识交接。
+
+worker 回复全文以 `text_chunk.text` 写入各 run 的 live 日志；有界摘要保留最近文字，
+不再只留开场计划。完成通知使用 JSON `task_delivery` 回执，含真实 worker/session/run ID、
+验证结果、证据尾部和全文日志路径。`pending_other_todos` 统计所有 owner/class 的未完成项，
+不是共享任务池大小；`awaiting_review` 不代表科学结论通过或整个 goal 已终局。
+外部评分、算力就绪等状态仍需应用适配器监控，watchdog 不会自行查询任意外部服务。
 
 区分 **存活、活动、进展**。`write/edit` 执行开始只是产物活动代理；shell 不自动算写入，
 provider input/execution 阶段不重复计数。真实进展来自新产物、验证结果、指标改善或假设

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -30,7 +30,8 @@ pub struct RunSummary {
     pub error: Option<String>,
     /// Tool names invoked this turn, in order.
     pub tools: Vec<String>,
-    /// Concatenated assistant text this turn (bounded to a few KB).
+    /// Latest assistant text this turn (bounded rolling tail). Full text chunks
+    /// remain in the live journal when enabled; this is not a full transcript.
     pub text: String,
     /// usage payload from agent_end, when present.
     pub usage: Option<Value>,
@@ -555,6 +556,13 @@ async fn consume_run_stream(
                     line["phase"] = serde_json::Value::String(p.to_string());
                 }
             }
+            // Keep complete reply text on disk before reducing the in-memory
+            // summary. Final outcomes must remain recoverable after truncation.
+            if ev.r#type == "text_chunk" {
+                if let Some(text) = data.get("text") {
+                    line["text"] = text.clone();
+                }
+            }
             // Tee usage so the read-only dashboard can expose real-time
             // in/out tokens + cost for an in-flight run (each request emits
             // exactly one `usage` event, so summing them never double-counts).
@@ -607,9 +615,7 @@ async fn consume_run_stream(
                     }
                     summary.text.push_str(text);
                     if summary.text.len() > 8_000 {
-                        // truncate at a UTF-8 char boundary — str::truncate panics mid-char
-                        let boundary = summary.text.floor_char_boundary(8_000);
-                        summary.text.truncate(boundary);
+                        summary.text = crate::completion::tail(&summary.text, 8_000);
                     }
                 }
             }

--- a/orchestration/loop/src/agents/supervision.rs
+++ b/orchestration/loop/src/agents/supervision.rs
@@ -131,7 +131,9 @@ pub async fn flush(store: &mut Store, goal_id: &str, client: &mut AgentClient) -
                 if !assigned.contains(dedup_key) {
                     assigned.insert(dedup_key.clone());
                     keys.push(dedup_key.clone());
-                    lines.push(crate::decision::truncate(message, 800));
+                    // Delivery receipts are already bounded and carry final
+                    // outcome + evidence pointers; do not clip them at 800 chars.
+                    lines.push(crate::executor::truncate_evidence(message, 4096));
                     if keys.len() == MAX_BATCH_NOTES {
                         break;
                     }

--- a/orchestration/loop/src/completion.rs
+++ b/orchestration/loop/src/completion.rs
@@ -1,0 +1,134 @@
+//! Completion evidence shared by manual and automatic paths. These checks
+//! enforce declared contracts, not the truth of a scientific claim.
+use crate::state::{Goal, RunRecord, TaskClass, Todo, TodoStatus};
+
+/// The caller owns explicit manual overrides; automatic writeback never bypasses
+/// this check. Validate the evidence that will actually survive in the ledger.
+pub fn evidence_error(todo: &Todo, evidence: &str) -> Option<String> {
+    if todo.class != TaskClass::Advancement {
+        return None;
+    }
+    let evidence = evidence.trim();
+    if evidence.is_empty() {
+        return Some(format!(
+            "todo {} needs non-empty --evidence (artifacts, results and verification); --force is a manual operator override only",
+            todo.id
+        ));
+    }
+    if let Some(acceptance) = &todo.acceptance {
+        let lower = evidence.to_lowercase();
+        let missing: Vec<_> = acceptance
+            .split(',')
+            .map(str::trim)
+            .filter(|token| !token.is_empty() && !lower.contains(&token.to_lowercase()))
+            .collect();
+        if !missing.is_empty() {
+            return Some(format!(
+                "todo {} acceptance contract unmet: evidence must contain [{}] (missing: [{}]); repair the handoff, not the criteria",
+                todo.id, acceptance, missing.join(", ")
+            ));
+        }
+    }
+    None
+}
+
+pub fn check_record(todo: &Todo, record: &mut RunRecord) {
+    if record.terminal_state == "completed" && record.error.is_none() {
+        record.error = evidence_error(todo, &record.evidence);
+    }
+}
+
+/// A rolling UTF-8-safe tail. Full assistant text is retained in the live journal;
+/// bounded summaries prioritize the latest outcome, not the opening plan.
+pub fn tail(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    const MARK: &str = "…";
+    if max_bytes < MARK.len() {
+        return String::new();
+    }
+    let start = text.ceil_char_boundary(text.len() - (max_bytes - MARK.len()));
+    format!("{MARK}{}", &text[start..])
+}
+
+/// Notification != global closure. Count all pending classes/owners, including
+/// deferred/blocked work; never infer global state from the shared frontier.
+pub fn pending_others(goal: &Goal, todo_id: &str) -> usize {
+    goal.todos
+        .iter()
+        .filter(|t| {
+            t.id != todo_id && !matches!(t.status, TodoStatus::Done | TodoStatus::Superseded)
+        })
+        .count()
+}
+
+/// A structured, bounded handoff with trusted run identity and a full-evidence
+/// pointer. Artifact/score claims remain in evidence; do not invent parsed facts.
+pub fn notice(
+    goal: &Goal,
+    record: &RunRecord,
+    agent_id: Option<&str>,
+    session_id: &str,
+    journal: &std::path::Path,
+) -> String {
+    let validation = record.validation.as_ref().map(|v| {
+        serde_json::json!({
+            "status": v.status,
+            "ok": v.ok,
+            "exit_code": v.exit_code,
+            "diagnostics_tail": tail(&v.summary, 400),
+        })
+    });
+    serde_json::json!({
+        "type": "task_delivery",
+        "goal_id": goal.goal_id,
+        "todo_id": record.todo_id,
+        "agent_id": agent_id,
+        "session_id": session_id,
+        "run_id": record.run_id,
+        "execution_state": record.terminal_state,
+        "delivery": "awaiting_review",
+        "pending_other_todos": pending_others(goal, &record.todo_id),
+        "validation": validation,
+        "evidence_tail": tail(&record.evidence, 800),
+        "full_text_journal": journal,
+        "next_action": "Read artifacts and current goal state; a task delivery is not global completion.",
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_evidence_gate_checks_empty_and_all_tokens() {
+        let mut todo = Todo::advancement("t", "deliver");
+        todo.acceptance = Some("attempt, scored".into());
+        assert!(evidence_error(&todo, " ").is_some());
+        assert!(evidence_error(&todo, "attempt queued").is_some());
+        assert!(evidence_error(&todo, "ATTEMPT 123 SCORED 0; failed science").is_none());
+        // Tokens are a contract floor, NOT a guarantee of positive results.
+    }
+
+    #[test]
+    fn tail_keeps_late_multibyte_results_with_a_byte_bound() {
+        for limit in 0..40 {
+            let result = tail(&"原始证据".repeat(30), limit);
+            assert!(result.len() <= limit);
+        }
+        let text = format!("{}FINAL: attempt 123 scored", "初期探索".repeat(4000));
+        assert!(tail(&text, 4000).ends_with("FINAL: attempt 123 scored"));
+    }
+
+    #[test]
+    fn pending_counts_owners_and_blocked_work_not_the_shared_frontier() {
+        let mut goal = Goal::new("g", "work", ".");
+        goal.add(Todo::advancement("a", "a").owned_by("alice"));
+        goal.add(Todo::advancement("b", "b").owned_by("bob"));
+        goal.add(Todo::coordination("review", "review").blocking(&["a", "b"]));
+        assert_eq!(goal.runnable_advancement().count(), 0);
+        assert_eq!(pending_others(&goal, "a"), 2);
+    }
+}

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -2591,43 +2591,12 @@ fn todo_complete(store: &mut Store, args: &[String]) -> Result<()> {
     } else {
         "manual_review"
     };
-    // O6: completion evidence contract (retrospective: 11/33 completions
-    // shipped <60-char evidence, several fully empty, and every one of those
-    // todos had to be reopened by hand). Advancement todos must carry real,
-    // non-empty evidence of what landed — `--force` is the explicit override
-    // for mechanical closeouts the operator owns.
-    let evidence_trim = evidence.as_deref().map(str::trim).unwrap_or("");
-    if is_advancement && evidence_trim.is_empty() && !force {
-        bail!(
-            "todo {todo_id} needs non-empty --evidence (what actually landed: attempt ids, \
-             paths, outputs, measurements). Add --force only for an explicit operator closeout."
-        );
-    }
-    // O7: acceptance contract (`todo add --acceptance "a,b"`) — evidence must
-    // contain every declared token (case-insensitive) before completion is
-    // accepted; `--force` overrides. Turns the ACCEPTANCE text convention
-    // (e.g. a platform attempt id) into a hard check.
-    if is_advancement {
-        if let Some(acc) = t.acceptance.as_deref() {
-            let tokens: Vec<&str> = acc
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .collect();
-            let lower = evidence_trim.to_lowercase();
-            let missing: Vec<&str> = tokens
-                .iter()
-                .filter(|tok| !lower.contains(&tok.to_lowercase()))
-                .copied()
-                .collect();
-            if !missing.is_empty() && !force {
-                bail!(
-                    "todo {todo_id} acceptance contract unmet: evidence must contain [{}] \
-                     (missing: [{}]). Declared via `todo add --acceptance`; --force overrides.",
-                    acc,
-                    missing.join(", ")
-                );
-            }
+    // Shared with automatic writeback. Only this explicit manual path can
+    // override the evidence floor; a normal model return cannot bypass it.
+    if !force {
+        if let Some(error) = crate::completion::evidence_error(t, evidence.as_deref().unwrap_or(""))
+        {
+            bail!("{error}");
         }
     }
     let successors = successor.clone().into_iter().collect::<Vec<_>>();
@@ -4955,26 +4924,32 @@ async fn run_turns(
             ))
             .await;
         }
-        // Writeback: complete with closure intent — remaining open todos
-        // become successors; the LAST todo declares no-follow-up (LoopX
-        // completion contract, verified against the real control plane).
-        let successors: Vec<String> = goal
-            .runnable_advancement()
-            .filter(|t| t.id != todo_id)
-            .map(|t| t.id.clone())
-            .collect();
-        let is_last = successors.is_empty();
-        // Validation-gated completion: `todo add --verify` keeps the todo open
-        // until the independent validator exits 0 (bounded retry below).
-        let succeeded = crate::executor::turn_succeeded(&record);
-        let completion = if succeeded {
-            Some((is_last, successors.clone()))
-        } else {
-            None
-        };
+        // Reconcile current state: the contract may have changed while the
+        // worker ran. Completing this slice never invents dependency edges to
+        // other runnable tasks and never means the whole goal is complete.
         let mut g = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
+        let mut record = record;
+        if let Some(current) = g.todo(&todo_id) {
+            crate::completion::check_record(current, &mut record);
+            if current.validator != goal.todo(&todo_id).and_then(|t| t.validator.clone()) {
+                record.error = Some(
+                    "completion contract changed during execution: rerun the current validator"
+                        .into(),
+                );
+            }
+        }
+        let successors = g
+            .todo(&todo_id)
+            .map(|t| t.successor_ids.clone())
+            .unwrap_or_default();
+        let no_follow_up = successors.is_empty();
+        let already_closed = g
+            .todo(&todo_id)
+            .is_none_or(|t| matches!(t.status, TodoStatus::Done | TodoStatus::Superseded));
+        let succeeded = !already_closed && crate::executor::turn_succeeded(&record);
+        let completion = succeeded.then(|| (no_follow_up, successors.clone()));
         let monitor_changed = if mode == crate::contract::TurnMode::MonitorPoll {
             Some(record.evidence.to_uppercase().contains("EXISTS"))
         } else {
@@ -4982,7 +4957,6 @@ async fn run_turns(
         };
         // G-7: stamp the spend source on the ledger entry before writeback
         // so quota accounting classifies it (run/agent/heartbeat).
-        let mut record = record;
         record.spend_source = Some(
             crate::quota::slot_accounting::classify_mode(mode)
                 .as_str()
@@ -4992,7 +4966,13 @@ async fn run_turns(
         // and the caller (cmd_run) uses it to decide session retention.
         record.failure_kind = Some(crate::executor::classify_failure(&record));
         *last_failure_kind = record.failure_kind;
-        writeback(&mut g, &record, monitor_changed, completion);
+        if already_closed {
+            // Keep spend/run evidence without reopening or re-completing a todo
+            // closed manually or superseded while this turn was in flight.
+            g.history.push(record.clone());
+        } else {
+            writeback(&mut g, &record, monitor_changed, completion);
+        }
         store.append_run(goal_id, &record)?;
         // Project-local per-run mirror (runs/ under the goal state dir).
         let _ = crate::compat::write_run(&store.goal_dir(goal_id), goal_id, &record);
@@ -5066,7 +5046,7 @@ async fn run_turns(
             store.append(Event::TodoCompleted {
                 goal_id: goal_id.to_string(),
                 todo_id: todo_id.clone(),
-                no_follow_up: is_last,
+                no_follow_up,
                 successor_ids: successors.clone(),
                 evidence: Some(record.evidence.clone()),
                 ts: now_epoch(),
@@ -5081,16 +5061,16 @@ async fn run_turns(
                 g.supervisor_session_id.as_deref(),
                 "completed",
                 &todo_id,
-                &format!(
-                    "[future-loop] goal {goal_id}: todo {todo_id} completed{} — evidence: {}",
-                    if is_last {
-                        " (last todo — closure pending)"
-                    } else {
-                        ""
-                    },
-                    crate::decision::truncate(&record.evidence, 300)
+                &crate::completion::notice(
+                    &g,
+                    &record,
+                    agent_id,
+                    session_id,
+                    &std::path::PathBuf::from(store.root_path())
+                        .join("runs")
+                        .join(format!("{}.live.jsonl", record.run_id)),
                 ),
-                &format!("completed:{todo_id}"),
+                &format!("completed:{todo_id}:{}", record.run_id),
             )
             .await;
             // P0-2①: a completed advancement todo is a delivery pending

--- a/orchestration/loop/src/executor.rs
+++ b/orchestration/loop/src/executor.rs
@@ -133,7 +133,11 @@ pub fn classify_failure(record: &crate::state::RunRecord) -> crate::state::Failu
         };
     }
     if record.terminal_state == "completed" {
-        return FailureKind::None;
+        return if record.error.is_some() {
+            FailureKind::HardError
+        } else {
+            FailureKind::None
+        };
     }
     // cancelled / incomplete / other non-terminal: treat as infra-recoverable
     // (budget-truncated or externally stopped; not a science failure).
@@ -143,7 +147,9 @@ pub fn classify_failure(record: &crate::state::RunRecord) -> crate::state::Failu
 /// A turn counts as succeeded only when the agent finished AND any attached
 /// independent validator passed (no validator ⇒ not required ⇒ ok).
 pub fn turn_succeeded(record: &RunRecord) -> bool {
-    record.terminal_state == "completed" && record.validation.as_ref().map(|v| v.ok).unwrap_or(true)
+    record.terminal_state == "completed"
+        && record.error.is_none()
+        && record.validation.as_ref().map(|v| v.ok).unwrap_or(true)
 }
 
 /// O3: evaluate turn-end progress. Returns `Some(idle_secs)` when the last
@@ -198,7 +204,7 @@ pub fn validator_tautology(cmd: &str) -> Option<&'static str> {
 /// `todo add --verify "cmd"` attaches a validator; the kernel runs it in the
 /// goal cwd and only completes the todo when it exits 0. No validator ⇒
 /// `None` (validation not required ⇒ material results default to ok).
-async fn run_validator(goal: &Goal, todo: &Todo) -> Option<TaskValidation> {
+pub(crate) async fn run_validator(goal: &Goal, todo: &Todo) -> Option<TaskValidation> {
     let cmd = todo.validator.as_deref()?;
     let timeout = std::env::var("FUTURE_LOOP_VALIDATOR_TIMEOUT_SECS")
         .ok()
@@ -346,7 +352,7 @@ pub async fn execute_turn(
         tokens_out_delta: after.tokens_out.saturating_sub(before.tokens_out),
         cost_delta: (after.cost - before.cost).max(0.0),
         tools: summary.tools,
-        evidence: truncate_evidence(&summary.text, 4_000),
+        evidence: crate::completion::tail(&summary.text, 4_000),
         recorded_at: now_epoch(),
         // G-7: stamped by the caller (main.rs writeback) with the mode-based
         // spend source before the record hits the ledger.
@@ -366,6 +372,7 @@ pub async fn execute_turn(
     } else {
         None
     };
+    crate::completion::check_record(todo, &mut record);
     Ok(record)
 }
 
@@ -386,6 +393,11 @@ pub fn writeback(
     monitor_changed: Option<bool>,
     completion: Option<(bool, Vec<String>)>,
 ) {
+    // Apply the same evidence floor even for direct/embedded writeback callers.
+    let mut record = record.clone();
+    if let Some(todo) = goal.todo(&record.todo_id) {
+        crate::completion::check_record(todo, &mut record);
+    }
     if let Some(changed) = monitor_changed {
         if let Some(m) = goal.todo_mut(&record.todo_id) {
             if changed {
@@ -407,10 +419,8 @@ pub fn writeback(
         }
         return;
     }
-    let failure_kind = record
-        .failure_kind
-        .unwrap_or_else(|| classify_failure(record));
-    if turn_succeeded(record) {
+    let failure_kind = classify_failure(&record);
+    if turn_succeeded(&record) {
         let (no_follow_up, successors) = completion.unwrap_or((true, vec![]));
         if let Some(t) = goal.todo_mut(&record.todo_id) {
             t.complete(no_follow_up, successors);

--- a/orchestration/loop/src/lib.rs
+++ b/orchestration/loop/src/lib.rs
@@ -17,6 +17,7 @@ pub mod canary;
 pub mod cli;
 pub mod cli_projection;
 pub mod compat;
+pub mod completion;
 pub mod console;
 pub mod contract;
 pub mod decision;

--- a/orchestration/loop/src/worker_bridge.rs
+++ b/orchestration/loop/src/worker_bridge.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::contract::TurnMode;
 use crate::decision::decide_for;
-use crate::executor::writeback;
+use crate::executor::{classify_failure, run_validator, turn_succeeded, writeback};
 use crate::state::{now_epoch, RunRecord};
 use crate::store::{Event, Store};
 
@@ -117,7 +117,7 @@ pub async fn run_bridge(store: &mut Store, opts: &BridgeOptions) -> Result<()> {
         let mut goal = store
             .replay(&opts.goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {} not found", opts.goal_id))?;
-        let record = RunRecord {
+        let mut record = RunRecord {
             turn,
             todo_id: result.todo_id.clone(),
             run_id: format!("worker-{turn}-{}", crate::state::now_epoch()),
@@ -139,19 +139,26 @@ pub async fn run_bridge(store: &mut Store, opts: &BridgeOptions) -> Result<()> {
             validation: None,
             truncation: None,
         };
-        // Completion contract: last remaining todo closes with no-follow-up;
-        // otherwise remaining todos become successors.
-        let successors: Vec<String> = goal
-            .runnable_advancement_for(opts.agent_id.as_deref())
-            .filter(|t| t.id != result.todo_id)
-            .map(|t| t.id.clone())
-            .collect();
-        let is_last = successors.is_empty();
-        let completion = if record.terminal_state == "completed" {
-            Some((is_last, successors.clone()))
-        } else {
-            None
-        };
+        // The stdio bridge is another automatic entry point, not an escape
+        // hatch around the selected todo's evidence and machine checks.
+        if record.terminal_state == "completed" {
+            if sel.as_deref() != Some(result.todo_id.as_str()) {
+                record.error = Some("worker result does not match the selected todo".into());
+            } else if let Some(todo) = goal.todo(&result.todo_id) {
+                crate::completion::check_record(todo, &mut record);
+                record.validation = run_validator(&goal, todo).await;
+            } else {
+                record.error = Some("worker result names a missing todo".into());
+            }
+        }
+        record.failure_kind = Some(classify_failure(&record));
+        let successors = goal
+            .todo(&result.todo_id)
+            .map(|t| t.successor_ids.clone())
+            .unwrap_or_default();
+        let no_follow_up = successors.is_empty();
+        let succeeded = turn_succeeded(&record);
+        let completion = succeeded.then(|| (no_follow_up, successors.clone()));
         writeback(&mut goal, &record, None, completion);
         store.append_run(&opts.goal_id, &record)?;
         store.append(Event::RunRecorded {
@@ -159,11 +166,11 @@ pub async fn run_bridge(store: &mut Store, opts: &BridgeOptions) -> Result<()> {
             record: record.clone(),
             ts: now_epoch(),
         })?;
-        if record.terminal_state == "completed" {
+        if succeeded {
             store.append(Event::TodoCompleted {
                 goal_id: opts.goal_id.clone(),
                 todo_id: result.todo_id.clone(),
-                no_follow_up: is_last,
+                no_follow_up,
                 successor_ids: successors.clone(),
                 evidence: Some(record.evidence.clone()),
                 ts: now_epoch(),

--- a/orchestration/loop/tests/agent_client_executor.rs
+++ b/orchestration/loop/tests/agent_client_executor.rs
@@ -364,7 +364,8 @@ fn run_turn_long_text_truncates_at_char_boundary() {
         let mut client = AgentClient::connect(&addr).await.unwrap();
         let summary = client.run_turn("sess", "mine", None, None).await.unwrap();
         assert!(summary.text.len() <= 8003, "{}", summary.text.len());
-        assert!(summary.text.starts_with("aaaa"));
+        assert!(summary.text.starts_with('…'));
+        assert!(summary.text.ends_with(&"b".repeat(200)));
     });
 }
 

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -66,7 +66,7 @@ fn run_anonymous_single_todo_to_terminal() {
 }
 
 #[test]
-fn run_with_agent_id_auto_registers_and_chains_successors() {
+fn run_with_agent_id_auto_registers_without_inventing_successors() {
     let cr = cli_root();
     let (_rt, shared) = mock_env(MockState {
         events: vec![
@@ -97,9 +97,10 @@ fn run_with_agent_id_auto_registers_and_chains_successors() {
     assert!(g.todos.iter().all(|t| t.status == TodoStatus::Done));
     assert!(g.registered_agents.contains(&"worker-7".to_string()));
     assert_eq!(shared.lock().unwrap().prompts, 2);
-    // The first completion names the second todo as successor.
+    // Runnable peers are independent work, not implicit semantic successors.
     let first = g.todos.first().unwrap();
-    assert_eq!(first.successor_ids.len(), 1, "successor chain: {first:?}");
+    assert!(first.successor_ids.is_empty(), "unexpected edge: {first:?}");
+    assert!(first.no_follow_up, "this slice has no declared follow-up");
 }
 
 #[test]

--- a/orchestration/loop/tests/completion_contract.rs
+++ b/orchestration/loop/tests/completion_contract.rs
@@ -1,0 +1,252 @@
+//! End-to-end (mock-agent) completion regressions: contracts are enforced on
+//! automatic writeback, final results survive long streams, and owner-scoped
+//! tasks cannot disappear from the supervisor's view.
+mod common;
+use common::mock_agent::*;
+use common::*;
+use future_loop::state::TodoStatus;
+use future_loop::store::Event;
+
+fn mock(text: &str) -> (tokio::runtime::Runtime, SharedState) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let events = replies("mock-run-1", &[text]);
+    let (addr, state) = runtime.block_on(spawn_mock(MockState {
+        events,
+        ..Default::default()
+    }));
+    std::env::set_var("FUTURE_LOOP_AGENT_ADDR", addr);
+    (runtime, state)
+}
+
+fn replies(run: &str, chunks: &[&str]) -> Vec<future_rpc::proto::StreamEvent> {
+    let mut events = vec![ev(run, 0, "agent_start", "{}")];
+    for (index, text) in chunks.iter().enumerate() {
+        events.push(ev(
+            run,
+            index as i64 + 1,
+            "text_chunk",
+            &serde_json::json!({"text": text}).to_string(),
+        ));
+    }
+    events.push(ev(
+        run,
+        chunks.len() as i64 + 1,
+        "agent_end",
+        r#"{"state":"completed"}"#,
+    ));
+    events
+}
+
+fn prepared_goal(cr: &CliRoot) -> String {
+    let goal = init_goal(cr, "completion contract regression");
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &first_todo_id(&cr.root, &goal),
+        "--no-follow-up",
+        "--evidence",
+        "connection checked",
+    ]);
+    goal
+}
+
+#[test]
+fn automatic_and_manual_paths_reject_missing_tokens_then_accept_a_repaired_handoff() {
+    let cr = cli_root();
+    let (_runtime, state) = mock("attempt 123 queued");
+    let goal = prepared_goal(&cr);
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "deliver result",
+        "--owner",
+        "solver",
+        "--acceptance",
+        "attempt,scored",
+    ]);
+    let todo = todo_id_by_text(&cr.root, &goal, "deliver result");
+    let _ = cli_err(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "solver",
+        "--max-turns",
+        "1",
+    ]);
+    let store = open_store(&cr);
+    let current = store.replay(&goal).unwrap().unwrap();
+    assert_eq!(current.todo(&todo).unwrap().status, TodoStatus::Open);
+    let record = current.history.iter().find(|r| r.todo_id == todo).unwrap();
+    assert!(record
+        .error
+        .as_ref()
+        .unwrap()
+        .contains("acceptance contract unmet"));
+    assert!(!store.events(&goal).unwrap().iter().any(|e| matches!(
+        &e.event, Event::TodoCompleted { todo_id, .. } if todo_id == &todo
+    )));
+    assert!(cli_err(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &todo,
+        "--no-follow-up",
+        "--evidence",
+        "attempt 123 queued",
+    ])
+    .contains("acceptance contract unmet"));
+    state.lock().unwrap().events = replies(
+        "mock-run-2",
+        &["attempt 123 SCORED 0; scientific requirements not met"],
+    );
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "solver",
+        "--max-turns",
+        "3",
+    ]);
+    assert_eq!(
+        open_store(&cr)
+            .replay(&goal)
+            .unwrap()
+            .unwrap()
+            .todo(&todo)
+            .unwrap()
+            .status,
+        TodoStatus::Done
+    );
+}
+
+#[test]
+fn normal_model_return_without_evidence_does_not_close_a_todo() {
+    let cr = cli_root();
+    let (_runtime, _) = mock("   ");
+    let goal = prepared_goal(&cr);
+    let todo = add_todo(&cr, &goal, "write an artifact");
+    let _ = cli_err(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "solver",
+        "--max-turns",
+        "1",
+    ]);
+    let goal = open_store(&cr).replay(&goal).unwrap().unwrap();
+    assert_eq!(goal.todo(&todo).unwrap().status, TodoStatus::Open);
+    assert!(goal
+        .history
+        .last()
+        .unwrap()
+        .error
+        .as_ref()
+        .unwrap()
+        .contains("non-empty"));
+}
+
+#[test]
+fn late_result_survives_stream_ledger_and_structured_notice_with_other_owners_pending() {
+    let cr = cli_root();
+    let (_runtime, state) = mock("");
+    let early = "Opening exploration. ".repeat(1000);
+    let final_text = "FINAL: attempt 456 scored 91. Verified artifact work/result.json; remaining uncertainty documented.";
+    state.lock().unwrap().events = replies("mock-run-1", &[&early, final_text]);
+    let goal = prepared_goal(&cr);
+    for (owner, text) in [("alice", "alice work"), ("bob", "bob work")] {
+        cli_ok(&[
+            "todo",
+            "add",
+            "--goal",
+            &goal,
+            "--text",
+            text,
+            "--owner",
+            owner,
+            "--acceptance",
+            "attempt,scored",
+        ]);
+    }
+    let alice = todo_id_by_text(&cr.root, &goal, "alice work");
+    let bob = todo_id_by_text(&cr.root, &goal, "bob work");
+    cli_ok(&[
+        "todo",
+        "add",
+        "--goal",
+        &goal,
+        "--text",
+        "global review",
+        "--class",
+        "coordination",
+        "--blocks",
+        &format!("{alice},{bob}"),
+    ]);
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "alice",
+        "--max-turns",
+        "3",
+    ]);
+    let store = open_store(&cr);
+    let current = store.replay(&goal).unwrap().unwrap();
+    assert_eq!(current.todo(&alice).unwrap().status, TodoStatus::Done);
+    assert_eq!(current.todo(&bob).unwrap().status, TodoStatus::Open);
+    assert!(
+        current.todo(&alice).unwrap().successor_ids.is_empty(),
+        "unrelated work is not a semantic successor"
+    );
+    assert!(!current.is_terminal());
+    let record = current.history.iter().find(|r| r.todo_id == alice).unwrap();
+    assert!(record.evidence.ends_with(final_text));
+    let notice = store
+        .events(&goal)
+        .unwrap()
+        .into_iter()
+        .find_map(|e| match e.event {
+            Event::SupervisorNote {
+                todo_id,
+                note_kind,
+                message,
+                ..
+            } if todo_id == alice && note_kind == "completed" => Some(message),
+            _ => None,
+        })
+        .unwrap();
+    let receipt: serde_json::Value = serde_json::from_str(&notice).unwrap();
+    assert_eq!(receipt["pending_other_todos"], 2);
+    assert_eq!(receipt["agent_id"], "alice");
+    assert_eq!(receipt["run_id"], record.run_id);
+    assert_eq!(receipt["session_id"], "mock-session-1");
+    assert_eq!(receipt["delivery"], "awaiting_review");
+    assert!(receipt["evidence_tail"]
+        .as_str()
+        .unwrap()
+        .contains(final_text));
+    assert!(!notice.contains("last todo"));
+    let journal = std::fs::read_to_string(receipt["full_text_journal"].as_str().unwrap()).unwrap();
+    let full_text: String = journal
+        .lines()
+        .filter_map(|line| {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap();
+            value["text"].as_str().map(str::to_owned)
+        })
+        .collect();
+    assert_eq!(full_text, format!("{early}{final_text}"));
+}

--- a/orchestration/loop/tests/console_subprocess_drive.rs
+++ b/orchestration/loop/tests/console_subprocess_drive.rs
@@ -84,6 +84,70 @@ fn init_goal(root: &str, objective: &str) -> String {
 // ── worker-bridge ──────────────────────────────────────────────────────────
 
 #[test]
+fn worker_bridge_enforces_acceptance_and_machine_validation() {
+    for (contract, validator, evidence) in [
+        (Some("attempt,scored"), None, "attempt queued"),
+        (None, Some("exit 7"), "artifact written"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_str().unwrap();
+        let gid = init_goal(root, "bridge completion gates");
+        let store = future_loop::store::Store::open(root).unwrap();
+        let bootstrap = store.replay(&gid).unwrap().unwrap().todos[0].id.clone();
+        assert_eq!(
+            run(
+                root,
+                &[
+                    "todo",
+                    "supersede",
+                    "--goal",
+                    &gid,
+                    "--todo-id",
+                    &bootstrap,
+                    "--reason",
+                    "test setup"
+                ]
+            )
+            .2,
+            0
+        );
+        let mut args = vec!["todo", "add", "--goal", &gid, "--text", "checked delivery"];
+        if let Some(value) = contract {
+            args.extend(["--acceptance", value]);
+        }
+        if let Some(value) = validator {
+            args.extend(["--verify", value]);
+        }
+        assert_eq!(run(root, &args).2, 0);
+        let id = store
+            .replay(&gid)
+            .unwrap()
+            .unwrap()
+            .todos
+            .iter()
+            .find(|t| t.text.contains("checked delivery"))
+            .unwrap()
+            .id
+            .clone();
+        let input = format!(
+            "{}\nBRIDGE done\n",
+            serde_json::json!({
+                "todo_id": id, "terminal_state": "completed", "evidence": evidence,
+            })
+        );
+        let (_, err, code) = run_stdin(root, &["worker-bridge", "--goal", &gid], &input);
+        assert_eq!(code, 0, "{err}");
+        let after = store.replay(&gid).unwrap().unwrap();
+        assert_eq!(
+            after.todo(&id).unwrap().status,
+            future_loop::state::TodoStatus::Open
+        );
+        let record = after.history.last().unwrap();
+        assert!(!future_loop::executor::turn_succeeded(record));
+    }
+}
+
+#[test]
 fn worker_bridge_worker_finishes_on_eof_and_done() {
     let root = tmp_root("bridge-eof");
     let gid = init_goal(&root, "bridge eof");
@@ -182,10 +246,10 @@ fn worker_bridge_failed_turns_hit_max_turns() {
 }
 
 #[test]
-fn worker_bridge_successor_chain_on_non_final_todo() {
+fn worker_bridge_does_not_invent_successor_chain() {
     let root = tmp_root("bridge-succ");
     let gid = init_goal(&root, "bridge successors");
-    // A second open todo → completing the selected one names it as successor.
+    // A second open todo is independent work, not an implicit successor.
     let (_, _, code) = run(
         &root,
         &["todo", "add", "--goal", &gid, "--text", "second task"],
@@ -222,11 +286,11 @@ fn worker_bridge_successor_chain_on_non_final_todo() {
     assert!(rest.contains("BRIDGE writeback"), "{rest}");
     let status = child.wait().unwrap();
     assert!(status.success());
-    // The completed todo carries the remaining one as its successor.
+    // The completed slice does not create an edge to unrelated work.
     let store = future_loop::store::Store::open(&root).unwrap();
     let g = store.replay(&gid).unwrap().unwrap();
     let done = g.todos.iter().find(|t| t.id == todo_id).unwrap();
-    assert_eq!(done.successor_ids.len(), 1, "{done:?}");
+    assert!(done.successor_ids.is_empty(), "{done:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #497, addressing three still-open correctness issues found in real multi-worker runs:

1. **Enforce completion evidence on automatic paths.** Manual completion, agent-backed runs, embedded writeback and the stdio worker bridge share nonempty-evidence/acceptance checks. Normal model return alone does not close a rejected handoff. The bridge also executes configured validators. Manual `--force` remains explicit; token checks are not scientific correctness checks.
2. **Preserve late outcomes and hand off evidence reliably.** Persist full reply text chunks in per-run live journals, keep bounded recent tails in summaries, and deliver structured JSON receipts carrying goal/todo/agent/run/session identity, verification, pending-work count and the full-text journal pointer. Do not cut receipts back to the old 300/800-character opening snippets.
3. **Do not confuse a slice finishing with the goal finishing.** Count pending work across owners/classes; remove the misleading last-todo claim and stop inventing successor edges from unrelated runnable tasks. Reconcile current task/validator state before writeback and avoid duplicate closure of already closed tasks.

Sync English AND Chinese architecture and control-plane guides. Bump the skills submodule to merged future-skills PR https://github.com/futuregene/future-skills/pull/46 (future-loop v4.1 and research v3.3).

## Validation

- `cargo fmt --all --check` — passed.
- `cargo clippy -p future-loop --all-targets --offline -- -D warnings` — passed.
- Full `cargo test -p future-loop --offline -- --test-threads=1` — passed before the final bridge entry-point hardening; bridge suite subsequently passed 12/12, including new acceptance/validator regressions.
- New completion tests cover empty evidence, missing tokens, repaired handoff, long-stream late results, full-text recovery, trusted notification identities and other owner-scoped work remaining open.
- Existing successor tests now assert no invented peer edges; the workers still execute both independent tasks.
- Skills offline document/fixture checks passed; no paid model or external competition submission was made.

## Scope

No protobuf or event-schema migration; old records remain readable. Structured receipts are serialized in the existing SupervisorNote message. This does not install/restart the production agent, add a science policy engine, promise a monetary cap, or provide an external scoring/GPU adapter. Those remain separate work.
