### PR TITLE
fix(mobile): prevent pending prompts crossing pairing boundaries

### DIFF
--- a/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
+++ b/mobile/src/remote/__tests__/pendingPromptStorage.test.ts
@@ -23,7 +23,9 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 
 const mockedAsync = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
 const pending: PendingPrompt = {
-  version: 1,
+  version: 2,
+  pairId: "pair",
+  expectedDesktopId: "desktop",
   commandId: "prompt_1",
   draftKey: "s1",
   sessionId: "s1",
@@ -54,6 +56,15 @@ describe("pending prompt storage", () => {
 
   test("ignores a record with an invalid shape", async () => {
     mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify({ version: 1 }));
+    await expect(loadPendingPrompt()).resolves.toBeNull();
+  });
+
+  test.each([
+    { ...pending, version: 1 },
+    { ...pending, pairId: undefined },
+    { ...pending, expectedDesktopId: "" },
+  ])("never replays legacy or unidentified records: %j", async record => {
+    mockedAsync.getItem.mockResolvedValueOnce(JSON.stringify(record));
     await expect(loadPendingPrompt()).resolves.toBeNull();
   });
 

--- a/mobile/src/remote/__tests__/usePromptOutbox.test.ts
+++ b/mobile/src/remote/__tests__/usePromptOutbox.test.ts
@@ -155,7 +155,9 @@ describe("usePromptOutbox recovery", () => {
 
   it("reconciles a prompt while an existing conversation and draft are active", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-1",
       draftKey: "session-1",
       sessionId: "session-1",
@@ -176,6 +178,31 @@ describe("usePromptOutbox recovery", () => {
     expect(reconcileSession).toHaveBeenCalledWith("session-1", "reconnect");
     expect(refreshSessions).toHaveBeenCalledTimes(1);
 
+    await act(async () => renderer.unmount());
+  });
+
+  it.each([
+    { pairId: "other-pair", expectedDesktopId: credentials.expectedDesktopId },
+    { pairId: credentials.pairId, expectedDesktopId: "other-desktop" },
+  ])("never queries or uploads a prompt from another pairing: %j", async identity => {
+    await savePendingPrompt({
+      version: 2,
+      ...identity,
+      commandId: "foreign-prompt",
+      draftKey: "draft:new",
+      sessionId: "",
+      text: "private draft for another desktop",
+      attachments: [attachment],
+      modelId: "provider/model",
+      thinkingLevel: "medium",
+      mode: "chat",
+      workspaceId: "",
+      createdAt: 1,
+    });
+    const { requestRetry, renderer } = await mountOutbox();
+    expect(requestRetry).not.toHaveBeenCalled();
+    expect(mockedUploadAttachments).not.toHaveBeenCalled();
+    await expect(loadPendingPrompt()).resolves.toBeNull();
     await act(async () => renderer.unmount());
   });
 
@@ -277,6 +304,7 @@ describe("usePromptOutbox sendMessage", () => {
       renderer,
       requestRetry,
       clientRef,
+      credentialsRef,
       selectedRef,
       streamingRef,
       conversationEpochRef,
@@ -307,7 +335,9 @@ describe("usePromptOutbox sendMessage", () => {
 
   it("rejects a concurrent send while one is already in flight", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-busy",
       draftKey: "session-1",
       sessionId: "session-1",
@@ -380,6 +410,24 @@ describe("usePromptOutbox sendMessage", () => {
     await expect(h.result.sendMessage("hi")).rejects.toThrow("send_streaming");
   });
 
+  it("stops delivery when pairing changes during an attachment upload", async () => {
+    const upload = deferred<MobileAttachment[]>();
+    mockedUploadAttachments.mockReturnValue(upload.promise);
+    const h = await mountSend();
+    let sending!: Promise<void>;
+    act(() => {
+      sending = h.result.sendMessage("private", [attachment]);
+    });
+    const rejected = expect(sending).rejects.toThrow("pairing_changed");
+    await flush();
+    h.credentialsRef.current = { ...credentials, pairId: "new-pair" };
+    upload.resolve([]);
+    await act(async () => {
+      await rejected;
+    });
+    expect(h.requestRetry).not.toHaveBeenCalled();
+  });
+
   it("delivers a prompt with attachments and mutates the target timeline", async () => {
     mockedUploadAttachments.mockResolvedValue([{ ...attachment, uploadId: "u1" }]);
     const h = await mountSend({ engine: fakeEngine() });
@@ -397,7 +445,9 @@ describe("usePromptOutbox sendMessage", () => {
 
   it("acknowledges a matching pending prompt via its receipt", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-match",
       draftKey: "session-1",
       sessionId: "session-1",
@@ -423,9 +473,38 @@ describe("usePromptOutbox sendMessage", () => {
     expect(engine.mutate).toHaveBeenCalled();
   });
 
+  it("does not receipt-check a foreign prompt when the user sends a new message", async () => {
+    await savePendingPrompt({
+      version: 2,
+      pairId: "other-pair",
+      expectedDesktopId: "other-desktop",
+      commandId: "foreign",
+      draftKey: "session-1",
+      sessionId: "session-1",
+      text: "hello",
+      attachments: [],
+      modelId: "provider/model",
+      thinkingLevel: "medium",
+      mode: "chat",
+      workspaceId: "",
+      createdAt: 1,
+    });
+    const h = await mountSend();
+    await act(async () => {
+      await h.result.sendMessage("hello");
+    });
+    expect(h.requestRetry).toHaveBeenCalledTimes(1);
+    expect(h.requestRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "prompt", message: "hello" }),
+      "session-1",
+    );
+  });
+
   it("replaces a stale pending prompt before delivering a new one", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-old",
       draftKey: "session-1",
       sessionId: "session-1",
@@ -468,7 +547,9 @@ describe("usePromptOutbox sendMessage", () => {
 
   it("clears the pending prompt and rethrows a non-transient send failure", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-fail",
       draftKey: "session-1",
       sessionId: "session-1",
@@ -718,7 +799,9 @@ describe("usePromptOutbox recovery error handling", () => {
 
   it("clears and records a non-transient prompt recovery failure", async () => {
     await savePendingPrompt({
-      version: 1,
+      version: 2,
+      pairId: credentials.pairId,
+      expectedDesktopId: credentials.expectedDesktopId,
       commandId: "prompt-err",
       draftKey: "session-1",
       sessionId: "session-1",

--- a/mobile/src/remote/__tests__/useRemoteConnection.test.ts
+++ b/mobile/src/remote/__tests__/useRemoteConnection.test.ts
@@ -5,7 +5,7 @@ import { AppState } from "react-native";
 import type { ConnectionState } from "../connectionState";
 import { attemptPendingRevoke, claimPairingCode, serverRevoke } from "../pairing";
 import { discardPendingContinuation } from "../pendingContinuationStorage";
-import { clearPendingPrompt, loadPendingPrompt } from "../pendingPromptStorage";
+import { discardPendingPrompt } from "../pendingPromptStorage";
 import {
   clearCredentials,
   clearPendingRevoke,
@@ -43,8 +43,7 @@ jest.mock("../pairing", () => ({
 
 jest.mock("../pendingPromptStorage", () => ({
   __esModule: true,
-  clearPendingPrompt: jest.fn(async () => {}),
-  loadPendingPrompt: jest.fn(async () => null),
+  discardPendingPrompt: jest.fn(async () => {}),
 }));
 
 jest.mock("../pendingContinuationStorage", () => ({
@@ -224,7 +223,6 @@ describe("useRemoteConnection", () => {
     renderer = null;
     cast<jest.Mock>(loadPendingRevoke).mockResolvedValue(null);
     cast<jest.Mock>(loadCredentials).mockResolvedValue(null);
-    cast<jest.Mock>(loadPendingPrompt).mockResolvedValue(null);
     cast<jest.Mock>(claimPairingCode).mockResolvedValue(credentials);
     cast<jest.Mock>(Network.getNetworkStateAsync).mockResolvedValue(wifiState);
     cast<{ currentState: string }>(AppState).currentState = "active";
@@ -339,6 +337,7 @@ describe("useRemoteConnection", () => {
       act(() => c.callbacks.onPresence({ ...presence, unpaired: true }));
       expect(clearCredentials).toHaveBeenCalled();
       expect(discardPendingContinuation).toHaveBeenCalled();
+      expect(discardPendingPrompt).toHaveBeenCalled();
       expect(options.resetCatalog).toHaveBeenCalled();
       expect(options.resetConversation).toHaveBeenCalled();
       expect(options.resetTimeline).toHaveBeenCalled();
@@ -579,7 +578,7 @@ describe("useRemoteConnection", () => {
       expect(options.resetTimeline).toHaveBeenCalled();
       expect(serverRevoke).toHaveBeenCalledWith(credentials);
       expect(clearCredentials).toHaveBeenCalled();
-      expect(loadPendingPrompt).toHaveBeenCalled();
+      expect(discardPendingPrompt).toHaveBeenCalled();
       expect(options.resetCatalog).toHaveBeenCalled();
       expect(options.resetConversation).toHaveBeenCalled();
       expect(result.current.phase).toBe("unpaired");
@@ -603,11 +602,10 @@ describe("useRemoteConnection", () => {
 
     test("unpair clears a pending prompt", async () => {
       await mountConnected();
-      cast<jest.Mock>(loadPendingPrompt).mockResolvedValue({ commandId: "c1" });
       await act(async () => {
         await result.current.unpair();
       });
-      expect(clearPendingPrompt).toHaveBeenCalledWith("c1");
+      expect(discardPendingPrompt).toHaveBeenCalled();
     });
 
     test("clearError resets the error", async () => {

--- a/mobile/src/remote/pendingPromptStorage.ts
+++ b/mobile/src/remote/pendingPromptStorage.ts
@@ -3,8 +3,10 @@ import { createAsyncOperationQueue } from "./asyncOperationQueue";
 import type { MobileAttachment, ThinkingLevel } from "./types";
 
 export interface PendingPrompt {
-  version: 1;
+  version: 2;
   commandId: string;
+  pairId: string;
+  expectedDesktopId: string;
   draftKey: string;
   sessionId: string;
   text: string;
@@ -25,7 +27,13 @@ async function loadPendingPromptDirect(): Promise<PendingPrompt | null> {
     if (!raw) return null;
     const value = JSON.parse(raw) as Partial<PendingPrompt>;
     if (
-      value.version !== 1 ||
+      // Legacy records have no safe destination identity. Leave drafts alone,
+      // but never automatically replay these records on the current pairing.
+      value.version !== 2 ||
+      typeof value.pairId !== "string" ||
+      !value.pairId ||
+      typeof value.expectedDesktopId !== "string" ||
+      !value.expectedDesktopId ||
       typeof value.commandId !== "string" ||
       !value.commandId ||
       typeof value.draftKey !== "string" ||
@@ -52,6 +60,11 @@ export function loadPendingPrompt(): Promise<PendingPrompt | null> {
 
 export async function savePendingPrompt(prompt: PendingPrompt): Promise<void> {
   await enqueueOperation(() => AsyncStorage.setItem(KEY, JSON.stringify(prompt)));
+}
+
+/** Drop all pending delivery state on unpair, including legacy records. */
+export async function discardPendingPrompt(): Promise<void> {
+  await enqueueOperation(() => AsyncStorage.removeItem(KEY));
 }
 
 /** Clear only the record this caller completed; a newer send must survive. */

--- a/mobile/src/remote/usePromptOutbox.ts
+++ b/mobile/src/remote/usePromptOutbox.ts
@@ -64,13 +64,17 @@ async function deliverPendingPrompt(
   pending: PendingPrompt,
   checkReceipt: boolean,
   receiptSupported: boolean,
+  assertCurrentPairing: () => void,
   onUploadProgress?: (completedBytes: number, totalBytes: number) => void,
 ): Promise<PromptAck> {
+  assertCurrentPairing();
   if (checkReceipt && receiptSupported) {
     const receipt = await pendingPromptReceipt(client, pending.commandId);
+    assertCurrentPairing();
     if (receipt) return receipt;
   }
   const uploaded = await uploadAttachments(client, pending.attachments, onUploadProgress);
+  assertCurrentPairing();
   return (
     await client.requestRetry<PromptAck>(
       {
@@ -116,8 +120,8 @@ async function deliverPendingContinuation(
   ).data;
 }
 
-function continuationMatchesCredentials(
-  pending: PendingContinuation,
+function pendingMatchesCredentials(
+  pending: Pick<PendingPrompt, "pairId" | "expectedDesktopId">,
   credentials: RemoteCredentials,
 ): boolean {
   return (
@@ -189,8 +193,19 @@ export function usePromptOutbox({
       onUploadProgress?: (completedBytes: number, totalBytes: number) => void,
     ) => {
       const client = clientRef.current;
+      const credentials = credentialsRef.current;
       if (!text.trim() && attachments.length === 0) return;
-      if (!client) throw new Error("not_connected");
+      if (!client || !credentials) throw new Error("not_connected");
+      const assertCurrentPairing = () => {
+        const current = credentialsRef.current;
+        if (
+          clientRef.current !== client ||
+          !current ||
+          !pendingMatchesCredentials(credentials, current)
+        ) {
+          throw new Error("pairing_changed");
+        }
+      };
       if (sendingRef.current) throw new Error("send_busy");
       if (attachments.length > 0 && !fileTransferSupported) {
         throw new Error("attachment_unsupported_desktop");
@@ -204,6 +219,8 @@ export function usePromptOutbox({
       const conversationEpoch = conversationEpochRef.current;
       const engine = syncEngineRef.current;
       const candidate = {
+        pairId: credentials.pairId,
+        expectedDesktopId: credentials.expectedDesktopId,
         draftKey: targetSessionId || "draft:new",
         sessionId: targetSessionId,
         text,
@@ -221,6 +238,11 @@ export function usePromptOutbox({
       setSending(true);
       try {
         let pending = await loadPendingPrompt();
+        assertCurrentPairing();
+        if (pending && !pendingMatchesCredentials(pending, credentials)) {
+          await clearPendingPrompt(pending.commandId);
+          pending = null;
+        }
         let checkReceipt = false;
         if (pending && samePendingPrompt(pending, candidate)) {
           checkReceipt = true;
@@ -229,11 +251,13 @@ export function usePromptOutbox({
             const previousReceipt = promptReceiptSupported
               ? await pendingPromptReceipt(client, pending.commandId)
               : null;
+            assertCurrentPairing();
             if (previousReceipt) await clearSessionDraftIfMatches(pending.draftKey, pending);
             await clearPendingPrompt(pending.commandId);
           }
+          assertCurrentPairing();
           pending = {
-            version: 1,
+            version: 2,
             commandId: randomId("prompt"),
             ...candidate,
             createdAt: Date.now(),
@@ -246,6 +270,7 @@ export function usePromptOutbox({
             pending,
             checkReceipt,
             promptReceiptSupported,
+            assertCurrentPairing,
             onUploadProgress,
           );
           await clearPendingPrompt(pending.commandId);
@@ -296,6 +321,7 @@ export function usePromptOutbox({
     },
     [
       clientRef,
+      credentialsRef,
       conversationEpochRef,
       draft,
       draftMode,
@@ -319,15 +345,36 @@ export function usePromptOutbox({
     if (sendingRef.current) return;
     if (pendingRecoveryRef.current) return pendingRecoveryRef.current;
     const client = clientRef.current;
-    if (!client || !credentialsRef.current) return;
+    const credentials = credentialsRef.current;
+    if (!client || !credentials) return;
+    const assertCurrentPairing = () => {
+      const current = credentialsRef.current;
+      if (
+        clientRef.current !== client ||
+        !current ||
+        !pendingMatchesCredentials(credentials, current)
+      ) {
+        throw new Error("pairing_changed");
+      }
+    };
     // Publish ownership synchronously, before loadPendingPrompt yields.
     sendingRef.current = true;
     setSending(true);
     const recovery = (async () => {
       const pending = await loadPendingPrompt();
       if (!pending) return;
+      if (!pendingMatchesCredentials(pending, credentials)) {
+        await clearPendingPrompt(pending.commandId);
+        return;
+      }
       try {
-        const receipt = await deliverPendingPrompt(client, pending, true, promptReceiptSupported);
+        const receipt = await deliverPendingPrompt(
+          client,
+          pending,
+          true,
+          promptReceiptSupported,
+          assertCurrentPairing,
+        );
         await clearPendingPrompt(pending.commandId);
         await clearSessionDraftIfMatches(pending.draftKey, pending);
         void refreshSessions();
@@ -369,7 +416,7 @@ export function usePromptOutbox({
         const credentials = credentialsRef.current;
         if (!client || !credentials) throw new Error("not_connected");
         let pending = await loadPendingContinuation();
-        if (pending && !continuationMatchesCredentials(pending, credentials)) {
+        if (pending && !pendingMatchesCredentials(pending, credentials)) {
           await discardPendingContinuation();
           pending = null;
         }
@@ -425,7 +472,7 @@ export function usePromptOutbox({
     if (!client || !credentials || continuationInFlightRef.current) return;
     const pending = await loadPendingContinuation();
     if (!pending || continuationInFlightRef.current) return;
-    if (!continuationMatchesCredentials(pending, credentials)) {
+    if (!pendingMatchesCredentials(pending, credentials)) {
       await discardPendingContinuation();
       return;
     }

--- a/mobile/src/remote/useRemoteConnection.ts
+++ b/mobile/src/remote/useRemoteConnection.ts
@@ -6,7 +6,7 @@ import { RemoteClient } from "./client";
 import type { ConnectionState } from "./connectionState";
 import { classifyError } from "./connectionState";
 import { attemptPendingRevoke, claimPairingCode, serverRevoke } from "./pairing";
-import { clearPendingPrompt, loadPendingPrompt } from "./pendingPromptStorage";
+import { discardPendingPrompt } from "./pendingPromptStorage";
 import { discardPendingContinuation } from "./pendingContinuationStorage";
 import {
   INITIAL_PRESENCE_STATE,
@@ -133,6 +133,7 @@ export function useRemoteConnection({
             void clientRef.current?.close("Unpair");
             clientRef.current = null;
             void clearCredentials();
+            void discardPendingPrompt();
             void discardPendingContinuation();
             setCredentials(null);
             setPresence(null);
@@ -170,9 +171,12 @@ export function useRemoteConnection({
           if (state === "ready") {
             setPhase("ready");
             setError(null);
-          } else if (state === "revoked") setPhase("revoked");
-          else if (state === "unpaired") setPhase("unpaired");
-          else if (state === "refreshing") setPhase("refreshing");
+          } else if (state === "revoked" || state === "unpaired") {
+            credentialsRef.current = null;
+            void discardPendingPrompt();
+            void discardPendingContinuation();
+            setPhase(state);
+          } else if (state === "refreshing") setPhase("refreshing");
           else if (state === "failed") setPhase("failed");
           else if (state === "connecting") setPhase("connecting");
           else setPhase("reconnecting");
@@ -373,6 +377,8 @@ export function useRemoteConnection({
       if (message === "invalid_jwt") {
         credentialsRef.current = null;
         await clearCredentials();
+        await discardPendingPrompt();
+        await discardPendingContinuation();
         setCredentials(null);
         setPhase("unpaired");
         setError(null);
@@ -405,8 +411,7 @@ export function useRemoteConnection({
       }
     }
     await clearCredentials();
-    const pendingPrompt = await loadPendingPrompt();
-    if (pendingPrompt) await clearPendingPrompt(pendingPrompt.commandId);
+    await discardPendingPrompt();
     await discardPendingContinuation();
     setCredentials(null);
     setPresence(null);


### PR DESCRIPTION
## Summary
- Address audit F02: persist pair and desktop identity on pending prompts; reject legacy/unidentified records.
- Check destination before receipt lookup/upload, reject pairing changes during delivery, and never query a foreign prompt receipt.
- Clear delivery state on local/remote unpair, revoked connection and invalid credentials.
- Preserve the separate user draft storage.

## Validation
- Mobile typecheck, eslint (existing warnings only), prettier check
- Complete mobile Jest suite: 37 suites / 573 tests passed
- Regression coverage: foreign pair/desktop, manual send over foreign pending record, pairing change during upload, legacy schema and remote unpair.