### PR TITLE
chore(skills): make future-explore non-builtin

### DIFF
--- a/docs/wiki/en/Skills.md
+++ b/docs/wiki/en/Skills.md
@@ -29,7 +29,6 @@ The catalogue is updated over time, so the exact list you see may differ from th
 | **Deep research** | End-to-end research: gathers and cross-checks many sources, writes a cited report. |
 | **Document** | Turns PDF and Word files into structured Markdown. |
 | **Experimental design** | Designs experiments and research protocols before data collection. |
-| **Explore** | Evidence-driven method comparison, experiments, optimization and feasibility assessment when the answer is not yet known (`/future-explore`). |
 | **Image** | Generates, edits, and analyzes images — including reading text in an image. |
 | **Loop** | Turns long-running goals into durable, verifiable plans — objectives, todos, gates, monitors, and validated completion (`/future-loop`). |
 | **Paper** | Finds papers (PubMed / ArXiv / DOI) and retrieves full text. |

--- a/docs/wiki/zh/Skills.md
+++ b/docs/wiki/zh/Skills.md
@@ -29,7 +29,6 @@ Skills 页有两个标签:
 | **Deep research** | 端到端研究:多源收集并交叉核对,产出带引用的报告。 |
 | **Document** | 把 PDF / Word 文件转成结构化 Markdown。 |
 | **Experimental design** | 在数据收集前设计实验与研究方案。 |
-| **Explore** | 面向答案未知的问题，以证据驱动方法比较、实验、优化和可行性评估（`/future-explore`）。 |
 | **Image** | 生成、编辑和分析图像——包括读取图中文字。 |
 | **Loop** | 把长程目标变成持久、可验证的计划——目标、任务、门禁、监控与验证式收尾（`/future-loop`）。 |
 | **Paper** | 检索文献(PubMed / ArXiv / DOI)并获取全文。 |


### PR DESCRIPTION
## Summary
- Bump future-skills to futuregene/future-skills#56, moving future-explore unchanged to third-party and removing its builtin registry flag.
- Remove Explore from the English and Chinese built-in skill tables.
- CLI prefix-based install-builtin selection is unchanged.

## Validation
- python3 scripts/check-docs.py
- git diff origin/main --check
- Skills structure, orchestration fixtures and custom skill validation passed in the skills PR.
- No Rust or desktop implementation changes.