### PR TITLE
docs(loop): reference future-loop in architecture guides

### DIFF
--- a/orchestration/loop/ARCHITECTURE.md
+++ b/orchestration/loop/ARCHITECTURE.md
@@ -1,8 +1,7 @@
 # Loop architecture: durable kanban, reliable controls, evidence-driven agents
 
 Operational commands: [control plane guide](../../docs/loop-control-plane.md).
-Agent driving policy: `skills/builtin/future-loop/SKILL.md`; research methodology:
-`skills/builtin/future-explore/SKILL.md` (the skills submodule).
+Agent driving policy: `skills/builtin/future-loop/SKILL.md` (the skills submodule).
 
 ## Boundaries
 

--- a/orchestration/loop/ARCHITECTURE.zh-CN.md
+++ b/orchestration/loop/ARCHITECTURE.zh-CN.md
@@ -1,8 +1,8 @@
 # Loop 架构：持久看板、可靠控制、基于证据的 Agent
 
 操作指南：[Loop 控制面](../../docs/loop-control-plane.zh-CN.md)。编排驾驶手册：
-`skills/builtin/future-loop/SKILL.md`；研究方法：`skills/builtin/future-explore/SKILL.md`。
-两份 skill 都由 skills 子模块分发。英文详细契约见 [ARCHITECTURE.md](ARCHITECTURE.md)。
+`skills/builtin/future-loop/SKILL.md`（由 skills 子模块分发）。
+英文详细契约见 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 ## 边界
 


### PR DESCRIPTION
## Summary
- Remove the exploration-methodology reference from the English and Chinese loop architecture introductions.
- Keep future-loop as the agent driving-policy skill reference, as requested.

## Validation
- Checked both documents retain future-loop and no longer reference future-explore.
- git diff --check passed.
- Documentation-only change; no Rust/TypeScript code changed.