### PR TITLE
fix: clear desktop and mobile lint warnings

### DIFF
--- a/desktop/src/features/agent/MentionEditor.tsx
+++ b/desktop/src/features/agent/MentionEditor.tsx
@@ -555,7 +555,7 @@ export function MentionEditor({
         spellCheck={false}
         suppressContentEditableWarning
         className={cn(
-          "max-h-[40vh] min-h-14 w-full overflow-y-auto whitespace-pre-wrap break-words px-2 py-1 text-sm leading-5 text-ink outline-none",
+          "max-h-[40vh] min-h-14 w-full overflow-y-auto whitespace-pre-wrap wrap-break-word px-2 py-1 text-sm leading-5 text-ink outline-none",
           className,
         )}
         onInput={() => {

--- a/desktop/src/features/agent/ThinkingBlock.tsx
+++ b/desktop/src/features/agent/ThinkingBlock.tsx
@@ -22,7 +22,7 @@ export function ThinkingBlock({
         // A dimmed, borderless aside with a left rail — reads as reasoning, not
         // a filled content box (which is now reserved for code blocks).
         "border-l-2 border-line-soft pl-3 text-ink-muted",
-        "[&_*]:text-ink-muted",
+        "**:text-ink-muted",
       )}
     >
       <StreamingMarkdownContent content={text} workspaceId={workspaceId} live={live} />

--- a/desktop/src/features/settings/ModelsPage.tsx
+++ b/desktop/src/features/settings/ModelsPage.tsx
@@ -119,7 +119,7 @@ export function ModelsPage({
                     description={(
                       <>
                         {description
-                          ? <div className="line-clamp-3 break-words">{description}</div>
+                          ? <div className="line-clamp-3 wrap-break-word">{description}</div>
                           : null}
                         <div>{modelSubtitle(model)}</div>
                       </>

--- a/mobile/src/components/__tests__/MarkdownText.test.ts
+++ b/mobile/src/components/__tests__/MarkdownText.test.ts
@@ -1,7 +1,7 @@
 import type { ReactTestRenderer } from "react-test-renderer";
-import React from "react";
+import { createElement } from "react";
 import { Alert, Image, Linking, Text } from "react-native";
-import TestRenderer, { act } from "react-test-renderer";
+import { act, create } from "react-test-renderer";
 import { MarkdownText } from "../MarkdownText";
 
 jest.mock("react-i18next", () => ({
@@ -13,8 +13,8 @@ describe("MarkdownText", () => {
     let renderer: ReactTestRenderer | undefined;
     const onOpenFile = jest.fn();
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, {
+      renderer = create(
+        createElement(MarkdownText, {
           text: "**[gomoku.html](<./gomoku.html>)**",
           onOpenFile,
         }),
@@ -38,8 +38,8 @@ describe("MarkdownText", () => {
   test("uses the shared GFM parser for tables, tasks and nested formatting", () => {
     let renderer: ReactTestRenderer | undefined;
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, {
+      renderer = create(
+        createElement(MarkdownText, {
           text: "| A | B |\n|---|---|\n| **bold** | ~~old~~ |\n\n- [x] done",
         }),
       );
@@ -55,8 +55,8 @@ describe("MarkdownText", () => {
     const onOpenFile = jest.fn();
     let renderer: ReactTestRenderer | undefined;
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, {
+      renderer = create(
+        createElement(MarkdownText, {
           text: "![diagram](assets/pic.png)",
           onOpenFile,
         }),
@@ -71,8 +71,8 @@ describe("MarkdownText", () => {
     const alert = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     let renderer: ReactTestRenderer | undefined;
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, {
+      renderer = create(
+        createElement(MarkdownText, {
           mode: "file-preview",
           text: "![diagram](assets/pic.png)",
         }),
@@ -87,8 +87,8 @@ describe("MarkdownText", () => {
   test("renders only http(s) Markdown images as remote images", () => {
     let renderer: ReactTestRenderer | undefined;
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, {
+      renderer = create(
+        createElement(MarkdownText, {
           text: "![remote](https://example.com/pic.png) ![blocked](data:image/png;base64,x)",
         }),
       );
@@ -102,9 +102,7 @@ describe("MarkdownText", () => {
     const open = jest.spyOn(Linking, "openURL").mockResolvedValue(true);
     let renderer: ReactTestRenderer | undefined;
     act(() => {
-      renderer = TestRenderer.create(
-        React.createElement(MarkdownText, { text: "[bad](javascript:alert(1))" }),
-      );
+      renderer = create(createElement(MarkdownText, { text: "[bad](javascript:alert(1))" }));
     });
     const pressable = renderer?.root.findAllByType(Text).find(node => node.props.onPress);
     expect(pressable).toBeUndefined();

--- a/mobile/src/features/chat/__tests__/useChatScroll.test.ts
+++ b/mobile/src/features/chat/__tests__/useChatScroll.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import { useChatScroll } from "../useChatScroll";
@@ -27,7 +27,7 @@ describe("useChatScroll inverted-list model", () => {
   beforeEach(() => {
     result = { current: undefined as never };
     act(() => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
   });
 
@@ -62,7 +62,7 @@ describe("useChatScroll inverted-list model", () => {
     act(() => result.current.onScroll(scrollEvent(200)));
     expect(result.current.atLatest).toBe(false);
 
-    act(() => renderer!.update(React.createElement(Harness, { sessionId: "s2" })));
+    act(() => renderer!.update(createElement(Harness, { sessionId: "s2" })));
 
     expect(result.current.atLatest).toBe(true);
   });

--- a/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
+++ b/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import { useTimelinePaging } from "../useTimelinePaging";
@@ -45,7 +45,7 @@ describe("timeline paging on an inverted list", () => {
     requestOlder.mockResolvedValue(undefined);
     result = { current: undefined as never };
     act(() => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
   });
 
@@ -93,9 +93,9 @@ describe("timeline paging on an inverted list", () => {
   });
 
   test("does not request while loading or when no older page exists", () => {
-    act(() => renderer!.update(React.createElement(Harness, { loadingOlder: true })));
+    act(() => renderer!.update(createElement(Harness, { loadingOlder: true })));
     act(() => result.current.loadOlder());
-    act(() => renderer!.update(React.createElement(Harness, { canLoadOlder: false })));
+    act(() => renderer!.update(createElement(Harness, { canLoadOlder: false })));
     act(() => result.current.loadOlder());
     expect(requestOlder).not.toHaveBeenCalled();
   });
@@ -103,7 +103,7 @@ describe("timeline paging on an inverted list", () => {
   test("switching sessions clears a pending edge load", () => {
     act(() => result.current.onScroll(scrollEvent(1_400)));
     expect(result.current.showLoadOlderHint).toBe(true);
-    act(() => renderer!.update(React.createElement(Harness, { sessionId: "s2" })));
+    act(() => renderer!.update(createElement(Harness, { sessionId: "s2" })));
     expect(result.current.showLoadOlderHint).toBe(false);
     act(() => jest.advanceTimersByTime(350));
     expect(requestOlder).not.toHaveBeenCalled();

--- a/mobile/src/remote/__tests__/useConversationController.test.ts
+++ b/mobile/src/remote/__tests__/useConversationController.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { RemoteClient } from "../client";
 import {
@@ -139,7 +139,7 @@ async function mountController(opts: MountOpts = {}) {
   }
 
   await act(async () => {
-    renderer = create(React.createElement(Harness));
+    renderer = create(createElement(Harness));
   });
   await flush();
 

--- a/mobile/src/remote/__tests__/usePromptOutbox.test.ts
+++ b/mobile/src/remote/__tests__/usePromptOutbox.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { RemoteClient } from "../client";
 import { uploadAttachments } from "../files";
@@ -145,7 +145,7 @@ describe("usePromptOutbox recovery", () => {
     }
 
     await act(async () => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -295,7 +295,7 @@ describe("usePromptOutbox sendMessage", () => {
     }
 
     await act(async () => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
     await flush();
 
@@ -626,7 +626,7 @@ describe("usePromptOutbox continueRun", () => {
     }
 
     await act(async () => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
     await flush();
 
@@ -790,7 +790,7 @@ describe("usePromptOutbox recovery error handling", () => {
     }
 
     await act(async () => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
     await flush();
 

--- a/mobile/src/remote/__tests__/useRemoteConnection.test.ts
+++ b/mobile/src/remote/__tests__/useRemoteConnection.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import * as Network from "expo-network";
 import { AppState } from "react-native";
@@ -192,7 +192,7 @@ describe("useRemoteConnection", () => {
 
   function render(): void {
     act(() => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
   }
 

--- a/mobile/src/remote/__tests__/useSessionCatalog.test.ts
+++ b/mobile/src/remote/__tests__/useSessionCatalog.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement, type MutableRefObject } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { useSessionCatalog } from "../useSessionCatalog";
 import type { RemoteClient } from "../client";
@@ -25,15 +25,15 @@ describe("useSessionCatalog", () => {
 
   function TestComponent(): null {
     result.current = useSessionCatalog(
-      clientRef as React.MutableRefObject<RemoteClient | null>,
-      selectedRef as React.MutableRefObject<string>,
+      clientRef as MutableRefObject<RemoteClient | null>,
+      selectedRef as MutableRefObject<string>,
     );
     return null;
   }
 
   function render(): void {
     act(() => {
-      renderer = create(React.createElement(TestComponent));
+      renderer = create(createElement(TestComponent));
     });
   }
 

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { RemoteClient } from "../client";
 import { emptyTimeline } from "../timeline";
@@ -36,7 +36,7 @@ describe("useTimelineController", () => {
 
   function render(): void {
     act(() => {
-      renderer = create(React.createElement(Harness));
+      renderer = create(createElement(Harness));
     });
   }
 


### PR DESCRIPTION
## Summary
- replace deprecated Tailwind utility spellings in Desktop
- use named React and test-renderer imports in Mobile tests to satisfy ESLint
- format the affected Markdown renderer test with Prettier

## Validation
- Desktop: ESLint, TypeScript, Stylelint
- Mobile: ESLint, TypeScript, Prettier
- Focused Mobile Jest: 8 suites, 170 tests
- Rust workspace and Tauri cargo fmt --check
- git diff --check