### PR TITLE
Refine desktop activity rail layout

### DIFF
--- a/desktop/DEV_MD/COLOR.md
+++ b/desktop/DEV_MD/COLOR.md
@@ -34,7 +34,15 @@ GUI 的颜色全部走 [`tailwind.config.js`](../tailwind.config.js) 里定义�
 | `accent-soft`     | `#e8f0ff` | 强调浅底                     |
 | `accent-hover`    | `#1d4ed8` | 强调 hover                   |
 | `accent-disabled` | `#bfdbfe` | 强调禁用                     |
+| `accent-pulse`    | 蓝色 28%  | Skills 导航提示脉冲的光晕    |
 | `focus`           | `#93c5fd` | focus ring                   |
+
+### 搜索高亮
+
+| token            | hex       | 用途                     |
+| ---------------- | --------- | ------------------------ |
+| `search-match`   | `#fde047` | 当前会话搜索的普通匹配项 |
+| `search-current` | `#fb923c` | 当前定位的搜索匹配项     |
 
 ### 状态(三件套:文字 / 浅底 / 边框)
 

--- a/desktop/src/components/layout/ActivityRail.test.tsx
+++ b/desktop/src/components/layout/ActivityRail.test.tsx
@@ -62,7 +62,7 @@ describe("activity rail conversation hierarchy", () => {
       act(() => byTitle("root")!.click());
       expect(p.onSelectThread).toHaveBeenCalledWith(p.threads[2]);
       expect(byTitle("child")).toBeNull();
-      const expand = container.querySelector<HTMLButtonElement>("button[aria-expanded=false]")!;
+      const expand = byTitle("root")!.parentElement!.querySelector<HTMLButtonElement>("button[aria-expanded=false]")!;
       act(() => expand.click());
       expect(byTitle("child")).not.toBeNull();
       expect(byTitle("grandchild")).toBeNull();
@@ -76,6 +76,34 @@ describe("activity rail conversation hierarchy", () => {
       act(() => rootRow.querySelector<HTMLButtonElement>("button[aria-expanded=true]")!.click());
       expect(byTitle("child")).toBeNull();
       expect(byTitle("grandchild")).toBeNull();
+    }
+    finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("keeps the selection toolbar outside the shared workspace/chat viewport", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => root.render(<ActivityRail {...props([thread("root")])} />));
+    await flushAsync();
+    try {
+      const menuTrigger = container.querySelector<HTMLButtonElement>("button[aria-label=\"Chat section actions\"]")!;
+      act(() => menuTrigger.click());
+      act(() => container.querySelector<HTMLButtonElement>("[role=\"menuitem\"]")!.click());
+
+      const viewport = container.querySelector("[data-activity-rail-scroll=\"true\"]")!;
+      const toolbar = container.querySelector("[data-activity-rail-selection-toolbar=\"true\"]")!;
+      expect(viewport.contains(toolbar)).toBe(false);
+      expect(viewport.parentElement?.parentElement?.contains(toolbar)).toBe(true);
+      expect(viewport.querySelector("[data-activity-rail-content=\"true\"]")).not.toBeNull();
+      expect(toolbar.classList.contains("-mb-2")).toBe(false);
+      expect(toolbar.querySelectorAll(".activity-rail-selection-action")).toHaveLength(2);
+      expect(toolbar.querySelectorAll(".activity-rail-selection-action-label")).toHaveLength(2);
+      expect(toolbar.querySelector<HTMLButtonElement>("button[aria-label=\"Delete\"]")?.title).toBe("Delete");
+      expect(toolbar.querySelector<HTMLButtonElement>("button[aria-label=\"Cancel\"]")?.title).toBe("Cancel");
     }
     finally {
       act(() => root.unmount());

--- a/desktop/src/components/layout/ActivityRail.tsx
+++ b/desktop/src/components/layout/ActivityRail.tsx
@@ -7,36 +7,31 @@ import {
   Blocks,
   ChevronDown,
   ChevronRight,
-  Download,
   Folder,
   MessageSquare,
   PanelLeft,
   Plus,
-  Settings,
   Smartphone,
   Sparkles,
   SquarePen,
-  Trash2,
-  Wallet,
-  X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SkillIntroBubble } from "../../features/skills/SkillIntroBubble";
 import { listInstalledSkills } from "../../integrations/skills/skillsClient";
 import { cn } from "../../lib/cn";
 import { onFutureEvent } from "../../lib/futureEvents";
 import { isMacOS } from "../../lib/platform";
-import { useDismissableLayer } from "../../lib/useDismissableLayer";
 import { useFloatingScrollbar } from "../../lib/useFloatingScrollbar";
 import { useIsFullscreen } from "../../lib/useIsFullscreen";
 import { startWindowDrag } from "../../lib/windowDrag";
-import { Button } from "../ui/Button";
 import { FloatingScrollbar } from "../ui/FloatingScrollbar";
 import { IconButton } from "../ui/IconButton";
-import { MenuPanel } from "../ui/MenuPanel";
+import { ActivityRailAccountFooter } from "./ActivityRailAccountFooter";
 import { ChatSectionMenu, WorkspaceHeaderMenu } from "./ActivityRailMenus";
+import { ActivityRailSelectionToolbar } from "./ActivityRailSelectionToolbar";
 import { usePendingApprovalCounts } from "./hooks/usePendingApprovalCounts";
+import { useRailSelection } from "./hooks/useRailSelection";
 import { ThreadListItem } from "./ThreadListItem";
 import { buildThreadTree, visibleThreadRows } from "./threadTree";
 
@@ -89,12 +84,6 @@ interface ActivityRailProps {
 // Section handling logic is preserved; only the left-nav items are removed —
 // add them back to restore. (Research was removed entirely; see PRODUCT.md §4.9.)
 const featureItems: Array<{ id: ActivitySection; label: string; icon: LucideIcon }> = [];
-
-const settingsItem = { id: "settings", label: "Settings", icon: Settings } satisfies {
-  id: ActivitySection;
-  label: string;
-  icon: LucideIcon;
-};
 
 export function ActivityRail({
   active,
@@ -178,10 +167,6 @@ export function ActivityRail({
   // independent of the per-workspace group collapse above.
   const [workspaceSectionCollapsed, setWorkspaceSectionCollapsed] = useState(false);
   const [chatSectionCollapsed, setChatSectionCollapsed] = useState(false);
-  // Batch selection mode.
-  const [selectionMode, setSelectionMode] = useState(false);
-  const [selectionScope, setSelectionScope] = useState<"chat" | string>("chat");
-  const [selectedThreadIds, setSelectedThreadIds] = useState<Set<string>>(() => new Set());
   // Chat section header menu.
   const [chatSectionMenuOpen, setChatSectionMenuOpen] = useState(false);
   // Attention state for the Skills nav entry: pulsed for a few seconds when
@@ -230,43 +215,9 @@ export function ActivityRail({
     });
   }
 
-  // Stable row callbacks for the memoized ThreadListItem: one instance shared
-  // by every row (each row passes its own thread back), instead of fresh
-  // per-row closures on every render.
-  const toggleThreadSelection = useCallback((thread: StoredThread) => {
-    setSelectedThreadIds((current) => {
-      const next = new Set(current);
-      if (next.has(thread.id)) {
-        next.delete(thread.id);
-      }
-      else {
-        next.add(thread.id);
-      }
-      return next;
-    });
-  }, []);
-
   const handleThreadMenuOpenChange = useCallback((thread: StoredThread, open: boolean) => {
     setOpenThreadMenuId(open ? thread.id : null);
   }, []);
-
-  function exitSelectionMode() {
-    setSelectionMode(false);
-    setSelectedThreadIds(new Set());
-  }
-
-  // Esc key exits selection mode.
-  useEffect(() => {
-    if (!selectionMode)
-      return;
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        exitSelectionMode();
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectionMode]);
 
   // Derived thread lists are memoized: the rail re-renders whenever any
   // run/streaming status changes, but these depend only on the thread list
@@ -287,58 +238,25 @@ export function ActivityRail({
     }
     return scopes;
   }, [threadTree, visibleThreads]);
-  // Selection includes collapsed descendants in the displayed root's scope.
-  const scopedThreads = useMemo(() => visibleThreads.filter(thread => threadScopes.get(thread.id) === selectionScope), [selectionScope, threadScopes, visibleThreads]);
-
-  function enterChatSelectionMode() {
-    setSelectionScope("chat");
-    setSelectedThreadIds(new Set());
-    setSelectionMode(true);
-  }
-
-  function enterWorkspaceSelectionMode(workspaceId: string) {
-    setSelectionScope(workspaceId);
-    setSelectedThreadIds(new Set());
-    setSelectionMode(true);
-  }
-
-  function selectAll() {
-    setSelectedThreadIds(new Set(scopedThreads.map(t => t.id)));
-  }
-
-  function deselectAll() {
-    setSelectedThreadIds(new Set());
-  }
-
-  /** Whether a thread is selectable in the current selection scope. */
-  const isThreadInScope = useCallback((thread: StoredThread) => {
-    return threadScopes.get(thread.id) === selectionScope;
-  }, [selectionScope, threadScopes]);
-
-  // One stable row-click handler for all memoized ThreadListItems: in
-  // selection mode it toggles in-scope threads (out-of-scope rows are a
-  // deliberate no-op), otherwise it opens the thread.
-  const handleRowSelect = useCallback((thread: StoredThread) => {
-    if (selectionMode) {
-      if (isThreadInScope(thread))
-        toggleThreadSelection(thread);
-      return;
-    }
-    onSelectThread(thread);
-  }, [isThreadInScope, onSelectThread, selectionMode, toggleThreadSelection]);
+  const {
+    deleteSelected,
+    deselectAll,
+    enterSelectionMode,
+    exitSelectionMode,
+    handleRowSelect,
+    isThreadInScope,
+    scopedThreads,
+    selectAll,
+    selectedThreadIds,
+    selectionMode,
+    toggleThreadSelection,
+  } = useRailSelection({ onBatchDeleteThreads, onSelectThread, threadScopes, visibleThreads });
 
   /** Whether this thread should show a selection checkbox. */
   function threadSelectionMode(thread: StoredThread): boolean {
     return selectionMode && isThreadInScope(thread);
   }
 
-  function handleStartBatchDelete() {
-    const selectedThreads = visibleThreads.filter(t => selectedThreadIds.has(t.id));
-    if (selectedThreads.length === 0)
-      return;
-    onBatchDeleteThreads(selectedThreads);
-    exitSelectionMode();
-  }
   // Pinned threads are hoisted into a single global section (regardless of
   // workspace/chat); the per-group lists show only the unpinned rest.
   const pinnedThreads = useMemo(() => visibleThreadRows(threadTree.filter(node => node.thread.pinned), expandedThreads), [threadTree, expandedThreads]);
@@ -447,26 +365,208 @@ export function ActivityRail({
                       </div>
                     )
                   : null}
-                <div className="group relative -mx-2 flex min-h-0 flex-1">
-                  <div
-                    ref={listScrollbar.scrollRef}
-                    className="floating-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto px-2"
-                    onScroll={listScrollbar.handleScroll}
-                  >
-                    {pinnedThreads.length > 0
-                      ? (
-                          <div className="mb-3 space-y-0.5">
-                            <div className="sticky top-0 z-10 flex h-6 items-center bg-surface px-2 text-xs font-medium text-ink-muted">
-                              <span>{t("activityRail.pinnedHeader")}</span>
+                <div className="flex min-h-0 flex-1 flex-col">
+                  <div className="group relative -mx-2 flex min-h-0 flex-1">
+                    <div
+                      ref={listScrollbar.scrollRef}
+                      className="floating-scrollbar min-h-0 flex-1 overflow-y-auto px-2"
+                      data-activity-rail-scroll="true"
+                      onScroll={listScrollbar.handleScroll}
+                    >
+                      <div ref={listScrollbar.contentRef} className="flex min-h-full flex-col" data-activity-rail-content="true">
+                        {pinnedThreads.length > 0
+                          ? (
+                              <div className="mb-3 space-y-0.5">
+                                <div className="sticky top-0 z-20 flex h-6 items-center bg-surface px-2 text-xs font-medium text-ink-muted">
+                                  <span>{t("activityRail.pinnedHeader")}</span>
+                                </div>
+                                {pinnedThreads.map(({ thread, depth, hasChildren }) => (
+                                  <ThreadListItem
+                                    active={thread.id === activeThreadId}
+                                    archived={thread.status === "archived"}
+                                    key={thread.id}
+                                    menuOpen={openThreadMenuId === thread.id}
+                                    pendingApprovalCount={pendingApprovalCounts.get(thread.id)}
+                                    runStatus={threadRunStatuses[thread.id]}
+                                    selected={selectedThreadIds.has(thread.id)}
+                                    selectionMode={threadSelectionMode(thread)}
+                                    thread={thread}
+                                    depth={depth}
+                                    hasChildren={hasChildren}
+                                    expanded={expandedThreads.has(thread.id)}
+                                    onToggleExpanded={toggleThreadExpanded}
+                                    isStreaming={threadStreamingStatuses[thread.id]}
+                                    unread={unreadThreadIds.has(thread.id)}
+                                    onDeleteThread={onDeleteThread}
+                                    onMenuOpenChange={handleThreadMenuOpenChange}
+                                    onRenameThread={onRenameThread}
+                                    onRestoreThread={onRestoreThread}
+                                    onSelectThread={handleRowSelect}
+                                    onTogglePinThread={onTogglePinThread}
+                                    onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
+                                  />
+                                ))}
+                              </div>
+                            )
+                          : null}
+                        <div className="space-y-0.5">
+                          <div className="sticky top-0 z-20 flex h-6 items-center justify-between bg-surface px-2 text-xs font-medium text-ink-muted">
+                            <span>{t("activityRail.workspace")}</span>
+                            <div className="flex items-center gap-0.5">
+                              <SectionToggle
+                                collapsed={workspaceSectionCollapsed}
+                                label={workspaceSectionCollapsed
+                                  ? t("activityRail.expandWorkspaceSection")
+                                  : t("activityRail.collapseWorkspaceSection")}
+                                onToggle={() => setWorkspaceSectionCollapsed(value => !value)}
+                              />
+                              <button
+                                aria-label={t("activityRail.newWorkspace")}
+                                className="inline-flex size-5 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
+                                onClick={onNewWorkspace}
+                                title={t("activityRail.newWorkspace")}
+                                type="button"
+                              >
+                                <Plus className="size-3.5" />
+                              </button>
                             </div>
-                            {pinnedThreads.map(({ thread, depth, hasChildren }) => (
+                          </div>
+                          {!workspaceSectionCollapsed && workspaceGroups.length === 0
+                            ? (
+                                <div className="px-2 py-1 text-xs text-ink-muted">{t("activityRail.noWorkspaceThreads")}</div>
+                              )
+                            : null}
+                          {visibleWorkspaceGroups.map(({ workspace, threads: groupThreads, rows }) => {
+                            const collapsed = collapsedWorkspaces.has(workspace.id);
+                            return (
+                              <div key={workspace.id} className="space-y-0.5">
+                                {/* Group header: hover only, no selected state (req 4).
+                                Right-click anywhere on the row opens the same
+                                actions menu as the `...` button. */}
+                                <div
+                                  className="group flex h-7 w-full items-center gap-1 rounded-md px-2 text-left transition-colors hover:bg-surface-subtle"
+                                  onContextMenu={(event) => {
+                                    event.preventDefault();
+                                    setOpenWorkspaceMenuId(workspace.id);
+                                  }}
+                                >
+                                  <button
+                                    aria-label={collapsed ? t("activityRail.expandWorkspace") : t("activityRail.collapseWorkspace")}
+                                    className="inline-flex size-4 shrink-0 items-center justify-center text-ink-muted transition-colors hover:text-ink-soft"
+                                    onClick={() => toggleWorkspaceCollapsed(workspace.id)}
+                                    type="button"
+                                  >
+                                    {collapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+                                  </button>
+                                  <button
+                                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                                    onClick={() => onSelectWorkspace(workspace, groupThreads)}
+                                    type="button"
+                                  >
+                                    <Folder className="size-4 shrink-0 text-ink-soft" />
+                                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink-soft" title={workspace.name}>
+                                      {workspace.name}
+                                    </span>
+                                  </button>
+                                  <WorkspaceHeaderMenu
+                                    open={openWorkspaceMenuId === workspace.id}
+                                    workspace={workspace}
+                                    onDelete={onDeleteWorkspace}
+                                    onOpenChange={open => setOpenWorkspaceMenuId(open ? workspace.id : null)}
+                                    onRename={onRenameWorkspace}
+                                    onSelect={selectionMode ? undefined : () => enterSelectionMode(workspace.id)}
+                                  />
+                                  <button
+                                    aria-label={t("activityRail.newChatInWorkspace", { name: workspace.name })}
+                                    className="inline-flex size-5 shrink-0 items-center justify-center rounded text-ink-muted opacity-0 transition hover:bg-surface hover:text-ink-soft group-hover:opacity-100"
+                                    onClick={() => onNewChat(workspace.id)}
+                                    title={t("activityRail.newChatInWorkspace", { name: workspace.name })}
+                                    type="button"
+                                  >
+                                    <Plus className="size-3.5" />
+                                  </button>
+                                </div>
+                                {!collapsed && groupThreads.length > 0
+                                  ? (
+                                      <div className="space-y-0.5">
+                                        {rows.map(({ thread, depth, hasChildren }) => (
+                                          <ThreadListItem
+                                            active={thread.id === activeThreadId}
+                                            archived={thread.status === "archived"}
+                                            key={thread.id}
+                                            menuOpen={openThreadMenuId === thread.id}
+                                            pendingApprovalCount={pendingApprovalCounts.get(thread.id)}
+                                            runStatus={threadRunStatuses[thread.id]}
+                                            selected={selectedThreadIds.has(thread.id)}
+                                            selectionMode={threadSelectionMode(thread)}
+                                            thread={thread}
+                                            depth={depth}
+                                            hasChildren={hasChildren}
+                                            expanded={expandedThreads.has(thread.id)}
+                                            onToggleExpanded={toggleThreadExpanded}
+                                            isStreaming={threadStreamingStatuses[thread.id]}
+                                            unread={unreadThreadIds.has(thread.id)}
+                                            compact
+                                            onDeleteThread={onDeleteThread}
+                                            onMenuOpenChange={handleThreadMenuOpenChange}
+                                            onRenameThread={onRenameThread}
+                                            onRestoreThread={onRestoreThread}
+                                            onSelectThread={handleRowSelect}
+                                            onTogglePinThread={onTogglePinThread}
+                                            onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
+                                          />
+                                        ))}
+                                      </div>
+                                    )
+                                  : null}
+                              </div>
+                            );
+                          })}
+                        </div>
+                        <div className="mt-3 flex flex-1 flex-col space-y-0.5">
+                          <div className="sticky top-0 z-20 flex h-6 items-center justify-between bg-surface px-2 text-xs font-medium text-ink-muted">
+                            <span>{t("activityRail.chatHeader")}</span>
+                            <div className="flex items-center gap-0.5">
+                              <SectionToggle
+                                collapsed={chatSectionCollapsed}
+                                label={chatSectionCollapsed
+                                  ? t("activityRail.expandChatSection")
+                                  : t("activityRail.collapseChatSection")}
+                                onToggle={() => setChatSectionCollapsed(value => !value)}
+                              />
+                              {!selectionMode
+                                ? (
+                                    <ChatSectionMenu
+                                      open={chatSectionMenuOpen}
+                                      onOpenChange={setChatSectionMenuOpen}
+                                      onSelect={() => enterSelectionMode("chat")}
+                                    />
+                                  )
+                                : null}
+                              <button
+                                aria-label={t("activityRail.newChatShort")}
+                                className="inline-flex size-5 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
+                                onClick={() => onNewChat()}
+                                title={t("activityRail.newChatShort")}
+                                type="button"
+                              >
+                                <Plus className="size-3.5" />
+                              </button>
+                            </div>
+                          </div>
+                          {!chatSectionCollapsed && chatThreads.length === 0
+                            ? <div className="px-2 py-1 text-xs text-ink-muted">{t("activityRail.noChats")}</div>
+                            : null}
+                          <div className="shrink-0 space-y-0.5">
+                            {visibleChatThreads.map(({ thread, depth, hasChildren }) => (
                               <ThreadListItem
-                                active={thread.id === activeThreadId}
+                                active={thread.id === activeThreadId && active === "chat"}
                                 archived={thread.status === "archived"}
                                 key={thread.id}
                                 menuOpen={openThreadMenuId === thread.id}
                                 pendingApprovalCount={pendingApprovalCounts.get(thread.id)}
                                 runStatus={threadRunStatuses[thread.id]}
+                                isStreaming={threadStreamingStatuses[thread.id]}
                                 selected={selectedThreadIds.has(thread.id)}
                                 selectionMode={threadSelectionMode(thread)}
                                 thread={thread}
@@ -474,7 +574,6 @@ export function ActivityRail({
                                 hasChildren={hasChildren}
                                 expanded={expandedThreads.has(thread.id)}
                                 onToggleExpanded={toggleThreadExpanded}
-                                isStreaming={threadStreamingStatuses[thread.id]}
                                 unread={unreadThreadIds.has(thread.id)}
                                 onDeleteThread={onDeleteThread}
                                 onMenuOpenChange={handleThreadMenuOpenChange}
@@ -486,233 +585,25 @@ export function ActivityRail({
                               />
                             ))}
                           </div>
-                        )
-                      : null}
-                    <div className="space-y-0.5">
-                      <div className="sticky top-0 z-10 flex h-6 items-center justify-between bg-surface px-2 text-xs font-medium text-ink-muted">
-                        <span>{t("activityRail.workspace")}</span>
-                        <div className="flex items-center gap-0.5">
-                          <SectionToggle
-                            collapsed={workspaceSectionCollapsed}
-                            label={workspaceSectionCollapsed
-                              ? t("activityRail.expandWorkspaceSection")
-                              : t("activityRail.collapseWorkspaceSection")}
-                            onToggle={() => setWorkspaceSectionCollapsed(value => !value)}
-                          />
-                          <button
-                            aria-label={t("activityRail.newWorkspace")}
-                            className="inline-flex size-5 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
-                            onClick={onNewWorkspace}
-                            title={t("activityRail.newWorkspace")}
-                            type="button"
-                          >
-                            <Plus className="size-3.5" />
-                          </button>
                         </div>
                       </div>
-                      {!workspaceSectionCollapsed && workspaceGroups.length === 0
-                        ? (
-                            <div className="px-2 py-1 text-xs text-ink-muted">{t("activityRail.noWorkspaceThreads")}</div>
-                          )
-                        : null}
-                      {visibleWorkspaceGroups.map(({ workspace, threads: groupThreads, rows }) => {
-                        const collapsed = collapsedWorkspaces.has(workspace.id);
-                        return (
-                          <div key={workspace.id} className="space-y-0.5">
-                            {/* Group header: hover only, no selected state (req 4).
-                                Right-click anywhere on the row opens the same
-                                actions menu as the `...` button. */}
-                            <div
-                              className="group flex h-7 w-full items-center gap-1 rounded-md px-2 text-left transition-colors hover:bg-surface-subtle"
-                              onContextMenu={(event) => {
-                                event.preventDefault();
-                                setOpenWorkspaceMenuId(workspace.id);
-                              }}
-                            >
-                              <button
-                                aria-label={collapsed ? t("activityRail.expandWorkspace") : t("activityRail.collapseWorkspace")}
-                                className="inline-flex size-4 shrink-0 items-center justify-center text-ink-muted transition-colors hover:text-ink-soft"
-                                onClick={() => toggleWorkspaceCollapsed(workspace.id)}
-                                type="button"
-                              >
-                                {collapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
-                              </button>
-                              <button
-                                className="flex min-w-0 flex-1 items-center gap-2 text-left"
-                                onClick={() => onSelectWorkspace(workspace, groupThreads)}
-                                type="button"
-                              >
-                                <Folder className="size-4 shrink-0 text-ink-soft" />
-                                <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink-soft" title={workspace.name}>
-                                  {workspace.name}
-                                </span>
-                              </button>
-                              <WorkspaceHeaderMenu
-                                open={openWorkspaceMenuId === workspace.id}
-                                workspace={workspace}
-                                onDelete={onDeleteWorkspace}
-                                onOpenChange={open => setOpenWorkspaceMenuId(open ? workspace.id : null)}
-                                onRename={onRenameWorkspace}
-                                onSelect={selectionMode ? undefined : () => enterWorkspaceSelectionMode(workspace.id)}
-                              />
-                              <button
-                                aria-label={t("activityRail.newChatInWorkspace", { name: workspace.name })}
-                                className="inline-flex size-5 shrink-0 items-center justify-center rounded text-ink-muted opacity-0 transition hover:bg-surface hover:text-ink-soft group-hover:opacity-100"
-                                onClick={() => onNewChat(workspace.id)}
-                                title={t("activityRail.newChatInWorkspace", { name: workspace.name })}
-                                type="button"
-                              >
-                                <Plus className="size-3.5" />
-                              </button>
-                            </div>
-                            {!collapsed && groupThreads.length > 0
-                              ? (
-                                  <div className="space-y-0.5">
-                                    {rows.map(({ thread, depth, hasChildren }) => (
-                                      <ThreadListItem
-                                        active={thread.id === activeThreadId}
-                                        archived={thread.status === "archived"}
-                                        key={thread.id}
-                                        menuOpen={openThreadMenuId === thread.id}
-                                        pendingApprovalCount={pendingApprovalCounts.get(thread.id)}
-                                        runStatus={threadRunStatuses[thread.id]}
-                                        selected={selectedThreadIds.has(thread.id)}
-                                        selectionMode={threadSelectionMode(thread)}
-                                        thread={thread}
-                                        depth={depth}
-                                        hasChildren={hasChildren}
-                                        expanded={expandedThreads.has(thread.id)}
-                                        onToggleExpanded={toggleThreadExpanded}
-                                        isStreaming={threadStreamingStatuses[thread.id]}
-                                        unread={unreadThreadIds.has(thread.id)}
-                                        compact
-                                        onDeleteThread={onDeleteThread}
-                                        onMenuOpenChange={handleThreadMenuOpenChange}
-                                        onRenameThread={onRenameThread}
-                                        onRestoreThread={onRestoreThread}
-                                        onSelectThread={handleRowSelect}
-                                        onTogglePinThread={onTogglePinThread}
-                                        onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
-                                      />
-                                    ))}
-                                  </div>
-                                )
-                              : null}
-                          </div>
-                        );
-                      })}
                     </div>
-                    <div className="mt-3 space-y-0.5">
-                      <div className="sticky top-0 z-10 flex h-6 items-center justify-between bg-surface px-2 text-xs font-medium text-ink-muted">
-                        <span>{t("activityRail.chatHeader")}</span>
-                        <div className="flex items-center gap-0.5">
-                          <SectionToggle
-                            collapsed={chatSectionCollapsed}
-                            label={chatSectionCollapsed
-                              ? t("activityRail.expandChatSection")
-                              : t("activityRail.collapseChatSection")}
-                            onToggle={() => setChatSectionCollapsed(value => !value)}
-                          />
-                          {!selectionMode
-                            ? (
-                                <ChatSectionMenu
-                                  open={chatSectionMenuOpen}
-                                  onOpenChange={setChatSectionMenuOpen}
-                                  onSelect={enterChatSelectionMode}
-                                />
-                              )
-                            : null}
-                          <button
-                            aria-label={t("activityRail.newChatShort")}
-                            className="inline-flex size-5 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
-                            onClick={() => onNewChat()}
-                            title={t("activityRail.newChatShort")}
-                            type="button"
-                          >
-                            <Plus className="size-3.5" />
-                          </button>
-                        </div>
-                      </div>
-                      {!chatSectionCollapsed && chatThreads.length === 0
-                        ? <div className="px-2 py-1 text-xs text-ink-muted">{t("activityRail.noChats")}</div>
-                        : null}
-                      {visibleChatThreads.map(({ thread, depth, hasChildren }) => (
-                        <ThreadListItem
-                          active={thread.id === activeThreadId && active === "chat"}
-                          archived={thread.status === "archived"}
-                          key={thread.id}
-                          menuOpen={openThreadMenuId === thread.id}
-                          pendingApprovalCount={pendingApprovalCounts.get(thread.id)}
-                          runStatus={threadRunStatuses[thread.id]}
-                          isStreaming={threadStreamingStatuses[thread.id]}
-                          selected={selectedThreadIds.has(thread.id)}
-                          selectionMode={threadSelectionMode(thread)}
-                          thread={thread}
-                          depth={depth}
-                          hasChildren={hasChildren}
-                          expanded={expandedThreads.has(thread.id)}
-                          onToggleExpanded={toggleThreadExpanded}
-                          unread={unreadThreadIds.has(thread.id)}
-                          onDeleteThread={onDeleteThread}
-                          onMenuOpenChange={handleThreadMenuOpenChange}
-                          onRenameThread={onRenameThread}
-                          onRestoreThread={onRestoreThread}
-                          onSelectThread={handleRowSelect}
-                          onTogglePinThread={onTogglePinThread}
-                          onToggleSelection={threadSelectionMode(thread) ? toggleThreadSelection : undefined}
-                        />
-                      ))}
-                    </div>
-                    {/* Batch selection action bar. */}
-                    {selectionMode
-                      ? (
-                          <div className="sticky bottom-0 z-10 -mx-2 -mb-0.5 border-t border-line-soft bg-surface px-2 py-2">
-                            <div className="flex items-center gap-2">
-                              <SelectAllCheckbox
-                                checked={scopedThreads.length > 0 && selectedThreadIds.size === scopedThreads.length}
-                                indeterminate={selectedThreadIds.size > 0 && selectedThreadIds.size < scopedThreads.length}
-                                onChange={() => {
-                                  if (selectedThreadIds.size === scopedThreads.length) {
-                                    deselectAll();
-                                  }
-                                  else {
-                                    selectAll();
-                                  }
-                                }}
-                              />
-                              <span className="flex-1 text-xs text-ink-soft">
-                                {selectedThreadIds.size > 0
-                                  ? t("activityRail.threadsSelected", { count: selectedThreadIds.size })
-                                  : t("activityRail.selectAll")}
-                              </span>
-                              <Button
-                                disabled={selectedThreadIds.size === 0}
-                                leftIcon={<Trash2 className="size-3.5" />}
-                                onClick={handleStartBatchDelete}
-                                size="sm"
-                                type="button"
-                                variant="danger"
-                              >
-                                {t("activityRail.deleteSelected")}
-                              </Button>
-                              <Button
-                                leftIcon={<X className="size-3.5" />}
-                                onClick={exitSelectionMode}
-                                size="sm"
-                                type="button"
-                                variant="secondary"
-                              >
-                                {t("common:cancel")}
-                              </Button>
-                            </div>
-                          </div>
-                        )
-                      : null}
+                    <FloatingScrollbar
+                      scrollbar={listScrollbar.scrollbar}
+                      onPointerDown={listScrollbar.handleThumbPointerDown}
+                    />
                   </div>
-                  <FloatingScrollbar
-                    scrollbar={listScrollbar.scrollbar}
-                    onPointerDown={listScrollbar.handleThumbPointerDown}
-                  />
+                  {selectionMode
+                    ? (
+                        <ActivityRailSelectionToolbar
+                          selectedCount={selectedThreadIds.size}
+                          totalCount={scopedThreads.length}
+                          onCancel={exitSelectionMode}
+                          onDelete={deleteSelected}
+                          onToggleAll={selectedThreadIds.size === scopedThreads.length ? deselectAll : selectAll}
+                        />
+                      )
+                    : null}
                 </div>
               </>
             )
@@ -772,174 +663,19 @@ export function ActivityRail({
               </>
             )}
       </div>
-      <div className="border-t border-line-soft/40 p-2">
-        {expanded
-          ? (
-              userEmail && !communityEdition
-                ? (
-                    <AccountMenuButton
-                      balance={futureBalance ?? null}
-                      email={userEmail}
-                      hasUpdate={hasUpdate}
-                      onOpenSettings={() => onChange(settingsItem.id)}
-                      onOpenUpdate={onOpenUpdate}
-                      onRecharge={onRecharge}
-                    />
-                  )
-                : (
-                    <button
-                      className={cn(
-                        "flex h-8 w-full items-center gap-2 rounded-md border border-transparent px-2 text-sm font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink",
-                        active === settingsItem.id && "border-accent bg-accent-soft text-accent",
-                      )}
-                      onClick={() => onChange(settingsItem.id)}
-                      type="button"
-                    >
-                      <span className="relative inline-flex shrink-0">
-                        <Settings className="size-4" />
-                        {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
-                      </span>
-                      <span className="truncate">{t("activityRail.settings")}</span>
-                    </button>
-                  )
-            )
-          : (
-              <IconButton
-                icon={(
-                  <span className="relative inline-flex">
-                    <Settings className="size-4" />
-                    {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
-                  </span>
-                )}
-                label={t("activityRail.settings")}
-                active={active === settingsItem.id}
-                onClick={() => onChange(settingsItem.id)}
-              />
-            )}
-      </div>
+      <ActivityRailAccountFooter
+        active={active}
+        balance={futureBalance ?? null}
+        communityEdition={communityEdition}
+        expanded={expanded}
+        hasUpdate={hasUpdate}
+        onChange={onChange}
+        onOpenUpdate={onOpenUpdate}
+        onRecharge={onRecharge}
+        userEmail={userEmail}
+      />
       {!floating ? <div className="pointer-events-none absolute inset-y-0 right-0 z-30 w-6 shadow-sidebar-divider" /> : null}
     </nav>
-  );
-}
-
-/**
- * Signed-in account chip (avatar initial + email prefix) that opens a flat
- * popover with Settings / Balance (+Recharge). A blue update-download icon sits to the
- * right of the avatar when a new app version is available (opening the Settings
- * update tab). Replaces the plain Settings button at the bottom of the rail.
- *
- * The chip is a flex row of two sibling buttons — the trigger (avatar + name)
- * and the upgrade action — because nesting a `<button>` inside the trigger
- * `<button>` is invalid HTML.
- */
-function AccountMenuButton({
-  balance,
-  email,
-  hasUpdate,
-  onOpenSettings,
-  onOpenUpdate,
-  onRecharge,
-}: {
-  balance: number | null;
-  email: string;
-  hasUpdate?: boolean;
-  onOpenSettings: () => void;
-  onOpenUpdate?: () => void;
-  onRecharge?: () => void;
-}) {
-  const { t } = useTranslation("layout");
-  const [open, setOpen] = useState(false);
-  const layerRef = useDismissableLayer<HTMLDivElement>({ enabled: open, onDismiss: () => setOpen(false) });
-
-  const prefix = email.split("@")[0] || email;
-  const initial = (prefix[0] ?? "?").toUpperCase();
-  const close = () => setOpen(false);
-
-  return (
-    <div className="relative" ref={layerRef}>
-      <div
-        className="flex w-full cursor-pointer items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        onClick={() => setOpen(value => !value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            setOpen(value => !value);
-          }
-        }}
-        role="button"
-        tabIndex={0}
-      >
-        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent-soft text-sm font-semibold uppercase leading-none text-accent">
-          {initial}
-        </span>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink">{prefix}</span>
-        {hasUpdate
-          ? (
-              <button
-                aria-label={t("userMenu.upgrade")}
-                className="ml-auto inline-flex size-7 shrink-0 items-center justify-center rounded text-accent transition-colors hover:bg-accent-soft"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onOpenUpdate?.();
-                  close();
-                }}
-                onKeyDown={event => event.stopPropagation()}
-                title={t("userMenu.upgrade")}
-                type="button"
-              >
-                <Download className="size-4" />
-              </button>
-            )
-          : null}
-      </div>
-      {open
-        ? (
-            <MenuPanel className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden p-0">
-              <MenuRow
-                icon={Settings}
-                label={t("activityRail.settings")}
-                onClick={() => {
-                  onOpenSettings();
-                  close();
-                }}
-              />
-              <MenuRow
-                action={<ActionBadge>{t("userMenu.recharge")}</ActionBadge>}
-                icon={Wallet}
-                label={t("userMenu.balance", { credits: balance != null ? Math.trunc(balance) : "—" })}
-                onClick={() => {
-                  onRecharge?.();
-                  close();
-                }}
-              />
-            </MenuPanel>
-          )
-        : null}
-    </div>
-  );
-}
-
-/** A borderless row inside the account popover; the whole row is clickable. */
-function MenuRow({ action, icon: Icon, label, onClick }: { action?: ReactNode; icon?: LucideIcon; label: string; onClick: () => void }) {
-  return (
-    <button
-      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-subtle"
-      onClick={onClick}
-      type="button"
-    >
-      {Icon ? <Icon className="size-4 shrink-0 text-ink-soft" /> : null}
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {action ?? null}
-    </button>
-  );
-}
-
-/** Solid accent pill used as the right-hand action label (Recharge). */
-function ActionBadge({ children }: { children: ReactNode }) {
-  return (
-    <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium leading-none text-white">
-      {children}
-    </span>
   );
 }
 
@@ -955,32 +691,6 @@ function sortThreads(items: StoredThread[]) {
 
 function threadSortTime(thread: StoredThread) {
   return thread.lastMessageAt ?? thread.updatedAt ?? thread.createdAt;
-}
-
-/** Tri-state checkbox for select-all / deselect-all in the selection action bar. */
-function SelectAllCheckbox({
-  checked,
-  indeterminate,
-  onChange,
-}: {
-  checked: boolean;
-  indeterminate: boolean;
-  onChange: () => void;
-}) {
-  const ref = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (ref.current)
-      ref.current.indeterminate = indeterminate;
-  }, [indeterminate]);
-  return (
-    <input
-      ref={ref}
-      checked={checked}
-      className="size-4 shrink-0 rounded border-line accent-accent"
-      onChange={onChange}
-      type="checkbox"
-    />
-  );
 }
 
 /**

--- a/desktop/src/components/layout/ActivityRailAccountFooter.tsx
+++ b/desktop/src/components/layout/ActivityRailAccountFooter.tsx
@@ -1,0 +1,219 @@
+import type { KeyboardEvent, ReactNode } from "react";
+import type { ActivitySection } from "./ActivityRail";
+import { Download, Settings, Wallet } from "lucide-react";
+import { useCallback, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "../../lib/cn";
+import { useDismissableLayer } from "../../lib/useDismissableLayer";
+import { IconButton } from "../ui/IconButton";
+import { MenuPanel } from "../ui/MenuPanel";
+
+export function ActivityRailAccountFooter({
+  active,
+  balance,
+  communityEdition,
+  expanded,
+  hasUpdate,
+  onChange,
+  onOpenUpdate,
+  onRecharge,
+  userEmail,
+}: {
+  active: ActivitySection;
+  balance: number | null;
+  communityEdition?: boolean;
+  expanded: boolean;
+  hasUpdate?: boolean;
+  onChange: (section: ActivitySection) => void;
+  onOpenUpdate?: () => void;
+  onRecharge?: () => void;
+  userEmail?: string | null;
+}) {
+  const { t } = useTranslation("layout");
+  return (
+    <div className="shrink-0 border-t border-line-soft/40 p-2">
+      {expanded
+        ? (
+            userEmail && !communityEdition
+              ? (
+                  <AccountMenuButton
+                    balance={balance}
+                    email={userEmail}
+                    hasUpdate={hasUpdate}
+                    onOpenSettings={() => onChange("settings")}
+                    onOpenUpdate={onOpenUpdate}
+                    onRecharge={onRecharge}
+                  />
+                )
+              : (
+                  <button
+                    className={cn(
+                      "flex h-8 w-full items-center gap-2 rounded-md border border-transparent px-2 text-sm font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink",
+                      active === "settings" && "border-accent bg-accent-soft text-accent",
+                    )}
+                    onClick={() => onChange("settings")}
+                    type="button"
+                  >
+                    <span className="relative inline-flex shrink-0">
+                      <Settings className="size-4" />
+                      {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
+                    </span>
+                    <span className="truncate">{t("activityRail.settings")}</span>
+                  </button>
+                )
+          )
+        : (
+            <IconButton
+              icon={(
+                <span className="relative inline-flex">
+                  <Settings className="size-4" />
+                  {hasUpdate ? <span className="absolute -right-1 -top-1 size-2 rounded-full bg-accent" /> : null}
+                </span>
+              )}
+              label={t("activityRail.settings")}
+              active={active === "settings"}
+              onClick={() => onChange("settings")}
+            />
+          )}
+    </div>
+  );
+}
+
+function AccountMenuButton({
+  balance,
+  email,
+  hasUpdate,
+  onOpenSettings,
+  onOpenUpdate,
+  onRecharge,
+}: {
+  balance: number | null;
+  email: string;
+  hasUpdate?: boolean;
+  onOpenSettings: () => void;
+  onOpenUpdate?: () => void;
+  onRecharge?: () => void;
+}) {
+  const { t } = useTranslation("layout");
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  const layerRef = useDismissableLayer<HTMLDivElement>({
+    enabled: open,
+    onDismiss: close,
+    onEscapeDismiss: () => {
+      close();
+      triggerRef.current?.focus();
+    },
+  });
+  const prefix = email.split("@")[0] || email;
+  const initial = (prefix[0] ?? "?").toUpperCase();
+
+  function handleMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const items = [...event.currentTarget.querySelectorAll<HTMLButtonElement>("button:not(:disabled)")];
+    const index = items.indexOf(document.activeElement as HTMLButtonElement);
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      items[(index + delta + items.length) % items.length]?.focus();
+    }
+    else if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      items[event.key === "Home" ? 0 : items.length - 1]?.focus();
+    }
+  }
+
+  function openMenu() {
+    setOpen(true);
+    window.requestAnimationFrame(() => layerRef.current?.querySelector<HTMLButtonElement>("[role=menuitem]")?.focus());
+  }
+
+  return (
+    <div className="relative" ref={layerRef}>
+      <div className="flex w-full items-center rounded-md border border-transparent transition-colors hover:bg-surface-subtle">
+        <button
+          ref={triggerRef}
+          aria-controls={menuId}
+          aria-expanded={open}
+          aria-haspopup="menu"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          onClick={() => open ? close() : openMenu()}
+          type="button"
+        >
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent-soft text-sm font-semibold uppercase leading-none text-accent">
+            {initial}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink">{prefix}</span>
+        </button>
+        {hasUpdate
+          ? (
+              <button
+                aria-label={t("userMenu.upgrade")}
+                className="mr-1 inline-flex size-7 shrink-0 items-center justify-center rounded text-accent transition-colors hover:bg-accent-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                onClick={() => {
+                  onOpenUpdate?.();
+                  close();
+                }}
+                title={t("userMenu.upgrade")}
+                type="button"
+              >
+                <Download className="size-4" />
+              </button>
+            )
+          : null}
+      </div>
+      {open
+        ? (
+            <MenuPanel
+              id={menuId}
+              className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden p-0"
+              onKeyDown={handleMenuKeyDown}
+              role="menu"
+            >
+              <MenuRow
+                icon={<Settings className="size-4 shrink-0 text-ink-soft" />}
+                label={t("activityRail.settings")}
+                onClick={() => {
+                  onOpenSettings();
+                  close();
+                }}
+              />
+              <MenuRow
+                action={<ActionBadge>{t("userMenu.recharge")}</ActionBadge>}
+                icon={<Wallet className="size-4 shrink-0 text-ink-soft" />}
+                label={t("userMenu.balance", { credits: balance != null ? Math.trunc(balance) : "—" })}
+                onClick={() => {
+                  onRecharge?.();
+                  close();
+                }}
+              />
+            </MenuPanel>
+          )
+        : null}
+    </div>
+  );
+}
+
+function MenuRow({ action, icon, label, onClick }: { action?: ReactNode; icon: ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus"
+      onClick={onClick}
+      role="menuitem"
+      type="button"
+    >
+      {icon}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {action ?? null}
+    </button>
+  );
+}
+
+function ActionBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium leading-none text-white">
+      {children}
+    </span>
+  );
+}

--- a/desktop/src/components/layout/ActivityRailMenus.tsx
+++ b/desktop/src/components/layout/ActivityRailMenus.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import type { StoredWorkspace } from "../../integrations/storage/threadStore";
 import { Archive, CheckSquare, FolderOpen, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react";
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { openPath } from "../../integrations/storage/files";
 import { cn } from "../../lib/cn";
@@ -32,6 +33,8 @@ export function ThreadItemMenu({
   return (
     <MenuPanel
       ref={menuRef}
+      onKeyDown={handleMenuKeyDown}
+      role="menu"
       className={cn(
         "absolute right-1 z-40 w-36 p-1",
         dropUp ? "bottom-7" : "top-7",
@@ -81,12 +84,23 @@ export function WorkspaceHeaderMenu({
 }) {
   const { t } = useTranslation("layout");
   const revealLabel = t("activityRail.revealInFinder");
-  const layerRef = useDismissableLayer<HTMLDivElement>({ enabled: open, onDismiss: () => onOpenChange(false) });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const layerRef = useDismissableLayer<HTMLDivElement>({
+    enabled: open,
+    onDismiss: () => onOpenChange(false),
+    onEscapeDismiss: () => {
+      onOpenChange(false);
+      triggerRef.current?.focus();
+    },
+  });
   const { menuRef, dropUp } = useDropUpMenu(open);
 
   return (
     <div className="relative" ref={layerRef}>
       <button
+        ref={triggerRef}
+        aria-expanded={open}
+        aria-haspopup="menu"
         aria-label={t("activityRail.workspaceActions", { name: workspace.name })}
         className={cn(
           "inline-flex size-5 shrink-0 items-center justify-center rounded text-ink-muted opacity-0 transition hover:bg-surface hover:text-ink-soft group-hover:opacity-100",
@@ -105,6 +119,8 @@ export function WorkspaceHeaderMenu({
         ? (
             <MenuPanel
               ref={menuRef}
+              onKeyDown={handleMenuKeyDown}
+              role="menu"
               className={cn(
                 "absolute right-0 z-40 w-max min-w-36 p-1",
                 dropUp ? "bottom-7" : "top-7",
@@ -146,12 +162,23 @@ export function ChatSectionMenu({
   onSelect: () => void;
 }) {
   const { t } = useTranslation("layout");
-  const layerRef = useDismissableLayer<HTMLDivElement>({ enabled: open, onDismiss: () => onOpenChange(false) });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const layerRef = useDismissableLayer<HTMLDivElement>({
+    enabled: open,
+    onDismiss: () => onOpenChange(false),
+    onEscapeDismiss: () => {
+      onOpenChange(false);
+      triggerRef.current?.focus();
+    },
+  });
   const { menuRef, dropUp } = useDropUpMenu(open);
 
   return (
     <div className="relative" ref={layerRef}>
       <button
+        ref={triggerRef}
+        aria-expanded={open}
+        aria-haspopup="menu"
         aria-label={t("activityRail.chatSectionActions")}
         className="inline-flex size-5 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft"
         onClick={(event) => {
@@ -167,6 +194,8 @@ export function ChatSectionMenu({
         ? (
             <MenuPanel
               ref={menuRef}
+              onKeyDown={handleMenuKeyDown}
+              role="menu"
               className={cn(
                 "absolute right-0 z-40 w-max min-w-36 p-1",
                 dropUp ? "bottom-7" : "top-7",
@@ -205,10 +234,27 @@ function ThreadMenuItem({
         onClose();
         onClick();
       }}
+      role="menuitem"
       type="button"
     >
       {icon}
       <span className="whitespace-nowrap">{children}</span>
     </button>
   );
+}
+
+function handleMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End")
+    return;
+  const items = [...event.currentTarget.querySelectorAll<HTMLButtonElement>("[role=menuitem]:not(:disabled)")];
+  if (items.length === 0)
+    return;
+  event.preventDefault();
+  if (event.key === "Home" || event.key === "End") {
+    items[event.key === "Home" ? 0 : items.length - 1]?.focus();
+    return;
+  }
+  const current = items.indexOf(document.activeElement as HTMLButtonElement);
+  const delta = event.key === "ArrowDown" ? 1 : -1;
+  items[(current + delta + items.length) % items.length]?.focus();
 }

--- a/desktop/src/components/layout/ActivityRailSelectionToolbar.tsx
+++ b/desktop/src/components/layout/ActivityRailSelectionToolbar.tsx
@@ -1,0 +1,81 @@
+import { Trash2, X } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "../ui/Button";
+
+export function ActivityRailSelectionToolbar({
+  onCancel,
+  onDelete,
+  onToggleAll,
+  selectedCount,
+  totalCount,
+}: {
+  onCancel: () => void;
+  onDelete: () => void;
+  onToggleAll: () => void;
+  selectedCount: number;
+  totalCount: number;
+}) {
+  const { t } = useTranslation("layout");
+  const checked = totalCount > 0 && selectedCount === totalCount;
+  const checkboxRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (checkboxRef.current)
+      checkboxRef.current.indeterminate = selectedCount > 0 && selectedCount < totalCount;
+  }, [selectedCount, totalCount]);
+
+  return (
+    <div
+      aria-label={t("activityRail.selectThreads")}
+      className="activity-rail-selection-toolbar -mx-2 shrink-0 border-t border-line-soft bg-surface px-2 pt-2"
+      data-activity-rail-selection-toolbar="true"
+      role="toolbar"
+    >
+      <div className="flex items-center gap-2">
+        <label className="flex min-w-0 flex-1 items-center gap-2 text-xs text-ink-soft">
+          <input
+            ref={checkboxRef}
+            checked={checked}
+            className="size-4 shrink-0 rounded border-line accent-accent"
+            onChange={onToggleAll}
+            type="checkbox"
+          />
+          <span className="truncate">
+            {selectedCount > 0
+              ? t("activityRail.threadsSelected", { count: selectedCount })
+              : t("activityRail.selectAll")}
+          </span>
+        </label>
+        <Button
+          aria-label={t("activityRail.deleteSelected")}
+          className="activity-rail-selection-action shrink-0"
+          disabled={selectedCount === 0}
+          leftIcon={<Trash2 className="size-3.5" />}
+          onClick={onDelete}
+          size="sm"
+          title={t("activityRail.deleteSelected")}
+          type="button"
+          variant="danger"
+        >
+          <span className="activity-rail-selection-action-label whitespace-nowrap">
+            {t("activityRail.deleteSelected")}
+          </span>
+        </Button>
+        <Button
+          aria-label={t("common:cancel")}
+          className="activity-rail-selection-action shrink-0"
+          leftIcon={<X className="size-3.5" />}
+          onClick={onCancel}
+          size="sm"
+          title={t("common:cancel")}
+          type="button"
+          variant="secondary"
+        >
+          <span className="activity-rail-selection-action-label whitespace-nowrap">
+            {t("common:cancel")}
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -509,7 +509,7 @@ export function AppShell() {
                 aria-valuemin={MIN_LEFT_PANEL_WIDTH}
                 aria-valuemax={leftPanel.maxWidth}
                 aria-valuenow={leftPanel.width}
-                className="absolute inset-y-0 -right-1 z-40 w-2 cursor-ew-resize touch-none hover:bg-accent/20 focus-visible:bg-accent/20 focus-visible:outline-none"
+                className="absolute inset-y-0 -right-1 z-40 w-2 cursor-col-resize touch-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
                 tabIndex={0}
                 onPointerDown={leftPanel.startResize}
                 onKeyDown={(event) => {
@@ -522,12 +522,12 @@ export function AppShell() {
             </div>
           )
         : null}
-      {leftPanel.resizing ? <div className="fixed inset-0 z-50 cursor-ew-resize select-none" /> : null}
+      {leftPanel.resizing ? <div className="fixed inset-0 z-50 cursor-col-resize select-none" /> : null}
       {!leftExpanded
         ? (
             <div
               aria-hidden="true"
-              className="absolute left-0 top-0 z-30 h-full w-2 cursor-ew-resize"
+              className="absolute left-0 top-0 z-30 h-full w-2 cursor-col-resize"
               onMouseEnter={() => handlePreviewLeftPanel(true)}
             />
           )
@@ -641,7 +641,7 @@ export function AppShell() {
       {/* While dragging the divider, a full-window overlay keeps the cursor and
           captures mouse events even over embedded iframes (PDF preview). */}
       {rightPanelResizing && !hideRightPanel
-        ? <div className="fixed inset-0 z-50 cursor-ew-resize select-none" />
+        ? <div className="fixed inset-0 z-50 cursor-col-resize select-none" />
         : null}
       <AppShellDialogs
         batchDeleteDialog={batchDeleteDialog}

--- a/desktop/src/components/layout/ContextPanel.tsx
+++ b/desktop/src/components/layout/ContextPanel.tsx
@@ -326,7 +326,7 @@ export function ContextPanel({
       <div
         aria-label={t("contextPanel.resize")}
         aria-orientation="vertical"
-        className="absolute -left-1 top-0 z-20 h-full w-2 cursor-ew-resize"
+        className="absolute -left-1 top-0 z-20 h-full w-2 cursor-col-resize"
         onMouseDown={onResizeStart}
         onKeyDown={(event) => {
           if (event.key === "ArrowLeft") {

--- a/desktop/src/components/layout/ThreadListItem.tsx
+++ b/desktop/src/components/layout/ThreadListItem.tsx
@@ -1,7 +1,7 @@
 import type { StoredThread } from "../../integrations/storage/threadStore";
 import type { ThreadRunInfo } from "./hooks/useThreadStore";
 import { ChevronDown, ChevronRight, CircleAlert, MoreHorizontal } from "lucide-react";
-import { memo } from "react";
+import { memo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useCachedAgentState } from "../../integrations/agent/agentStateCache";
 import { cn } from "../../lib/cn";
@@ -72,9 +72,14 @@ function ThreadListItemImpl({
   onToggleSelection?: (thread: StoredThread) => void;
 }) {
   const { t } = useTranslation("layout");
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useDismissableLayer<HTMLDivElement>({
     enabled: menuOpen,
     onDismiss: () => onMenuOpenChange(thread, false),
+    onEscapeDismiss: () => {
+      onMenuOpenChange(thread, false);
+      menuButtonRef.current?.focus();
+    },
   });
 
   // Agent session_name is authoritative; DB title is fallback.
@@ -146,28 +151,16 @@ function ThreadListItemImpl({
       {archived ? <span className="pointer-events-none shrink-0 text-[11px] text-ink-muted group-hover/thread:hidden">{t("activityRail.archived")}</span> : null}
       {selectionMode
         ? (
-            <button
+            <input
               aria-label={t("activityRail.selectThread", { title: displayTitle })}
-              className={cn(
-                "relative z-10 flex size-5 shrink-0 items-center justify-center rounded transition-colors",
-                selected
-                  ? "bg-accent text-white"
-                  : "border border-line-soft text-transparent hover:border-line",
-              )}
-              onClick={(event) => {
+              checked={selected}
+              className="relative z-10 size-5 shrink-0 rounded border-line accent-accent"
+              onChange={(event) => {
                 event.stopPropagation();
                 onToggleSelection?.(thread);
               }}
-              type="button"
-            >
-              {selected
-                ? (
-                    <svg className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  )
-                : null}
-            </button>
+              type="checkbox"
+            />
           )
         : (
             <>
@@ -186,6 +179,9 @@ function ThreadListItemImpl({
                 <ThreadRunIndicator status={effectiveRunStatus} unread={unread} />
               </span>
               <button
+                ref={menuButtonRef}
+                aria-expanded={menuOpen}
+                aria-haspopup="menu"
                 aria-label={t("activityRail.threadActions", { title: displayTitle })}
                 className={cn(
                   "relative z-10 hidden size-5 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink-soft group-hover/thread:inline-flex",

--- a/desktop/src/components/layout/hooks/panelGeometry.ts
+++ b/desktop/src/components/layout/hooks/panelGeometry.ts
@@ -1,0 +1,2 @@
+export const MIN_CENTER_PANEL_WIDTH = 384;
+export const MIN_RIGHT_PANEL_WIDTH = 384;

--- a/desktop/src/components/layout/hooks/useLeftPanelWidth.test.ts
+++ b/desktop/src/components/layout/hooks/useLeftPanelWidth.test.ts
@@ -36,7 +36,7 @@ describe("left panel resizing", () => {
     const restored = renderHook(() => useLeftPanelWidth(false));
     expect(restored.current.width).toBe(480);
     act(() => restored.current.nudge(-1000));
-    expect(restored.current.width).toBe(180);
+    expect(restored.current.width).toBe(224);
     restored.unmount();
   });
 

--- a/desktop/src/components/layout/hooks/useLeftPanelWidth.ts
+++ b/desktop/src/components/layout/hooks/useLeftPanelWidth.ts
@@ -1,9 +1,9 @@
 import type { PointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { MIN_CENTER_PANEL_WIDTH, MIN_RIGHT_PANEL_WIDTH } from "./panelGeometry";
 
 const STORAGE_KEY = "future.leftPanelWidth";
-export const MIN_LEFT_PANEL_WIDTH = 180;
-const MIN_CENTER = 384;
+export const MIN_LEFT_PANEL_WIDTH = 224;
 const MAX_LEFT_PANEL_WIDTH = 480;
 
 function initialWidth(): number {
@@ -23,7 +23,10 @@ export function useLeftPanelWidth(rightExpanded: boolean) {
   const [resizing, setResizing] = useState(false);
   const cleanupRef = useRef<(() => void) | null>(null);
   // Reserve the existing right panel's floor; its own hook re-clamps its width.
-  const maxWidth = Math.max(MIN_LEFT_PANEL_WIDTH, Math.min(MAX_LEFT_PANEL_WIDTH, windowWidth - MIN_CENTER - (rightExpanded ? 384 : 0)));
+  const maxWidth = Math.max(
+    MIN_LEFT_PANEL_WIDTH,
+    Math.min(MAX_LEFT_PANEL_WIDTH, windowWidth - MIN_CENTER_PANEL_WIDTH - (rightExpanded ? MIN_RIGHT_PANEL_WIDTH : 0)),
+  );
   const width = Math.min(maxWidth, Math.max(MIN_LEFT_PANEL_WIDTH, preferredWidth));
 
   useEffect(() => {

--- a/desktop/src/components/layout/hooks/useRailSelection.test.ts
+++ b/desktop/src/components/layout/hooks/useRailSelection.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import type { StoredThread } from "../../../integrations/storage/threadStore";
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "../../../test/renderHook";
+import { useRailSelection } from "./useRailSelection";
+
+function thread(id: string): StoredThread {
+  return { id, agentSessionId: id, title: id, mode: "chat", workspaceId: id, status: "active", pinned: false, readonly: false, createdAt: 0, updatedAt: 0 };
+}
+
+describe("rail selection", () => {
+  it("keeps selection scoped and removes IDs that disappear externally", () => {
+    const first = thread("first");
+    const second = thread("second");
+    let visibleThreads = [first, second];
+    let threadScopes = new Map([[first.id, "chat"], [second.id, "chat"]]);
+    const onBatchDeleteThreads = vi.fn();
+    const h = renderHook(() => useRailSelection({
+      onBatchDeleteThreads,
+      onSelectThread: vi.fn(),
+      threadScopes,
+      visibleThreads,
+    }));
+
+    act(() => h.current.enterSelectionMode("chat"));
+    act(() => h.current.toggleThreadSelection(first));
+    expect([...h.current.selectedThreadIds]).toEqual([first.id]);
+
+    visibleThreads = [second];
+    threadScopes = new Map([[second.id, "chat"]]);
+    h.rerender();
+    expect(h.current.selectedThreadIds.size).toBe(0);
+
+    act(() => h.current.selectAll());
+    act(() => h.current.deleteSelected());
+    expect(onBatchDeleteThreads).toHaveBeenCalledWith([second]);
+    expect(h.current.selectionMode).toBe(false);
+    h.unmount();
+  });
+
+  it("routes row activation to selection without opening the thread", () => {
+    const item = thread("item");
+    const onSelectThread = vi.fn();
+    const h = renderHook(() => useRailSelection({
+      onBatchDeleteThreads: vi.fn(),
+      onSelectThread,
+      threadScopes: new Map([[item.id, "chat"]]),
+      visibleThreads: [item],
+    }));
+
+    act(() => h.current.handleRowSelect(item));
+    expect(onSelectThread).toHaveBeenCalledWith(item);
+    act(() => h.current.enterSelectionMode("chat"));
+    act(() => h.current.handleRowSelect(item));
+    expect(onSelectThread).toHaveBeenCalledTimes(1);
+    expect(h.current.selectedThreadIds.has(item.id)).toBe(true);
+    h.unmount();
+  });
+});

--- a/desktop/src/components/layout/hooks/useRailSelection.ts
+++ b/desktop/src/components/layout/hooks/useRailSelection.ts
@@ -1,0 +1,111 @@
+import type { StoredThread } from "../../../integrations/storage/threadStore";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export function useRailSelection({
+  onBatchDeleteThreads,
+  onSelectThread,
+  threadScopes,
+  visibleThreads,
+}: {
+  onBatchDeleteThreads: (threads: StoredThread[]) => void;
+  onSelectThread: (thread: StoredThread) => void;
+  threadScopes: Map<string, string>;
+  visibleThreads: StoredThread[];
+}) {
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectionScope, setSelectionScope] = useState("chat");
+  const [selectedThreadIds, setSelectedThreadIds] = useState<Set<string>>(() => new Set());
+
+  const scopedThreads = useMemo(
+    () => visibleThreads.filter(thread => threadScopes.get(thread.id) === selectionScope),
+    [selectionScope, threadScopes, visibleThreads],
+  );
+
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedThreadIds(new Set());
+  }, []);
+
+  useEffect(() => {
+    if (!selectionMode)
+      return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape")
+        exitSelectionMode();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [exitSelectionMode, selectionMode]);
+
+  // Threads may be archived or deleted by another client while selection mode
+  // is open. Keep the selection inside the live scope so counts and tri-state
+  // checkbox state never include stale IDs.
+  useEffect(() => {
+    if (!selectionMode)
+      return;
+    const allowed = new Set(scopedThreads.map(thread => thread.id));
+    setSelectedThreadIds((current) => {
+      const next = new Set([...current].filter(id => allowed.has(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [scopedThreads, selectionMode]);
+
+  const enterSelectionMode = useCallback((scope: string) => {
+    setSelectionScope(scope);
+    setSelectedThreadIds(new Set());
+    setSelectionMode(true);
+  }, []);
+
+  const isThreadInScope = useCallback(
+    (thread: StoredThread) => threadScopes.get(thread.id) === selectionScope,
+    [selectionScope, threadScopes],
+  );
+
+  const toggleThreadSelection = useCallback((thread: StoredThread) => {
+    setSelectedThreadIds((current) => {
+      const next = new Set(current);
+      if (next.has(thread.id))
+        next.delete(thread.id);
+      else
+        next.add(thread.id);
+      return next;
+    });
+  }, []);
+
+  const handleRowSelect = useCallback((thread: StoredThread) => {
+    if (selectionMode) {
+      if (isThreadInScope(thread))
+        toggleThreadSelection(thread);
+      return;
+    }
+    onSelectThread(thread);
+  }, [isThreadInScope, onSelectThread, selectionMode, toggleThreadSelection]);
+
+  const selectAll = useCallback(() => {
+    setSelectedThreadIds(new Set(scopedThreads.map(thread => thread.id)));
+  }, [scopedThreads]);
+
+  const deselectAll = useCallback(() => setSelectedThreadIds(new Set()), []);
+
+  const deleteSelected = useCallback(() => {
+    const selectedThreads = scopedThreads.filter(thread => selectedThreadIds.has(thread.id));
+    if (selectedThreads.length === 0)
+      return;
+    onBatchDeleteThreads(selectedThreads);
+    exitSelectionMode();
+  }, [exitSelectionMode, onBatchDeleteThreads, scopedThreads, selectedThreadIds]);
+
+  return {
+    deleteSelected,
+    deselectAll,
+    enterSelectionMode,
+    exitSelectionMode,
+    handleRowSelect,
+    isThreadInScope,
+    scopedThreads,
+    selectAll,
+    selectedThreadIds,
+    selectionMode,
+    toggleThreadSelection,
+  };
+}

--- a/desktop/src/components/layout/hooks/useRightPanelWidth.ts
+++ b/desktop/src/components/layout/hooks/useRightPanelWidth.ts
@@ -1,5 +1,6 @@
 import type { MouseEvent, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { MIN_CENTER_PANEL_WIDTH, MIN_RIGHT_PANEL_WIDTH } from "./panelGeometry";
 
 /**
  * One shared width for the whole app session (sessionStorage → cleared on
@@ -14,8 +15,6 @@ const STORAGE_KEY = "future.rightPanelWidth";
  *  smallest supported window (1024px) both panels still fit.
  */
 export const RIGHT_PANEL_DEFAULT_WIDTH = 384;
-const MIN_RIGHT = 384;
-const MIN_CENTER = 384;
 
 function readStoredWidth(): number {
   try {
@@ -39,8 +38,8 @@ function clampWidth(desired: number, centerLeft: number): number {
   // Center is the priority: never let it fall below MIN_CENTER. On a window too
   // narrow to honor both floors, the upper bound wins and the right panel takes
   // whatever is left (Math.max keeps the range non-inverted).
-  const maxRight = Math.max(MIN_RIGHT, available - MIN_CENTER);
-  return Math.min(Math.max(Math.round(desired), MIN_RIGHT), maxRight);
+  const maxRight = Math.max(MIN_RIGHT_PANEL_WIDTH, available - MIN_CENTER_PANEL_WIDTH);
+  return Math.min(Math.max(Math.round(desired), MIN_RIGHT_PANEL_WIDTH), maxRight);
 }
 
 /**

--- a/desktop/src/components/ui/MenuPanel.tsx
+++ b/desktop/src/components/ui/MenuPanel.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode, Ref } from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
 import { cn } from "../../lib/cn";
 
 /**
@@ -13,17 +13,19 @@ export function MenuPanel({
   className,
   style,
   children,
+  ...props
 }: {
   ref?: Ref<HTMLDivElement>;
   className?: string;
   style?: CSSProperties;
   children: ReactNode;
-}) {
+} & HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn("rounded-lg border border-line-soft bg-surface shadow-panel", className)}
       ref={ref}
       style={style}
+      {...props}
     >
       {children}
     </div>

--- a/desktop/src/features/agent/ThreadSearch.test.tsx
+++ b/desktop/src/features/agent/ThreadSearch.test.tsx
@@ -184,7 +184,6 @@ describe("thread search", () => {
     const close = container.querySelector("button:last-of-type")!;
     act(() => close.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     expect(container.querySelector("input")).toBeNull();
-    expect(container.querySelector("style")?.textContent).toContain("thread-search-match");
     act(() => root.unmount());
     document.removeEventListener("keydown", downstreamKeydown);
     container.remove();

--- a/desktop/src/features/agent/ThreadSearch.tsx
+++ b/desktop/src/features/agent/ThreadSearch.tsx
@@ -10,11 +10,6 @@ const CURRENT_HIGHLIGHT = "thread-search-current";
 /** Bound result objects and painted ranges for low-specificity queries in very long threads. */
 const MAX_MATCHES = 300;
 const MAX_PAINTED_MATCHES = 80;
-const HIGHLIGHT_STYLES = `
-  ::highlight(thread-search-match) { color: #0f172a; background: #fde047; }
-  ::highlight(thread-search-current) { color: #0f172a; background: #fb923c; }
-`;
-
 interface HighlightRegistryLike {
   delete: (name: string) => boolean;
   get?: (name: string) => { clear?: () => void } | undefined;
@@ -197,7 +192,6 @@ export function ThreadSearch({ canLoadOlder, contentKey, onLoadOlder, rootRef }:
 
   return (
     <>
-      <style>{HIGHLIGHT_STYLES}</style>
       {open
         ? (
             <div

--- a/desktop/src/features/markdown/renderers/MathBlock.tsx
+++ b/desktop/src/features/markdown/renderers/MathBlock.tsx
@@ -23,7 +23,7 @@ export function MathBlock({ code }: MathBlockProps) {
       });
     }
     catch {
-      return `<span class="text-red-500">${escapeHtml(code)}</span>`;
+      return `<span class="text-danger">${escapeHtml(code)}</span>`;
     }
   }, [code]);
 

--- a/desktop/src/features/markdown/renderers/MathFallback.test.tsx
+++ b/desktop/src/features/markdown/renderers/MathFallback.test.tsx
@@ -34,14 +34,14 @@ function mount(node: React.ReactElement) {
 describe("math fallback on KaTeX failure", () => {
   it("mathBlock falls back to escaped raw code when KaTeX throws", () => {
     const { container, cleanup } = mount(createElement(MathBlock, { code: "<b>bold & amp</b>" }));
-    expect(container.querySelector(".text-red-500")).toBeTruthy();
+    expect(container.querySelector(".text-danger")).toBeTruthy();
     expect(container.textContent).toContain("<b>bold & amp</b>");
     cleanup();
   });
 
   it("mathInline falls back to escaped raw code when KaTeX throws", () => {
     const { container, cleanup } = mount(createElement(MathInline, { code: "<i>x</i>" }));
-    expect(container.querySelector(".text-red-500")).toBeTruthy();
+    expect(container.querySelector(".text-danger")).toBeTruthy();
     expect(container.textContent).toContain("<i>x</i>");
     cleanup();
   });

--- a/desktop/src/features/markdown/renderers/MathInline.tsx
+++ b/desktop/src/features/markdown/renderers/MathInline.tsx
@@ -23,7 +23,7 @@ export function MathInline({ code }: MathInlineProps) {
       });
     }
     catch {
-      return `<span class="text-red-500">${escapeHtml(code)}</span>`;
+      return `<span class="text-danger">${escapeHtml(code)}</span>`;
     }
   }, [code]);
 

--- a/desktop/src/i18n/locales/en/layout.json
+++ b/desktop/src/i18n/locales/en/layout.json
@@ -53,7 +53,7 @@
     "deselectAll": "Deselect all",
     "chatSectionActions": "Chat section actions",
     "threadsSelected": "{{count}} selected",
-    "deleteSelected": "Delete selected"
+    "deleteSelected": "Delete"
   },
   "appShell": {
     "storeInitFailed": "FutureOS local storage failed to initialize: ",

--- a/desktop/src/i18n/locales/zh/layout.json
+++ b/desktop/src/i18n/locales/zh/layout.json
@@ -53,7 +53,7 @@
     "deselectAll": "取消全选",
     "chatSectionActions": "对话区操作",
     "threadsSelected": "已选择 {{count}} 个",
-    "deleteSelected": "删除所选"
+    "deleteSelected": "删除"
   },
   "appShell": {
     "storeInitFailed": "FutureOS 本地存储初始化失败：",

--- a/desktop/src/lib/useDismissableLayer.ts
+++ b/desktop/src/lib/useDismissableLayer.ts
@@ -3,13 +3,19 @@ import { useEffect, useRef } from "react";
 interface DismissableLayerOptions {
   enabled: boolean;
   onDismiss: () => void;
+  onEscapeDismiss?: () => void;
 }
 
 export function useDismissableLayer<T extends HTMLElement>({
   enabled,
   onDismiss,
+  onEscapeDismiss,
 }: DismissableLayerOptions) {
   const ref = useRef<T | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  const onEscapeDismissRef = useRef(onEscapeDismiss);
+  onDismissRef.current = onDismiss;
+  onEscapeDismissRef.current = onEscapeDismiss;
 
   useEffect(() => {
     if (!enabled)
@@ -22,7 +28,7 @@ export function useDismissableLayer<T extends HTMLElement>({
       if (ref.current?.contains(target))
         return;
 
-      onDismiss();
+      onDismissRef.current();
     }
 
     function handleKeyDown(event: KeyboardEvent) {
@@ -31,7 +37,7 @@ export function useDismissableLayer<T extends HTMLElement>({
         // parent Overlay's own Escape-to-close doesn't ALSO fire — otherwise one
         // press would dismiss both this layer and the modal containing it.
         event.stopPropagation();
-        onDismiss();
+        (onEscapeDismissRef.current ?? onDismissRef.current)();
       }
     }
 
@@ -42,7 +48,7 @@ export function useDismissableLayer<T extends HTMLElement>({
       document.removeEventListener("pointerdown", handlePointerDown, true);
       document.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [enabled, onDismiss]);
+  }, [enabled]);
 
   return ref;
 }

--- a/desktop/src/lib/useFloatingScrollbar.test.tsx
+++ b/desktop/src/lib/useFloatingScrollbar.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useFloatingScrollbar } from "./useFloatingScrollbar";
+
+const observed: Element[] = [];
+
+class ResizeObserverStub {
+  observe(element: Element) {
+    observed.push(element);
+  }
+
+  disconnect() {}
+}
+
+afterEach(() => {
+  observed.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe("floating scrollbar", () => {
+  it("observes the explicit content wrapper instead of an arbitrary first child", () => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    function Probe() {
+      const scrollbar = useFloatingScrollbar();
+      return (
+        <div ref={scrollbar.scrollRef} data-testid="viewport">
+          <div data-testid="unrelated" />
+          <div ref={scrollbar.contentRef} data-testid="content" />
+        </div>
+      );
+    }
+
+    act(() => root.render(<Probe />));
+    expect(observed).toContain(container.querySelector("[data-testid=\"viewport\"]"));
+    expect(observed).toContain(container.querySelector("[data-testid=\"content\"]"));
+    expect(observed).not.toContain(container.querySelector("[data-testid=\"unrelated\"]"));
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/desktop/src/lib/useFloatingScrollbar.ts
+++ b/desktop/src/lib/useFloatingScrollbar.ts
@@ -28,6 +28,7 @@ const HIDE_DELAY_MS = 1200;
  */
 export function useFloatingScrollbar() {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Detach for an in-progress thumb drag, so unmounting mid-drag (e.g. switching
   // threads while dragging) removes the document listeners instead of leaking
@@ -111,8 +112,9 @@ export function useFloatingScrollbar() {
     const observer = new ResizeObserver(recompute);
     if (container) {
       observer.observe(container);
-      if (container.firstElementChild)
-        observer.observe(container.firstElementChild);
+      const content = contentRef.current ?? container.firstElementChild;
+      if (content)
+        observer.observe(content);
     }
     window.addEventListener("resize", recompute);
 
@@ -127,5 +129,5 @@ export function useFloatingScrollbar() {
   // Detach any in-progress drag on unmount (the normal path detaches on pointerup).
   useEffect(() => () => dragCleanupRef.current?.(), []);
 
-  return { scrollRef, scrollbar, updateFloatingScrollbar, handleScroll, handleThumbPointerDown };
+  return { contentRef, scrollRef, scrollbar, updateFloatingScrollbar, handleScroll, handleThumbPointerDown };
 }

--- a/desktop/src/styles/globals.css
+++ b/desktop/src/styles/globals.css
@@ -30,15 +30,43 @@
 @keyframes skill-entry-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
   50% {
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.28);
+    box-shadow: 0 0 0 3px theme(colors.accent-pulse);
   }
 }
 
 .animate-skill-entry-pulse {
   animation: skill-entry-pulse 0.9s ease-in-out 3;
+}
+
+/* Keep the selection toolbar on one row without sacrificing its checkbox
+   label. At narrow rail widths the two self-explanatory actions collapse to
+   icon buttons; their accessible names and title tooltips remain available. */
+.activity-rail-selection-toolbar {
+  container: activity-rail-selection-toolbar / inline-size;
+}
+
+@container activity-rail-selection-toolbar (max-width: 279px) {
+  .activity-rail-selection-action {
+    width: 2rem;
+    padding-inline: 0;
+  }
+
+  .activity-rail-selection-action-label {
+    display: none;
+  }
+}
+
+::highlight(thread-search-match) {
+  color: theme(colors.ink-strong);
+  background: theme(colors.search-match);
+}
+
+::highlight(thread-search-current) {
+  color: theme(colors.ink-strong);
+  background: theme(colors.search-current);
 }
 
 :root {

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -21,7 +21,11 @@ export default {
         "accent-soft": "#e8f0ff",
         "accent-hover": "#1d4ed8",
         "accent-disabled": "#bfdbfe",
+        "accent-pulse": "rgba(37, 99, 235, 0.28)",
         focus: "#93c5fd",
+        // ─── Search highlights ───────────────────────────────
+        "search-match": "#fde047",
+        "search-current": "#fb923c",
         // ─── Status tones (text / soft bg / line) ─────────────
         success: "#15803d",
         "success-soft": "#f0fdf4",


### PR DESCRIPTION
## Summary
- restructure the activity rail into a shared workspace and conversation scroll viewport with an external fixed selection toolbar
- split account footer, selection toolbar, and selection state from ActivityRail while hardening stale selection and floating scrollbar updates
- normalize sidebar colors and icons, improve menu and checkbox accessibility, and unify panel resize behavior and geometry

## Validation
- npm --prefix desktop run lint
- npm --prefix desktop run stylelint
- npm --prefix desktop test -- --reporter=dot (81 files, 732 tests)
- npm --prefix desktop run build -- --logLevel error
- git diff --cached --check

The production build succeeds. Its CSS optimizer emits two non-blocking warnings for the standards-based Custom Highlight API selector.