### PR TITLE
fix(agent): retry interrupted streams and show reconnect status

### DIFF
--- a/agent/src/agent/events.rs
+++ b/agent/src/agent/events.rs
@@ -9,6 +9,12 @@ pub enum RunEvent {
         started_at_ms: u64,
     },
     Model(ModelStreamEvent),
+    StreamRetry {
+        attempt: usize,
+        max_retries: usize,
+        delay_ms: u64,
+    },
+    StreamResumed,
     CompactionStarted {
         operation_id: String,
         trigger: crate::compaction::CompactionTrigger,

--- a/agent/src/agent/mod.rs
+++ b/agent/src/agent/mod.rs
@@ -863,7 +863,7 @@ mod tests {
             .load(std::sync::atomic::Ordering::SeqCst));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn provider_eof_without_stop_marks_run_incomplete() {
         let loop_ = make_loop();
         let result = loop_.run_streaming("test prompt".to_string(), |_| {}).await;

--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -7,6 +7,9 @@ use tokio_stream::StreamExt;
 
 use super::{Loop, RunEvent, C_GREEN, C_MAGENTA, C_RESET, DEFAULT_MAX_TURNS};
 
+// Separate from HTTP request retries: five additional attempts per model step.
+const MAX_STREAM_RETRIES: usize = 5;
+
 #[derive(Debug, Default)]
 struct AccumulatedReasoningBlock {
     id: String,
@@ -201,6 +204,14 @@ impl Loop {
 
         let tool_defs: Vec<_> = self.tools.iter().map(|t| t.def.clone()).collect();
         let mut retry_attempt = 0;
+        let max_stream_retries = if self.config.max_retries > 0 {
+            MAX_STREAM_RETRIES
+        } else {
+            0
+        };
+        let mut stream_retry_attempt = 0;
+        let mut reconnecting = false;
+        let mut retry_text = String::new();
         let mut provider_limit_checkpoint_id: Option<String> = None;
 
         if self.verbose {
@@ -376,11 +387,30 @@ impl Loop {
                     }
                 }
             };
-            let work_messages: Vec<AgentMessage> = prompt
+            let mut work_messages: Vec<AgentMessage> = prompt
                 .messages
                 .into_iter()
                 .map(|projected| projected.message)
                 .collect();
+
+            // Make continuation explicit rather than relying on assistant
+            // prefill support. This is request-only recovery context, not a
+            // fabricated user submission in the durable conversation or UI.
+            if stream_retry_attempt > 0
+                && work_messages
+                    .last()
+                    .is_some_and(|message| message.role == "assistant")
+            {
+                let mut recovery = AgentMessage {
+                    role: "user".into(),
+                    content: vec![ContentBlock::text(
+                        "[Automatic recovery after a connection interruption. Continue the original task from the preserved partial response. Do not repeat text already delivered or rerun completed tool calls.]",
+                    )],
+                    ..Default::default()
+                };
+                recovery.ensure_journal_entry_id();
+                work_messages.push(recovery);
+            }
 
             // Emit message_start
 
@@ -585,7 +615,7 @@ impl Loop {
             }
 
             // Process stream events
-            let mut assistant_text = String::new();
+            let mut assistant_text = retry_text.clone();
             let mut reasoning_blocks: Vec<AccumulatedReasoningBlock> = Vec::new();
             let mut text_blocks: Vec<AccumulatedTextBlock> = Vec::new();
             let mut assistant_block_order: Vec<AssistantBlockOrder> = Vec::new();
@@ -626,7 +656,33 @@ impl Loop {
                         break;
                     }
                 };
-                on_event(RunEvent::Model(model_event.clone()));
+                // HTTP headers alone do not mean recovery. Wait for real model
+                // progress; EOF cleanup/usage events must not clear the hint.
+                if reconnecting
+                    && matches!(
+                        &model_event,
+                        ModelStreamEvent::TextStart { .. }
+                            | ModelStreamEvent::TextDelta { .. }
+                            | ModelStreamEvent::ReasoningStart { .. }
+                            | ModelStreamEvent::ReasoningDelta { .. }
+                            | ModelStreamEvent::ToolInputStart { .. }
+                            | ModelStreamEvent::ToolInputDelta { .. }
+                            | ModelStreamEvent::Finish { .. }
+                    )
+                {
+                    reconnecting = false;
+                    on_event(RunEvent::StreamResumed);
+                }
+                // Clients treat `error` as terminal. Do not stop their stream
+                // for a disconnect that will be recovered below.
+                let retryable_disconnect = matches!(
+                    &model_event,
+                    ModelStreamEvent::Error { message }
+                        if message.starts_with(crate::llm::UPSTREAM_DISCONNECTED)
+                );
+                if !retryable_disconnect || stream_retry_attempt >= max_stream_retries {
+                    on_event(RunEvent::Model(model_event.clone()));
+                }
 
                 // Close the text-output block before switching to a different
                 // event type — text_end may never arrive from the LLM.
@@ -869,7 +925,6 @@ impl Loop {
                             error = %message,
                             "LLM model stream failed"
                         );
-                        saw_terminal_event = true;
                         model_stream_failed = true;
                         // A model-stream error always leaves the accumulated
                         // response as a prefix. Preserve both that fact and a
@@ -877,13 +932,14 @@ impl Loop {
                         // without matching reqwest/provider wording.
                         stream_truncated = true;
                         truncation_detected_by.get_or_insert(
-                            if message.contains("[UPSTREAM_DISCONNECTED]") {
+                            if message.starts_with(crate::llm::UPSTREAM_DISCONNECTED) {
                                 "upstream_disconnected"
                             } else {
                                 "model_response_error"
                             },
                         );
                         stream_error = Some(anyhow!(message));
+                        break;
                     }
                 }
             }
@@ -898,6 +954,19 @@ impl Loop {
                 }
             }
 
+            // Apply this LLM call's final cost to cumulative_cost, once per
+            // call (total_usage holds the LAST complete usage chunk — adding
+            // every intermediate chunk would inflate the total N×). Future
+            // providers report an authoritative `credit_cost`; when absent
+            // (most other providers), fall back to a token×price estimate so
+            // mixed-model sessions still account for every request.
+            if let Some(ref u) = total_usage {
+                let cost = u.credit_cost.unwrap_or_else(|| self.estimate_usage_cost(u));
+                if cost > 0.0 {
+                    *self.cumulative_cost.lock() += cost;
+                }
+            }
+
             // Build a partial assistant message from whatever was accumulated
             // before the interrupt — reasoning, text, and tool calls should
             // survive an abort so the user doesn't lose generated content.
@@ -905,57 +974,53 @@ impl Loop {
             // placeholder tool-result messages, otherwise the LLM API rejects
             // the conversation on resume (HTTP 400: "assistant message with
             // tool_calls must be followed by tool messages").
-            let build_partial_assistant =
-                |messages: &mut Vec<AgentMessage>,
-                 assistant_block_order: &[AssistantBlockOrder],
-                 reasoning_blocks: &[AccumulatedReasoningBlock],
-                 text_blocks: &[AccumulatedTextBlock],
-                 tool_calls: &[AgentToolCall]| {
-                    let first_new_message = messages.len();
-                    let msg = AgentMessage {
-                        role: "assistant".to_string(),
-                        content: assemble_assistant_content(
-                            assistant_block_order,
-                            reasoning_blocks,
-                            text_blocks,
-                            tool_calls,
-                        ),
-                        ..Default::default()
-                    };
-                    // Don't push an empty assistant — the LLM API rejects
-                    // messages with neither content nor tool_calls.
-                    if !msg.content.is_empty() {
-                        messages.push(msg);
-                    }
-                    // Append placeholder tool-result for every unexecuted
-                    // tool call so the conversation remains API-valid.
-                    for tc in tool_calls {
-                        let cancelled = format!(
-                            "[Tool execution cancelled — {} was not executed due to interrupt]",
-                            tc.name
-                        );
-                        messages.push(AgentMessage {
-                            role: "tool".to_string(),
-                            content: vec![ContentBlock::tool_result(
-                                tc.id.clone(),
-                                &cancelled,
-                                false,
-                            )],
-                            name: tc.name.clone(),
-                            ..Default::default()
-                        });
-                    }
-                    // Partial output is part of the authoritative conversation,
-                    // just like a normally completed assistant/tool message.
-                    // Persist every entry added by this interrupt path so the
-                    // append-only terminal commit cannot leave memory and JSONL
-                    // permanently divergent after abort/restart.
-                    if let Some(ref save) = ctx.save_callback {
-                        for message in &mut messages[first_new_message..] {
-                            save(message);
-                        }
-                    }
+            let build_partial_assistant = |messages: &mut Vec<AgentMessage>,
+                                           assistant_block_order: &[AssistantBlockOrder],
+                                           reasoning_blocks: &[AccumulatedReasoningBlock],
+                                           text_blocks: &[AccumulatedTextBlock],
+                                           tool_calls: &[AgentToolCall],
+                                           reason: &str| {
+                let first_new_message = messages.len();
+                let msg = AgentMessage {
+                    role: "assistant".to_string(),
+                    content: assemble_assistant_content(
+                        assistant_block_order,
+                        reasoning_blocks,
+                        text_blocks,
+                        tool_calls,
+                    ),
+                    ..Default::default()
                 };
+                // Don't push an empty assistant — the LLM API rejects
+                // messages with neither content nor tool_calls.
+                if !msg.content.is_empty() {
+                    messages.push(msg);
+                }
+                // Append placeholder tool-result for every unexecuted
+                // tool call so the conversation remains API-valid.
+                for tc in tool_calls {
+                    let cancelled = format!(
+                        "[Tool execution cancelled — {} was not executed due to {reason}]",
+                        tc.name
+                    );
+                    messages.push(AgentMessage {
+                        role: "tool".to_string(),
+                        content: vec![ContentBlock::tool_result(tc.id.clone(), &cancelled, false)],
+                        name: tc.name.clone(),
+                        ..Default::default()
+                    });
+                }
+                // Partial output is part of the authoritative conversation,
+                // just like a normally completed assistant/tool message.
+                // Persist every entry added by this interrupt path so the
+                // append-only terminal commit cannot leave memory and JSONL
+                // permanently divergent after abort/restart.
+                if let Some(ref save) = ctx.save_callback {
+                    for message in &mut messages[first_new_message..] {
+                        save(message);
+                    }
+                }
+            };
 
             // Check for stream errors, and for a pending interrupt that
             // arrived during the API call or last stream event (tokio::select!
@@ -966,6 +1031,75 @@ impl Loop {
                 || interrupt_rx
                     .as_mut()
                     .is_some_and(|irx| irx.try_recv().is_ok());
+            let disconnected = matches!(
+                truncation_detected_by,
+                Some("upstream_disconnected" | "eof_no_terminal")
+            );
+            if disconnected
+                && !interrupted_after_stream
+                && stream_retry_attempt < max_stream_retries
+            {
+                // Resume from durable history, never from the beginning of the
+                // run. This step's tools have not executed: pair even partial
+                // calls with skipped results before sending history upstream.
+                build_partial_assistant(
+                    &mut messages,
+                    &assistant_block_order,
+                    &reasoning_blocks,
+                    &text_blocks,
+                    &agent_tool_calls,
+                    "connection interruption (retrying)",
+                );
+                for tc in &agent_tool_calls {
+                    let output = format!(
+                        "[Tool execution cancelled — {} was not executed due to connection interruption (retrying)]",
+                        tc.name
+                    );
+                    on_event(RunEvent::ToolExecutionFinished {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        output: output.clone(),
+                        error: Some(output),
+                        exit_code: None,
+                        is_soft_fail: None,
+                        target_path: None,
+                    });
+                }
+                // Close a possibly unfinished reasoning display before the
+                // next attempt. No synthetic reasoning metadata is persisted.
+                for block in &reasoning_blocks {
+                    on_event(RunEvent::Model(ModelStreamEvent::ReasoningEnd {
+                        id: block.id.clone(),
+                        provider_metadata: block.provider_metadata.clone(),
+                    }));
+                }
+                retry_text = assistant_text;
+                stream_retry_attempt += 1;
+                let delay_ms = 2000_u64 << (stream_retry_attempt - 1);
+                reconnecting = true;
+                on_event(RunEvent::StreamRetry {
+                    attempt: stream_retry_attempt,
+                    max_retries: max_stream_retries,
+                    delay_ms,
+                });
+                tracing::warn!(
+                    turn,
+                    attempt = stream_retry_attempt,
+                    max_retries = max_stream_retries,
+                    delay_ms,
+                    error = ?stream_error,
+                    "LLM stream disconnected; reconnecting"
+                );
+                if self
+                    .sleep_or_interrupt(Duration::from_millis(delay_ms), interrupt_rx.as_mut())
+                    .await
+                {
+                    return Ok((String::new(), messages));
+                }
+                // Opening another HTTP stream is not success: only a complete
+                // model step resets this budget. Retries do not consume turns.
+                continue;
+            }
             if stream_error.is_some() || interrupted_after_stream {
                 build_partial_assistant(
                     &mut messages,
@@ -973,6 +1107,7 @@ impl Loop {
                     &reasoning_blocks,
                     &text_blocks,
                     &agent_tool_calls,
+                    "interrupt",
                 );
                 if model_stream_failed {
                     self.stream_incomplete
@@ -1026,19 +1161,6 @@ impl Loop {
                 .map(agent_tool_call_to_tool_call)
                 .collect();
 
-            // Apply this LLM call's final cost to cumulative_cost, once per
-            // call (total_usage holds the LAST complete usage chunk — adding
-            // every intermediate chunk would inflate the total N×). Future
-            // providers report an authoritative `credit_cost`; when absent
-            // (most other providers), fall back to a token×price estimate so
-            // mixed-model sessions still account for every request.
-            if let Some(ref u) = total_usage {
-                let cost = u.credit_cost.unwrap_or_else(|| self.estimate_usage_cost(u));
-                if cost > 0.0 {
-                    *self.cumulative_cost.lock() += cost;
-                }
-            }
-
             // Stream was truncated mid-reply: the assistant text is a prefix,
             // not a finished answer. End the turn as `incomplete` (keeping the
             // partial text so it isn't lost) rather than presenting a cut-off
@@ -1077,6 +1199,9 @@ impl Loop {
                 );
                 return Ok((assistant_text, messages));
             }
+
+            stream_retry_attempt = 0;
+            retry_text.clear();
 
             // Check stop condition. The is_some_and closure keeps the None
             // edge branchless (a nested if's closing brace here collected a
@@ -1479,6 +1604,8 @@ mod tests {
     struct ScriptedProvider {
         scripts: parking_lot::Mutex<std::collections::VecDeque<Script>>,
         system_prompts: parking_lot::Mutex<Vec<String>>,
+        requests: parking_lot::Mutex<Vec<Vec<AgentMessage>>>,
+        request_times: parking_lot::Mutex<Vec<tokio::time::Instant>>,
     }
 
     impl ScriptedProvider {
@@ -1486,6 +1613,8 @@ mod tests {
             Arc::new(Self {
                 scripts: parking_lot::Mutex::new(scripts.into()),
                 system_prompts: parking_lot::Mutex::new(vec![]),
+                requests: parking_lot::Mutex::new(vec![]),
+                request_times: parking_lot::Mutex::new(vec![]),
             })
         }
     }
@@ -1511,6 +1640,8 @@ mod tests {
                 return Ok(ReceiverStream::new(rx));
             }
             self.system_prompts.lock().push(request.system_prompt);
+            self.requests.lock().push(request.messages);
+            self.request_times.lock().push(tokio::time::Instant::now());
             let script = self
                 .scripts
                 .lock()
@@ -2228,6 +2359,389 @@ mod tests {
                 .map(|truncation| truncation.detected_by),
             Some("model_response_error".to_string())
         );
+    }
+
+    fn ev_disconnect() -> ModelStreamEvent {
+        ModelStreamEvent::Error {
+            message: format!("{} connection reset", crate::llm::UPSTREAM_DISCONNECTED),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_succeeds_on_fifth_retry_without_consuming_turns() {
+        let mut scripts: Vec<_> = (0..5)
+            .map(|_| Script::Events(vec![ev_text("part "), ev_disconnect()]))
+            .collect();
+        scripts.push(Script::Events(vec![ev_text("done"), ev_stop()]));
+        let provider = ScriptedProvider::new(scripts);
+        let loop_ = Loop::new(provider.clone(), "mock").with_config(crate::types::AgentConfig {
+            max_turns: 1,
+            ..Default::default()
+        });
+        let events = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let saved = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let (text, messages) = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext {
+                    save_callback: Some({
+                        let saved = saved.clone();
+                        Arc::new(move |message| saved.lock().push(message.clone()))
+                    }),
+                    ..Default::default()
+                },
+                noop_on_text,
+                {
+                    let events = events.clone();
+                    move |event| events.lock().push(event)
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "part part part part part done");
+        assert_eq!(messages.len(), 7);
+        assert_eq!(saved.lock().len(), 6);
+        let requests = provider.requests.lock();
+        assert_eq!(requests.len(), 6, "initial request plus five retries");
+        for (attempt, request) in requests.iter().enumerate() {
+            assert_eq!(request.len(), attempt + 1 + usize::from(attempt > 0));
+            assert!(request
+                .iter()
+                .skip(1)
+                .take(attempt)
+                .all(|message| message.text() == "part "));
+            assert_eq!(request.last().unwrap().role, "user");
+        }
+        let times = provider.request_times.lock();
+        let delays: Vec<_> = times
+            .windows(2)
+            .map(|pair| (pair[1] - pair[0]).as_secs())
+            .collect();
+        assert_eq!(delays, vec![2, 4, 8, 16, 32]);
+        let lifecycle: Vec<_> = events
+            .lock()
+            .iter()
+            .filter_map(|event| match event {
+                RunEvent::StreamRetry {
+                    attempt,
+                    max_retries,
+                    delay_ms,
+                } => Some(format!("retry:{attempt}/{max_retries}:{delay_ms}")),
+                RunEvent::StreamResumed => Some("resumed".into()),
+                _ => None,
+            })
+            .collect();
+        let expected: Vec<_> = (1..=5)
+            .flat_map(|attempt| {
+                [
+                    format!("retry:{attempt}/5:{}", 2000_u64 << (attempt - 1)),
+                    "resumed".into(),
+                ]
+            })
+            .collect();
+        assert_eq!(lifecycle, expected);
+        {
+            let events = events.lock();
+            for (index, event) in events.iter().enumerate() {
+                if matches!(event, RunEvent::StreamResumed) {
+                    assert!(matches!(
+                        events[index + 1],
+                        RunEvent::Model(ModelStreamEvent::TextDelta { .. })
+                    ));
+                }
+            }
+        }
+        assert!(!events
+            .lock()
+            .iter()
+            .any(|event| matches!(event, RunEvent::Model(ModelStreamEvent::Error { .. }))));
+        assert!(!loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+        assert!(loop_.stream_truncation.lock().is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_does_not_resume_on_usage_or_eof_cleanup() {
+        let scripts = (0..6)
+            .map(|_| {
+                Script::Events(vec![
+                    ModelStreamEvent::Usage(Default::default()),
+                    ModelStreamEvent::ReasoningEnd {
+                        id: "r".into(),
+                        provider_metadata: Default::default(),
+                    },
+                    ev_disconnect(),
+                ])
+            })
+            .collect();
+        let loop_ = Loop::new(ScriptedProvider::new(scripts), "mock");
+        let events = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                {
+                    let events = events.clone();
+                    move |event| events.lock().push(event)
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        let events = events.lock();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, RunEvent::StreamRetry { .. }))
+                .count(),
+            5
+        );
+        assert!(!events.iter().any(|e| matches!(e, RunEvent::StreamResumed)));
+        assert!(matches!(
+            events.last(),
+            Some(RunEvent::Model(ModelStreamEvent::Error { .. }))
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_exhaustion_is_bounded_for_disconnects_and_bare_eof() {
+        for explicit_error in [true, false] {
+            let scripts = (0..6)
+                .map(|_| {
+                    let mut events = vec![ev_text("part")];
+                    if explicit_error {
+                        events.push(ev_disconnect());
+                    }
+                    Script::Events(events)
+                })
+                .collect();
+            let provider = ScriptedProvider::new(scripts);
+            let loop_ = Loop::new(provider.clone(), "mock");
+            let errors = Arc::new(parking_lot::Mutex::new(Vec::new()));
+            let (_, messages) = loop_
+                .run_streaming_with_messages(
+                    user_messages("hi"),
+                    &StreamContext::default(),
+                    noop_on_text,
+                    {
+                        let errors = errors.clone();
+                        move |event| {
+                            if let RunEvent::Model(ModelStreamEvent::Error { message }) = event {
+                                errors.lock().push(message);
+                            }
+                        }
+                    },
+                    None,
+                )
+                .await
+                .unwrap();
+            assert_eq!(provider.requests.lock().len(), 6);
+            assert_eq!(messages.len(), 7, "all partial replies survive exhaustion");
+            assert_eq!(errors.lock().len(), usize::from(explicit_error));
+            assert!(loop_
+                .stream_incomplete
+                .load(std::sync::atomic::Ordering::SeqCst));
+            assert_eq!(
+                loop_.stream_truncation.lock().as_ref().unwrap().detected_by,
+                if explicit_error {
+                    "upstream_disconnected"
+                } else {
+                    "eof_no_terminal"
+                }
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_preserves_executed_tools_and_skips_interrupted_calls() {
+        let provider = ScriptedProvider::new(vec![
+            Script::Events(vec![
+                ev_toolcall_start(0, "executed", "echo", "{}"),
+                ev_toolcall_end(),
+                ev_stop(),
+            ]),
+            // Even syntactically complete arguments must not be executed until
+            // the provider finishes this response successfully.
+            Script::Events(vec![
+                ev_toolcall_start(0, "skipped", "echo", "{}"),
+                ev_toolcall_end(),
+                ev_disconnect(),
+            ]),
+            Script::Events(vec![
+                ev_toolcall_start(0, "retried", "echo", "{}"),
+                ev_toolcall_end(),
+                ev_stop(),
+            ]),
+            Script::Events(vec![ev_text("done"), ev_stop()]),
+        ]);
+        let loop_ = Loop::new(provider.clone(), "mock").with_tools(vec![echo_tool()]);
+        let events = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let (text, _) = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                {
+                    let events = events.clone();
+                    move |event| events.lock().push(event)
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "done");
+        let requests = provider.requests.lock();
+        assert_eq!(requests.len(), 4);
+        let history = &requests[2];
+        assert_eq!(history.iter().filter(|m| m.role == "tool").count(), 2);
+        assert!(history[2].text().contains("echo:"));
+        assert!(history[4]
+            .text()
+            .contains("not executed due to connection interruption"));
+        let events = events.lock();
+        let executed: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                RunEvent::ToolExecutionStarted { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(executed, vec!["executed", "retried"]);
+        assert!(events.iter().any(|event| matches!(event,
+            RunEvent::ToolExecutionFinished { id, error: Some(_), .. } if id == "skipped")));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_budget_resets_only_after_a_successful_model_step() {
+        let mut scripts: Vec<_> = (0..5)
+            .map(|_| Script::Events(vec![ev_disconnect()]))
+            .collect();
+        scripts.push(Script::Events(vec![
+            ev_toolcall_start(0, "call", "echo", "{}"),
+            ev_toolcall_end(),
+            ev_stop(),
+        ]));
+        scripts.extend((0..5).map(|_| Script::Events(vec![ev_disconnect()])));
+        scripts.push(Script::Events(vec![ev_text("done"), ev_stop()]));
+        let provider = ScriptedProvider::new(scripts);
+        let loop_ = Loop::new(provider.clone(), "mock").with_tools(vec![echo_tool()]);
+        let (text, _) = loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "done");
+        assert_eq!(provider.requests.lock().len(), 12);
+        assert!(!loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_backoff_can_be_cancelled_by_channel_or_flag() {
+        for use_channel in [true, false] {
+            let provider = ScriptedProvider::new(vec![Script::Events(vec![
+                ev_text("partial"),
+                ev_disconnect(),
+            ])]);
+            let loop_ = Loop::new(provider.clone(), "mock");
+            let flag = loop_.interrupt_flag.clone();
+            let (tx, rx) = mpsc::channel(1);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                if use_channel {
+                    tx.send(()).await.unwrap();
+                } else {
+                    flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+            });
+            let events = Arc::new(parking_lot::Mutex::new(Vec::new()));
+            let start = tokio::time::Instant::now();
+            let (_, messages) = loop_
+                .run_streaming_with_messages(
+                    user_messages("hi"),
+                    &StreamContext::default(),
+                    noop_on_text,
+                    {
+                        let events = events.clone();
+                        move |event| events.lock().push(event)
+                    },
+                    if use_channel { Some(rx) } else { None },
+                )
+                .await
+                .unwrap();
+            assert!(start.elapsed() < Duration::from_secs(2));
+            assert_eq!(provider.requests.lock().len(), 1);
+            assert_eq!(messages[1].text(), "partial");
+            assert!(matches!(
+                events.lock().last(),
+                Some(RunEvent::StreamRetry { attempt: 1, .. })
+            ));
+            assert!(!events
+                .lock()
+                .iter()
+                .any(|event| matches!(event, RunEvent::StreamResumed)));
+            assert!(!loop_
+                .stream_incomplete
+                .load(std::sync::atomic::Ordering::SeqCst));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_keeps_reported_cost_from_interrupted_attempts() {
+        let usage = |cost| {
+            ModelStreamEvent::Usage(crate::types::Usage {
+                credit_cost: Some(cost),
+                ..Default::default()
+            })
+        };
+        let provider = ScriptedProvider::new(vec![
+            Script::Events(vec![usage(1.0), usage(2.0), ev_disconnect()]),
+            Script::Events(vec![ev_text("done"), usage(0.5), ev_stop()]),
+        ]);
+        let loop_ = Loop::new(provider, "mock");
+        loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*loop_.cumulative_cost.lock(), 2.5);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stream_retry_honors_disabled_auto_retry() {
+        let provider = ScriptedProvider::new(vec![Script::Events(vec![ev_disconnect()])]);
+        let loop_ = Loop::new(provider.clone(), "mock").with_config(crate::types::AgentConfig {
+            max_retries: 0,
+            ..Default::default()
+        });
+        loop_
+            .run_streaming_with_messages(
+                user_messages("hi"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(provider.requests.lock().len(), 1);
+        assert!(loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3808,7 +4322,10 @@ mod tests {
         let provider = ScriptedProvider::new(vec![Script::Events(vec![ev_toolcall_start(
             0, "t1", "echo", "{}",
         )])]);
-        let loop_ = Loop::new(provider, "mock");
+        let loop_ = Loop::new(provider, "mock").with_config(crate::types::AgentConfig {
+            max_retries: 0,
+            ..Default::default()
+        });
         loop_
             .run_streaming_with_messages(
                 user_messages("hi"),

--- a/agent/src/llm/adapters/anthropic.rs
+++ b/agent/src/llm/adapters/anthropic.rs
@@ -419,11 +419,17 @@ fn lower_messages(request: &ModelRequest) -> Result<Vec<Value>> {
                     }
                 }
                 ContentBlock::ToolCall { id, name, args, .. } => {
+                    let input = parse_json_arguments(&args);
+                    // Interrupted calls can retain a partial JSON string or
+                    // null in history. Anthropic requires an object even for
+                    // calls paired with a skipped result. Normalize only the
+                    // wire projection; keep the original arguments for display.
+                    let input = if input.is_object() { input } else { json!({}) };
                     assistant.push(json!({
                         "type": "tool_use",
                         "id": id,
                         "name": name,
-                        "input": parse_json_arguments(&args),
+                        "input": input,
                     }));
                 }
                 ContentBlock::ToolResult {
@@ -686,6 +692,41 @@ mod tests {
         assert_eq!(messages[0]["content"][1]["type"], "tool_use");
         assert_eq!(messages[1]["role"], "user");
         assert_eq!(messages[1]["content"][0]["type"], "tool_result");
+    }
+
+    #[test]
+    fn tool_input_projection_requires_objects_without_mutating_history() {
+        for (args, expected) in [
+            (Value::Null, json!({})),
+            (json!("{\"command\":"), json!({})),
+            (json!(""), json!({})),
+            (json!([]), json!({})),
+            (json!("null"), json!({})),
+            (json!("{\"q\":\"rust\"}"), json!({"q": "rust"})),
+            (json!({"q": "rust"}), json!({"q": "rust"})),
+        ] {
+            let request = ModelRequest {
+                model: "claude".into(),
+                system_prompt: String::new(),
+                messages: vec![crate::types::AgentMessage {
+                    role: "assistant".into(),
+                    content: vec![ContentBlock::tool_call(
+                        "tool_1",
+                        "lookup",
+                        args.clone(),
+                        ProviderMetadata::new(),
+                    )],
+                    ..Default::default()
+                }],
+                tools: Vec::new(),
+            };
+            let messages = lower_messages(&request).unwrap();
+            assert_eq!(messages[0]["content"][0]["input"], expected);
+            assert!(matches!(
+                &request.messages[0].content[0],
+                ContentBlock::ToolCall { args: preserved, .. } if preserved == &args
+            ));
+        }
     }
 
     #[test]

--- a/agent/src/llm/adapters/openai_responses.rs
+++ b/agent/src/llm/adapters/openai_responses.rs
@@ -448,6 +448,15 @@ impl ProtocolAdapter for OpenAiResponsesAdapter {
         if state.finished {
             return Ok(Vec::new());
         }
+        // These items never received output_item.done. Keep their display
+        // content, but do not replay unfinished provider-owned state on retry.
+        // Completed reasoning (including encrypted_content) was emitted earlier.
+        for reasoning in state.reasoning_open.values_mut() {
+            reasoning.provider_id = None;
+        }
+        for tool in state.tools.values_mut() {
+            tool.item_id.clear();
+        }
         let mut events = close_open(state);
         events.push(ModelStreamEvent::Finish {
             reason: FinishReason::Incomplete,
@@ -2257,7 +2266,8 @@ mod tests {
         let events = adapter.finish_stream(state.as_mut()).unwrap();
         assert!(events.iter().any(|e| matches!(
             e,
-            ModelStreamEvent::ReasoningEnd { id, .. } if id == "rs_1"
+            ModelStreamEvent::ReasoningEnd { id, provider_metadata }
+                if id == "rs_1" && provider_metadata["openai"].get("id").is_none()
         )));
         assert!(events.iter().any(|e| matches!(
             e,

--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -340,6 +340,7 @@ impl crate::types::LLMProvider for Client {
             // after that finish_reason, and token accounting would be lost if
             // the byte-stream pump stopped at Finish instead of `[DONE]`.
             let mut protocol_terminal = false;
+            let mut transport_error = None;
             loop {
                 let next = tokio::select! {
                     _ = tx.closed() => return,
@@ -386,14 +387,13 @@ impl crate::types::LLMProvider for Client {
                             cause_chain = %causes,
                             "LLM response stream disconnected"
                         );
-                        let _ = tx
-                            .send(schema::ModelStreamEvent::Error {
-                                message: format!(
-                                    "{UPSTREAM_DISCONNECTED} {error}; {progress}, causes={causes}"
-                                ),
-                            })
-                            .await;
-                        return;
+                        // Use the same adapter cleanup as clean EOF before
+                        // reporting the disconnect. Otherwise unfinished tool
+                        // item ids leak into the retry's request history.
+                        transport_error = Some(format!(
+                            "{UPSTREAM_DISCONNECTED} {error}; {progress}, causes={causes}"
+                        ));
+                        break;
                     }
                     None => break,
                 };
@@ -445,15 +445,22 @@ impl crate::types::LLMProvider for Client {
                 }
             }
 
-            let frames = match decoder.finish() {
-                Ok(frames) => frames,
-                Err(error) => {
-                    let _ = tx
-                        .send(schema::ModelStreamEvent::Error {
-                            message: format!("{MODEL_RESPONSE_ERROR} {error:#}"),
-                        })
-                        .await;
-                    return;
+            // Only clean EOF can flush an unterminated SSE frame. After a
+            // transport error the buffered tail may be cut mid-JSON/UTF-8; do
+            // not decode it or turn a retryable disconnect into a parse error.
+            let frames = if transport_error.is_some() {
+                Vec::new()
+            } else {
+                match decoder.finish() {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        let _ = tx
+                            .send(schema::ModelStreamEvent::Error {
+                                message: format!("{MODEL_RESPONSE_ERROR} {error:#}"),
+                            })
+                            .await;
+                        return;
+                    }
                 }
             };
             frames_decoded = frames_decoded.saturating_add(frames.len() as u64);
@@ -483,21 +490,23 @@ impl crate::types::LLMProvider for Client {
                 }
             }
             if !protocol_terminal {
-                tracing::warn!(
-                    protocol = %protocol,
-                    model = %model,
-                    status = response_status,
-                    chunks_received,
-                    bytes_received,
-                    frames_decoded,
-                    elapsed_ms = started_at.elapsed().as_millis() as u64,
-                    "LLM response stream reached EOF before a terminal event"
-                );
+                if transport_error.is_none() {
+                    tracing::warn!(
+                        protocol = %protocol,
+                        model = %model,
+                        status = response_status,
+                        chunks_received,
+                        bytes_received,
+                        frames_decoded,
+                        elapsed_ms = started_at.elapsed().as_millis() as u64,
+                        "LLM response stream reached EOF before a terminal event"
+                    );
+                }
                 match adapter.finish_stream(state.as_mut()) {
                     Ok(events) => {
                         for event in events {
-                            // EOF is a transport interruption, not a provider-declared
-                            // incomplete response (e.g. an exhausted output budget).
+                            // EOF/errors are transport interruptions, not provider-declared
+                            // incomplete responses (e.g. an exhausted output budget).
                             // Keep the adapter's closing blocks, but make the missing
                             // terminal frame distinguishable for stream retries.
                             let event = if let schema::ModelStreamEvent::Finish { usage, .. } =
@@ -513,10 +522,10 @@ impl crate::types::LLMProvider for Client {
                                     }
                                 }
                                 schema::ModelStreamEvent::Error {
-                                    message: format!(
+                                    message: transport_error.clone().unwrap_or_else(|| format!(
                                         "{UPSTREAM_DISCONNECTED} stream ended before a terminal event; {}",
                                         stream_progress("eof", chunks_received, bytes_received, frames_decoded, started_at),
-                                    ),
+                                    )),
                                 }
                             } else {
                                 event
@@ -1295,6 +1304,152 @@ mod tests {
             Some(schema::ModelStreamEvent::Error { message })
                 if message.starts_with(UPSTREAM_DISCONNECTED) && message.contains("kind=eof")
         ));
+    }
+
+    #[tokio::test]
+    async fn responses_transport_error_cleans_unfinished_items_before_retry() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            use std::io::{BufRead, BufReader, Read, Write};
+            let mut requests = Vec::new();
+            for attempt in 0..2 {
+                let (socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+                    .unwrap();
+                let mut reader = BufReader::new(socket);
+                let mut length = 0;
+                loop {
+                    let mut line = String::new();
+                    assert!(reader.read_line(&mut line).unwrap() > 0);
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        length = value.trim().parse::<usize>().unwrap();
+                    }
+                }
+                let mut body = vec![0; length];
+                reader.read_exact(&mut body).unwrap();
+                requests.push(serde_json::from_slice::<Value>(&body).unwrap());
+                let mut socket = reader.into_inner();
+                let body = if attempt == 0 {
+                    concat!(
+                        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_done\",\"summary\":[],\"encrypted_content\":\"cipher\"}}\n\n",
+                        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_partial\"}}\n\n",
+                        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":1,\"item_id\":\"rs_partial\",\"summary_index\":0,\"delta\":\"thinking\"}\n\n",
+                        "data: {\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"id\":\"fc_unfinished\",\"call_id\":\"call_1\",\"name\":\"echo\"}}\n\n",
+                        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":2,\"delta\":\"{}\"}\n\n",
+                        // Broken buffered SSE must not mask the transport error.
+                        "data: {\"type\":",
+                    )
+                } else {
+                    concat!(
+                        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"done\"}\n\n",
+                        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n",
+                    )
+                };
+                // Closing with a short body produces a reqwest transport error,
+                // not the clean EOF covered by the other retry integration test.
+                let length = body.len() + if attempt == 0 { 100 } else { 0 };
+                write!(socket, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {length}\r\nConnection: close\r\n\r\n{body}").unwrap();
+            }
+            requests
+        });
+        let client = Client::from_target(protocol_target(
+            &format!("http://127.0.0.1:{port}"),
+            schema::ProtocolConfig::OpenAiResponses(Default::default()),
+        ));
+        let loop_ = crate::agent::Loop::new(std::sync::Arc::new(client), "mock");
+        assert_eq!(
+            loop_.run_streaming("hi".into(), |_| {}).await.unwrap(),
+            "done"
+        );
+        let requests = server.join().unwrap();
+        let input = requests[1]["input"].as_array().unwrap();
+        let tool = input
+            .iter()
+            .find(|item| item["type"] == "function_call")
+            .unwrap();
+        assert!(tool.get("id").is_none(), "unfinished item replayed: {tool}");
+        assert_eq!(tool["call_id"], "call_1");
+        assert!(input
+            .iter()
+            .any(|item| item["type"] == "function_call_output" && item["call_id"] == "call_1"));
+        let reasoning: Vec<_> = input
+            .iter()
+            .filter(|item| item["type"] == "reasoning")
+            .collect();
+        assert_eq!(reasoning.len(), 1, "only completed reasoning is replayable");
+        assert_eq!(reasoning[0]["id"], "rs_done");
+        assert_eq!(reasoning[0]["encrypted_content"], "cipher");
+        assert!(!loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn anthropic_retry_projects_partial_tool_arguments_as_an_object() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let server = mock_server(move |_| {
+            let body = if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                concat!(
+                    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"echo\",\"input\":{}}}\n\n",
+                    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\"}}\n\n",
+                )
+            } else {
+                concat!(
+                    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+                    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"done\"}}\n\n",
+                    "data: {\"type\":\"message_stop\"}\n\n",
+                )
+            };
+            (200, "text/event-stream", body.to_string())
+        });
+        let client = Client::from_target(protocol_target(
+            &server.base_url,
+            schema::ProtocolConfig::AnthropicMessages(Default::default()),
+        ));
+        let loop_ = crate::agent::Loop::new(std::sync::Arc::new(client), "mock");
+        let (text, history) = loop_
+            .run_streaming_with_messages(
+                canonical_request().messages,
+                &crate::agent::StreamContext::default(),
+                |_| {},
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "done");
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let retry: Value = serde_json::from_str(&requests[1]).unwrap();
+        let blocks: Vec<_> = retry["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|message| message["content"].as_array().unwrap())
+            .collect();
+        let tool = blocks
+            .iter()
+            .find(|block| block["type"] == "tool_use")
+            .unwrap();
+        assert_eq!(tool["input"], serde_json::json!({}));
+        let result = blocks
+            .iter()
+            .find(|block| block["type"] == "tool_result")
+            .unwrap();
+        assert_eq!(result["tool_use_id"], tool["id"]);
+        assert!(result["content"].as_str().unwrap().contains("not executed"));
+        assert!(history.iter().flat_map(|message| &message.content).any(|block| matches!(
+            block,
+            crate::types::ContentBlock::ToolCall { args, .. } if args == &serde_json::json!("{\"command\":")
+        )), "wire normalization must not erase the original partial arguments");
+        assert!(!loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/agent/src/llm/mod.rs
+++ b/agent/src/llm/mod.rs
@@ -20,7 +20,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::info;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 1800;
-const UPSTREAM_DISCONNECTED: &str = "[UPSTREAM_DISCONNECTED]";
+pub(crate) const UPSTREAM_DISCONNECTED: &str = "[UPSTREAM_DISCONNECTED]";
 const MODEL_RESPONSE_ERROR: &str = "[MODEL_RESPONSE_ERROR]";
 
 fn reqwest_stream_error_kind(error: &reqwest::Error) -> &'static str {
@@ -355,6 +355,14 @@ impl crate::types::LLMProvider for Client {
                         bytes
                     }
                     Some(Err(error)) => {
+                        // Chat may still be waiting for usage after finish_reason.
+                        // Losing that accounting tail must not replay a response
+                        // the provider already completed (and its tool calls).
+                        if protocol_terminal {
+                            tracing::warn!(protocol = %protocol, model = %model, error = %error,
+                                "LLM stream disconnected after terminal event");
+                            return;
+                        }
                         let kind = reqwest_stream_error_kind(&error);
                         let causes = error_source_chain(&error);
                         let progress = stream_progress(
@@ -488,6 +496,31 @@ impl crate::types::LLMProvider for Client {
                 match adapter.finish_stream(state.as_mut()) {
                     Ok(events) => {
                         for event in events {
+                            // EOF is a transport interruption, not a provider-declared
+                            // incomplete response (e.g. an exhausted output budget).
+                            // Keep the adapter's closing blocks, but make the missing
+                            // terminal frame distinguishable for stream retries.
+                            let event = if let schema::ModelStreamEvent::Finish { usage, .. } =
+                                event
+                            {
+                                if let Some(usage) = usage {
+                                    if tx
+                                        .send(schema::ModelStreamEvent::Usage(usage))
+                                        .await
+                                        .is_err()
+                                    {
+                                        return;
+                                    }
+                                }
+                                schema::ModelStreamEvent::Error {
+                                    message: format!(
+                                        "{UPSTREAM_DISCONNECTED} stream ended before a terminal event; {}",
+                                        stream_progress("eof", chunks_received, bytes_received, frames_decoded, started_at),
+                                    ),
+                                }
+                            } else {
+                                event
+                            };
                             if tx.send(event).await.is_err() {
                                 return;
                             }
@@ -1238,7 +1271,7 @@ mod tests {
     async fn stream_model_flushes_buffered_frame_on_clean_eof() {
         // No trailing blank line: the final SSE frame is only flushed by
         // `decoder.finish()` once the upstream stream ends without a terminal
-        // event, and `finish_stream` then emits an incomplete finish.
+        // event, and the missing terminal frame is reported as a disconnect.
         let server = mock_server(|_| {
             (
                 200,
@@ -1259,11 +1292,129 @@ mod tests {
         )));
         assert!(matches!(
             events.last(),
-            Some(schema::ModelStreamEvent::Finish {
-                reason: schema::FinishReason::Incomplete,
-                ..
-            })
+            Some(schema::ModelStreamEvent::Error { message })
+                if message.starts_with(UPSTREAM_DISCONNECTED) && message.contains("kind=eof")
         ));
+    }
+
+    #[tokio::test]
+    async fn responses_disconnect_retries_with_partial_history_over_http() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let server = mock_server(move |_| {
+            let body = if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                concat!(
+                    "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_partial\"}}\n\n",
+                    "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"item_id\":\"rs_partial\",\"summary_index\":0,\"delta\":\"thinking\"}\n\n",
+                    "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"part \"}\n\n",
+                )
+            } else {
+                concat!(
+                    "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"done\"}\n\n",
+                    "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n",
+                )
+            };
+            (200, "text/event-stream", body.to_string())
+        });
+        let client = Client::from_target(protocol_target(
+            &server.base_url,
+            schema::ProtocolConfig::OpenAiResponses(Default::default()),
+        ));
+        let loop_ = crate::agent::Loop::new(std::sync::Arc::new(client), "mock");
+        let text = loop_.run_streaming("hi".into(), |_| {}).await.unwrap();
+        assert_eq!(text, "part done");
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let retry: Value = serde_json::from_str(&requests[1]).unwrap();
+        let input = retry["input"].as_array().unwrap();
+        assert!(
+            !input.iter().any(|item| item["type"] == "reasoning"),
+            "unfinished reasoning must not be replayed as a provider-owned item"
+        );
+        assert_eq!(input.last().unwrap()["role"], "user");
+        let partial = &input[input.len() - 2];
+        assert_eq!(partial["role"], "assistant");
+        assert_eq!(partial["content"][0]["text"], "part ");
+        assert!(!loop_
+            .stream_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn stream_model_eof_is_retryable_for_every_protocol() {
+        for protocol in [
+            schema::ProtocolConfig::OpenAiResponses(Default::default()),
+            schema::ProtocolConfig::OpenAiChat(Default::default()),
+            schema::ProtocolConfig::AnthropicMessages(Default::default()),
+        ] {
+            let server = mock_server(|_| (200, "text/event-stream", ": heartbeat\n\n".into()));
+            let client = Client::from_target(protocol_target(&server.base_url, protocol));
+            let events: Vec<_> = client
+                .stream_model(canonical_request())
+                .await
+                .unwrap()
+                .collect()
+                .await;
+            assert!(
+                matches!(events.last(), Some(schema::ModelStreamEvent::Error { message })
+                if message.starts_with(UPSTREAM_DISCONNECTED))
+            );
+            assert!(!events
+                .iter()
+                .any(|event| matches!(event, schema::ModelStreamEvent::Finish { .. })));
+        }
+    }
+
+    #[tokio::test]
+    async fn chat_disconnect_after_finish_does_not_retry_a_completed_response() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            use std::io::{BufRead, BufReader, Read, Write};
+            let (socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+                .unwrap();
+            let mut reader = BufReader::new(socket);
+            let mut length = 0;
+            loop {
+                let mut line = String::new();
+                assert!(reader.read_line(&mut line).unwrap() > 0);
+                if line == "\r\n" {
+                    break;
+                }
+                if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    length = value.trim().parse::<usize>().unwrap();
+                }
+            }
+            reader.read_exact(&mut vec![0; length]).unwrap();
+            let mut socket = reader.into_inner();
+            let body = "data: {\"choices\":[{\"delta\":{\"content\":\"done\"},\"finish_reason\":\"stop\"}]}\n\n";
+            // HTTP is truncated, but the model's terminal frame arrived intact.
+            write!(socket, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len() + 100).unwrap();
+        });
+        let client = Client::from_target(chat_target(
+            &format!("http://127.0.0.1:{port}"),
+            "secret",
+            None,
+            None,
+        ));
+        let events: Vec<_> = client
+            .stream_model(canonical_request())
+            .await
+            .unwrap()
+            .collect()
+            .await;
+        server.join().unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            schema::ModelStreamEvent::Finish {
+                reason: schema::FinishReason::Stop,
+                ..
+            }
+        )));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, schema::ModelStreamEvent::Error { .. })));
     }
 
     #[tokio::test]

--- a/agent/src/llm/stream_wait_tests.rs
+++ b/agent/src/llm/stream_wait_tests.rs
@@ -199,10 +199,11 @@ async fn total_request_deadline_still_ends_a_silent_http_stream() {
     let events: Vec<_> = tokio::time::timeout(Duration::from_secs(2), stream.collect())
         .await
         .unwrap();
-    assert!(
-        matches!(events.as_slice(), [ModelStreamEvent::Error { message }]
-        if message.contains("kind=timeout") && !message.contains("idle_timeout"))
-    );
+    assert!(matches!(events.as_slice(), [
+            ModelStreamEvent::ReasoningEnd { provider_metadata, .. },
+            ModelStreamEvent::Error { message },
+        ] if provider_metadata["openai"].get("id").is_none()
+            && message.contains("kind=timeout") && !message.contains("idle_timeout")));
     tokio::time::timeout(Duration::from_secs(2), server)
         .await
         .unwrap()

--- a/agent/src/rpc/prompt_helpers.rs
+++ b/agent/src/rpc/prompt_helpers.rs
@@ -19,6 +19,23 @@ pub(super) fn run_event_to_sse(event: crate::agent::RunEvent) -> Option<super::S
                 ("type", serde_json::json!("agent_start")),
             ]),
         ),
+        RunEvent::StreamRetry {
+            attempt,
+            max_retries,
+            delay_ms,
+        } => (
+            "stream_retry",
+            ordered_data([
+                ("type", serde_json::json!("stream_retry")),
+                ("attempt", serde_json::json!(attempt)),
+                ("maxRetries", serde_json::json!(max_retries)),
+                ("delayMs", serde_json::json!(delay_ms)),
+            ]),
+        ),
+        RunEvent::StreamResumed => (
+            "stream_resumed",
+            ordered_data([("type", serde_json::json!("stream_resumed"))]),
+        ),
         RunEvent::CompactionStarted {
             operation_id,
             trigger,
@@ -426,6 +443,20 @@ mod tests {
     #[test]
     fn typed_run_events_preserve_public_wire_shapes() {
         let fixtures = [
+            (
+                RunEvent::StreamRetry {
+                    attempt: 1,
+                    max_retries: 5,
+                    delay_ms: 2000,
+                },
+                "stream_retry",
+                r#"{"type":"stream_retry","attempt":1,"maxRetries":5,"delayMs":2000}"#,
+            ),
+            (
+                RunEvent::StreamResumed,
+                "stream_resumed",
+                r#"{"type":"stream_resumed"}"#,
+            ),
             (
                 RunEvent::AgentStart { started_at_ms: 42 },
                 "agent_start",

--- a/agent/src/rpc/protocol.rs
+++ b/agent/src/rpc/protocol.rs
@@ -1763,6 +1763,50 @@ mod tests {
     }
 
     #[test]
+    fn projection_preserves_reconnect_lifecycle_beyond_replay_ring() {
+        let broadcaster = SseBroadcaster::new();
+        broadcaster.start_run("run-retry".to_string(), 1);
+        broadcaster.broadcast(SseEvent::new(
+            "stream_retry",
+            serde_json::json!({
+                "type": "stream_retry", "attempt": 1, "maxRetries": 5, "delayMs": 2000
+            }),
+        ));
+        broadcaster.broadcast(SseEvent::new(
+            "stream_resumed",
+            serde_json::json!({"type": "stream_resumed"}),
+        ));
+        for _ in 0..2100 {
+            broadcaster.broadcast(SseEvent::new(
+                "text_chunk",
+                serde_json::json!({"text": "a"}),
+            ));
+        }
+        broadcaster.broadcast(SseEvent::new(
+            "stream_retry",
+            serde_json::json!({
+                "type": "stream_retry", "attempt": 2, "maxRetries": 5, "delayMs": 4000
+            }),
+        ));
+        let projection = broadcaster
+            .attach("run-retry", 0)
+            .unwrap()
+            .projection
+            .unwrap();
+        let lifecycle: Vec<_> = projection
+            .events
+            .iter()
+            .filter(|e| e.event_type.starts_with("stream_"))
+            .collect();
+        assert_eq!(lifecycle.len(), 3);
+        assert_eq!(lifecycle[0].event_type, "stream_retry");
+        assert_eq!(lifecycle[1].event_type, "stream_resumed");
+        assert_eq!(lifecycle[2].event_type, "stream_retry");
+        let payload: serde_json::Value = serde_json::from_str(&lifecycle[2].data).unwrap();
+        assert_eq!(payload["attempt"], 2);
+    }
+
+    #[test]
     fn projection_skips_raw_text_deltas() {
         let mut projection = Vec::new();
         apply_to_projection(

--- a/desktop/src/features/agent/MessageBlock.reconnecting.test.tsx
+++ b/desktop/src/features/agent/MessageBlock.reconnecting.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import type { AgentMessage } from "@future-os/thread-projection";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+import i18n from "../../i18n";
+import { MessageBlock } from "./MessageBlock";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+it.each(["en", "zh"])("shows reconnect attempts visibly in %s and clears on resume or termination", async (language) => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const base: AgentMessage = {
+    id: "retry-message",
+    role: "assistant",
+    authorKey: "author.researchCopilot",
+    content: "",
+    createdAt: new Date().toISOString(),
+    status: "streaming",
+  };
+  const render = async (patch: Partial<AgentMessage>) => {
+    await act(async () => root.render(<MessageBlock message={{ ...base, ...patch }} hovered={false} onHover={vi.fn()} onLeave={vi.fn()} />));
+  };
+  try {
+    await act(async () => {
+      await i18n.changeLanguage(language);
+    });
+    for (const attempt of [1, 5]) {
+      await render({ reconnecting: { attempt, maxRetries: 5, delayMs: 2000 } });
+      const label = language === "zh" ? `正在重连 ${attempt}/5` : `Reconnecting ${attempt}/5`;
+      const status = container.querySelector("[role=\"status\"]");
+      expect(status?.textContent).toBe(label);
+      expect(status?.getAttribute("aria-label")).toBe(label);
+    }
+    await render({});
+    expect(container.querySelector("[role=\"status\"]")?.textContent).toBe("");
+    expect(container.querySelector("[role=\"status\"]")?.getAttribute("aria-label")).toBe(i18n.t("agent:message.generating"));
+    for (const status of ["complete", "failed"] as const) {
+      await render({ status, reconnecting: { attempt: 5, maxRetries: 5, delayMs: 32000 } });
+      expect(container.querySelector("[role=\"status\"]")).toBeNull();
+      expect(container.textContent).not.toContain("5/5");
+    }
+  }
+  finally {
+    act(() => root.unmount());
+    container.remove();
+    await i18n.changeLanguage("en");
+  }
+});

--- a/desktop/src/features/agent/MessageBlock.tsx
+++ b/desktop/src/features/agent/MessageBlock.tsx
@@ -267,7 +267,14 @@ function MessageBlockImpl({
         </div>
         <div className={cn("flex items-center gap-2", isUser ? "mt-1 justify-end" : "mt-3")}>
           {streaming
-            ? <StreamingIndicator label={t("message.generating")} />
+            ? (
+                <StreamingIndicator
+                  label={message.reconnecting
+                    ? t("message.reconnecting", { attempt: message.reconnecting.attempt, maxRetries: message.reconnecting.maxRetries })
+                    : t("message.generating")}
+                  showLabel={Boolean(message.reconnecting)}
+                />
+              )
             : copyableText
               ? (
                   <CopyButton
@@ -404,15 +411,16 @@ function CompactionDivider({
 /**
  * Live "generating" marker shown in place of the copy button while a reply
  * streams: a small amber dot with a pulsing ping halo (no brain icon — the
- * motion is the signal). `label` is exposed to assistive tech only.
+ * motion is the signal). Reconnect status also gets a visible label.
  */
-function StreamingIndicator({ label }: { label: string }) {
+function StreamingIndicator({ label, showLabel }: { label: string; showLabel: boolean }) {
   return (
-    <div aria-label={label} className="flex items-center px-1 py-1.5" role="status">
+    <div aria-label={label} className="flex items-center gap-2 px-1 py-1.5" role="status">
       <span className="relative flex size-2">
         <span className="absolute inline-flex size-full animate-ping rounded-full bg-generating opacity-75" />
         <span className="relative inline-flex size-2 rounded-full bg-generating" />
       </span>
+      {showLabel ? <span className="text-xs text-ink-muted">{label}</span> : null}
     </div>
   );
 }

--- a/desktop/src/features/agent/agentActivity.test.ts
+++ b/desktop/src/features/agent/agentActivity.test.ts
@@ -610,3 +610,55 @@ describe("buildAssistantRunProjection edge branches", () => {
     expect(projection.activityItems[0]?.status).toBe("failed");
   });
 });
+
+describe("stream reconnect lifecycle", () => {
+  const retry = { attempt: 1, maxRetries: 5, delayMs: 2000 };
+
+  it("replays and incrementally updates retries without changing answer text", () => {
+    const log = events([
+      ["text_chunk", { text: "partial" }],
+      ["stream_retry", retry],
+      ["stream_resumed", {}],
+      ["stream_retry", { ...retry, attempt: 2, delayMs: 4000 }],
+      ["stream_resumed", {}],
+      ["text_chunk", { text: " done" }],
+    ]);
+    const projector = createRunProjector();
+    expect(projector.ingest(log.slice(0, 2))).toMatchObject({ content: "partial", reconnecting: retry });
+    expect(projector.ingest(log.slice(1, 4)).reconnecting).toEqual({ ...retry, attempt: 2, delayMs: 4000 });
+    expect(projector.ingest(log.slice(4))).toEqual(buildAssistantRunProjection(log));
+    expect(projector.ingest([]).reconnecting).toBeUndefined();
+    expect(projector.ingest([]).content).toBe("partial done");
+  });
+
+  it.each([
+    ["stream_resumed", {}],
+    ["error", { message: "failed" }],
+    ["agent_end", { reason: "incomplete" }],
+    ["agent_end", { state: "cancelled" }],
+    ["agent_end", {}],
+  ] as Array<[string, Record<string, unknown>]>)("clears retry state on %s (%j)", (type, payload) => {
+    expect(buildAssistantRunProjection(events([["stream_retry", retry], [type, payload]])).reconnecting).toBeUndefined();
+  });
+
+  it("does not treat usage or cleanup as restored connectivity or leak across runs", () => {
+    const projector = createRunProjector();
+    expect(projector.ingest(events([
+      ["stream_retry", retry],
+      ["usage", {}],
+      ["thinking_end", {}],
+    ])).reconnecting).toEqual(retry);
+    expect(createRunProjector().ingest([]).reconnecting).toBeUndefined();
+  });
+
+  it.each([
+    {},
+    { ...retry, attempt: 0 },
+    { ...retry, attempt: 6 },
+    { ...retry, attempt: "1" },
+    { ...retry, maxRetries: 1.5 },
+    { ...retry, delayMs: -1 },
+  ])("ignores invalid retry payload %j", (payload) => {
+    expect(buildAssistantRunProjection(events([["stream_retry", payload]])).reconnecting).toBeUndefined();
+  });
+});

--- a/desktop/src/features/agent/threadRunProjection.async.test.ts
+++ b/desktop/src/features/agent/threadRunProjection.async.test.ts
@@ -222,11 +222,12 @@ describe("updatePendingMessageFromRunEvents", () => {
     expect(setMessages).not.toHaveBeenCalled();
   });
 
-  it("returns early when nothing is renderable yet", async () => {
+  it("keeps state unchanged when nothing is renderable yet", async () => {
     listRunEventsSince.mockResolvedValue([]);
-    const { setMessages } = collect([]);
+    const initial = [message("pending")];
+    const { setMessages, state } = collect(initial);
     await updatePendingMessageFromRunEvents("r-p2", "pending", setMessages);
-    expect(setMessages).not.toHaveBeenCalled();
+    expect(state()).toBe(initial);
   });
 
   it("updates the pending bubble in place and ignores a missing bubble", async () => {
@@ -310,5 +311,41 @@ describe("applyRunMetadata run lookup", () => {
     const messages = [userMessage("u1"), message("a1", { runId: "missing-run", content: "x" })];
     const result = applyRunMetadata(messages, [otherRun]);
     expect(result[1]).toMatchObject({ runId: "missing-run" });
+  });
+});
+
+describe("reconnect-only live previews", () => {
+  const retry = { attempt: 1, maxRetries: 5, delayMs: 2000 };
+
+  it("shows retry state on reattach before any answer text exists", async () => {
+    listRunEventsSince.mockResolvedValue(runEvents("retry-attach", [["stream_retry", retry]]));
+    expect(await buildStreamingPreview("retry-attach")).toMatchObject({
+      content: "",
+      status: "streaming",
+      reconnecting: retry,
+    });
+    listRunEventsSince.mockResolvedValue([]);
+    expect(await buildStreamingPreview("retry-other-run")).toBeNull();
+  });
+
+  it("updates and clears an empty pending bubble", async () => {
+    const pending = collect([message("pending", { status: "streaming" })]);
+    listRunEventsSince.mockResolvedValue(runEvents("retry-pending", [["stream_retry", retry]]));
+    await updatePendingMessageFromRunEvents("retry-pending", "pending", pending.setMessages);
+    expect(pending.state()[0]?.reconnecting).toEqual(retry);
+    listRunEventsSince.mockResolvedValue(runEvents("retry-pending", [["stream_resumed", {}]], 1));
+    await updatePendingMessageFromRunEvents("retry-pending", "pending", pending.setMessages);
+    expect(pending.state()[0]?.reconnecting).toBeUndefined();
+    expect(pending.state()[0]?.content).toBe("");
+  });
+
+  it("clears the reattached bubble on cancellation with no text", async () => {
+    const live = collect([]);
+    listRunEventsSince.mockResolvedValue(runEvents("retry-cancel", [["stream_retry", retry]]));
+    await upsertStreamingPreview("retry-cancel", null, live.setMessages);
+    expect(live.state()[0]?.reconnecting).toEqual(retry);
+    listRunEventsSince.mockResolvedValue(runEvents("retry-cancel", [["agent_end", { state: "cancelled" }]], 1));
+    await upsertStreamingPreview("retry-cancel", null, live.setMessages);
+    expect(live.state()[0]?.reconnecting).toBeUndefined();
   });
 });

--- a/desktop/src/features/agent/threadRunProjection.ts
+++ b/desktop/src/features/agent/threadRunProjection.ts
@@ -235,6 +235,7 @@ export async function upsertStreamingPreview(
         segments: projection.segments,
         content: content || base[existingIndex]!.content,
         thinkingActive: projection.thinkingActive,
+        reconnecting: projection.reconnecting,
         outputTokens: projection.outputTokens,
       };
       // Replace in place — the old filter+append moved the bubble to the
@@ -271,6 +272,7 @@ export async function buildStreamingPreview(
     !projection.content.trim()
     && projection.activityItems.length === 0
     && projection.segments.length === 0
+    && !projection.reconnecting
   ) {
     return null;
   }
@@ -293,6 +295,7 @@ function streamingBubble(
     activityItems: projection.activityItems,
     segments: projection.segments,
     thinkingActive: projection.thinkingActive,
+    reconnecting: projection.reconnecting,
     outputTokens: projection.outputTokens,
     // Feed MessageMeta's live elapsed timer so a re-attached run keeps
     // ticking instead of dropping its duration stat on switch-back.
@@ -312,23 +315,24 @@ export async function updatePendingMessageFromRunEvents(
     if (!projection)
       return;
 
-    // Nothing renderable yet: no answer text, no tool activity, and no inline
-    // segments. Reasoning-only exchanges DO carry a thinking segment, so this must
-    // check segments too — otherwise the live thinking view (show-thinking on)
-    // is swallowed until the first text/tool lands.
-    if (!projection.content.trim() && projection.activityItems.length === 0 && projection.segments.length === 0)
-      return;
-
     setMessages((current) => {
       const existingIndex = current.findIndex(m => m.id === pendingId);
       if (existingIndex === -1)
         return current;
+      // Retry-only events are renderable even before the first token. An empty
+      // resumed/terminal projection must also clear a previously shown retry.
+      if (!projection.content.trim() && projection.activityItems.length === 0
+        && projection.segments.length === 0 && !projection.reconnecting
+        && !current[existingIndex]!.reconnecting) {
+        return current;
+      }
       const updated: AgentMessage = {
         ...current[existingIndex]!,
         activityItems: projection.activityItems,
         segments: projection.segments,
         content: projection.content.trim() ? projection.content : current[existingIndex]!.content,
         thinkingActive: projection.thinkingActive,
+        reconnecting: projection.reconnecting,
         outputTokens: projection.outputTokens,
       };
       // Replace in place (see upsertStreamingPreview).

--- a/desktop/src/i18n/locales/en/agent.json
+++ b/desktop/src/i18n/locales/en/agent.json
@@ -238,6 +238,7 @@
     "retry": "Retry",
     "continue": "Continue",
     "generating": "Generating",
+    "reconnecting": "Reconnecting {{attempt}}/{{maxRetries}}",
     "justNow": "just now",
     "thinking": "Thinking…",
     "stopped": "Stopped",

--- a/desktop/src/i18n/locales/zh/agent.json
+++ b/desktop/src/i18n/locales/zh/agent.json
@@ -239,6 +239,7 @@
     "retry": "重试",
     "continue": "继续",
     "generating": "生成中",
+    "reconnecting": "正在重连 {{attempt}}/{{maxRetries}}",
     "justNow": "刚刚",
     "thinking": "正在思考中…",
     "stopped": "已停止",

--- a/packages/rpc/proto/future.proto
+++ b/packages/rpc/proto/future.proto
@@ -1131,6 +1131,7 @@ message StreamRequest {
   // Valid types: "ping", "agent_start", "agent_end", "text_chunk",
   // "thinking_start", "thinking_delta", "thinking_end", "tool_start",
   // "tool_delta", "tool_end", "approval_request", "error", "stop",
+  // "stream_retry", "stream_resumed",
   // plus "session_created" on the global control-plane stream.
   repeated string event_types = 1;
 
@@ -1160,6 +1161,11 @@ message StreamEvent {
   //   agent_start / agent_end      run lifecycle (agent_start carries the run's
   //                                started_at_ms; agent_end carries error/usage/
   //                                duration_ms — the authoritative run totals)
+  //   stream_retry                 upstream reconnect scheduled (non-terminal);
+  //                                attempt is 1-based, maxRetries excludes the
+  //                                initial request, delayMs is the backoff
+  //   stream_resumed               model output resumed after reconnecting;
+  //                                clear retry state (also on error/agent_end)
   //   user_message                 the user's prompt message
   //   text_chunk                   assistant text token (the projected token stream)
   //   thinking_start / thinking_delta / thinking_end   reasoning stream
@@ -1187,6 +1193,8 @@ message StreamEvent {
 
   // JSON-serialised event payload.  Structure depends on the event type.
   // Examples:
+  //   stream_retry:  {"type":"stream_retry","attempt":1,"maxRetries":5,"delayMs":2000}
+  //   stream_resumed: {"type":"stream_resumed"}
   //   text_chunk:    {"text": "Hello"}
   //   thinking_delta: {"text": "I need to..."}
   //   tool_start:    {"tool_id": "...", "tool_name": "read"}

--- a/packages/rpc/src/generated/proto.rs
+++ b/packages/rpc/src/generated/proto.rs
@@ -1219,6 +1219,7 @@ pub struct StreamRequest {
     /// Valid types: "ping", "agent_start", "agent_end", "text_chunk",
     /// "thinking_start", "thinking_delta", "thinking_end", "tool_start",
     /// "tool_delta", "tool_end", "approval_request", "error", "stop",
+    /// "stream_retry", "stream_resumed",
     /// plus "session_created" on the global control-plane stream.
     #[prost(string, repeated, tag = "1")]
     pub event_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
@@ -1249,6 +1250,11 @@ pub struct StreamEvent {
     ///    agent_start / agent_end      run lifecycle (agent_start carries the run's
     ///                                 started_at_ms; agent_end carries error/usage/
     ///                                 duration_ms — the authoritative run totals)
+    ///    stream_retry                 upstream reconnect scheduled (non-terminal);
+    ///                                 attempt is 1-based, maxRetries excludes the
+    ///                                 initial request, delayMs is the backoff
+    ///    stream_resumed               model output resumed after reconnecting;
+    ///                                 clear retry state (also on error/agent_end)
     ///    user_message                 the user's prompt message
     ///    text_chunk                   assistant text token (the projected token stream)
     ///    thinking_start / thinking_delta / thinking_end   reasoning stream
@@ -1276,6 +1282,8 @@ pub struct StreamEvent {
     pub r#type: ::prost::alloc::string::String,
     /// JSON-serialised event payload.  Structure depends on the event type.
     /// Examples:
+    ///    stream_retry:  {"type":"stream_retry","attempt":1,"maxRetries":5,"delayMs":2000}
+    ///    stream_resumed: {"type":"stream_resumed"}
     ///    text_chunk:    {"text": "Hello"}
     ///    thinking_delta: {"text": "I need to..."}
     ///    tool_start:    {"tool_id": "...", "tool_name": "read"}

--- a/packages/thread-projection/src/index.ts
+++ b/packages/thread-projection/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MessageAttachment,
   MessageRole,
   MessageSegment,
+  StreamRetryState,
 } from "./model";
 export type { RunEvent, SessionEntry } from "./events";
 export type {

--- a/packages/thread-projection/src/liveApply.ts
+++ b/packages/thread-projection/src/liveApply.ts
@@ -1,5 +1,5 @@
 import type { RunEvent } from "./events";
-import type { AgentActivityItem, AgentActivityKind, MessageSegment } from "./model";
+import type { AgentActivityItem, AgentActivityKind, MessageSegment, StreamRetryState } from "./model";
 import { isRecord, pathBasename, singleLine } from "./utils";
 import {
   COLLAPSIBLE_KINDS,
@@ -32,6 +32,7 @@ export interface AssistantRunProjection {
    * setting is off; not rendered as a top-of-message line.
    */
   thinkingActive: boolean;
+  reconnecting?: StreamRetryState;
   /**
    * The stream ended before the model finished: the agent's `agent_end` carried
    * reason "incomplete", so `content` is a truncated prefix. Mirrors desktop's
@@ -119,10 +120,26 @@ export function createRunProjector(options?: { preferEndTokens?: boolean }): Run
   // Set when the agent's `agent_end` carried `state: "cancelled"` — the user
   // stopped the run (distinct from a truncated stream).
   let stopped = false;
+  let reconnecting: StreamRetryState | undefined;
   let lastSequence = -1;
 
   function processEvent(event: RunEvent) {
     const payload = parseEventPayload(event.payload);
+
+    if (event.eventType === "stream_retry") {
+      if (isRecord(payload)) {
+        const { attempt, maxRetries, delayMs } = payload;
+        if (typeof attempt === "number" && Number.isSafeInteger(attempt) && attempt > 0
+          && typeof maxRetries === "number" && Number.isSafeInteger(maxRetries) && maxRetries >= attempt
+          && typeof delayMs === "number" && Number.isSafeInteger(delayMs) && delayMs >= 0) {
+          reconnecting = { attempt, maxRetries, delayMs };
+        }
+      }
+      return;
+    }
+
+    if (event.eventType === "stream_resumed" || event.eventType === "error" || event.eventType === "agent_end")
+      reconnecting = undefined;
 
     if (event.eventType === "usage") {
       usageOutputSum += usageOutputTokens(payload);
@@ -401,6 +418,7 @@ export function createRunProjector(options?: { preferEndTokens?: boolean }): Run
         : (sawUsageEvent ? usageOutputSum : agentEndOutput),
       thinking: thinkingText,
       thinkingActive,
+      ...(reconnecting ? { reconnecting: { ...reconnecting } } : {}),
       truncated,
       stopped,
     };

--- a/packages/thread-projection/src/model.ts
+++ b/packages/thread-projection/src/model.ts
@@ -59,6 +59,12 @@ export interface MessageAttachment {
   temporary?: boolean;
 }
 
+export interface StreamRetryState {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+}
+
 export interface AgentMessage {
   id: string;
   runId?: string | null;
@@ -121,4 +127,6 @@ export interface AgentMessage {
    * "thinking…" hint (only while streaming and the show-thinking setting is off).
    */
   thinkingActive?: boolean;
+  /** Transient upstream reconnect state, never assistant content. */
+  reconnecting?: StreamRetryState;
 }


### PR DESCRIPTION
## Summary
- Retry interrupted upstream model streams up to five additional times per model step, with interruptible 2/4/8/16/32-second backoff separate from HTTP request retries.
- Preserve partial responses, completed tool history and reported usage; do not execute interrupted tool calls.
- Route both clean EOF and HTTP body errors through adapter cleanup before retrying. Strip unfinished OpenAI Responses item identifiers while retaining completed reasoning metadata; ignore broken buffered SSE tails after transport errors.
- Normalize malformed/null Anthropic historical tool inputs to objects only in the outgoing request projection, preserving original partial arguments in the durable conversation.
- Publish non-terminal stream_retry / stream_resumed events through the existing RPC journal and projection path. Show localized desktop reconnect attempts, including before the first token and after reattaching; clear them on recovery, cancellation or failure.

## Validation
Updated with origin/main and checked in an isolated worktree using Rust 1.97.0:
- Agent: 1,729 tests passed; 10 existing ignored tests. Includes new HTTP recovery regressions for truncated Responses bodies and partial Anthropic tool arguments, plus object-input normalization cases.
- RPC: 116 tests passed.
- Agent/RPC fmt and clippy: all targets, warnings denied, passed.
- Desktop: TypeScript, ESLint, 750 tests and production build passed.
- Mobile/shared-projector consumer: TypeScript, ESLint and 600 tests passed.
- Regenerated RPC bindings match committed output; git diff --check passed.
- Installer regressions brought in by the main sync: 6 tests passed.

The running Agent/desktop were not restarted. Disconnect recovery was verified with local HTTP mocks, not a live-provider disconnect or native desktop end-to-end test.
