### PR TITLE
fix(skills): preserve installed versions when updates fail

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ futures-util.workspace = true
 async-trait.workspace = true
 indexmap = "2"
 rpassword = "7"
+tempfile.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/cli/src/commands/skills.rs
+++ b/cli/src/commands/skills.rs
@@ -535,16 +535,31 @@ async fn install_skill(skill_id: &str, version: Option<&str>, out: &Output) -> R
     let write_result = tokio::fs::write(&tmp_zip, zip_bytes).await;
     let result: Result<(), String> = async {
         write_result.map_err(|e| e.to_string())?;
-        if is_update {
-            tokio::fs::remove_dir_all(&dest)
-                .await
-                .map_err(|e| e.to_string())?;
-        }
-        tokio::fs::create_dir_all(&dest)
+        // Stage beside skills, not inside the discovery tree, on the same volume.
+        let parent = dest
+            .parent()
+            .and_then(Path::parent)
+            .ok_or("Invalid skills root")?;
+        tokio::fs::create_dir_all(parent)
             .await
             .map_err(|e| e.to_string())?;
-        unzip(&tmp_zip, &dest).await?;
-        flatten_single_subdir(&dest).await?;
+        let staging = tempfile::Builder::new()
+            .prefix(".skill-install-")
+            .tempdir_in(parent)
+            .map_err(|e| e.to_string())?;
+        let candidate = staging.path().join("candidate");
+        tokio::fs::create_dir(&candidate)
+            .await
+            .map_err(|e| e.to_string())?;
+        unzip(&tmp_zip, &candidate).await?;
+        flatten_single_subdir(&candidate).await?;
+        let entry = tokio::fs::read_to_string(candidate.join("SKILL.md"))
+            .await
+            .map_err(|e| format!("Invalid skill package: {e}"))?;
+        if entry.trim().is_empty() {
+            return Err("Invalid skill package: empty SKILL.md".into());
+        }
+        replace_skill_dir(&candidate, &dest).map_err(|e| e.to_string())?;
         Ok(())
     }
     .await;
@@ -557,6 +572,59 @@ async fn install_skill(skill_id: &str, version: Option<&str>, out: &Output) -> R
         if is_update { "Updated" } else { "Installed" },
         dest.display()
     ));
+    Ok(())
+}
+
+/// Commit a fully checked sibling staging directory, retaining the previous
+/// version until the new directory is in place. The stable backup also permits
+/// recovery on the next install after process termination between renames.
+fn replace_skill_dir(candidate: &Path, dest: &Path) -> std::io::Result<()> {
+    let root = dest
+        .parent()
+        .ok_or_else(|| std::io::Error::other("Invalid skill root"))?;
+    std::fs::create_dir_all(root)?;
+    let id = dest.file_name().unwrap_or_default().to_string_lossy();
+    let lock = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(format!(".{id}.install.lock")))?;
+    lock.try_lock().map_err(std::io::Error::other)?;
+    let backup = root
+        .parent()
+        .unwrap_or(root)
+        .join(format!(".skill-{id}.previous"));
+    if backup.exists() {
+        if dest.exists() {
+            std::fs::remove_dir_all(&backup)?;
+        } else {
+            std::fs::rename(&backup, dest)?;
+        }
+    }
+    let existed = dest.try_exists()?;
+    if existed && !std::fs::symlink_metadata(dest)?.is_dir() {
+        return Err(std::io::Error::other(
+            "Skill destination is not a regular directory",
+        ));
+    }
+    if existed {
+        std::fs::rename(dest, &backup)?;
+    }
+    if let Err(error) = std::fs::rename(candidate, dest) {
+        if existed {
+            std::fs::rename(&backup, dest).map_err(|restore| {
+                std::io::Error::other(format!(
+                    "Install failed: {error}; restore failed: {restore}; previous version at {}",
+                    backup.display()
+                ))
+            })?;
+        }
+        return Err(error);
+    }
+    // A leftover backup is safe and recovered/removed under the lock next time.
+    if existed {
+        let _ = std::fs::remove_dir_all(backup);
+    }
     Ok(())
 }
 
@@ -1545,6 +1613,72 @@ mod tests {
         assert!(
             stderr.contains("Skill version \"future-x@9.9\" not found."),
             "stderr: {stderr}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_updates_preserve_the_previous_skill() {
+        let _guard = crate::test_env::lock_env().await;
+        let _home = crate::test_env::EnvGuard::temp_home();
+        for package in [
+            b"not zip".to_vec(),
+            make_zip(&[("other.txt", "x")]),
+            make_zip(&[("SKILL.md", " ")]),
+        ] {
+            plant_skill("future-x", "1.0").await;
+            let base = crate::test_server::spawn_http(vec![crate::test_server::HttpRoute::binary(
+                "/client/v1/skills/future-x/versions/2.0/download",
+                200,
+                package,
+            )])
+            .await;
+            point_platform_at(&base).await;
+            let (out, _) = Output::memory();
+            assert!(install_skill("future-x", Some("2.0"), &out).await.is_err());
+            assert_eq!(
+                read_skill_md_version(&skills_dir().join("future-x/SKILL.md"))
+                    .await
+                    .as_deref(),
+                Some("1.0")
+            );
+        }
+    }
+
+    #[test]
+    fn skill_commit_rolls_back_recovers_and_excludes_competing_installers() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = temp.path().join("skills/future-x");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("SKILL.md"), "previous").unwrap();
+        let missing = temp.path().join("missing");
+        assert!(replace_skill_dir(&missing, &dest).is_err());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "previous"
+        );
+        let backup = temp.path().join(".skill-future-x.previous");
+        std::fs::rename(&dest, &backup).unwrap();
+        assert!(replace_skill_dir(&missing, &dest).is_err());
+        assert!(dest.join("SKILL.md").is_file());
+        assert!(!backup.exists());
+        let lock = std::fs::OpenOptions::new()
+            .write(true)
+            .open(temp.path().join("skills/.future-x.install.lock"))
+            .unwrap();
+        lock.lock().unwrap();
+        let candidate = temp.path().join("candidate");
+        std::fs::create_dir(&candidate).unwrap();
+        std::fs::write(candidate.join("SKILL.md"), "new").unwrap();
+        assert!(replace_skill_dir(&candidate, &dest).is_err());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "previous"
+        );
+        drop(lock);
+        replace_skill_dir(&candidate, &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "new"
         );
     }
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tonic",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 sha2 = "0.10"
 zip = { version = "8", default-features = false, features = ["deflate"] }
+tempfile = "3"
 chrono = "0.4"
 rand = "0.8"
 # Workspace file `@`-mention picker: gitignore-aware directory walk + fuzzy rank.

--- a/desktop/src-tauri/src/skills.rs
+++ b/desktop/src-tauri/src/skills.rs
@@ -296,21 +296,80 @@ pub fn uninstall_skill(id: &str) -> Result<bool, AppError> {
 }
 
 fn extract_skill_zip(bytes: &[u8], dest: &Path) -> Result<(), AppError> {
-    // Fresh install/update: clear any prior contents so removed files don't linger.
-    if dest.exists() {
-        std::fs::remove_dir_all(dest)?;
-    }
-    std::fs::create_dir_all(dest)?;
-
     let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
         .map_err(|error| AppError::Message(format!("Skill package is not a valid zip: {error}")))?;
+    // Keep incomplete candidates outside the agent's skills discovery tree.
+    let parent = dest
+        .parent()
+        .and_then(Path::parent)
+        .ok_or("Invalid skills root")?;
+    std::fs::create_dir_all(parent)?;
+    let staging = tempfile::Builder::new()
+        .prefix(".skill-install-")
+        .tempdir_in(parent)?;
+    let candidate = staging.path().join("candidate");
+    std::fs::create_dir(&candidate)?;
     archive
-        .extract(dest)
+        .extract(&candidate)
         .map_err(|error| AppError::Message(format!("Failed to extract skill: {error}")))?;
+    flatten_single_subdir(&candidate)?;
+    let entry = std::fs::read_to_string(candidate.join("SKILL.md"))
+        .map_err(|error| AppError::Message(format!("Invalid skill package: {error}")))?;
+    if entry.trim().is_empty() {
+        return Err("Invalid skill package: empty SKILL.md".into());
+    }
+    replace_skill_dir(&candidate, dest)?;
+    Ok(())
+}
 
-    // Some zips wrap everything in a single top-level directory; flatten it so
-    // SKILL.md lands at the skill root (matches the CLI).
-    flatten_single_subdir(dest)?;
+/// Same on-disk transaction/lock protocol as the CLI, so the two installers
+/// cannot interleave directory replacements. A crash leaves a recoverable backup.
+fn replace_skill_dir(candidate: &Path, dest: &Path) -> std::io::Result<()> {
+    let root = dest
+        .parent()
+        .ok_or_else(|| std::io::Error::other("Invalid skill root"))?;
+    std::fs::create_dir_all(root)?;
+    let id = dest.file_name().unwrap_or_default().to_string_lossy();
+    let lock = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(format!(".{id}.install.lock")))?;
+    lock.try_lock().map_err(std::io::Error::other)?;
+    let backup = root
+        .parent()
+        .unwrap_or(root)
+        .join(format!(".skill-{id}.previous"));
+    if backup.exists() {
+        if dest.exists() {
+            std::fs::remove_dir_all(&backup)?;
+        } else {
+            std::fs::rename(&backup, dest)?;
+        }
+    }
+    let existed = dest.try_exists()?;
+    if existed && !std::fs::symlink_metadata(dest)?.is_dir() {
+        return Err(std::io::Error::other(
+            "Skill destination is not a regular directory",
+        ));
+    }
+    if existed {
+        std::fs::rename(dest, &backup)?;
+    }
+    if let Err(error) = std::fs::rename(candidate, dest) {
+        if existed {
+            std::fs::rename(&backup, dest).map_err(|restore| {
+                std::io::Error::other(format!(
+                    "Install failed: {error}; restore failed: {restore}; previous version at {}",
+                    backup.display()
+                ))
+            })?;
+        }
+        return Err(error);
+    }
+    if existed {
+        let _ = std::fs::remove_dir_all(backup);
+    }
     Ok(())
 }
 
@@ -476,6 +535,63 @@ mod tests {
         assert!(dest.join("SKILL.md").exists());
         assert!(dest.join("lib/util.js").exists());
         assert!(!dest.join("wrapper").exists());
+    }
+
+    #[test]
+    fn invalid_updates_preserve_previous_skill() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = temp.path().join("skills/example");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("SKILL.md"), "previous").unwrap();
+        for bytes in [
+            b"not zip".to_vec(),
+            make_zip(&[("other.txt", b"x")]),
+            make_zip(&[("SKILL.md", b" ")]),
+        ] {
+            assert!(extract_skill_zip(&bytes, &dest).is_err());
+            assert_eq!(
+                std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+                "previous"
+            );
+        }
+    }
+
+    #[test]
+    fn skill_commit_rolls_back_recovers_and_excludes_competing_installers() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = temp.path().join("skills/example");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("SKILL.md"), "previous").unwrap();
+        let missing = temp.path().join("missing");
+        assert!(replace_skill_dir(&missing, &dest).is_err());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "previous"
+        );
+        let backup = temp.path().join(".skill-example.previous");
+        std::fs::rename(&dest, &backup).unwrap();
+        assert!(replace_skill_dir(&missing, &dest).is_err());
+        assert!(dest.join("SKILL.md").is_file());
+        assert!(!backup.exists());
+        let lock = std::fs::OpenOptions::new()
+            .write(true)
+            .open(temp.path().join("skills/.example.install.lock"))
+            .unwrap();
+        lock.lock().unwrap();
+        let candidate = temp.path().join("candidate");
+        std::fs::create_dir(&candidate).unwrap();
+        std::fs::write(candidate.join("SKILL.md"), "new").unwrap();
+        assert!(replace_skill_dir(&candidate, &dest).is_err());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "previous"
+        );
+        drop(lock);
+        replace_skill_dir(&candidate, &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "new"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Address F03 in CLI and desktop: unpack into a unique sibling staging directory, validate a nonempty root SKILL.md, then commit.
- Keep the previous directory until replacement succeeds; roll back failed renames and recover a stable backup on the next commit after interruption.
- Both installers use the same cross-process lock/backup protocol; reject non-directory destinations.
- Staging and backups stay outside agent skill discovery.

## Validation
- Rust 1.97 fmt and all-target clippy for future-cli and desktop backend
- Full CLI suite: 712 + 2 + 11 tests passed
- Full desktop backend: 1113 + 1 tests passed (one pre-existing ignored doctest)
- Bad ZIP/missing or empty SKILL.md preserve old content; rollback, interrupted rename recovery and competing installer locks tested.

## Boundary
Directory replacement uses recoverable two-phase renames, not an unsupported claim of an atomic cross-platform directory exchange. Power loss can leave a backup for recovery; it does not delete the previous content.