### PR TITLE
fix(mobile): make workspace list scrollable in new-session dialog

### DIFF
--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -426,7 +426,11 @@ export function SessionsScreen() {
                 ))}
               </View>
               {newMode === "workspace" && (
-                <ScrollView bounces={false} contentContainerStyle={styles.workspaceOptions}>
+                <ScrollView
+                  bounces={false}
+                  contentContainerStyle={styles.workspaceOptionsContent}
+                  style={styles.workspaceOptions}
+                >
                   {remote.workspaces.map(workspace => (
                     <Pressable
                       key={workspace.id}
@@ -689,7 +693,8 @@ const styles = StyleSheet.create({
   },
   modeOptionActive: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
   modeOptionText: { color: colors.ink, fontSize: 13, fontWeight: "700" },
-  workspaceOptions: { maxHeight: 180, gap: spacing.xs },
+  workspaceOptions: { maxHeight: 180 },
+  workspaceOptionsContent: { gap: spacing.xs },
   workspaceOption: {
     flexDirection: "row",
     alignItems: "center",


### PR DESCRIPTION
## Summary
- In the new-session dialog on Android, the workspace picker could not scroll when there were many workspaces.
- Root cause: `maxHeight` was set on the ScrollView's `contentContainerStyle` instead of its `style`. Capping the content container height (while leaving the viewport unbounded) makes the ScrollView measure zero overflow, so it never scrolls. Moving `maxHeight` to the ScrollView's own style bounds the viewport, leaving the content taller and scrollable.
- Kept the item `gap` on `contentContainerStyle` where it applies to the children.

## Validation
- Mobile typecheck, ESLint, and 600 tests pass.
- Fix is Android-scoped behavior; no Rust or shared-projector changes.

The running agent/desktop were not restarted.