### PR TITLE
fix(mobile): declare androidx.activity for the photo-picker probe

### DIFF
--- a/mobile/modules/future-native-ui/android/build.gradle
+++ b/mobile/modules/future-native-ui/android/build.gradle
@@ -13,3 +13,9 @@ android {
     versionName "1.0.0"
   }
 }
+
+dependencies {
+  // PickVisualMedia.isPhotoPickerAvailable (gates the gallery fallback on
+  // devices without a system Photo Picker).
+  implementation "androidx.activity:activity-ktx:1.11.0"
+}


### PR DESCRIPTION
## Summary
`future-native-ui` gained a `PickVisualMedia.isPhotoPickerAvailable` probe in #531 (gating the gallery fallback for devices without a system Photo Picker), but the module never declared `androidx.activity`. This was hidden while the local Android toolchain was incomplete; a full toolchain reveals it as a Kotlin compile error in `:future-native-ui:compileReleaseKotlin`.

This adds `androidx.activity:activity-ktx:1.11.0` (already resolved via expo-image-picker, no new download).

## Validation
- `./scripts/build-mobile-android.sh` completes and produces `mobile/android/app/build/outputs/apk/release/app-release.apk` (100MB, targetSdk 36, `cn.futureos.mobile`).
- Fixed by also completing the local Android SDK: installed `platforms;android-36`, `build-tools;36.0.0`, and a repaired `ndk;27.1.12297006` (previous NDK dir was a broken `.installer` remnant).