### PR TITLE
fix(cli): read installer assets independently of JSON layout

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,16 +41,39 @@ esac
 
 fetch() { curl -fsSL --proto '=https' --tlsv1.2 "$1"; }
 
-# Asset URL+SHA-256 for one key in the `assets` section of the pretty-printed
-# release manifest (latest.json), e.g. "linux-x86_64-deb" -> "URL SHA256".
-manifest_asset() {
-  awk -v key="$1" '
-    /"assets":/ { in_assets=1; next }
-    in_assets && index($0, "\"" key "\"") {
-      getline; u=$0; getline; s=$0;
-      gsub(/^.*"url": *"/,"",u); gsub(/".*$/,"",u);
-      gsub(/^.*"sha256": *"/,"",s); gsub(/".*$/,"",s);
-      print u, s; exit
+# Read the version (no argument) or assets[key] URL+SHA-256 from latest.json.
+# Tokenize strings and nesting rather than relying on lines or field order.
+# This only reads the release manifest string fields; no jq/Python is required.
+manifest_entry() {
+  awk -v asset_key="${1:-}" '
+    {
+      while (match($0, /"([^"\\]|\\.)*"|[][{}:,]/)) {
+        token = substr($0, RSTART, RLENGTH)
+        $0 = substr($0, RSTART + RLENGTH)
+        if (token == "{" || token == "[") {
+          path[++depth] = key
+          key = ""
+        } else if (token == "}" || token == "]") {
+          delete path[depth--]
+          key = ""
+        } else if (token == ":") {
+          key = value
+        } else if (token == ",") {
+          key = ""
+        } else {
+          value = substr(token, 2, length(token) - 2)
+          gsub(/\\\//, "/", value)
+          if (depth == 1 && key == "version") version = value
+          if (depth == 3 && path[2] == "assets" && path[3] == asset_key) {
+            if (key == "url") url = value
+            if (key == "sha256") sha = value
+          }
+        }
+      }
+    }
+    END {
+      if (asset_key == "") print version
+      else if (url != "") print url, sha
     }
   ' "$TMP/latest.json"
 }
@@ -94,7 +117,7 @@ VERSION=""
 resolve_latest() {
   if [[ -z "${FUTUREOS_VERSION:-}" ]]; then
     fetch "$LATEST" > "$TMP/latest.json"
-    VERSION="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$TMP/latest.json" | head -n1)"
+    VERSION="$(manifest_entry)"
     [[ -n "$VERSION" ]] || die "could not resolve the latest version from $LATEST"
   else
     VERSION="${FUTUREOS_VERSION#v}"
@@ -109,9 +132,9 @@ ASSET_SHA=""
 resolve_asset() {
   local key="$1" filename="$2" fallback_key="${3:-}" manifest_value=""
   if [[ -z "${FUTUREOS_VERSION:-}" ]]; then
-    manifest_value="$(manifest_asset "$key")"
+    manifest_value="$(manifest_entry "$key")"
     if [[ -z "$manifest_value" && -n "$fallback_key" ]]; then
-      manifest_value="$(manifest_asset "$fallback_key")"
+      manifest_value="$(manifest_entry "$fallback_key")"
     fi
     read -r ASSET_URL ASSET_SHA <<< "$manifest_value" || true
     [[ -n "$ASSET_URL" ]] || die "no release asset '$key' in $LATEST"

--- a/scripts/test-install.py
+++ b/scripts/test-install.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Offline regression tests: python3 scripts/test-install.py."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+INSTALLER = Path(__file__).with_name("install.sh").read_text().rsplit('\ncase "$OS" in', 1)[0]
+KEY = "linux-x86_64-portable"
+URL = "https://example.invalid/releases/1.2.3/FutureOS_linux_x86_64-portable.tar.gz"
+SHA = "a" * 64
+
+
+class InstallManifestTests(unittest.TestCase):
+    def run_installer(self, manifest, command):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "manifest.json"
+            fixture.write_text(manifest)
+            env = {k: v for k, v in os.environ.items() if not k.startswith("FUTUREOS_")}
+            env["MANIFEST_FIXTURE"] = str(fixture)
+            return subprocess.run(
+                ["bash"], input=INSTALLER + '\nfetch() { cat "$MANIFEST_FIXTURE"; }\n' + command,
+                env=env, text=True, capture_output=True,
+            )
+
+    def test_manifest_layouts_and_field_order(self):
+        for indent in (None, 2):
+            for reverse in (False, True):
+                asset = {"url": URL, "sha256": SHA}
+                if reverse:
+                    asset = dict(reversed(list(asset.items())))
+                manifest = {"version": "1.2.3", "platforms": {KEY: {"url": "wrong"}},
+                            "assets": {KEY: asset}}
+                with self.subTest(indent=indent, reverse=reverse):
+                    result = self.run_installer(json.dumps(manifest, indent=indent), f'''
+resolve_latest
+resolve_asset "{KEY}" unused
+printf '%s\\n' "$VERSION" "$ASSET_URL" "$ASSET_SHA"
+''')
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout.splitlines(), ["1.2.3", URL, SHA])
+
+    def test_inline_assets_with_pretty_printed_version(self):
+        # The old version reader succeeds, but its assets-line `next` skips the URL.
+        assets = json.dumps({KEY: {"url": URL, "sha256": SHA}})
+        manifest = '{\n  "version": "1.2.3",\n  "assets" : ' + assets + '\n}'
+        result = self.run_installer(manifest, f'''
+resolve_latest
+resolve_asset "{KEY}" unused
+printf '%s %s' "$ASSET_URL" "$ASSET_SHA"
+''')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, f"{URL} {SHA}")
+
+    def test_assets_scope_and_missing_key(self):
+        manifest = {"version": "1.2.3", "assets": {}, "platforms": {KEY: {"url": URL, "sha256": SHA}}}
+        result = self.run_installer(json.dumps(manifest, indent=2), f'''
+resolve_latest
+resolve_asset "{KEY}" unused
+''')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"no release asset '{KEY}'", result.stderr)
+
+    def test_platform_keys_and_legacy_deb_fallback(self):
+        for key in ("darwin-aarch64", "darwin-x86_64", "linux-x86_64-deb", "linux-aarch64-deb",
+                    "linux-x86_64-portable", "linux-aarch64-portable", "linux-x86_64"):
+            with self.subTest(key=key):
+                manifest = {"version": "1.2.3", "assets": {key: {"url": URL, "sha256": SHA}}}
+                requested = "linux-x86_64-deb" if key == "linux-x86_64" else key
+                result = self.run_installer(json.dumps(manifest), f'''
+resolve_latest
+resolve_asset "{requested}" unused "linux-x86_64"
+printf '%s %s' "$ASSET_URL" "$ASSET_SHA"
+''')
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, f"{URL} {SHA}")
+
+    def test_escaped_slashes_and_punctuation_in_other_fields(self):
+        manifest = {"version": "1.2.3", "notes": 'ignore {"assets": {}} and , : \\ text',
+                    "assets": {KEY: {"sha256": SHA, "url": URL}}}
+        result = self.run_installer(json.dumps(manifest).replace("/", r"\/"), f'''
+resolve_latest
+resolve_asset "{KEY}" unused
+printf '%s %s' "$ASSET_URL" "$ASSET_SHA"
+''')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, f"{URL} {SHA}")
+
+    def test_pinned_version_does_not_fetch_manifest(self):
+        result = self.run_installer("", '''
+FUTUREOS_VERSION=v1.2.3
+fetch() { return 1; }
+resolve_latest
+resolve_asset linux-x86_64-portable portable.tar.gz
+printf '%s\\n' "$VERSION" "$ASSET_URL" "$ASSET_SHA"
+''')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), ["1.2.3", "https://dl.future-os.cn/releases/1.2.3/portable.tar.gz", ""])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Read installer URLs and SHA-256 values strictly from `assets[key]`, without depending on JSON line breaks or field order.
- Use the same manifest reader for the version; preserve legacy Debian asset fallback and pinned-version behavior.
- Keep the installer dependency-free beyond its existing shell utilities (no jq/Python runtime requirement).

## Validation
- `bash -n scripts/install.sh`
- `python3 scripts/test-install.py` — 6 offline regression tests, including compact/inline JSON, reversed fields, assets/platforms scope, supported platform keys, escaped slashes, and pinned versions.
- `git diff --check`

## Limitations
- Live manifest retrieval and a real Linux installation were not verified in this environment.
- The download-site installer still needs to be published after this change merges.