### PR TITLE
fix(agent): make compaction deadline-safe

### DIFF
--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -254,6 +254,7 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
             source_meta: cmd.source_meta,
             enabled: cmd.enabled,
             command: cmd.command,
+            shell_timeout_ms: cmd.shell_timeout_ms,
             session_id: cmd.session_id,
             entry_id: cmd.entry_id,
             offset: cmd.offset,

--- a/agent/src/rpc/commands/mod.rs
+++ b/agent/src/rpc/commands/mod.rs
@@ -36,6 +36,13 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
     let id = &cmd.id;
     let cmd_type = &cmd.cmd_type;
 
+    // The shared policy is also the command registry used by every client to
+    // set a finite unary deadline. This makes it impossible to add a live
+    // dispatcher command while forgetting its timeout classification.
+    if future_rpc::command_policy::command_policy(cmd_type).is_none() {
+        return RpcResponse::build_fail(id, cmd_type, &format!("unknown command: {cmd_type}"));
+    }
+
     if cmd_type == "get_agent_info" {
         return providers::get_agent_info_response(state, id);
     }
@@ -119,6 +126,56 @@ pub fn handle_command_internal(state: &AppState, cmd: RpcCommand) -> String {
             "session not found — pass a valid session_id (new_session creates one)",
         );
     };
+
+    // Manual compaction owns a stable session snapshot until it commits or
+    // fails. Commands that mutate the session must never wait behind that
+    // read lease: a client-side deadline would expire while the detached
+    // spawn_blocking task later applied the mutation. Reject admission before
+    // any side effect so callers can safely retry after the terminal event.
+    const COMPACTION_CONFLICTS: &[&str] = &[
+        "abort_session",
+        "add_session_rule",
+        "append_system_prompt",
+        "cancel_queued_run",
+        "clone",
+        "cycle_model",
+        "cycle_thinking_level",
+        "disable_builtin_tools",
+        "disable_tools",
+        "fork",
+        "prompt",
+        "reload_config",
+        "retry_persistence",
+        "set_auto_compaction",
+        "set_auto_retry",
+        "set_cwd",
+        "set_ephemeral",
+        "set_model",
+        "set_permission_level",
+        "set_sandbox_policy",
+        "set_session_name",
+        "set_system_prompt",
+        "set_thinking_level",
+        "set_tools",
+        "shell",
+    ];
+    if COMPACTION_CONFLICTS.contains(&cmd_type.as_str())
+        && session
+            .read()
+            .compaction_in_progress
+            .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return RpcResponse::build_fail_code(
+            id,
+            cmd_type,
+            "session_busy",
+            "session context compaction is in progress",
+            serde_json::json!({
+                "busy_reason": "compaction",
+                "retryable": true,
+            }),
+        );
+    }
 
     match cmd_type.as_str() {
         "prompt" => run_control::handle_prompt(state, &session, &cmd, id),

--- a/agent/src/rpc/commands/observability_tests.rs
+++ b/agent/src/rpc/commands/observability_tests.rs
@@ -37,6 +37,20 @@ fn get_state_returns_session_info() {
 }
 
 #[test]
+fn get_state_reports_manual_compaction_in_progress() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    session
+        .read()
+        .compaction_in_progress
+        .store(true, std::sync::atomic::Ordering::Release);
+
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("get_state")));
+    assert_eq!(resp["success"], true);
+    assert_eq!(resp["data"]["isCompacting"], true);
+}
+
+#[test]
 fn get_state_reports_pending_approvals_for_owning_session() {
     let state = make_app_state();
     state

--- a/agent/src/rpc/commands/session_lifecycle.rs
+++ b/agent/src/rpc/commands/session_lifecycle.rs
@@ -172,6 +172,22 @@ pub(crate) fn cmd_delete_session(state: &AppState, cmd: &RpcCommand, id: &str) -
     }
     let live = state.sessions.read().get(&cmd.session_id).cloned();
     if let Some(session) = live {
+        if session
+            .read()
+            .compaction_in_progress
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return RpcResponse::build_fail_code(
+                id,
+                "delete_session",
+                "session_busy",
+                "session context compaction is in progress",
+                serde_json::json!({
+                    "busy_reason": "compaction",
+                    "retryable": true,
+                }),
+            );
+        }
         let (active, cancelled_count) = {
             let mut session = session.write();
             session.deleting = true;

--- a/agent/src/rpc/commands/settings.rs
+++ b/agent/src/rpc/commands/settings.rs
@@ -182,10 +182,110 @@ pub(crate) fn handle_compact(
     cmd: &RpcCommand,
     id: &str,
 ) -> String {
-    match session.read().compact(&cmd.custom_instructions) {
-        Ok(result) => RpcResponse::ok(id, "compact", result),
-        Err(error) => RpcResponse::build_fail(id, "compact", &error.to_string()),
+    use std::sync::atomic::Ordering;
+
+    let in_progress = session.read().compaction_in_progress.clone();
+    // A lost acknowledgement must not start a second compaction. Keep the
+    // accepted request id usable after the worker's terminal event so an
+    // exact retry always resolves to the same operation.
+    if let Some((_, operation_id)) = session
+        .read()
+        .compaction_request
+        .lock()
+        .as_ref()
+        .filter(|(request_id, _)| request_id == &cmd.id)
+    {
+        return RpcResponse::ok(
+            id,
+            "compact",
+            serde_json::json!({
+                "accepted": true,
+                "operationId": operation_id,
+            }),
+        );
     }
+    if in_progress
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return RpcResponse::build_fail(id, "compact", "context compaction is already running");
+    }
+
+    let operation_id = format!("cmp_{}", crate::utils::generate_entry_id());
+    *session.read().compaction_request.lock() = Some((cmd.id.clone(), operation_id.clone()));
+    let worker_operation_id = operation_id.clone();
+    let instructions = cmd.custom_instructions.clone();
+    let worker_session = session.clone();
+    let broadcaster = session.read().broadcaster.clone();
+    let spawn = std::thread::Builder::new()
+        .name("manual-compaction".to_string())
+        .spawn(move || {
+            struct ResetOnDrop(Arc<std::sync::atomic::AtomicBool>);
+            impl Drop for ResetOnDrop {
+                fn drop(&mut self) {
+                    self.0.store(false, Ordering::Release);
+                }
+            }
+            let _reset = ResetOnDrop(in_progress.clone());
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                worker_session
+                    .read()
+                    .compact_with_operation_id(&instructions, worker_operation_id.clone())
+            }));
+            match result {
+                Ok(Ok(result)) if result.get("checkpointId").is_none() => {
+                    in_progress.store(false, Ordering::Release);
+                    broadcaster.broadcast(SseEvent::new(
+                        "compaction_unchanged",
+                        serde_json::json!({
+                            "operation_id": worker_operation_id,
+                            "trigger": "manual",
+                            "phase": "standalone",
+                            "already_compacted": result
+                                .get("alreadyCompacted")
+                                .and_then(serde_json::Value::as_bool)
+                                .unwrap_or(false),
+                            "tokens_before": result
+                                .get("tokensBefore")
+                                .and_then(serde_json::Value::as_i64)
+                                .unwrap_or(0),
+                        }),
+                    ));
+                }
+                Ok(Ok(_)) | Ok(Err(_)) => {}
+                Err(_) => {
+                    in_progress.store(false, Ordering::Release);
+                    broadcaster.broadcast(SseEvent::new(
+                        "compaction_failed",
+                        serde_json::json!({
+                            "operation_id": worker_operation_id,
+                            "trigger": "manual",
+                            "phase": "standalone",
+                            "error": "context compaction worker panicked",
+                        }),
+                    ));
+                }
+            }
+        });
+    if let Err(error) = spawn {
+        let sess = session.read();
+        sess.compaction_in_progress.store(false, Ordering::Release);
+        *sess.compaction_request.lock() = None;
+        return RpcResponse::build_fail(
+            id,
+            "compact",
+            &format!("failed to start context compaction: {error}"),
+        );
+    }
+
+    RpcResponse::ok(
+        id,
+        "compact",
+        serde_json::json!({
+            "accepted": true,
+            "operationId": operation_id,
+        }),
+    )
 }
 
 pub(crate) fn handle_set_auto_compaction(
@@ -284,7 +384,15 @@ pub(crate) fn handle_shell(
     cmd: &RpcCommand,
     id: &str,
 ) -> String {
-    let result = session.write().execute_shell(&cmd.command);
+    let timeout = if cmd.shell_timeout_ms == 0 {
+        future_rpc::command_policy::SHELL_EXECUTION_TIMEOUT
+    } else {
+        std::time::Duration::from_millis(cmd.shell_timeout_ms).clamp(
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(30 * 60),
+        )
+    };
+    let result = session.write().execute_shell(&cmd.command, timeout);
     match result {
         Ok(r) => RpcResponse::ok(id, "shell", r),
         Err(e) => RpcResponse::build_fail(id, "shell", &e.to_string()),

--- a/agent/src/rpc/commands/settings_tests.rs
+++ b/agent/src/rpc/commands/settings_tests.rs
@@ -4,6 +4,34 @@ use crate::test_support::TestHome;
 
 use crate::rpc::commands::test_support::*;
 use crate::rpc::handle_command_internal;
+use crate::types::{AgentMessage, ContentBlock, LLMProvider};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+struct SlowSummaryProvider;
+
+#[async_trait::async_trait]
+impl LLMProvider for SlowSummaryProvider {
+    async fn stream_model(
+        &self,
+        _request: crate::llm::schema::ModelRequest,
+    ) -> anyhow::Result<ReceiverStream<crate::llm::schema::ModelStreamEvent>> {
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        let (tx, rx) = mpsc::channel(2);
+        tx.try_send(crate::llm::schema::ModelStreamEvent::TextDelta {
+            text: "## Objective\n- test\n\n## Important Details\n- none\n\n## Work State\n### Completed\n- none\n\n### Active\n- test\n\n### Blocked\n- none\n\n## Next Move\n1. test\n\n## Relevant Files\n- none".to_string(),
+            id: String::new(),
+        })
+        .unwrap();
+        tx.try_send(crate::llm::schema::ModelStreamEvent::Finish {
+            reason: crate::llm::schema::FinishReason::Stop,
+            usage: None,
+        })
+        .unwrap();
+        Ok(ReceiverStream::new(rx))
+    }
+}
 
 #[test]
 fn set_permission_level_valid() {
@@ -132,25 +160,145 @@ fn set_sandbox_policy_missing_payload() {
 }
 
 #[test]
-fn compact_empty_session() {
+fn compact_empty_session_returns_async_ack() {
     let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    let mut events = session.read().broadcaster.subscribe();
     let cmd = make_cmd("compact");
     let resp = parse_response(&handle_command_internal(&state, cmd));
     assert_eq!(resp["success"], true);
-    assert_eq!(resp["data"]["messagesRemoved"], 0);
+    assert_eq!(resp["data"]["accepted"], true);
+    let operation_id = resp["data"]["operationId"].as_str().unwrap();
+    let terminal = events.blocking_recv().unwrap();
+    assert_eq!(terminal.event_type, "compaction_unchanged");
+    assert!(!session
+        .read()
+        .compaction_in_progress
+        .load(std::sync::atomic::Ordering::Acquire));
+    let data: serde_json::Value = serde_json::from_str(&terminal.data).unwrap();
+    assert_eq!(data["operation_id"], operation_id);
 }
 
 #[test]
-fn compact_reports_busy_loop_error() {
+fn compact_reports_busy_loop_error_as_terminal_event() {
     let state = make_app_state();
     // Hold the run-configuration lock so the compaction snapshot's try_read
     // fails — the manual /compact path must report that as a clean error.
     let session = state.get_session("default").unwrap();
+    let mut events = session.read().broadcaster.subscribe();
     let agent_loop = session.read().agent_loop.clone();
     let _guard = agent_loop.try_write().unwrap();
     let resp = parse_response(&handle_command_internal(&state, make_cmd("compact")));
+    assert_eq!(resp["success"], true);
+    let operation_id = resp["data"]["operationId"].as_str().unwrap();
+    let terminal = events.blocking_recv().unwrap();
+    assert_eq!(terminal.event_type, "compaction_failed");
+    assert!(!session
+        .read()
+        .compaction_in_progress
+        .load(std::sync::atomic::Ordering::Acquire));
+    let data: serde_json::Value = serde_json::from_str(&terminal.data).unwrap();
+    assert_eq!(data["operation_id"], operation_id);
+    assert!(data["error"].as_str().unwrap().contains("busy"));
+}
+
+#[test]
+fn compact_rejects_a_duplicate_async_request() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    session
+        .read()
+        .compaction_in_progress
+        .store(true, std::sync::atomic::Ordering::Release);
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("compact")));
     assert_eq!(resp["success"], false);
-    assert!(resp["error"].as_str().unwrap().contains("busy"));
+    assert!(resp["error"].as_str().unwrap().contains("already running"));
+    session
+        .read()
+        .compaction_in_progress
+        .store(false, std::sync::atomic::Ordering::Release);
+}
+
+#[test]
+fn compact_retry_with_the_same_request_id_reuses_the_operation() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    session
+        .read()
+        .compaction_in_progress
+        .store(true, std::sync::atomic::Ordering::Release);
+    *session.read().compaction_request.lock() =
+        Some(("test_cmd".to_string(), "cmp-existing".to_string()));
+
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("compact")));
+    assert_eq!(resp["success"], true);
+    assert_eq!(resp["data"]["operationId"], "cmp-existing");
+}
+
+#[test]
+fn completed_compact_retry_with_the_same_request_id_reuses_the_operation() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    *session.read().compaction_request.lock() =
+        Some(("test_cmd".to_string(), "cmp-complete".to_string()));
+
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("compact")));
+    assert_eq!(resp["success"], true);
+    assert_eq!(resp["data"]["operationId"], "cmp-complete");
+    assert!(!session
+        .read()
+        .compaction_in_progress
+        .load(std::sync::atomic::Ordering::Acquire));
+}
+
+#[test]
+fn session_mutations_fail_before_waiting_for_compaction() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    session
+        .read()
+        .compaction_in_progress
+        .store(true, std::sync::atomic::Ordering::Release);
+
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("prompt")));
+    assert_eq!(resp["success"], false);
+    assert_eq!(resp["error_code"], "session_busy");
+    assert_eq!(resp["error_data"]["busy_reason"], "compaction");
+    assert_eq!(resp["error_data"]["retryable"], true);
+}
+
+#[test]
+fn compact_ack_does_not_wait_for_the_summary_provider() {
+    let state = make_app_state();
+    let session = state.get_session("default").unwrap();
+    {
+        let session = session.write();
+        session.agent_loop.try_write().unwrap().provider = Arc::new(SlowSummaryProvider);
+        let mut messages = session.messages.write();
+        for (role, text) in [("user", "investigate"), ("assistant", "working")] {
+            let mut message = AgentMessage {
+                role: role.to_string(),
+                content: vec![ContentBlock::text(text)],
+                ..Default::default()
+            };
+            message.ensure_journal_entry_id();
+            messages.push(message);
+        }
+    }
+    let mut events = session.read().broadcaster.subscribe();
+    let started_at = std::time::Instant::now();
+    let resp = parse_response(&handle_command_internal(&state, make_cmd("compact")));
+    assert_eq!(resp["success"], true);
+    assert!(started_at.elapsed() < std::time::Duration::from_millis(100));
+    assert_eq!(
+        events.blocking_recv().unwrap().event_type,
+        "compaction_started"
+    );
+    let terminal = events.blocking_recv().unwrap();
+    assert!(matches!(
+        terminal.event_type.as_str(),
+        "compaction_committed" | "compaction_failed"
+    ));
 }
 
 #[test]

--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -573,7 +573,9 @@ fn get_state_internal(
         image_support,
         thinking_level: sess.thinking_level.clone(),
         is_streaming: sess.is_streaming.load(std::sync::atomic::Ordering::Relaxed),
-        is_compacting: false,
+        is_compacting: sess
+            .compaction_in_progress
+            .load(std::sync::atomic::Ordering::Relaxed),
         // Always non-empty here: get_session returns None for an empty id,
         // and only map-stored (hydrated or created) sessions reach this point.
         session_file: Some(String::new()),

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -56,6 +56,8 @@ pub struct RpcCommand {
     // shell
     #[serde(default)]
     pub command: String,
+    #[serde(default)]
+    pub shell_timeout_ms: u64,
 
     // Session
     #[serde(default)]

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -56,6 +56,14 @@ pub struct ServerSession {
     pub auto_compaction: bool,
     /// Whether automatic retry on transient LLM errors is enabled.
     pub auto_retry: bool,
+    /// Serializes explicit manual compaction requests. The RPC acknowledgement
+    /// is asynchronous, so the session itself must reject duplicate requests
+    /// until the accepted operation reaches a terminal lifecycle event.
+    pub compaction_in_progress: Arc<std::sync::atomic::AtomicBool>,
+    /// Last accepted manual-compaction request and its stable operation id.
+    /// Retrying the same RPC request id returns the original acknowledgement
+    /// instead of starting a second summary operation.
+    pub compaction_request: Arc<parking_lot::Mutex<Option<(String, String)>>>,
     /// On-disk session store (JSONL files).  Shared across everything that
     /// reads/writes session history.
     pub session_manager: Arc<Manager>,
@@ -214,6 +222,8 @@ impl ServerSession {
             thinking_level: "xhigh".to_string(), // Match default
             auto_compaction: true,               // Match default
             auto_retry: true,
+            compaction_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            compaction_request: Arc::new(parking_lot::Mutex::new(None)),
             session_manager: manager,
             persistence,
             cwd: cwd.to_string(),
@@ -511,6 +521,17 @@ impl ServerSession {
     }
 
     pub fn compact(&self, instructions: &str) -> Result<serde_json::Value> {
+        self.compact_with_operation_id(
+            instructions,
+            format!("cmp_{}", crate::utils::generate_entry_id()),
+        )
+    }
+
+    pub(crate) fn compact_with_operation_id(
+        &self,
+        instructions: &str,
+        operation_id: String,
+    ) -> Result<serde_json::Value> {
         let context_window = self
             .model_registry
             .read()
@@ -523,6 +544,7 @@ impl ServerSession {
             crate::compaction::CompactionPhase::Standalone,
             context_window,
             None,
+            operation_id,
         )
     }
 
@@ -533,6 +555,7 @@ impl ServerSession {
         phase: crate::compaction::CompactionPhase,
         context_window: i32,
         fallback: Option<(std::sync::Arc<dyn crate::types::LLMProvider>, String)>,
+        operation_id: String,
     ) -> Result<serde_json::Value> {
         use std::sync::atomic::Ordering;
         // A standalone manual compaction can arrive immediately after the
@@ -581,10 +604,24 @@ impl ServerSession {
             model: self.model.clone(),
         };
         let (provider, interrupted, current_model) = {
-            let loop_ = self
-                .agent_loop
-                .try_read()
-                .map_err(|_| anyhow::anyhow!("session configuration is busy; retry /compact"))?;
+            let loop_ = match self.agent_loop.try_read() {
+                Ok(loop_) => loop_,
+                Err(_) => {
+                    let error = anyhow::anyhow!("session configuration is busy; retry /compact");
+                    self.compaction_in_progress.store(false, Ordering::Release);
+                    if let Some(event) = super::prompt_helpers::run_event_to_sse(
+                        crate::agent::RunEvent::CompactionFailed {
+                            operation_id,
+                            trigger,
+                            phase,
+                            error: error.to_string(),
+                        },
+                    ) {
+                        self.broadcaster.broadcast(event);
+                    }
+                    return Err(error);
+                }
+            };
             (
                 loop_.provider.clone(),
                 loop_.interrupt_flag.clone(),
@@ -596,7 +633,6 @@ impl ServerSession {
             ..manager
         };
         let instructions = instructions.to_string();
-        let operation_id = format!("cmp_{}", crate::utils::generate_entry_id());
         let worker_operation_id = operation_id.clone();
         let started_broadcaster = self.broadcaster.clone();
         // RPC dispatch is synchronous today. Run the async, tool-free summary
@@ -640,6 +676,7 @@ impl ServerSession {
         let prepared = match prepared {
             Ok(prepared) => prepared,
             Err(error) => {
+                self.compaction_in_progress.store(false, Ordering::Release);
                 if let Some(event) = super::prompt_helpers::run_event_to_sse(
                     crate::agent::RunEvent::CompactionFailed {
                         operation_id,
@@ -666,6 +703,7 @@ impl ServerSession {
                     .persistence
                     .commit_checkpoint(crate::session::checkpoint_to_entry(&checkpoint))
                 {
+                    self.compaction_in_progress.store(false, Ordering::Release);
                     if let Some(event) = super::prompt_helpers::run_event_to_sse(
                         crate::agent::RunEvent::CompactionFailed {
                             operation_id,
@@ -681,6 +719,11 @@ impl ServerSession {
                 if let Ok(loop_) = self.agent_loop.try_write() {
                     *loop_.active_checkpoint.lock() = Some((*checkpoint).clone());
                 }
+                // Publish the terminal event only after the session admission
+                // fence is open again. Desktop enables Send when it observes
+                // this event, so this ordering prevents a transient
+                // `session_busy` on the very next command.
+                self.compaction_in_progress.store(false, Ordering::Release);
                 if let Some(event) = super::prompt_helpers::run_event_to_sse(
                     crate::agent::RunEvent::CompactionCommitted {
                         operation_id,
@@ -763,17 +806,84 @@ impl ServerSession {
         self.ephemeral = ephemeral;
     }
 
-    pub fn execute_shell(&self, command: &str) -> Result<serde_json::Value> {
+    pub fn execute_shell(
+        &self,
+        command: &str,
+        timeout: std::time::Duration,
+    ) -> Result<serde_json::Value> {
+        use std::io::Read;
+
         // Same platform-shell contract as the shell tool (bash -c on Unix,
         // the PowerShell wrapper on Windows) so exit codes are reliable.
         let (program, args) = crate::sandbox::shell_invocation(command);
-        let output = std::process::Command::new(program)
+        let mut process = std::process::Command::new(program);
+        process
             .args(&args)
             .current_dir(&self.cwd)
             .env("PWD", &self.cwd)
-            .output()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            process.process_group(0);
+        }
+        let mut child = process.spawn()?;
+        #[cfg(unix)]
+        let process_group = child.id() as i32;
+        #[cfg(windows)]
+        let job = crate::sandbox::windows::Job::create().ok().and_then(|job| {
+            job.assign(child.id()).ok()?;
+            Some(job)
+        });
+        let stdout = child.stdout.take().map(|mut stream| {
+            std::thread::spawn(move || {
+                let mut bytes = Vec::new();
+                let _ = stream.read_to_end(&mut bytes);
+                bytes
+            })
+        });
+        let stderr = child.stderr.take().map(|mut stream| {
+            std::thread::spawn(move || {
+                let mut bytes = Vec::new();
+                let _ = stream.read_to_end(&mut bytes);
+                bytes
+            })
+        });
+        let started = std::time::Instant::now();
+        let status = loop {
+            if let Some(status) = child.try_wait()? {
+                break status;
+            }
+            if started.elapsed() >= timeout {
+                #[cfg(unix)]
+                // SAFETY: the child was created as leader of this process group.
+                unsafe {
+                    libc::killpg(process_group, libc::SIGKILL);
+                }
+                #[cfg(windows)]
+                if let Some(job) = &job {
+                    job.terminate();
+                }
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout.map(std::thread::JoinHandle::join);
+                let _ = stderr.map(std::thread::JoinHandle::join);
+                anyhow::bail!(
+                    "shell command timed out after {} seconds",
+                    timeout.as_secs_f64()
+                );
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        };
+        let stdout = stdout
+            .and_then(|reader| reader.join().ok())
+            .unwrap_or_default();
+        let stderr = stderr
+            .and_then(|reader| reader.join().ok())
+            .unwrap_or_default();
+        let stdout = String::from_utf8_lossy(&stdout);
+        let stderr = String::from_utf8_lossy(&stderr);
         Ok(serde_json::json!({
             "output": format!(
                 "{}{}",
@@ -784,7 +894,7 @@ impl ServerSession {
                     format!("\n{}", stderr)
                 }
             ),
-            "exitCode": output.status.code().unwrap_or(-1),
+            "exitCode": status.code().unwrap_or(-1),
         }))
     }
 
@@ -1569,7 +1679,12 @@ mod tests {
         let session = make_test_session("s1");
         // Create the cwd directory so the shell can cd into it
         std::fs::create_dir_all(&session.cwd).unwrap();
-        let result = session.execute_shell("echo hello").unwrap();
+        let result = session
+            .execute_shell(
+                "echo hello",
+                future_rpc::command_policy::SHELL_EXECUTION_TIMEOUT,
+            )
+            .unwrap();
         let output = result["output"].as_str().unwrap();
         assert!(output.contains("hello"));
         assert_eq!(result["exitCode"], 0);
@@ -1579,8 +1694,29 @@ mod tests {
     fn execute_shell_nonzero_exit() {
         let session = make_test_session("s1");
         std::fs::create_dir_all(&session.cwd).unwrap();
-        let result = session.execute_shell("false").unwrap();
+        let result = session
+            .execute_shell("false", future_rpc::command_policy::SHELL_EXECUTION_TIMEOUT)
+            .unwrap();
         assert_eq!(result["exitCode"], 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn execute_shell_timeout_kills_the_process_group() {
+        let session = make_test_session("shell-timeout");
+        std::fs::create_dir_all(&session.cwd).unwrap();
+        let marker = std::path::Path::new(&session.cwd).join("late-child-output");
+        let command = format!("(sleep 0.4; printf leaked > '{}') & wait", marker.display());
+
+        let started = std::time::Instant::now();
+        let error = session
+            .execute_shell(&command, std::time::Duration::from_millis(50))
+            .unwrap_err();
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(!marker.exists(), "a descendant survived the shell timeout");
     }
 
     #[tokio::test]
@@ -2938,7 +3074,12 @@ mod tests {
     fn execute_shell_captures_stderr() {
         let session = make_test_session("stderr");
         std::fs::create_dir_all(&session.cwd).unwrap();
-        let result = session.execute_shell("echo out; echo err 1>&2").unwrap();
+        let result = session
+            .execute_shell(
+                "echo out; echo err 1>&2",
+                future_rpc::command_policy::SHELL_EXECUTION_TIMEOUT,
+            )
+            .unwrap();
         let output = result["output"].as_str().unwrap();
         assert!(output.contains("out"), "{output}");
         assert!(output.contains("err"), "{output}");

--- a/channels/src/dingtalk/bridge.rs
+++ b/channels/src/dingtalk/bridge.rs
@@ -241,7 +241,7 @@ impl DingtalkBridge {
                     }
                     "/compact" => {
                         if let Ok(()) = agent.compact(&sid).await {
-                            reply_md("Compact", "Context compacted.");
+                            reply_md("Compact", "Context compaction started.");
                         }
                     }
                     "/effort" if !arg.is_empty() => {
@@ -949,7 +949,7 @@ mod tests {
             .handle_event(event(&fx.base, "m4", "/compact"))
             .await
             .unwrap();
-        assert!(wait_hook(&fx.http, "Context compacted").await);
+        assert!(wait_hook(&fx.http, "Context compaction started").await);
 
         fx.bridge
             .handle_event(event(&fx.base, "m5", "/effort turbo"))

--- a/channels/src/feishu/bridge.rs
+++ b/channels/src/feishu/bridge.rs
@@ -684,7 +684,7 @@ impl Bridge {
                                     .reply_message(
                                         message_id,
                                         "text",
-                                        &serde_json::json!({"text": "Context compacted."})
+                                        &serde_json::json!({"text": "Context compaction started."})
                                             .to_string(),
                                     )
                                     .await?;
@@ -1780,7 +1780,7 @@ mod tests {
             .unwrap();
         assert!(replies(&fx.http, "om_3")
             .iter()
-            .any(|b| b.contains("Context compacted")));
+            .any(|b| b.contains("Context compaction started")));
         assert_eq!(ts::recorded_of(&fx.grpc, "compact").len(), 1);
         drop(fx);
 

--- a/channels/src/grpc_client.rs
+++ b/channels/src/grpc_client.rs
@@ -91,7 +91,7 @@ impl AgentClient {
         let connected = future_rpc::transport::connect_channel(
             Some(addr),
             std::time::Duration::from_secs(10),
-            std::time::Duration::from_secs(60),
+            None,
         )
         .await
         .map_err(|e| anyhow!("Failed to connect to agent: {e}"))?;
@@ -128,7 +128,7 @@ impl AgentClient {
 
     /// Execute a command and return the parsed JSON response data.
     async fn call(&mut self, cmd_type: &str, session_id: &str, extra: RpcCommand) -> Result<Value> {
-        let request = tonic::Request::new(RpcCommand {
+        let request = future_rpc::command_policy::request_with_timeout(RpcCommand {
             id: uuid::Uuid::new_v4().to_string(),
             r#type: cmd_type.to_string(),
             session_id: session_id.to_string(),

--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -65,13 +65,13 @@ impl RunClient {
         let connected = future_rpc::transport::connect_channel(
             Some(&self.addr),
             Duration::from_secs(timeout_secs.min(5)),
-            Duration::from_secs(timeout_secs),
+            None,
         )
         .await
         .map_err(|e| e.to_string())?;
         let mut client = FutureAgentClient::new(connected.channel);
         let response = client
-            .execute_command(cmd)
+            .execute_command(future_rpc::command_policy::request_with_timeout(cmd))
             .await
             .map_err(|status| {
                 let msg = status.message();
@@ -375,8 +375,9 @@ impl RunClient {
         let connected = future_rpc::transport::connect_channel(
             Some(&self.addr),
             Duration::from_secs(5),
-            // TS: 5-minute setTimeout — the whole stream is bounded by it.
-            Duration::from_secs(300),
+            // The stream has its own lifecycle/watchdogs; never apply an
+            // overall channel or gRPC request deadline.
+            None,
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/desktop/DEV_MD/CONTEXT_COMPACTION.md
+++ b/desktop/DEV_MD/CONTEXT_COMPACTION.md
@@ -137,11 +137,13 @@ loader 已同时接受：
 
 每次真正进入压缩流程时生成唯一 `operation_id`，并通过 run-event journal 发出完整生命周期：
 
-1. `compaction_started`：摘要请求开始前发出，UI 显示“正在压缩”；
-2. `compaction_committed`：checkpoint durable commit 成功后发出，UI 将同一 marker 原位更新为成功；
-3. `compaction_failed`：摘要、边界规划或持久化任一步失败时发出，UI 将同一 marker 原位更新为失败并保留错误详情。
+1. 客户端调用 `compact` RPC，立即返回 `operationId`，不再让一次 unary RPC 同步等待模型摘要；
+2. `compaction_started`：摘要请求开始前发出，UI 显示“正在压缩”；
+3. `compaction_committed`：checkpoint durable commit 成功后发出，UI 将同一 marker 原位更新为成功；
+4. `compaction_failed`：摘要、边界规划或持久化任一步失败时发出，UI 将同一 marker 原位更新为失败并保留错误详情；
+5. `compaction_unchanged`：没有可压缩的新内容时结束异步操作，UI 恢复输入提交并显示无需压缩提示。
 
-三种事件都携带同一个 `operation_id`；`trigger` 和 `phase` 在 started/failed 中明确携带，committed 从 checkpoint 携带。未达到阈值、无需压缩的 `Unchanged` 路径不发 started，避免产生虚假状态。
+四种事件都携带同一个 `operation_id`；`trigger` 和 `phase` 在 started/failed/unchanged 中明确携带，committed 从 checkpoint 携带。无需压缩的 `Unchanged` 路径不发 started，直接以 unchanged 结束已受理的手动操作，避免产生虚假状态。
 
 checkpoint 与消息 append 共用同一个 FIFO 持久化队列。只有此前 append、checkpoint append、flush 和 `fsync` 全部成功后，才允许：
 
@@ -518,7 +520,7 @@ deterministic-emergency-v1
 
 ### 12.2 Run-event 与 RPC
 
-新增 `compaction_started`；`compaction_committed` 与 `compaction_failed` 加法携带 `operation_id`/`phase`，不删除或改名任何既有字段。三态事件进入现有 run-event journal 和 RPC `StreamEvent`，不新增 session JSONL 顶层行类型。成功后的 prompt projection 仍只以 checkpoint journal entry 为事实来源；started/failed 只描述操作状态，不得改变历史上下文。旧 `compaction_end`、缺少 `operation_id` 的旧 committed 事件和旧 marker 去重规则保持兼容。
+手动 `compact` RPC 返回异步受理结果 `accepted + operationId`；`compaction_started`、`compaction_committed`、`compaction_failed` 与 `compaction_unchanged` 进入现有 run-event journal 和 RPC `StreamEvent`，不新增 session JSONL 顶层行类型。成功后的 prompt projection 仍只以 checkpoint journal entry 为事实来源；started/failed/unchanged 只描述操作状态，不得改变历史上下文。
 
 ### 12.3 SQLite
 

--- a/desktop/src-tauri/src/agent_bridge/client.rs
+++ b/desktop/src-tauri/src/agent_bridge/client.rs
@@ -11,6 +11,52 @@ use tonic::transport::Channel;
 
 use crate::agent_proto::{Attachment, FutureAgentClient, RpcCommand, RpcResponse};
 
+/// Desktop client wrapper that applies the shared per-command deadline while
+/// leaving streaming RPCs on the underlying client deadline-free.
+#[derive(Clone, Debug)]
+pub struct AgentClient {
+    inner: FutureAgentClient<Channel>,
+}
+
+impl AgentClient {
+    fn new(inner: FutureAgentClient<Channel>) -> Self {
+        Self { inner }
+    }
+
+    pub async fn execute_command(
+        &mut self,
+        command: RpcCommand,
+    ) -> Result<tonic::Response<RpcResponse>, tonic::Status> {
+        self.inner
+            .execute_command(future_rpc::command_policy::request_with_timeout(command))
+            .await
+    }
+
+    async fn execute_command_with_timeout(
+        &mut self,
+        command: RpcCommand,
+        timeout: Duration,
+    ) -> Result<tonic::Response<RpcResponse>, tonic::Status> {
+        let mut request = tonic::Request::new(command);
+        request.set_timeout(timeout);
+        self.inner.execute_command(request).await
+    }
+}
+
+impl std::ops::Deref for AgentClient {
+    type Target = FutureAgentClient<Channel>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for AgentClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 /// Cap on how long a single connection attempt may take. Without it a hung agent
 /// can stall a caller indefinitely — e.g. the GUI's 10s model poll would pile up
 /// overlapping calls, and a late failure could clobber fresh state.
@@ -73,6 +119,10 @@ fn agent_channel_runtime() -> tokio::runtime::Handle {
 pub fn map_rpc_error(context: &str, status: tonic::Status) -> crate::AppError {
     if status.code() == tonic::Code::Unavailable {
         crate::AppError::AgentUnavailable(format!("{context}: {}", status.message()))
+    } else if status.code() == tonic::Code::DeadlineExceeded {
+        crate::AppError::Message(format!(
+            "{context}: command timed out; its outcome may be unknown"
+        ))
     } else {
         crate::AppError::Message(format!("{context}: {status}"))
     }
@@ -88,7 +138,7 @@ static AGENT_CHANNEL: tokio::sync::Mutex<Option<(String, Channel)>> =
 /// Resolve the agent endpoint and open a gRPC client. A connection failure maps
 /// to `AppError::AgentUnavailable` so callers can tolerate a down agent (e.g.
 /// `abort_run` still cancels the run locally).
-pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppError> {
+pub async fn connect_agent() -> Result<AgentClient, crate::AppError> {
     let configured = raw_agent_addr();
     // A cached channel already targeting this discovery configuration is
     // reused as-is.
@@ -96,9 +146,11 @@ pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppErr
         let cached = AGENT_CHANNEL.lock().await;
         if let Some((addr, channel)) = cached.as_ref() {
             if addr == &configured {
-                return Ok(FutureAgentClient::new(channel.clone())
-                    .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-                    .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE));
+                return Ok(AgentClient::new(
+                    FutureAgentClient::new(channel.clone())
+                        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+                        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
+                ));
             }
         }
     }
@@ -108,7 +160,7 @@ pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppErr
             let connected = future_rpc::transport::connect_channel(
                 Some(&configured_for_connect),
                 CONNECT_TIMEOUT,
-                CONNECT_TIMEOUT,
+                None,
             )
             .await
             .map_err(|error| {
@@ -118,30 +170,31 @@ pub async fn connect_agent() -> Result<FutureAgentClient<Channel>, crate::AppErr
             })?;
             let label = connected.endpoint.label();
             let ch = connected.channel;
-            let mut client = FutureAgentClient::new(ch.clone())
-                .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-                .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE);
+            let mut client = AgentClient::new(
+                FutureAgentClient::new(ch.clone())
+                    .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+                    .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
+            );
             health_check(&mut client, &label).await?;
             Ok::<Channel, crate::AppError>(ch)
         })
         .await
         .expect("agent channel task: pinned runtime outlives the process")?;
     *AGENT_CHANNEL.lock().await = Some((configured, channel.clone()));
-    Ok(FutureAgentClient::new(channel)
-        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE))
+    Ok(AgentClient::new(
+        FutureAgentClient::new(channel)
+            .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
+    ))
 }
 
 /// One-shot reachability check run when the shared channel is first
 /// established: validates the lazy channel with a cheap, no-side-effect RPC
 /// so a down agent surfaces the familiar AgentUnavailable message rather
 /// than a raw tonic transport error on the next real command.
-async fn health_check(
-    client: &mut FutureAgentClient<Channel>,
-    endpoint_str: &str,
-) -> Result<(), crate::AppError> {
+async fn health_check(client: &mut AgentClient, endpoint_str: &str) -> Result<(), crate::AppError> {
     client
-        .execute_command(list_streaming_sessions_command())
+        .execute_command_with_timeout(list_streaming_sessions_command(), CONNECT_TIMEOUT)
         .await
         .map_err(|status| {
             crate::AppError::AgentUnavailable(format!(
@@ -425,6 +478,7 @@ pub(super) fn base_command(command_type: &str, session_id: String) -> RpcCommand
         source_meta: String::new(),
         enabled: false,
         command: String::new(),
+        shell_timeout_ms: 0,
         session_id,
         entry_id: String::new(),
         name: String::new(),
@@ -587,6 +641,13 @@ mod tests {
         let internal = map_rpc_error("ctx", tonic::Status::internal("boom"));
         assert!(matches!(internal, crate::AppError::Message(_)));
         assert!(internal.to_string().starts_with("ctx: "));
+
+        let deadline = map_rpc_error("ctx", tonic::Status::deadline_exceeded("expired"));
+        assert!(matches!(deadline, crate::AppError::Message(_)));
+        assert_eq!(
+            deadline.to_string(),
+            "ctx: command timed out; its outcome may be unknown"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent_bridge/observer.rs
+++ b/desktop/src-tauri/src/agent_bridge/observer.rs
@@ -107,6 +107,7 @@ const FORWARDED_EVENTS: &[&str] = &[
     "compaction_started",
     "compaction_committed",
     "compaction_failed",
+    "compaction_unchanged",
     "user_message",
     "model_changed",
     "thinking_level_changed",

--- a/desktop/src-tauri/src/agent_bridge/session.rs
+++ b/desktop/src-tauri/src/agent_bridge/session.rs
@@ -4,13 +4,11 @@
 
 use std::collections::HashMap;
 
-use tonic::transport::Channel;
-
 use super::client::{
     fork_command, get_state_command, new_session_command, set_cwd_command,
     set_permission_level_command, set_sandbox_policy_command, RpcResponseExt,
 };
-use crate::{agent_proto::FutureAgentClient, store};
+use crate::store;
 
 /// Outcome of `ensure_agent_session`.
 #[derive(Debug)]
@@ -29,7 +27,7 @@ pub(super) struct EnsuredSession {
 /// `model_id` and `thinking_level` are applied to newly-created sessions so
 /// the agent starts with the user's selection immediately.
 pub(super) async fn ensure_agent_session(
-    client: &mut FutureAgentClient<Channel>,
+    client: &mut super::client::AgentClient,
     session_id: &str,
     cwd: &str,
     model_id: Option<&str>,
@@ -93,7 +91,7 @@ pub(super) async fn ensure_agent_session(
 }
 
 pub(super) async fn set_agent_permission_level(
-    client: &mut FutureAgentClient<Channel>,
+    client: &mut super::client::AgentClient,
     session_id: &str,
     level: &str,
 ) -> Result<(), crate::AppError> {
@@ -115,7 +113,7 @@ pub(super) async fn set_agent_permission_level(
 /// `"manual"` (ask), `"sandbox"` (the available OS sandbox wraps shell commands), or `"off"`
 /// (fully open). The tier is a global app preference, defaulting to `"manual"`.
 pub(super) async fn set_agent_sandbox_policy(
-    client: &mut FutureAgentClient<Channel>,
+    client: &mut super::client::AgentClient,
     session_id: &str,
     _thread_id: &str,
 ) -> Result<(), crate::AppError> {
@@ -526,7 +524,7 @@ mod tests {
 
     async fn mock_client() -> (
         super::super::test_support::MockAgentGuard,
-        FutureAgentClient<Channel>,
+        super::super::client::AgentClient,
     ) {
         let mock = mock_agent();
         let client = super::super::client::connect_agent()

--- a/desktop/src-tauri/src/agent_supervisor.rs
+++ b/desktop/src-tauri/src/agent_supervisor.rs
@@ -44,7 +44,7 @@ fn agent_reachable(configured: &str) -> bool {
                     .block_on(future_rpc::transport::connect_channel(
                         Some(&configured),
                         Duration::from_millis(300),
-                        Duration::from_millis(300),
+                        Some(Duration::from_millis(300)),
                     ))
                     .ok()
             })

--- a/desktop/src-tauri/src/commands/threads.rs
+++ b/desktop/src-tauri/src/commands/threads.rs
@@ -349,11 +349,15 @@ pub async fn compact_thread_context(
         .into_inner()
         .ok_or_rpc_error("compact returned an error")?;
     let value = future_rpc::decode::response_data(&response);
-    Ok(if value.is_null() {
-        serde_json::json!({})
-    } else {
-        value
-    })
+    let valid_ack = value.get("accepted").and_then(serde_json::Value::as_bool) == Some(true)
+        && value
+            .get("operationId")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|operation_id| !operation_id.is_empty());
+    if !valid_ack {
+        return Err("compact returned an invalid acknowledgement".into());
+    }
+    Ok(value)
 }
 
 /// Fetch session entries from the agent (user, assistant, tool messages).
@@ -678,7 +682,13 @@ mod tests {
         let _home = init("cmd_compact_context");
         let thread = make_thread(&_home, Some("sess_compact"));
         let agent = crate::commands::agent_mock::ensure_mock_agent();
-        script_mock_agent(MockScript::default());
+        script_mock_agent(MockScript {
+            data: HashMap::from([(
+                "compact".to_string(),
+                r#"{"accepted":true,"operationId":"cmp-test"}"#.to_string(),
+            )]),
+            ..Default::default()
+        });
 
         compact_thread_context(thread.id).await.expect("compact");
 
@@ -695,7 +705,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compact_thread_context_returns_empty_object_for_empty_agent_data() {
+    async fn compact_thread_context_rejects_empty_agent_data() {
         let _lock = mock_agent_lock();
         let _home = init("cmd_compact_empty_data");
         let thread = make_thread(&_home, Some("sess_compact_empty"));
@@ -704,8 +714,8 @@ mod tests {
             data: HashMap::from([("compact".to_string(), String::new())]),
             ..Default::default()
         });
-        let value = compact_thread_context(thread.id).await.expect("compact");
-        assert_eq!(value, serde_json::json!({}));
+        let error = compact_thread_context(thread.id).await.unwrap_err();
+        assert!(error.to_string().contains("invalid acknowledgement"));
         script_mock_agent(MockScript::default());
     }
 

--- a/desktop/src/features/agent/AgentThread.tsx
+++ b/desktop/src/features/agent/AgentThread.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FloatingScrollbar } from "../../components/ui/FloatingScrollbar";
 import { compactThreadContext } from "../../integrations/agent/agentClient";
+import { useCachedAgentState } from "../../integrations/agent/agentStateCache";
 import { forkThread } from "../../integrations/storage/threadStore";
 import { cn } from "../../lib/cn";
 import { errorMessage } from "../../lib/errors";
@@ -26,6 +27,7 @@ import { useStickyAutoScroll } from "./useStickyAutoScroll";
 
 /** How many user exchanges one loaded page renders. */
 const PAGE_USER_EXCHANGES = 10;
+const COMPACTION_TERMINAL_TIMEOUT_MS = 30 * 60 * 1000;
 
 interface AgentThreadProps {
   thread: StoredThread | null;
@@ -81,6 +83,7 @@ export function AgentThread({
   onToggleLeftPanel,
 }: AgentThreadProps) {
   const { t } = useTranslation("agent");
+  const agentState = useCachedAgentState(thread?.id);
   const {
     handleAbort,
     handleSend,
@@ -107,6 +110,12 @@ export function AgentThread({
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
   const searchRootRef = useRef<HTMLDivElement>(null);
+  const compactionWaitCleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(
+    () => () => compactionWaitCleanupRef.current?.(),
+    [thread?.id, thread?.agentSessionId],
+  );
 
   const {
     scrollRef,
@@ -257,11 +266,91 @@ export function AgentThread({
   const handleCompactContext = useCallback(async () => {
     if (!thread)
       return;
+    interface TerminalCompactionEvent {
+      eventType: "compaction_committed" | "compaction_failed" | "compaction_unchanged";
+      payload: Record<string, unknown>;
+    }
+    let expectedOperationId: string | undefined;
+    let bufferedTerminal: TerminalCompactionEvent | undefined;
+    let resolveTerminal: ((event: TerminalCompactionEvent) => void) | undefined;
+    let rejectTerminal: ((error: Error) => void) | undefined;
+    const terminalPromise = new Promise<TerminalCompactionEvent>((resolve, reject) => {
+      resolveTerminal = resolve;
+      rejectTerminal = reject;
+    });
+    const handleAgentEvent = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        threadId?: string;
+        sessionId?: string;
+        eventType?: string;
+        payload?: Record<string, unknown>;
+      } | undefined;
+      if (
+        !detail
+        || detail.threadId !== thread.id
+        || detail.sessionId !== thread.agentSessionId
+        || !detail.payload
+        || ![
+          "compaction_committed",
+          "compaction_failed",
+          "compaction_unchanged",
+        ].includes(detail.eventType ?? "")
+      ) {
+        return;
+      }
+      const operationId = typeof detail.payload.operation_id === "string"
+        ? detail.payload.operation_id
+        : undefined;
+      const terminal = detail as TerminalCompactionEvent;
+      if (!expectedOperationId) {
+        bufferedTerminal = terminal;
+      }
+      else if (operationId === expectedOperationId) {
+        resolveTerminal?.(terminal);
+      }
+    };
+    window.addEventListener("future:agent-event", handleAgentEvent);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelWait: () => void;
+    const cleanup = () => {
+      window.removeEventListener("future:agent-event", handleAgentEvent);
+      if (timeoutId)
+        clearTimeout(timeoutId);
+      if (compactionWaitCleanupRef.current === cancelWait)
+        compactionWaitCleanupRef.current = null;
+    };
+    cancelWait = () => {
+      cleanup();
+      const error = new Error("compaction wait cancelled");
+      error.name = "AbortError";
+      rejectTerminal?.(error);
+    };
+    compactionWaitCleanupRef.current?.();
+    compactionWaitCleanupRef.current = cancelWait;
     try {
       const result = await compactThreadContext(thread.id);
-      if (!result.checkpointId) {
+      expectedOperationId = result.operationId;
+      const bufferedOperationId = typeof bufferedTerminal?.payload.operation_id === "string"
+        ? bufferedTerminal.payload.operation_id
+        : undefined;
+      if (bufferedTerminal && bufferedOperationId === expectedOperationId)
+        resolveTerminal?.(bufferedTerminal);
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(t("composer.compactionWaitTimedOut"))),
+          COMPACTION_TERMINAL_TIMEOUT_MS,
+        );
+      });
+      const terminal = await Promise.race([terminalPromise, timeoutPromise]);
+      if (terminal.eventType === "compaction_failed") {
+        const message = typeof terminal.payload.error === "string"
+          ? terminal.payload.error
+          : t("failure.unknown");
+        throw new Error(message);
+      }
+      if (terminal.eventType === "compaction_unchanged") {
         emitFutureEvent("toast", {
-          message: t(result.alreadyCompacted
+          message: t(terminal.payload.already_compacted
             ? "composer.compactionNoNewContent"
             : "composer.compactionNotNeeded"),
           tone: "info",
@@ -269,10 +358,15 @@ export function AgentThread({
       }
     }
     catch (error) {
+      if (error instanceof Error && error.name === "AbortError")
+        return;
       emitFutureEvent("toast", {
         message: t("composer.compactionRequestFailed", { message: errorMessage(error) }),
         tone: "error",
       });
+    }
+    finally {
+      cleanup();
     }
   }, [thread, t]);
 
@@ -394,6 +488,7 @@ export function AgentThread({
               sending={isSending}
               onAbort={handleComposerAbort}
               onCompactContext={thread?.agentSessionId ? handleCompactContext : undefined}
+              compactionInProgress={agentState?.isCompacting ?? false}
               onSend={handleComposerSend}
               workspaceId={thread?.workspaceId}
               draftKey={thread?.id}

--- a/desktop/src/features/agent/Composer.tsx
+++ b/desktop/src/features/agent/Composer.tsx
@@ -79,6 +79,8 @@ interface ComposerProps {
   onAbort?: () => void;
   /** Run a standalone compaction for the current conversation. */
   onCompactContext?: () => void | Promise<void>;
+  /** A compaction reported by the agent is still running (survives reloads). */
+  compactionInProgress?: boolean;
   placeholder?: string;
   textareaClassName?: string;
   workspaceId?: string | null;
@@ -113,6 +115,7 @@ function ComposerImpl({
   sending,
   onAbort,
   onCompactContext,
+  compactionInProgress,
   placeholder,
   textareaClassName,
   workspaceId,
@@ -138,10 +141,11 @@ function ComposerImpl({
   // until it settles.
   const [sendPending, setSendPending] = useState(false);
   const [contextActionPending, setContextActionPending] = useState(false);
+  const compactionPending = contextActionPending || compactionInProgress;
   const editorRef = useRef<MentionEditorHandle | null>(null);
 
   const contextTools = useMemo<ContextToolOption[]>(() => {
-    if (!onCompactContext || sending || contextActionPending)
+    if (!onCompactContext || sending || compactionPending)
       return [];
     return [{
       id: "compact",
@@ -149,16 +153,16 @@ function ComposerImpl({
       description: t("composer.compactContextDescription"),
       searchText: "compact compaction compress context 压缩 上下文",
     }];
-  }, [contextActionPending, onCompactContext, sending, t]);
+  }, [compactionPending, onCompactContext, sending, t]);
   const handleContextToolSelect = useCallback((toolId: string) => {
-    if (toolId !== "compact" || !onCompactContext || contextActionPending)
+    if (toolId !== "compact" || !onCompactContext || compactionPending)
       return;
     const result = onCompactContext();
     if (result) {
       setContextActionPending(true);
       result.catch(() => {}).finally(() => setContextActionPending(false));
     }
-  }, [contextActionPending, onCompactContext]);
+  }, [compactionPending, onCompactContext]);
 
   // Installed skills for the `/` menu. The name stays the English slash-command
   // name; the description follows the UI language (mirrors SkillsView). Skill
@@ -305,7 +309,7 @@ function ComposerImpl({
       || disabled
       || sendPending
       || sending
-      || contextActionPending
+      || compactionPending
     ) {
       return;
     }
@@ -757,7 +761,7 @@ function ComposerImpl({
                     (inputEmpty && attachments.length === 0)
                     || disabled
                     || sendPending
-                    || contextActionPending
+                    || compactionPending
                   }
                   type="submit"
                   aria-label={t("composer.send")}

--- a/desktop/src/i18n/locales/en/agent.json
+++ b/desktop/src/i18n/locales/en/agent.json
@@ -136,6 +136,7 @@
     "compactContextDescription": "Compact this conversation's context",
     "compactionNotNeeded": "There is no conversation context to compact.",
     "compactionNoNewContent": "No conversation content was added after the last compaction.",
+    "compactionWaitTimedOut": "Timed out waiting for the Agent's compaction result.",
     "compactionRequestFailed": "Context compaction failed: {{message}}",
     "approval": "Approval mode",
     "approvalTier": {

--- a/desktop/src/i18n/locales/zh/agent.json
+++ b/desktop/src/i18n/locales/zh/agent.json
@@ -137,6 +137,7 @@
     "compactContextDescription": "压缩此对话的上下文",
     "compactionNotNeeded": "当前没有可压缩的对话上下文。",
     "compactionNoNewContent": "自上次压缩后没有新增对话内容，无需再次压缩。",
+    "compactionWaitTimedOut": "等待 Agent 返回压缩结果超时。",
     "compactionRequestFailed": "上下文压缩失败：{{message}}",
     "approval": "审批模式",
     "approvalTier": {

--- a/desktop/src/integrations/agent/agentClient.ts
+++ b/desktop/src/integrations/agent/agentClient.ts
@@ -94,11 +94,8 @@ export async function loadAgentModelOptions() {
 }
 
 export interface CompactContextResult {
-  checkpointId?: string;
-  alreadyCompacted?: boolean;
-  messagesRemoved?: number;
-  tokensBefore?: number;
-  tokensAfter?: number;
+  operationId: string;
+  accepted: true;
 }
 
 /** Run standalone semantic compaction for an existing conversation. */

--- a/desktop/src/integrations/agent/agentStateCache.test.ts
+++ b/desktop/src/integrations/agent/agentStateCache.test.ts
@@ -93,6 +93,7 @@ describe("agentStateCache fetch/cache", () => {
   it("fetches and parses session state including activeRun variants", async () => {
     invokeMock.mockResolvedValue(
       statePayload({
+        isCompacting: true,
         activeRun: { runId: "r1", state: "running", epoch: 2, lastEventIdx: 7 },
       }),
     );
@@ -103,6 +104,7 @@ describe("agentStateCache fetch/cache", () => {
       sessionName: "Session",
       sessionId: "s1",
       cwd: "/w",
+      isCompacting: true,
       activeRun: { runId: "r1", state: "running", epoch: 2, lastEventIdx: 7 },
     });
 
@@ -351,7 +353,14 @@ describe("agentStateCache event listener", () => {
       operation_id: "cmp_2",
       error: "provider unavailable",
     });
-    expect(received).toHaveLength(4);
+    emit({
+      _eventType: "compaction_unchanged",
+      sessionId: "s1",
+      threadId: "t1",
+      operation_id: "cmp_3",
+      already_compacted: true,
+    });
+    expect(received).toHaveLength(5);
     expect(received[0]?.detail).toMatchObject({
       threadId: "t1",
       eventType: "user_message",
@@ -371,9 +380,35 @@ describe("agentStateCache event listener", () => {
       eventType: "compaction_failed",
       payload: { operation_id: "cmp_2", error: "provider unavailable" },
     });
+    expect(received[4]?.detail).toMatchObject({
+      threadId: "t1",
+      eventType: "compaction_unchanged",
+      payload: { operation_id: "cmp_3", already_compacted: true },
+    });
     // Without a threadId the event is dropped.
     emit({ _eventType: "agent_end", sessionId: "s1" });
-    expect(received).toHaveLength(4);
+    expect(received).toHaveLength(5);
+  });
+
+  it("tracks compaction lifecycle in cached agent state", async () => {
+    invokeMock.mockResolvedValue(statePayload({ isCompacting: false }));
+    await getAgentState("t-compaction");
+
+    emit({
+      _eventType: "compaction_started",
+      sessionId: "s1",
+      threadId: "t-compaction",
+      operation_id: "cmp_1",
+    });
+    expect(getCachedAgentState("t-compaction")?.isCompacting).toBe(true);
+
+    emit({
+      _eventType: "compaction_committed",
+      sessionId: "s1",
+      threadId: "t-compaction",
+      operation_id: "cmp_1",
+    });
+    expect(getCachedAgentState("t-compaction")?.isCompacting).toBe(false);
   });
 });
 

--- a/desktop/src/integrations/agent/agentStateCache.ts
+++ b/desktop/src/integrations/agent/agentStateCache.ts
@@ -17,6 +17,8 @@ export interface AgentSessionState {
   parentSessionId?: string | null;
   /** Whether the agent is currently streaming a response for this session. */
   isStreaming?: boolean;
+  /** Whether a manual context compaction is currently running. */
+  isCompacting?: boolean;
   activeRun?: {
     runId: string;
     epoch: number;
@@ -114,6 +116,8 @@ export async function getAgentState(
           typeof raw.parentSessionId === "string" ? raw.parentSessionId : null,
         isStreaming:
           typeof raw.isStreaming === "boolean" ? raw.isStreaming : undefined,
+        isCompacting:
+          typeof raw.isCompacting === "boolean" ? raw.isCompacting : undefined,
         activeRun: parseActiveRun(raw.activeRun),
       };
       if ((versions.get(threadId) ?? 0) === requestVersion) {
@@ -305,8 +309,14 @@ export function installAgentEventListener() {
       case "compaction_started":
       case "compaction_committed":
       case "compaction_failed":
+      case "compaction_unchanged":
         if (!threadId)
           return;
+        applyCompactionEvent(
+          threadId,
+          sessionId,
+          eventType === "compaction_started",
+        );
         window.dispatchEvent(
           new CustomEvent("future:agent-event", {
             detail: { threadId, sessionId, eventType, payload: p },
@@ -315,6 +325,32 @@ export function installAgentEventListener() {
         break;
     }
   });
+}
+
+/** Keep the cached session snapshot aligned with compaction lifecycle events. */
+function applyCompactionEvent(
+  eventThreadId: string,
+  sessionId: string,
+  isCompacting: boolean,
+) {
+  let changed = false;
+  for (const [threadId, entry] of cache) {
+    if (threadId !== eventThreadId && entry.state.sessionId !== sessionId)
+      continue;
+    cache.set(threadId, {
+      state: { ...entry.state, isCompacting },
+      fetchedAt: Date.now(),
+    });
+    changed = true;
+  }
+  if (changed) {
+    notify();
+  }
+  else {
+    // The event can beat the active-thread prefetch after a reload. Fetching
+    // authoritative state avoids creating an incomplete cache entry.
+    void getAgentState(eventThreadId, { force: true }).catch(() => {});
+  }
 }
 
 /** Apply a settings-change event to the agent state cache. */

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -15,7 +15,7 @@ future tui        # terminal 2: the terminal UI
 
 For remote/development setups pass `--grpc-addr <host:port>` to the agent to
 serve TCP instead, and set `FUTURE_AGENT_GRPC_ADDR=<host:port>` on clients
-(explicit TCP is tried first, local IPC remains the fallback).
+(an explicit TCP target is authoritative and never falls back to local IPC).
 
 `future tui <args>` runs the TUI in-process; the standalone `future-tui`
 binary is equivalent but no longer installed by default (build it with

--- a/orchestration/loop/src/agent_client.rs
+++ b/orchestration/loop/src/agent_client.rs
@@ -121,13 +121,13 @@ pub struct AgentClient {
 impl AgentClient {
     /// Connect through the shared per-user transport discovery: an explicit
     /// TCP address (FUTURE_LOOP_AGENT_ADDR, or a test mock addr) is tried
-    /// first with local IPC as fallback; the `auto` sentinel selects only the
-    /// local endpoint. Same socket-first boundary as the TUI/CLI clients.
+    /// exclusively; the `auto` sentinel selects only the local endpoint. Same
+    /// target-selection boundary as the TUI/CLI clients.
     pub async fn connect(addr: &str) -> Result<Self> {
         let connected = future_rpc::transport::connect_channel(
             Some(addr),
             std::time::Duration::from_secs(10),
-            std::time::Duration::from_secs(120),
+            None,
         )
         .await
         .map_err(|e| anyhow!("Failed to connect to agent: {e}"))?;
@@ -137,7 +137,7 @@ impl AgentClient {
     }
 
     async fn call(&mut self, cmd_type: &str, session_id: &str, extra: RpcCommand) -> Result<Value> {
-        let request = tonic::Request::new(RpcCommand {
+        let request = future_rpc::command_policy::request_with_timeout(RpcCommand {
             id: uuid::Uuid::new_v4().to_string(),
             r#type: cmd_type.to_string(),
             session_id: session_id.to_string(),

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -104,6 +104,10 @@ message RpcCommand {
   // Shell command string.  Used when cmd_type = "shell".
   string command = 80;
 
+  // Optional server-owned shell timeout. Zero selects the 120-second default;
+  // non-zero values are clamped to 5 seconds through 30 minutes.
+  uint64 shell_timeout_ms = 81;
+
   // ── Session bookkeeping ────────────────────────────────────────────────
 
   // Target session ID.  Almost every command requires this so the
@@ -519,12 +523,9 @@ message Command {
 
 // compact response.
 message CompactResult {
-  int64 tokens_before = 1;
-  int64 tokens_after = 2;
-  string summary = 3;
-  int64 messages_removed = 4;
-  string checkpoint_id = 5;
-  bool already_compacted = 6;
+  // Async manual-compaction acknowledgement.
+  string operation_id = 1;
+  bool accepted = 2;
 }
 
 // shell response.
@@ -747,7 +748,7 @@ message SessionState {
   // Whether the agent loop is currently processing a prompt.
   bool is_streaming = 3;
 
-  // Whether a compaction run is in progress (always false in current code).
+  // Whether a compaction run is currently in progress for this session.
   bool is_compacting = 4;
 
   reserved 5, 6;
@@ -1167,7 +1168,7 @@ message StreamEvent {
   //   error                        run error
   //   tool_sandboxed / persistence_error / compaction_end /
   //   compaction_started / compaction_committed /
-  //   compaction_failed                                     sideband signals
+  //   compaction_failed / compaction_unchanged              sideband signals
   //   provider_config_changed  global provider/auth configuration committed
 //   session_created          global control-plane signal: a session was minted
 //                            (new_session / fork / clone, never disk hydration)

--- a/packages/rpc/src/command_policy.rs
+++ b/packages/rpc/src/command_policy.rs
@@ -1,0 +1,251 @@
+//! Shared per-command execution policy for every Future Agent RPC client.
+//!
+//! Transport connection establishment is bounded separately. These deadlines
+//! cover only one `ExecuteCommand` request; event streams deliberately do not
+//! use this policy because they are governed by handshake and idle watchdogs.
+
+use std::time::Duration;
+
+use tonic::Request;
+
+use crate::proto::RpcCommand;
+
+pub const CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
+pub const FAST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const PROMPT_ACK_TIMEOUT: Duration = Duration::from_secs(15);
+pub const NETWORK_TIMEOUT: Duration = Duration::from_secs(20);
+pub const STORAGE_TIMEOUT: Duration = Duration::from_secs(30);
+pub const SHELL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(120);
+pub const SHELL_RPC_TIMEOUT: Duration = Duration::from_secs(125);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryPolicy {
+    /// A read-only request may be retried once within the caller's operation budget.
+    SafeRead,
+    /// Retry only with the exact same request id/idempotency key.
+    SameRequestId,
+    /// A timeout leaves the mutation outcome unknown; never retry automatically.
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionKind {
+    Immediate,
+    Bounded,
+    AsyncAck,
+    ManagedProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandPolicy {
+    pub timeout: Duration,
+    pub retry: RetryPolicy,
+    pub execution: ExecutionKind,
+}
+
+const fn policy(timeout: Duration, retry: RetryPolicy, execution: ExecutionKind) -> CommandPolicy {
+    CommandPolicy {
+        timeout,
+        retry,
+        execution,
+    }
+}
+
+/// Every command accepted by the Agent dispatcher. Keep the policy match and
+/// its exhaustiveness test aligned with this list when adding a command.
+pub const KNOWN_COMMANDS: &[&str] = &[
+    "abort",
+    "abort_retry",
+    "abort_session",
+    "add_session_rule",
+    "append_system_prompt",
+    "approval_decision",
+    "cancel_queued_run",
+    "clone",
+    "compact",
+    "cycle_model",
+    "cycle_thinking_level",
+    "delete_provider",
+    "delete_session",
+    "disable_builtin_tools",
+    "disable_tools",
+    "export_html",
+    "fork",
+    "get_agent_info",
+    "get_commands",
+    "get_events_since",
+    "get_fork_messages",
+    "get_last_assistant_text",
+    "get_messages",
+    "get_runtime_metrics",
+    "get_session_entries",
+    "get_session_events_since",
+    "get_session_stats",
+    "get_state",
+    "list_models",
+    "list_providers",
+    "list_session_ids",
+    "list_sessions",
+    "list_streaming_sessions",
+    "new_session",
+    "probe_sandbox",
+    "probe_windows_sandbox",
+    "prompt",
+    "prune_run_events",
+    "refresh_skills",
+    "reload_auth",
+    "reload_config",
+    "reset_windows_sandbox",
+    "retry_persistence",
+    "set_auth",
+    "set_auto_compaction",
+    "set_auto_retry",
+    "set_cwd",
+    "set_default_model",
+    "set_enabled_models",
+    "set_ephemeral",
+    "set_model",
+    "set_permission_level",
+    "set_sandbox_policy",
+    "set_session_name",
+    "set_system_prompt",
+    "set_thinking_level",
+    "set_tools",
+    "shell",
+    "shutdown",
+    "switch_session",
+    "sync_future_models",
+    "upsert_provider",
+];
+
+pub fn command_policy(command: &str) -> Option<CommandPolicy> {
+    let value = match command {
+        "abort" | "abort_retry" | "abort_session" | "approval_decision" | "cancel_queued_run"
+        | "shutdown" => policy(
+            CONTROL_TIMEOUT,
+            RetryPolicy::Never,
+            ExecutionKind::Immediate,
+        ),
+        "compact" => policy(
+            CONTROL_TIMEOUT,
+            RetryPolicy::SameRequestId,
+            ExecutionKind::AsyncAck,
+        ),
+        "get_agent_info"
+        | "get_commands"
+        | "get_last_assistant_text"
+        | "get_runtime_metrics"
+        | "get_session_stats"
+        | "get_state"
+        | "list_models"
+        | "list_providers"
+        | "list_streaming_sessions" => policy(
+            FAST_TIMEOUT,
+            RetryPolicy::SafeRead,
+            ExecutionKind::Immediate,
+        ),
+        "prompt" => policy(
+            PROMPT_ACK_TIMEOUT,
+            RetryPolicy::SameRequestId,
+            ExecutionKind::Bounded,
+        ),
+        "sync_future_models" => policy(NETWORK_TIMEOUT, RetryPolicy::Never, ExecutionKind::Bounded),
+        "shell" => policy(
+            SHELL_RPC_TIMEOUT,
+            RetryPolicy::Never,
+            ExecutionKind::ManagedProcess,
+        ),
+        "get_events_since"
+        | "get_fork_messages"
+        | "get_messages"
+        | "get_session_entries"
+        | "get_session_events_since"
+        | "list_session_ids"
+        | "list_sessions"
+        | "probe_sandbox"
+        | "probe_windows_sandbox" => policy(
+            STORAGE_TIMEOUT,
+            RetryPolicy::SafeRead,
+            ExecutionKind::Bounded,
+        ),
+        "add_session_rule"
+        | "append_system_prompt"
+        | "clone"
+        | "cycle_model"
+        | "cycle_thinking_level"
+        | "delete_provider"
+        | "delete_session"
+        | "disable_builtin_tools"
+        | "disable_tools"
+        | "export_html"
+        | "fork"
+        | "new_session"
+        | "prune_run_events"
+        | "refresh_skills"
+        | "reload_auth"
+        | "reload_config"
+        | "reset_windows_sandbox"
+        | "retry_persistence"
+        | "set_auth"
+        | "set_auto_compaction"
+        | "set_auto_retry"
+        | "set_cwd"
+        | "set_default_model"
+        | "set_enabled_models"
+        | "set_ephemeral"
+        | "set_model"
+        | "set_permission_level"
+        | "set_sandbox_policy"
+        | "set_session_name"
+        | "set_system_prompt"
+        | "set_thinking_level"
+        | "set_tools"
+        | "switch_session"
+        | "upsert_provider" => policy(STORAGE_TIMEOUT, RetryPolicy::Never, ExecutionKind::Bounded),
+        _ => return None,
+    };
+    Some(value)
+}
+
+/// Wrap one unary command with its command-specific gRPC deadline.
+pub fn request_with_timeout(command: RpcCommand) -> Request<RpcCommand> {
+    let timeout = command_policy(&command.r#type)
+        .map(|policy| policy.timeout)
+        // Unknown commands are rejected immediately by the Agent. Keep a
+        // finite boundary for malformed/out-of-tree callers nonetheless.
+        .unwrap_or(FAST_TIMEOUT);
+    let mut request = Request::new(command);
+    request.set_timeout(timeout);
+    request
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_declared_command_has_an_explicit_policy() {
+        for command in KNOWN_COMMANDS {
+            assert!(
+                command_policy(command).is_some(),
+                "missing policy for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn long_work_is_not_mistaken_for_a_long_unary_rpc() {
+        assert_eq!(command_policy("compact").unwrap().timeout, CONTROL_TIMEOUT);
+        assert_eq!(command_policy("shell").unwrap().timeout, SHELL_RPC_TIMEOUT);
+        assert!(command_policy("unknown").is_none());
+    }
+
+    #[test]
+    fn request_deadline_is_encoded_in_grpc_metadata() {
+        let request = request_with_timeout(RpcCommand {
+            r#type: "compact".to_string(),
+            ..Default::default()
+        });
+        assert!(request.metadata().contains_key("grpc-timeout"));
+    }
+}

--- a/packages/rpc/src/decode.rs
+++ b/packages/rpc/src/decode.rs
@@ -641,12 +641,8 @@ fn commands_from_proto(response: &proto::CommandsResponse) -> crate::payloads_ex
 
 fn compact_from_proto(result: &proto::CompactResult) -> crate::payloads_ext::CompactPayload {
     crate::payloads_ext::CompactPayload {
-        checkpoint_id: (!result.checkpoint_id.is_empty()).then(|| result.checkpoint_id.clone()),
-        already_compacted: result.already_compacted.then_some(true),
-        tokens_before: result.tokens_before,
-        tokens_after: result.tokens_after,
-        summary: result.summary.clone(),
-        messages_removed: result.messages_removed,
+        operation_id: result.operation_id.clone(),
+        accepted: result.accepted,
     }
 }
 

--- a/packages/rpc/src/encode.rs
+++ b/packages/rpc/src/encode.rs
@@ -573,12 +573,8 @@ fn get_commands(data: &Value) -> Option<proto::CommandsResponse> {
 fn compact(data: &Value) -> Option<proto::CompactResult> {
     let payload: crate::payloads_ext::CompactPayload = serde_json::from_value(data.clone()).ok()?;
     Some(proto::CompactResult {
-        checkpoint_id: payload.checkpoint_id.unwrap_or_default(),
-        already_compacted: payload.already_compacted.unwrap_or(false),
-        tokens_before: payload.tokens_before,
-        tokens_after: payload.tokens_after,
-        summary: payload.summary,
-        messages_removed: payload.messages_removed,
+        operation_id: payload.operation_id,
+        accepted: payload.accepted,
     })
 }
 

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -43,6 +43,10 @@ pub struct RpcCommand {
     /// Shell command string.  Used when cmd_type = "shell".
     #[prost(string, tag = "80")]
     pub command: ::prost::alloc::string::String,
+    /// Optional server-owned shell timeout. Zero selects the 120-second default;
+    /// non-zero values are clamped to 5 seconds through 30 minutes.
+    #[prost(uint64, tag = "81")]
+    pub shell_timeout_ms: u64,
     /// Target session ID.  Almost every command requires this so the
     /// agent knows which session to operate on.  new_session uses it
     /// as the requested ID (generated if empty).
@@ -495,18 +499,11 @@ pub struct Command {
 /// compact response.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactResult {
-    #[prost(int64, tag = "1")]
-    pub tokens_before: i64,
-    #[prost(int64, tag = "2")]
-    pub tokens_after: i64,
-    #[prost(string, tag = "3")]
-    pub summary: ::prost::alloc::string::String,
-    #[prost(int64, tag = "4")]
-    pub messages_removed: i64,
-    #[prost(string, tag = "5")]
-    pub checkpoint_id: ::prost::alloc::string::String,
-    #[prost(bool, tag = "6")]
-    pub already_compacted: bool,
+    /// Async manual-compaction acknowledgement.
+    #[prost(string, tag = "1")]
+    pub operation_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub accepted: bool,
 }
 /// shell response.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -812,7 +809,7 @@ pub struct SessionState {
     /// Whether the agent loop is currently processing a prompt.
     #[prost(bool, tag = "3")]
     pub is_streaming: bool,
-    /// Whether a compaction run is in progress (always false in current code).
+    /// Whether a compaction run is currently in progress for this session.
     #[prost(bool, tag = "4")]
     pub is_compacting: bool,
     /// Reserved for session file path.  Always null in current code.
@@ -1258,7 +1255,7 @@ pub struct StreamEvent {
     ///    error                        run error
     ///    tool_sandboxed / persistence_error / compaction_end /
     ///    compaction_started / compaction_committed /
-    ///    compaction_failed                                     sideband signals
+    ///    compaction_failed / compaction_unchanged              sideband signals
     ///    provider_config_changed  global provider/auth configuration committed
     ///    session_created          global control-plane signal: a session was minted
     ///                             (new_session / fork / clone, never disk hydration)

--- a/packages/rpc/src/lib.rs
+++ b/packages/rpc/src/lib.rs
@@ -12,6 +12,7 @@
 //! this crate also owns the cross-client local transport so every frontend
 //! discovers the same per-user Agent endpoint.
 
+pub mod command_policy;
 pub mod transport;
 
 pub mod proto {

--- a/packages/rpc/src/parity.rs
+++ b/packages/rpc/src/parity.rs
@@ -476,21 +476,8 @@ fn compact_wire_parity() {
     assert_command_parity(
         "compact",
         json!({
-            "tokensBefore": 0,
-            "tokensAfter": 0,
-            "summary": "",
-            "messagesRemoved": 0
-        }),
-    );
-    assert_command_parity(
-        "compact",
-        json!({
-            "checkpointId": "cp-1",
-            "alreadyCompacted": true,
-            "tokensBefore": 100000,
-            "tokensAfter": 20000,
-            "summary": "The user asked about X.",
-            "messagesRemoved": 80000
+            "operationId": "cmp-1",
+            "accepted": true
         }),
     );
 }

--- a/packages/rpc/src/payloads_ext.rs
+++ b/packages/rpc/src/payloads_ext.rs
@@ -194,14 +194,8 @@ pub struct RefreshSkillsPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompactPayload {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checkpoint_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub already_compacted: Option<bool>,
-    pub tokens_before: i64,
-    pub tokens_after: i64,
-    pub summary: String,
-    pub messages_removed: i64,
+    pub operation_id: String,
+    pub accepted: bool,
 }
 
 // ── shell ────────────────────────────────────────────────────────────────────

--- a/packages/rpc/src/transport.rs
+++ b/packages/rpc/src/transport.rs
@@ -55,24 +55,30 @@ impl fmt::Display for ConnectError {
 
 impl std::error::Error for ConnectError {}
 
-/// Build the ordered connection plan. `None`, an empty value, and `auto`
-/// select only the per-user local transport. A configured TCP endpoint is
-/// tried first, with local IPC as a compatibility fallback.
+/// Build the connection plan. `None`, an empty value, and `auto` select the
+/// per-user local transport. An explicit TCP endpoint is authoritative: a
+/// failed remote/development target must not silently redirect commands to an
+/// unrelated local Agent.
 pub fn connection_plan(configured: Option<&str>) -> Vec<AgentEndpoint> {
     let configured = configured
         .map(str::trim)
         .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case(AUTO_ENDPOINT));
     match configured {
-        Some(addr) => vec![AgentEndpoint::Tcp(addr.to_string()), AgentEndpoint::Local],
+        Some(addr) => vec![AgentEndpoint::Tcp(addr.to_string())],
         None => vec![AgentEndpoint::Local],
     }
 }
 
 /// Connect to the first reachable endpoint in the discovery plan.
+///
+/// `connect_timeout` only bounds endpoint establishment. `request_timeout`
+/// optionally installs a channel-wide deadline for clients whose entire RPC
+/// surface is intentionally bounded; long-lived clients should pass `None`
+/// and set deadlines on individual requests where appropriate.
 pub async fn connect_channel(
     configured: Option<&str>,
     connect_timeout: Duration,
-    request_timeout: Duration,
+    request_timeout: Option<Duration>,
 ) -> Result<ConnectedChannel, ConnectError> {
     let mut failures = Vec::new();
     for endpoint in connection_plan(configured) {
@@ -99,13 +105,16 @@ pub async fn connect_channel(
 async fn connect_one(
     endpoint: &AgentEndpoint,
     connect_timeout: Duration,
-    request_timeout: Duration,
+    request_timeout: Option<Duration>,
 ) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
     match endpoint {
         AgentEndpoint::Tcp(addr) => {
-            let endpoint = Endpoint::from_shared(normalize_tcp_uri(addr))?
-                .connect_timeout(connect_timeout)
-                .timeout(request_timeout);
+            let endpoint =
+                Endpoint::from_shared(normalize_tcp_uri(addr))?.connect_timeout(connect_timeout);
+            let endpoint = match request_timeout {
+                Some(timeout) => endpoint.timeout(timeout),
+                None => endpoint,
+            };
             Ok(endpoint.connect().await?)
         }
         AgentEndpoint::Local => connect_local(request_timeout).await,
@@ -152,10 +161,14 @@ pub fn local_endpoint_label() -> String {
 
 #[cfg(unix)]
 async fn connect_local(
-    request_timeout: Duration,
+    request_timeout: Option<Duration>,
 ) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
     let path = local_socket_path();
-    let endpoint = Endpoint::try_from("http://future-agent.local")?.timeout(request_timeout);
+    let endpoint = Endpoint::try_from("http://future-agent.local")?;
+    let endpoint = match request_timeout {
+        Some(timeout) => endpoint.timeout(timeout),
+        None => endpoint,
+    };
     let channel = endpoint
         .connect_with_connector(service_fn(move |_| {
             let path = path.clone();
@@ -171,12 +184,16 @@ async fn connect_local(
 
 #[cfg(windows)]
 async fn connect_local(
-    request_timeout: Duration,
+    request_timeout: Option<Duration>,
 ) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
     use tokio::net::windows::named_pipe::ClientOptions;
 
     let pipe_name = local_pipe_name();
-    let endpoint = Endpoint::try_from("http://future-agent.local")?.timeout(request_timeout);
+    let endpoint = Endpoint::try_from("http://future-agent.local")?;
+    let endpoint = match request_timeout {
+        Some(timeout) => endpoint.timeout(timeout),
+        None => endpoint,
+    };
     let channel = endpoint
         .connect_with_connector(service_fn(move |_| {
             let pipe_name = pipe_name.clone();
@@ -449,13 +466,10 @@ mod tests {
     }
 
     #[test]
-    fn explicitly_configured_tcp_is_tried_before_local_ipc() {
+    fn explicitly_configured_tcp_never_falls_back_to_local_ipc() {
         assert_eq!(
             connection_plan(Some("http://127.0.0.1:50051")),
-            vec![
-                AgentEndpoint::Tcp("http://127.0.0.1:50051".into()),
-                AgentEndpoint::Local,
-            ]
+            vec![AgentEndpoint::Tcp("http://127.0.0.1:50051".into())]
         );
     }
 

--- a/tui/src/agent_supervisor.rs
+++ b/tui/src/agent_supervisor.rs
@@ -80,7 +80,7 @@ async fn agent_healthy(configured: &str) -> bool {
     let Ok(connected) = future_rpc::transport::connect_channel(
         Some(configured),
         Duration::from_millis(400),
-        Duration::from_secs(2),
+        Some(Duration::from_secs(2)),
     )
     .await
     else {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1023,7 +1023,7 @@ impl<T: TerminalIo> App<T> {
             }
             UiCmd::ThinkingCycled(Err(_)) => {}
             UiCmd::CompactDone(result) => match result {
-                Ok(_) => self.add_system_message("Context compacted".into()),
+                Ok(_) => self.add_system_message("Context compaction started".into()),
                 Err(err) => self.add_system_message(format!("Compact failed: {err}")),
             },
             UiCmd::ReloadDone { result, state } => match result {
@@ -5728,7 +5728,7 @@ mod tests {
 
         // CompactDone ok/err.
         app.handle_cmd(UiCmd::CompactDone(Ok("done".into())));
-        assert!(last_system(&app).contains("Context compacted"));
+        assert!(last_system(&app).contains("Context compaction started"));
         app.handle_cmd(UiCmd::CompactDone(Err("bad".into())));
         assert!(last_system(&app).contains("Compact failed"));
 
@@ -7180,7 +7180,7 @@ mod tests {
         pump(&mut app, &mut rx).await;
         assert!(system_messages(&app)
             .iter()
-            .any(|m| m.contains("Context compacted")));
+            .any(|m| m.contains("Context compaction started")));
         assert!(system_messages(&app)
             .iter()
             .any(|m| m.contains("Stopped current generation")));

--- a/tui/src/index.rs
+++ b/tui/src/index.rs
@@ -283,13 +283,13 @@ async fn execute_unary(
     let connected = future_rpc::transport::connect_channel(
         Some(addr),
         Duration::from_secs(timeout_secs.min(5)),
-        Duration::from_secs(timeout_secs),
+        None,
     )
     .await
     .map_err(|e| e.to_string())?;
     let mut client = FutureAgentClient::new(connected.channel);
     client
-        .execute_command(cmd)
+        .execute_command(future_rpc::command_policy::request_with_timeout(cmd))
         .await
         .map(|r| r.into_inner())
         .map_err(|status| {
@@ -450,14 +450,10 @@ async fn apply_cli_options(addr: &str, session_id: &str, args: &CliArgs) -> Resu
 
 /// Dial a channel for the event-stream subscription (print mode).
 async fn dial_channel(addr: &str) -> Result<tonic::transport::Channel, String> {
-    future_rpc::transport::connect_channel(
-        Some(addr),
-        Duration::from_secs(5),
-        Duration::from_secs(GRPC_DEADLINE_SEC),
-    )
-    .await
-    .map(|connected| connected.channel)
-    .map_err(|e| e.to_string())
+    future_rpc::transport::connect_channel(Some(addr), Duration::from_secs(5), None)
+        .await
+        .map(|connected| connected.channel)
+        .map_err(|e| e.to_string())
 }
 
 /// `runPrintMode` — connect, apply CLI options, stream events, prompt, output.

--- a/tui/src/rpc/grpc_client.rs
+++ b/tui/src/rpc/grpc_client.rs
@@ -592,13 +592,13 @@ async fn execute_unary(addr: &str, cmd: RpcCommand, timeout_secs: u64) -> Result
     let connected = future_rpc::transport::connect_channel(
         Some(addr),
         Duration::from_secs(timeout_secs.min(5)),
-        Duration::from_secs(timeout_secs),
+        None,
     )
     .await
     .map_err(|e| e.to_string())?;
     let mut client = FutureAgentClient::new(connected.channel);
     let response = client
-        .execute_command(cmd)
+        .execute_command(future_rpc::command_policy::request_with_timeout(cmd))
         .await
         .map_err(|status| {
             let msg = status.message();
@@ -828,7 +828,7 @@ async fn subscribe_stream(inner: &Arc<Inner>, session: &str) -> StreamExit {
     let connected = match future_rpc::transport::connect_channel(
         Some(&inner.addr),
         Duration::from_secs(TRY_CONNECT_TIMEOUT_SEC),
-        Duration::from_secs(GRPC_DEADLINE_SEC),
+        None,
     )
     .await
     {
@@ -1494,7 +1494,10 @@ mod tests {
                     "{\"models\":[{\"id\":\"gpt-4o\",\"label\":\"GPT-4o\",\"provider\":\"openai\"}, {\"bad\":true}]}".into(),
                 ),
                 ("cycle_thinking_level".into(), "{\"level\":\"high\"}".into()),
-                ("compact".into(), "{\"summary\":\"shorter\"}".into()),
+                (
+                    "compact".into(),
+                    "{\"accepted\":true,\"operationId\":\"cmp-1\"}".into(),
+                ),
                 ("reload_config".into(), "{\"reloaded\":true}".into()),
             ]))),
             ..Default::default()


### PR DESCRIPTION
## Summary

- acknowledge manual compaction immediately and correlate its terminal lifecycle by operation ID
- keep streaming channels deadline-free while applying shared per-command unary deadlines across Desktop, TUI, CLI, Channels, and Loop
- reject conflicting session mutations during compaction and make same-request retries idempotent
- add an Agent-owned shell timeout that terminates the process tree
- make explicit TCP transport authoritative after the local IPC migration

## Validation

- cargo fmt --all -- --check
- cargo fmt --check --manifest-path desktop/src-tauri/Cargo.toml
- cargo clippy for affected workspace crates and Desktop Tauri with -D warnings
- cargo check for RPC, Agent, Channels, Loop, CLI, TUI, and Desktop Tauri
- RPC wire and transport tests; Agent compaction, gRPC, session lifecycle, and shell-timeout tests
- Desktop Rust suite: 1112 passed
- Desktop Vitest suite: 692 passed
- Desktop ESLint and TypeScript checks; 3 existing Tailwind warnings, 0 errors
- proto regeneration and git diff --check