### PR TITLE
fix(desktop): align launchers with local agent IPC

### DIFF
--- a/scripts/start-desktop-linux.sh
+++ b/scripts/start-desktop-linux.sh
@@ -9,9 +9,9 @@
 # tested; future-agent owns the authoritative capability and security checks.
 #
 # Environment knobs:
-#   FUTURE_AGENT_GRPC_ADDR  Agent address (default: 127.0.0.1:50051)
+#   FUTURE_AGENT_GRPC_ADDR  Explicit TCP address (default: local IPC)
 #   DESKTOP_DEV_PORT        Vite dev-server port (default: 5173)
-#   REUSE_AGENT             Reuse an agent already listening (default: 0)
+#   REUSE_AGENT             Reuse an agent already reachable (default: 0)
 #   BUILD_AGENT             Build future-agent first (default: 1)
 #   BUILD_CLI               Build future CLI and add it to PATH (default: 1)
 #   CLEAN_STALE_APP_TASKS   Cancel stale runs/approvals first (default: 1)
@@ -27,9 +27,29 @@ AGENT_DIR="$ROOT_DIR/agent"
 CLI_DIR="$ROOT_DIR/cli"
 LOG_DIR="$ROOT_DIR/.logs"
 
-AGENT_ADDR="${FUTURE_AGENT_GRPC_ADDR:-127.0.0.1:50051}"
-AGENT_HOST="${AGENT_ADDR%%:*}"
-AGENT_PORT="${AGENT_ADDR##*:}"
+AGENT_ADDR="${FUTURE_AGENT_GRPC_ADDR:-auto}"
+case "$AGENT_ADDR" in
+  ""|[Aa][Uu][Tt][Oo])
+    AGENT_TRANSPORT="local"
+    AGENT_ADDR="auto"
+    if [[ -n "${FUTURE_AGENT_SOCKET:-}" ]]; then
+      AGENT_SOCKET="$FUTURE_AGENT_SOCKET"
+    elif [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+      AGENT_SOCKET="$XDG_RUNTIME_DIR/future/agent.sock"
+    else
+      AGENT_SOCKET="$HOME/.future/run/agent.sock"
+    fi
+    AGENT_ENDPOINT="unix://$AGENT_SOCKET"
+    ;;
+  *)
+    AGENT_TRANSPORT="tcp"
+    AGENT_TCP_ADDR="${AGENT_ADDR#http://}"
+    AGENT_TCP_ADDR="${AGENT_TCP_ADDR#https://}"
+    AGENT_HOST="${AGENT_TCP_ADDR%:*}"
+    AGENT_PORT="${AGENT_TCP_ADDR##*:}"
+    AGENT_ENDPOINT="http://$AGENT_TCP_ADDR"
+    ;;
+esac
 DESKTOP_DEV_PORT="${DESKTOP_DEV_PORT:-5173}"
 AGENT_LOG="$HOME/.future/agent/logs/agent.log"
 AGENT_CONSOLE_LOG="$LOG_DIR/future-agent-test.log.console"
@@ -57,6 +77,22 @@ require_tool() {
 
 port_is_open() {
   (exec 3<>"/dev/tcp/$AGENT_HOST/$AGENT_PORT") >/dev/null 2>&1
+}
+
+agent_is_ready() {
+  if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+    port_is_open
+    return
+  fi
+
+  [[ -S "$AGENT_SOCKET" ]] || return 1
+  if [[ -x "$ROOT_DIR/target/debug/future" ]]; then
+    (
+      unset FUTURE_AGENT_GRPC_ADDR
+      FUTURE_AGENT_SOCKET="$AGENT_SOCKET" \
+        "$ROOT_DIR/target/debug/future" models --json >/dev/null 2>&1
+    )
+  fi
 }
 
 pid_looks_like_agent() {
@@ -121,13 +157,13 @@ wait_for_agent() {
   local attempts=60
 
   for _ in $(seq 1 "$attempts"); do
-    if port_is_open; then
+    if agent_is_ready; then
       return 0
     fi
     sleep 1
   done
 
-  echo "future-agent did not become ready at $AGENT_ADDR"
+  echo "future-agent did not become ready at $AGENT_ENDPOINT"
   echo "Agent log: $AGENT_LOG"
   tail -n 80 "$AGENT_LOG" 2>/dev/null || true
   echo "Agent console log (stdout/stderr, panics): $AGENT_CONSOLE_LOG"
@@ -176,7 +212,7 @@ mkdir -p -- "$LOG_DIR"
 
 echo "FutureOS local desktop test (Linux)"
 echo "Workspace: $ROOT_DIR"
-echo "Agent gRPC: $AGENT_ADDR"
+echo "Agent endpoint: $AGENT_ENDPOINT"
 echo "Desktop dev port: $DESKTOP_DEV_PORT"
 if command -v bwrap >/dev/null 2>&1; then
   echo "Bubblewrap: $(command -v bwrap) ($(bwrap --version 2>/dev/null || echo 'version unavailable'))"
@@ -223,13 +259,13 @@ if [[ -x "$ROOT_DIR/target/debug/future" ]]; then
   export PATH="$ROOT_DIR/target/debug:$PATH"
 fi
 
-if [[ "$REUSE_AGENT" == "1" ]] && port_is_open; then
-  echo "Using existing future-agent at $AGENT_ADDR"
+if [[ "$REUSE_AGENT" == "1" ]] && agent_is_ready; then
+  echo "Using existing future-agent at $AGENT_ENDPOINT"
 else
   stop_pid_file_process
-  if port_is_open; then
-    echo "Port $AGENT_PORT is already in use, but not by the agent recorded in $AGENT_PID_FILE."
-    echo "Stop it manually, or use REUSE_AGENT=1 if it is the intended agent."
+  if agent_is_ready; then
+    echo "Agent endpoint $AGENT_ENDPOINT is already in use, but not by the process recorded in $AGENT_PID_FILE."
+    echo "Stop the old agent manually, or use REUSE_AGENT=1 if it is the intended agent."
     exit 1
   fi
 
@@ -242,7 +278,11 @@ else
   # not a cargo wrapper that could leave an orphan holding the gRPC port.
   (
     cd "$AGENT_DIR"
-    exec "$AGENT_BIN" --grpc-addr "$AGENT_ADDR" --log-file
+    if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+      exec "$AGENT_BIN" --grpc-addr "$AGENT_TCP_ADDR" --log-file
+    else
+      exec "$AGENT_BIN" --log-file
+    fi
   ) >"$AGENT_CONSOLE_LOG" 2>&1 &
   STARTED_AGENT_PID="$!"
   echo "$STARTED_AGENT_PID" >"$AGENT_PID_FILE"
@@ -269,7 +309,11 @@ echo "Starting desktop..."
 echo "Press Ctrl-C here to stop Desktop and the agent started by this script."
 
 if [[ "$DESKTOP_DEV_PORT" == "5173" ]]; then
-  (cd "$DESKTOP_DIR" && FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" npm run tauri:dev)
+  if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+    (cd "$DESKTOP_DIR" && FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" npm run tauri:dev)
+  else
+    (cd "$DESKTOP_DIR" && unset FUTURE_AGENT_GRPC_ADDR && npm run tauri:dev)
+  fi
 else
   TAURI_DEV_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/futureos-tauri-dev.XXXXXX")"
   printf '%s\n' \
@@ -281,7 +325,12 @@ else
     '}' >"$TAURI_DEV_CONFIG_FILE"
   (
     cd "$DESKTOP_DIR"
-    FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" \
+    if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+      FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" \
+        npm run tauri:dev -- --config "$TAURI_DEV_CONFIG_FILE"
+    else
+      unset FUTURE_AGENT_GRPC_ADDR
       npm run tauri:dev -- --config "$TAURI_DEV_CONFIG_FILE"
+    fi
   )
 fi

--- a/scripts/start-desktop-macos.sh
+++ b/scripts/start-desktop-macos.sh
@@ -11,9 +11,23 @@ AGENT_DIR="$ROOT_DIR/agent"
 CLI_DIR="$ROOT_DIR/cli"
 LOG_DIR="$ROOT_DIR/.logs"
 
-AGENT_ADDR="${FUTURE_AGENT_GRPC_ADDR:-127.0.0.1:50051}"
-AGENT_HOST="${AGENT_ADDR%%:*}"
-AGENT_PORT="${AGENT_ADDR##*:}"
+AGENT_ADDR="${FUTURE_AGENT_GRPC_ADDR:-auto}"
+case "$AGENT_ADDR" in
+  ""|[Aa][Uu][Tt][Oo])
+    AGENT_TRANSPORT="local"
+    AGENT_ADDR="auto"
+    AGENT_SOCKET="${FUTURE_AGENT_SOCKET:-$HOME/.future/run/agent.sock}"
+    AGENT_ENDPOINT="unix://$AGENT_SOCKET"
+    ;;
+  *)
+    AGENT_TRANSPORT="tcp"
+    AGENT_TCP_ADDR="${AGENT_ADDR#http://}"
+    AGENT_TCP_ADDR="${AGENT_TCP_ADDR#https://}"
+    AGENT_HOST="${AGENT_TCP_ADDR%:*}"
+    AGENT_PORT="${AGENT_TCP_ADDR##*:}"
+    AGENT_ENDPOINT="http://$AGENT_TCP_ADDR"
+    ;;
+esac
 DESKTOP_DEV_PORT="${DESKTOP_DEV_PORT:-5173}"
 # The agent writes to its default log location (~/.future/agent/logs/agent.log,
 # created by the agent itself) via bare `--log-file`; the repo .logs dir only
@@ -44,18 +58,34 @@ wait_for_agent() {
   local attempts=60
 
   for _ in $(seq 1 "$attempts"); do
-    if nc -z "$AGENT_HOST" "$AGENT_PORT" >/dev/null 2>&1; then
+    if agent_is_ready; then
       return 0
     fi
     sleep 1
   done
 
-  echo "future-agent did not become ready at $AGENT_ADDR"
+  echo "future-agent did not become ready at $AGENT_ENDPOINT"
   echo "Agent log: $AGENT_LOG"
   tail -n 80 "$AGENT_LOG" 2>/dev/null || true
   echo "Agent console log (stdout/stderr, panics): $AGENT_CONSOLE_LOG"
   tail -n 80 "$AGENT_CONSOLE_LOG" 2>/dev/null || true
   return 1
+}
+
+agent_is_ready() {
+  if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+    nc -z "$AGENT_HOST" "$AGENT_PORT" >/dev/null 2>&1
+    return
+  fi
+
+  [[ -S "$AGENT_SOCKET" ]] || return 1
+  if [[ -x "$ROOT_DIR/target/debug/future" ]]; then
+    (
+      unset FUTURE_AGENT_GRPC_ADDR
+      FUTURE_AGENT_SOCKET="$AGENT_SOCKET" \
+        "$ROOT_DIR/target/debug/future" models --json >/dev/null 2>&1
+    )
+  fi
 }
 
 stop_pid_file_process() {
@@ -142,7 +172,7 @@ trap cleanup EXIT INT TERM
 mkdir -p "$LOG_DIR"
 
 echo "Workspace: $ROOT_DIR"
-echo "Agent gRPC: $AGENT_ADDR"
+echo "Agent endpoint: $AGENT_ENDPOINT"
 echo "desktop dev port: $DESKTOP_DEV_PORT"
 
 if [[ "$DRY_RUN" == "1" ]]; then
@@ -187,13 +217,13 @@ if [[ -x "$ROOT_DIR/target/debug/future" ]]; then
   export PATH="$ROOT_DIR/target/debug:$PATH"
 fi
 
-if [[ "$REUSE_AGENT" == "1" ]] && nc -z "$AGENT_HOST" "$AGENT_PORT" >/dev/null 2>&1; then
-  echo "Using existing future-agent at $AGENT_ADDR"
+if [[ "$REUSE_AGENT" == "1" ]] && agent_is_ready; then
+  echo "Using existing future-agent at $AGENT_ENDPOINT"
 else
   stop_pid_file_process "$AGENT_PID_FILE" "future-agent"
-  if nc -z "$AGENT_HOST" "$AGENT_PORT" >/dev/null 2>&1; then
-    echo "Port $AGENT_PORT is already in use, but not by the agent process recorded in $AGENT_PID_FILE."
-    echo "Stop the old process manually, or run with REUSE_AGENT=1 if you intentionally want to reuse it."
+  if agent_is_ready; then
+    echo "Agent endpoint $AGENT_ENDPOINT is already in use, but not by the process recorded in $AGENT_PID_FILE."
+    echo "Stop the old agent manually, or run with REUSE_AGENT=1 if you intentionally want to reuse it."
     exit 1
   fi
   echo "Starting future-agent..."
@@ -217,7 +247,11 @@ else
   # shell redirection.
   (
     cd "$AGENT_DIR"
-    exec "$AGENT_BIN" --log-file
+    if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+      exec "$AGENT_BIN" --grpc-addr "$AGENT_TCP_ADDR" --log-file
+    else
+      exec "$AGENT_BIN" --log-file
+    fi
   ) >"$AGENT_CONSOLE_LOG" 2>&1 &
   STARTED_AGENT_PID="$!"
   echo "$STARTED_AGENT_PID" >"$AGENT_PID_FILE"
@@ -246,5 +280,10 @@ echo "Press Ctrl-C here to stop the desktop and the agent started by this script
 
 (
   cd "$DESKTOP_DIR"
-  FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" npm run tauri:dev
+  if [[ "$AGENT_TRANSPORT" == "tcp" ]]; then
+    FUTURE_AGENT_GRPC_ADDR="$AGENT_ADDR" npm run tauri:dev
+  else
+    unset FUTURE_AGENT_GRPC_ADDR
+    npm run tauri:dev
+  fi
 )

--- a/scripts/start-desktop-windows.bat
+++ b/scripts/start-desktop-windows.bat
@@ -6,9 +6,9 @@ rem builds + starts future-agent, then runs the Tauri desktop in dev mode agains
 rem and stops the agent it started when the desktop exits.
 rem
 rem Knobs (set before running, e.g. `set REUSE_AGENT=1`):
-rem   FUTURE_AGENT_GRPC_ADDR  default 127.0.0.1:50051
+rem   FUTURE_AGENT_GRPC_ADDR  explicit TCP address (default: local IPC)
 rem   DESKTOP_DEV_PORT            default 5173
-rem   REUSE_AGENT             1 = reuse an agent already listening on the port
+rem   REUSE_AGENT             1 = reuse an agent already reachable
 rem   BUILD_AGENT             1 = cargo build the agent first (default 1)
 rem   BUILD_CLI               1 = build the future CLI and put it on the agent's
 rem                               PATH so skills that call `future` work (default 1)
@@ -27,11 +27,21 @@ set "AGENT_DIR=%ROOT_DIR%\agent"
 set "CLI_DIR=%ROOT_DIR%\cli"
 set "LOG_DIR=%ROOT_DIR%\.logs"
 
-if not defined FUTURE_AGENT_GRPC_ADDR set "FUTURE_AGENT_GRPC_ADDR=127.0.0.1:50051"
-set "AGENT_ADDR=%FUTURE_AGENT_GRPC_ADDR%"
-for /f "tokens=1,2 delims=:" %%a in ("%AGENT_ADDR%") do (
-  set "AGENT_HOST=%%a"
-  set "AGENT_PORT=%%b"
+set "AGENT_MODE=local"
+set "AGENT_ADDR=auto"
+set "AGENT_ENDPOINT=per-user named pipe"
+if defined FUTURE_AGENT_GRPC_ADDR (
+  set "AGENT_ADDR=%FUTURE_AGENT_GRPC_ADDR%"
+  if /I not "%FUTURE_AGENT_GRPC_ADDR%"=="auto" set "AGENT_MODE=tcp"
+)
+if "%AGENT_MODE%"=="tcp" (
+  set "AGENT_TCP_ADDR=%AGENT_ADDR:http://=%"
+  set "AGENT_TCP_ADDR=!AGENT_TCP_ADDR:https://=!"
+  for /f "tokens=1,2 delims=:" %%a in ("!AGENT_TCP_ADDR!") do (
+    set "AGENT_HOST=%%a"
+    set "AGENT_PORT=%%b"
+  )
+  set "AGENT_ENDPOINT=http://!AGENT_TCP_ADDR!"
 )
 if not defined DESKTOP_DEV_PORT set "DESKTOP_DEV_PORT=5173"
 if not defined REUSE_AGENT set "REUSE_AGENT=0"
@@ -53,7 +63,7 @@ set "AGENT_PID="
 if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
 
 echo Workspace: %ROOT_DIR%
-echo Agent gRPC: %AGENT_ADDR%
+echo Agent endpoint: %AGENT_ENDPOINT%
 echo desktop dev port: %DESKTOP_DEV_PORT%
 
 if "%DRY_RUN%"=="1" (
@@ -96,23 +106,20 @@ rem resolve it. The agent (started below) inherits this process's environment.
 rem cargo build writes to the workspace-level target dir, not cli/target.
 if exist "%ROOT_DIR%\target\debug\future.exe" set "PATH=%ROOT_DIR%\target\debug;%PATH%"
 
-call :port_in_use
-set "PORT_BUSY=%ERRORLEVEL%"
+call :agent_is_ready
+set "AGENT_READY=%ERRORLEVEL%"
 
-if "%REUSE_AGENT%"=="1" if "%PORT_BUSY%"=="0" (
-  echo Using existing future-agent at %AGENT_ADDR%
+if "%REUSE_AGENT%"=="1" if "%AGENT_READY%"=="0" (
+  echo Using existing future-agent at %AGENT_ENDPOINT%
   goto :start_desktop
 )
 
-if "%PORT_BUSY%"=="0" (
-  echo Port %AGENT_PORT% is already in use.
-  call :stop_pid_file_process
-  call :port_in_use
-  set "PORT_BUSY=%ERRORLEVEL%"
-  if "!PORT_BUSY!"=="0" (
-    echo Stop the old process, or run with REUSE_AGENT=1 to reuse it.
-    exit /b 1
-  )
+call :stop_pid_file_process
+call :agent_is_ready
+if "%ERRORLEVEL%"=="0" (
+  echo Agent endpoint %AGENT_ENDPOINT% is already in use.
+  echo Stop the old agent, or run with REUSE_AGENT=1 to reuse it.
+  exit /b 1
 )
 
 if not exist "%AGENT_BIN%" (
@@ -128,7 +135,7 @@ rem PowerShell writes the PID to the pid file; we read it back. Do NOT capture
 rem the PID through `for /f` here: Start-Process redirection makes the spawned
 rem agent inherit the for-pipe handle, so `for /f` blocks until the agent exits.
 del /q "%AGENT_PID_FILE%" >nul 2>&1
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Start-Process -FilePath $env:AGENT_BIN -ArgumentList @('--grpc-addr', $env:AGENT_ADDR) -WorkingDirectory $env:AGENT_DIR -RedirectStandardOutput $env:AGENT_LOG -RedirectStandardError $env:AGENT_ERR -WindowStyle Hidden -PassThru; [System.IO.File]::WriteAllText($env:AGENT_PID_FILE, [string]$p.Id)"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$start = @{ FilePath = $env:AGENT_BIN; WorkingDirectory = $env:AGENT_DIR; RedirectStandardOutput = $env:AGENT_LOG; RedirectStandardError = $env:AGENT_ERR; WindowStyle = 'Hidden'; PassThru = $true }; if ($env:AGENT_MODE -eq 'tcp') { $start.ArgumentList = @('--grpc-addr', $env:AGENT_TCP_ADDR) }; $p = Start-Process @start; [System.IO.File]::WriteAllText($env:AGENT_PID_FILE, [string]$p.Id)"
 
 set "AGENT_PID="
 if exist "%AGENT_PID_FILE%" set /p AGENT_PID=<"%AGENT_PID_FILE%"
@@ -150,7 +157,11 @@ echo Starting desktop...
 echo Press Ctrl-C to stop the desktop. At the "Terminate batch job (Y/N)?" prompt choose N
 echo so this script can stop the agent it started; choosing Y leaves the agent running
 echo (the next run reclaims it via the pid file).
-set "FUTURE_AGENT_GRPC_ADDR=%AGENT_ADDR%"
+if "%AGENT_MODE%"=="tcp" (
+  set "FUTURE_AGENT_GRPC_ADDR=%AGENT_ADDR%"
+) else (
+  set "FUTURE_AGENT_GRPC_ADDR="
+)
 pushd "%DESKTOP_DIR%" || (call :cleanup & exit /b 1)
 if "%DESKTOP_DEV_PORT%"=="5173" (
   call npm run tauri:dev
@@ -211,13 +222,26 @@ rem Returns 0 (errorlevel) if AGENT_PORT is LISTENING, 1 otherwise.
 netstat -ano -p tcp | findstr /r /c:":%AGENT_PORT% .*LISTENING" >nul 2>&1
 exit /b %ERRORLEVEL%
 
+:agent_is_ready
+if "%AGENT_MODE%"=="tcp" goto :port_in_use
+if exist "%ROOT_DIR%\target\debug\future.exe" (
+  setlocal
+  set "FUTURE_AGENT_GRPC_ADDR="
+  "%ROOT_DIR%\target\debug\future.exe" models --json >nul 2>&1
+  exit /b !ERRORLEVEL!
+)
+rem Connect to the current user's protected named pipe. Unlike checking the
+rem pipe namespace, this rejects a stale name whose server is no longer alive.
+powershell -NoProfile -Command "$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value; $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', ('future-agent-' + $sid), [System.IO.Pipes.PipeDirection]::InOut); try { $pipe.Connect(300); exit 0 } catch { exit 1 } finally { $pipe.Dispose() }" >nul 2>&1
+exit /b %ERRORLEVEL%
+
 :wait_for_agent
 set /a _attempts=0
 :wait_loop
-call :port_in_use && exit /b 0
+call :agent_is_ready && exit /b 0
 set /a _attempts+=1
 if %_attempts% GEQ 60 (
-  echo future-agent did not become ready at %AGENT_ADDR%
+  echo future-agent did not become ready at %AGENT_ENDPOINT%
   echo Agent log: %AGENT_LOG%
   echo Agent err: %AGENT_ERR%
   exit /b 1


### PR DESCRIPTION
## Summary
- default macOS, Linux, and Windows desktop launchers to the agent local IPC transport
- use transport-aware readiness checks and preserve explicit TCP overrides
- keep desktop environment selection aligned with the launched agent

## Validation
- bash -n scripts/start-desktop-macos.sh scripts/start-desktop-linux.sh
- macOS default and explicit-TCP DRY_RUN=1 checks
- git diff --check
- focused agent singleton and RPC transport tests