### PR TITLE
fix(desktop): run skill upgrades safely across StrictMode and toggles

### DIFF
--- a/desktop/src/components/layout/hooks/useAutoUpgradeSkills.test.ts
+++ b/desktop/src/components/layout/hooks/useAutoUpgradeSkills.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { act, createElement, Fragment, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushAsync } from "../../../test/renderHook";
+import { useAutoUpgradeSkills } from "./useAutoUpgradeSkills";
+
+const mocks = vi.hoisted(() => ({
+  installed: vi.fn(),
+  available: vi.fn(),
+  install: vi.fn(),
+  emit: vi.fn(),
+}));
+vi.mock("../../../integrations/skills/skillsClient", () => ({
+  listInstalledSkills: mocks.installed,
+  listAvailableSkills: mocks.available,
+  installSkill: mocks.install,
+}));
+vi.mock("../../../features/skills/autoUpgrade", () => ({
+  computeSkillUpgrades: () => [{ id: "example", version: "2.0" }],
+}));
+vi.mock("../../../lib/futureEvents", () => ({ emitFutureEvent: mocks.emit }));
+
+const unmounts: Array<() => void> = [];
+function mount(enabled = true, strict = false) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  function App({ enabled: active }: { enabled: boolean }) {
+    useAutoUpgradeSkills(active);
+    return null;
+  }
+  const render = (active: boolean) => act(() => {
+    root.render(createElement(strict ? StrictMode : Fragment, null, createElement(App, { enabled: active })));
+  });
+  render(enabled);
+  const unmount = () => act(() => root.unmount());
+  unmounts.push(unmount);
+  return { render };
+}
+function deferred() {
+  let resolve!: (value: never[]) => void;
+  const promise = new Promise<never[]>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.installed.mockResolvedValue([]);
+  mocks.available.mockResolvedValue([]);
+  mocks.install.mockResolvedValue(undefined);
+});
+afterEach(() => {
+  for (const unmount of unmounts.splice(0))
+    unmount();
+  vi.restoreAllMocks();
+});
+
+describe("useAutoUpgradeSkills lifecycle", () => {
+  it("upgrades once under StrictMode", async () => {
+    mount(true, true);
+    await flushAsync();
+    expect(mocks.install).toHaveBeenCalledExactlyOnceWith("example", "2.0");
+    expect(mocks.emit).toHaveBeenCalledWith("skills-changed", undefined);
+  });
+
+  it("does nothing while disabled and starts when enabled", async () => {
+    const h = mount(false);
+    await flushAsync();
+    expect(mocks.available).not.toHaveBeenCalled();
+    h.render(true);
+    await flushAsync();
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not lose a re-enable while the cancelled catalogue fetch is pending", async () => {
+    const first = deferred();
+    mocks.installed.mockReturnValueOnce(first.promise);
+    const h = mount();
+    await flushAsync();
+    h.render(false);
+    h.render(true);
+    await flushAsync();
+    expect(mocks.installed).toHaveBeenCalledTimes(1);
+    first.resolve([]);
+    await flushAsync();
+    expect(mocks.installed).toHaveBeenCalledTimes(2);
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an in-flight install before starting the replacement effect", async () => {
+    const first = deferred();
+    mocks.install.mockReturnValueOnce(first.promise);
+    const h = mount();
+    await flushAsync();
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+    h.render(false);
+    h.render(true);
+    await flushAsync();
+    expect(mocks.installed).toHaveBeenCalledTimes(1);
+    first.resolve([]);
+    await flushAsync();
+    expect(mocks.installed).toHaveBeenCalledTimes(2);
+    expect(mocks.install).toHaveBeenCalledTimes(2);
+    expect(mocks.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install or notify after unmount", async () => {
+    const first = deferred();
+    mocks.installed.mockReturnValueOnce(first.promise);
+    mount();
+    await flushAsync();
+    unmounts.pop()!();
+    first.resolve([]);
+    await flushAsync();
+    expect(mocks.install).not.toHaveBeenCalled();
+    expect(mocks.emit).not.toHaveBeenCalled();
+  });
+
+  it("a catalogue failure does not poison the next enable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.available.mockRejectedValueOnce(new Error("offline"));
+    const h = mount();
+    await flushAsync();
+    h.render(false);
+    h.render(true);
+    await flushAsync();
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/components/layout/hooks/useAutoUpgradeSkills.ts
+++ b/desktop/src/components/layout/hooks/useAutoUpgradeSkills.ts
@@ -8,40 +8,36 @@ import {
 import { emitFutureEvent } from "../../../lib/futureEvents";
 
 /**
- * Silently upgrades installed skills to their latest catalogue version. Runs
- * whenever `enabled` becomes true — on app open if the setting is already on,
- * and immediately when the user toggles it on. Fully silent: successes and
- * failures only reach the console, never a toast. A run is skipped while a
- * previous one is still in flight, and if the catalogue can't be reached (e.g.
- * the platform is offline) it simply does nothing this launch.
+ * Silently upgrade when enabled. Each effect owns its cancellation signal;
+ * replacement effects wait for an in-flight install rather than being skipped.
+ * This also handles StrictMode's setup/cleanup/setup and rapid setting toggles.
  */
 export function useAutoUpgradeSkills(enabled: boolean): void {
-  const runningRef = useRef(false);
+  const pendingRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
-    if (!enabled || runningRef.current)
+    if (!enabled)
       return;
 
-    let cancelled = false;
-    runningRef.current = true;
-
-    void (async () => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    pendingRef.current = pendingRef.current.then(async () => {
+      if (signal.aborted)
+        return;
       try {
         const [installed, available] = await Promise.all([
           listInstalledSkills(),
           listAvailableSkills(),
         ]);
-        if (cancelled)
+        if (signal.aborted)
           return;
 
         const upgrades = computeSkillUpgrades(installed, available);
         let upgradedCount = 0;
         for (const upgrade of upgrades) {
-          if (cancelled)
+          if (signal.aborted)
             break;
           try {
-            // Overwrite-install the newer version. Sequential to avoid parallel
-            // writes into the shared skills directory.
             await installSkill(upgrade.id, upgrade.version);
             upgradedCount += 1;
           }
@@ -49,22 +45,14 @@ export function useAutoUpgradeSkills(enabled: boolean): void {
             console.warn(`[skills] auto-upgrade failed for ${upgrade.id}`, error);
           }
         }
-
-        // Let an open Skills view refresh so it reflects the new versions.
-        if (!cancelled && upgradedCount > 0)
+        if (!signal.aborted && upgradedCount > 0)
           emitFutureEvent("skills-changed", undefined);
       }
       catch (error) {
-        // Catalogue or installed-list fetch failed — stay silent.
         console.warn("[skills] auto-upgrade skipped", error);
       }
-      finally {
-        runningRef.current = false;
-      }
-    })();
+    });
 
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [enabled]);
 }


### PR DESCRIPTION
Addresses F06. Serialize effect-owned upgrade jobs with cancellation signals instead of skipping a replacement effect behind an in-flight running flag. Adds six lifecycle regressions: StrictMode, disabled/enabled, cancelled catalogue, pending install, unmount and retry after failure. Full desktop typecheck/eslint and 71 Vitest files / 697 tests passed; lint only reports existing unrelated warnings.