### PR TITLE
test(loop): keep CLI registry probes from leaking watchdogs

### DIFF
--- a/orchestration/loop/tests/cli_registry_contract.rs
+++ b/orchestration/loop/tests/cli_registry_contract.rs
@@ -29,6 +29,10 @@ fn tmp_root(tag: &str) -> String {
 fn run(root: &str, args: &[&str]) -> (String, String, i32) {
     let output = Command::new(bin())
         .env("FUTURE_LOOP_ROOT", root)
+        // This suite checks CLI dispatch, not background supervision. Registering
+        // a fake supervisor must not leave a watcher alive after the test exits.
+        // Production watchdog lifecycle is exercised in reliability_contract.
+        .env("FUTURE_LOOP_NO_DETACH", "1")
         .args(args)
         .output()
         .expect("loopx binary runs");


### PR DESCRIPTION
Follow-up to #499: the CLI registry subprocess suite registers a fake supervisor and previously left its non-LLM watchdog alive. Set FUTURE_LOOP_NO_DETACH=1 in this dispatch-only test harness; production detached watchdog lifecycle remains covered in reliability_contract. No production behavior changes. Validation: cargo fmt --all --check; cli_registry_contract 9/9, completion_contract 3/3, console_subprocess_drive 12/12 passed locally. Earlier full Linux CI for #499 passed.