### PR TITLE
fix(markdown): support LaTeX backslash math delimiters

### DIFF
--- a/desktop/src/features/markdown/MarkdownMath.test.tsx
+++ b/desktop/src/features/markdown/MarkdownMath.test.tsx
@@ -40,6 +40,33 @@ describe("math rendering in MarkdownContent", () => {
     expect(html).not.toContain("$E=mc^2$");
   });
 
+  it("renders LaTeX parentheses within bold prose as inline KaTeX", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownContent content={String.raw`最少需要 **\(\boxed{21}\)** 块瓷砖。`} />,
+    );
+    expect(html).toContain("katex-mathml");
+    expect(html).not.toContain("katex-display");
+    expect(html).not.toContain("katex-error");
+    expect(html).toContain("最少需要");
+    expect(html).toContain("块瓷砖。");
+  });
+
+  it("renders bracket-delimited aligned equations from the tiling answer", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownContent content={String.raw`\[
+\begin{aligned}
+&\underbrace{(16-a-b+1)}_{\text{不在两条链上}}
++\underbrace{2(a+b-2)}_{\text{只在一条链上}}+4\\
+&=16+a+b+1.
+\end{aligned}
+\]`}
+      />,
+    );
+    expect(html).toContain("katex-display");
+    expect(html).toContain("katex-mathml");
+    expect(html).not.toContain("katex-error");
+  });
+
   it("keeps prose text around inline math intact", () => {
     const html = renderToStaticMarkup(
       <MarkdownContent content={"Loss is $L(y, \\hat{y})$ where $y$ is the label."} />,

--- a/desktop/src/features/markdown/latexMath.test.ts
+++ b/desktop/src/features/markdown/latexMath.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { parseFutureMarkdown } from "./parseFutureMarkdown";
+import { splitStreamingMarkdown } from "./streamingMarkdownBlocks";
+
+const inline = (code: string) => ({ code, displayMode: false, type: "mathInline" });
+const block = (code: string) => ({ code, type: "mathBlock" });
+
+describe("latex math delimiters", () => {
+  it("parses parentheses in prose and emphasis without interpreting TeX as Markdown", () => {
+    expect(parseFutureMarkdown(String.raw`答案是 **\(\boxed{21}\)**，\(a_b * c\)。`).nodes).toEqual([
+      { type: "paragraph", children: [
+        { type: "text", text: "答案是 " },
+        { type: "strong", children: [inline(String.raw`\boxed{21}`)] },
+        { type: "text", text: "，" },
+        inline("a_b * c"),
+        { type: "text", text: "。" },
+      ] },
+    ]);
+  });
+
+  it.each(["\n", "\r\n"])("parses display equations with %j line endings and blank lines", (eol) => {
+    const code = [String.raw`\begin{aligned}`, String.raw`a&=b\\[2pt]`, "", String.raw`c&=d`, String.raw`\end{aligned}`].join(eol);
+    const nodes = parseFutureMarkdown(["Before", String.raw`\[`, code, String.raw`\]`, "After"].join(eol)).nodes;
+    expect(nodes.map(node => node.type)).toEqual(["paragraph", "mathBlock", "paragraph"]);
+    expect(nodes[1]).toEqual(block(code));
+  });
+
+  it("supports single-line bracket blocks and existing dollar delimiters", () => {
+    expect(parseFutureMarkdown(String.raw`\[\boxed{21}\]`).nodes).toEqual([block(String.raw`\boxed{21}`)]);
+    expect(parseFutureMarkdown("$$\nx^2\n$$").nodes).toEqual([block("x^2")]);
+    expect(parseFutureMarkdown("$x^2$").nodes).toEqual([block("x^2")]);
+  });
+
+  it("supports formulas in list items, blockquotes and table cells", () => {
+    expect(parseFutureMarkdown(String.raw`- Value \(a+b\)`).nodes).toMatchObject([
+      { type: "list", items: [{ children: [{ type: "text", text: "Value " }, inline("a+b")] }] },
+    ]);
+    expect(parseFutureMarkdown("- Formula\n\n  \\[\n  a+b\n  \\]").nodes).toMatchObject([
+      { type: "list", items: [{ blocks: [block("a+b")] }] },
+    ]);
+    expect(parseFutureMarkdown(["> \\[", "> x^2", "> \\]", "", "outside"].join("\n")).nodes).toMatchObject([
+      { type: "blockquote", children: [block("x^2")] },
+      { type: "paragraph" },
+    ]);
+    expect(parseFutureMarkdown("| Formula |\n| --- |\n| \\(a_b\\) |").nodes).toMatchObject([
+      { type: "table", rows: [[[inline("a_b")]]] },
+    ]);
+  });
+
+  it("leaves inline, fenced and indented code unchanged", () => {
+    const code = String.raw`\(x\) \[y\]`;
+    expect(parseFutureMarkdown(`\`${code}\``).nodes).toEqual([
+      { type: "paragraph", children: [{ type: "code", code }] },
+    ]);
+    for (const source of [`\`\`\`tex\n${code}\n\`\`\``, `~~~tex\n${code}\n~~~`, `    ${code}`]) {
+      expect(parseFutureMarkdown(source).nodes).toMatchObject([{ type: "code", code }]);
+    }
+  });
+
+  it("does not reinterpret escaped delimiters, link targets, HTML or dollar math", () => {
+    const escaped = parseFutureMarkdown(String.raw`\\(x\\) \\[y\\]`).nodes;
+    // Existing bracket/file-reference parsing is independent of math syntax.
+    expect(JSON.stringify(escaped)).not.toMatch(/mathInline|mathBlock/);
+    expect(parseFutureMarkdown(String.raw`[link](https://example.com/\(x\))`).nodes).toMatchObject([
+      { type: "paragraph", children: [{ type: "link", href: "https://example.com/(x)" }] },
+    ]);
+    const html = String.raw`<div>\(x\)</div>`;
+    expect(parseFutureMarkdown(html).nodes).toEqual([{ type: "paragraph", children: [{ type: "text", text: html }] }]);
+    expect(parseFutureMarkdown(String.raw`$\text{\(literal\)}$`).nodes).toEqual([block(String.raw`\text{\(literal\)}`)]);
+  });
+
+  it("preserves escaped backslashes within formulas", () => {
+    expect(parseFutureMarkdown(String.raw`Value \(a\\) + b\) end`).nodes).toMatchObject([
+      { type: "paragraph", children: [
+        { type: "text", text: "Value " },
+        inline(String.raw`a\\) + b`),
+        { type: "text", text: " end" },
+      ] },
+    ]);
+  });
+
+  it("falls back for unmatched inline delimiters and accepts an unfinished display block", () => {
+    expect(parseFutureMarkdown(String.raw`Before \(x+1`).nodes).toEqual([
+      { type: "paragraph", children: [{ type: "text", text: "Before (x+1" }] },
+    ]);
+    expect(parseFutureMarkdown("\\[\nx+1").nodes).toEqual([block("x+1")]);
+    expect(parseFutureMarkdown("> \\[\n> x+1\noutside").nodes).toMatchObject([
+      { type: "blockquote", children: [block("x+1")] },
+      { type: "paragraph" },
+    ]);
+  });
+});
+
+describe("streaming LaTeX blocks", () => {
+  it("keeps display math with blank lines in one source slice with exact offsets", () => {
+    const first = "First.\n\n";
+    const formula = "\\[\na=1\n\nb=2\n\\]\n\n";
+    const source = `${first}${formula}Last.`;
+    expect(splitStreamingMarkdown(source, true)).toEqual([
+      { start: 0, content: first, live: false },
+      { start: first.length, content: formula, live: false },
+      { start: first.length + formula.length, content: "Last.", live: true },
+    ]);
+    expect(splitStreamingMarkdown(source, false).every(part => !part.live)).toBe(true);
+  });
+
+  it("keeps an unfinished display equation live across blank lines until it closes", () => {
+    const first = "First.\n\n";
+    const equation = "\\[\na=1\n\nb=2\n\\]";
+    for (let length = 2; length <= equation.length; length++) {
+      const tail = equation.slice(0, length);
+      expect(splitStreamingMarkdown(first + tail, true)).toEqual([
+        { start: 0, content: first, live: false },
+        { start: first.length, content: tail, live: true },
+      ]);
+    }
+  });
+});

--- a/desktop/src/features/markdown/streamingMarkdownBlocks.ts
+++ b/desktop/src/features/markdown/streamingMarkdownBlocks.ts
@@ -1,3 +1,4 @@
+import { remarkLatexMath } from "@future-os/markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
@@ -19,7 +20,7 @@ interface StreamingMarkdownRoot {
   }>;
 }
 
-const streamingMarkdownProcessor = unified().use(remarkParse).use(remarkMath).use(remarkGfm);
+const streamingMarkdownProcessor = unified().use(remarkParse).use(remarkMath).use(remarkGfm).use(remarkLatexMath);
 
 /**
  * Desktop-only projection for the growing Markdown renderer. Completed source

--- a/package-lock.json
+++ b/package-lock.json
@@ -24161,6 +24161,8 @@
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+        "mdast-util-from-markdown": "^2.0.3",
+        "micromark-util-types": "^2.0.2",
         "typescript": "^6.0.3"
       }
     },

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
+    "mdast-util-from-markdown": "^2.0.3",
+    "micromark-util-types": "^2.0.2",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./localPath";
 export type { MarkdownTarget } from "./localPath";
 export { parseFutureMarkdown } from "./parseFutureMarkdown";
+export { remarkLatexMath } from "./remarkLatexMath";
 export { referenceKey } from "./types";
 export type {
   FutureMarkdownDocument,

--- a/packages/markdown/src/parseFutureMarkdown.ts
+++ b/packages/markdown/src/parseFutureMarkdown.ts
@@ -33,8 +33,9 @@ import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { localFilePath } from "./localPath";
+import { remarkLatexMath } from "./remarkLatexMath";
 
-const markdownProcessor = unified().use(remarkParse).use(remarkMath).use(remarkGfm);
+const markdownProcessor = unified().use(remarkParse).use(remarkMath).use(remarkGfm).use(remarkLatexMath);
 
 // Cross-instance parse cache: `useMemo([content])` in MarkdownContent only
 // survives within one mounted component, so a thread switch re-parses every

--- a/packages/markdown/src/remarkLatexMath.ts
+++ b/packages/markdown/src/remarkLatexMath.ts
@@ -1,0 +1,179 @@
+import type { Root } from "mdast";
+import type { Extension as FromMarkdownExtension, Handle } from "mdast-util-from-markdown";
+import type { Code, Construct, State, Tokenizer } from "micromark-util-types";
+import type { Plugin } from "unified";
+
+declare module "micromark-util-types" {
+  interface TokenTypeMap {
+    latexMathInline: "latexMathInline";
+    latexMathDisplay: "latexMathDisplay";
+    latexMathMarker: "latexMathMarker";
+    latexMathData: "latexMathData";
+  }
+}
+
+/**
+ * Native Markdown syntax for LaTeX's \\(…\\) and standalone \\[…\\] forms.
+ * Tokenizing before Markdown escapes are resolved protects TeX from emphasis,
+ * links, etc., while leaving code, HTML and link destinations alone. No source
+ * rewriting means streaming block offsets still refer to the original text.
+ */
+export const remarkLatexMath: Plugin<[], Root> = function () {
+  const data = this.data();
+  (data.micromarkExtensions ??= []).push({
+    text: { 92: { name: "latexMathInline", tokenize: tokenizeMath(false) } },
+    flow: { 92: { name: "latexMathDisplay", tokenize: tokenizeMath(true), concrete: true } },
+  });
+  (data.fromMarkdownExtensions ??= []).push(fromMarkdown);
+};
+
+const enterMath: Handle = function (token) {
+  this.enter(token.type === "latexMathDisplay"
+    ? { type: "math", meta: null, value: "" }
+    : { type: "inlineMath", value: "" }, token);
+  this.buffer();
+};
+
+const exitMath: Handle = function (token) {
+  const value = this.resume();
+  const node = this.stack[this.stack.length - 1];
+  if (node?.type === "math" || node?.type === "inlineMath") {
+    node.value = node.type === "math" ? value.trim() : value;
+  }
+  this.exit(token);
+};
+
+const exitData: Handle = function (token) {
+  this.config.enter.data!.call(this, token);
+  this.config.exit.data!.call(this, token);
+};
+
+const fromMarkdown: FromMarkdownExtension = {
+  enter: { latexMathInline: enterMath, latexMathDisplay: enterMath },
+  exit: { latexMathInline: exitMath, latexMathDisplay: exitMath, latexMathData: exitData },
+};
+
+// micromark represents line endings and expanded tabs with negative codes.
+function lineEnding(code: Code): boolean {
+  return code === -5 || code === -4 || code === -3;
+}
+
+function space(code: Code): boolean {
+  return code === 32 || code === -2 || code === -1;
+}
+
+/** Do not let an unclosed display block swallow text outside its list/quote. */
+const continuation: Construct = {
+  partial: true,
+  tokenize(effects, ok, nok) {
+    const context = this;
+    return start;
+    function start(code: Code): State | undefined {
+      effects.enter("lineEnding");
+      effects.consume(code);
+      effects.exit("lineEnding");
+      return next;
+    }
+    function next(code: Code): State | undefined {
+      return context.parser.lazy[context.now().line] ? nok(code) : ok(code);
+    }
+  },
+};
+
+function tokenizeMath(display: boolean): Tokenizer {
+  return function (effects, ok, nok) {
+    const context = this;
+    const type = display ? "latexMathDisplay" : "latexMathInline";
+    const open = display ? 91 : 40;
+    const close = display ? 93 : 41;
+    const closing: Construct = { partial: true, tokenize: tokenizeClose };
+    return start;
+
+    function start(code: Code): State | undefined {
+      effects.enter(type);
+      effects.enter("latexMathMarker");
+      effects.consume(code); // backslash
+      return opening;
+    }
+
+    function opening(code: Code): State | undefined {
+      if (code !== open) return nok(code);
+      effects.consume(code);
+      effects.exit("latexMathMarker");
+      return afterOpening;
+    }
+
+    function afterOpening(code: Code): State | undefined {
+      // Block math may interrupt a paragraph, just like a $$ fence.
+      if (display && context.interrupt) return ok(code);
+      return between(code);
+    }
+
+    function between(code: Code): State | undefined {
+      // Like dollar fences, unfinished display math remains one live block.
+      // Unmatched inline delimiters instead fall back to ordinary Markdown.
+      if (code === null) return display ? done(code) : nok(code);
+      if (lineEnding(code)) {
+        if (display) return effects.attempt(continuation, between, done)(code);
+        effects.enter("lineEnding");
+        effects.consume(code);
+        effects.exit("lineEnding");
+        return between;
+      }
+      if (code === 92) return effects.attempt(closing, done, escape)(code);
+      effects.enter("latexMathData");
+      return content(code);
+    }
+
+    function content(code: Code): State | undefined {
+      if (code === null || code === 92 || lineEnding(code)) {
+        effects.exit("latexMathData");
+        return between(code);
+      }
+      effects.consume(code);
+      return content;
+    }
+
+    function escape(code: Code): State | undefined {
+      effects.enter("latexMathData");
+      effects.consume(code);
+      return escaped;
+    }
+
+    function escaped(code: Code): State | undefined {
+      // Consume pairs so a TeX line break (\\\\) cannot start a delimiter.
+      if (code !== null && !lineEnding(code)) effects.consume(code);
+      effects.exit("latexMathData");
+      return code === null || lineEnding(code) ? between(code) : between;
+    }
+
+    function done(code: Code): State | undefined {
+      effects.exit(type);
+      return ok(code);
+    }
+
+    function tokenizeClose(closeEffects: Parameters<Tokenizer>[0], closeOk: State, closeNok: State): State {
+      return begin;
+      function begin(code: Code): State | undefined {
+        closeEffects.enter("latexMathMarker");
+        closeEffects.consume(code);
+        return marker;
+      }
+      function marker(code: Code): State | undefined {
+        if (code !== close) return closeNok(code);
+        closeEffects.consume(code);
+        return after;
+      }
+      function after(code: Code): State | undefined {
+        if (display && space(code)) {
+          closeEffects.consume(code);
+          return after;
+        }
+        // A display block's closing delimiter must end its line.
+        if (display && code !== null && !lineEnding(code)) return closeNok(code);
+        closeEffects.exit("latexMathMarker");
+        return closeOk(code);
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Add native Markdown tokenization for LaTeX inline `\(...\)` and standalone display `\[...\]` formulas, preserving existing dollar-delimited math.
- Use the same extension for desktop streaming block segmentation, preserving original source offsets and keeping unfinished display formulas together across blank lines.
- Leave code spans/fences, HTML, escaped delimiters, and link destinations under their existing Markdown rules.
- Add parser, streaming, and KaTeX rendering regressions, including the reported boxed answer and aligned derivation.

## Validation
- Markdown suite: 165 tests passed
- Desktop TypeScript check and shared Markdown package TypeScript check passed
- ESLint passed for changed desktop files
- Desktop production build passed
- git diff --check passed

## Scope
Source/frontend fix only; no packaged desktop app replacement or release deployment.