### PR TITLE
Adopt renamed builtin future-explore skill

### DIFF
--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Operational commands: [control plane guide](../../docs/loop-control-plane.md).
 Agent driving policy: `skills/builtin/future-loop/SKILL.md`; research methodology:
-`skills/builtin/future-research/SKILL.md` (the skills submodule).
+`skills/builtin/future-explore/SKILL.md` (the skills submodule).
 
 ## Boundaries
 

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -1,7 +1,7 @@
 # Loop 架构：持久看板、可靠控制、基于证据的 Agent
 
 操作指南：[Loop 控制面](../../docs/loop-control-plane.zh-CN.md)。编排驾驶手册：
-`skills/builtin/future-loop/SKILL.md`；研究方法：`skills/builtin/future-research/SKILL.md`。
+`skills/builtin/future-loop/SKILL.md`；研究方法：`skills/builtin/future-explore/SKILL.md`。
 两份 skill 都由 skills 子模块分发。英文详细契约见 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 ## 边界


### PR DESCRIPTION
## Summary
- Update the skills submodule to futuregene/future-skills#47 (6012aaf), renaming future-research to future-explore.
- Update English and Chinese loop architecture links to the new builtin path.

## Validation
- Submodule offline orchestration checks: passed (2 documents, 12 scenario definitions).
- Submodule deep-research checks: passed (5 documents, 15 scenarios).
- git diff --cached --check: passed.
- No Rust/TypeScript code changed; no build or model calls required.