### PR TITLE
Fix history paging momentum and viewport anchoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	build build-cli build-desktop build-mobile-android build-mobile-ios desktop-sidecars \
 	test test-agent test-channels test-cli test-tui test-cli-diff test-tui-diff test-tui-tmux \
 	test-desktop test-desktop-rust test-mobile \
-	lint lint-rust lint-desktop stylelint-desktop lint-mobile check-desktop check-mobile fmt fmt-mobile \
+	lint lint-rust lint-desktop stylelint-desktop lint-mobile check-desktop check-mobile fmt \
 	run-agent run-tui run-cli run-desktop run-mobile-android run-mobile-ios run-channels run-loop \
 	profile-agent-build profile-agent profile-quick profile-heap \
 	generate-models generate-proto \
@@ -248,16 +248,10 @@ check-desktop: lint-desktop stylelint-desktop desktop-sidecar-placeholder
 	cd desktop/src-tauri && cargo check
 
 check-mobile: lint-mobile test-mobile
-	cd mobile && npm run format:check
 
 fmt:
 	cargo fmt --all
 	cargo fmt --manifest-path desktop/src-tauri/Cargo.toml
-	$(MAKE) fmt-mobile
-
-fmt-mobile:
-	$(call npm-install-if-needed,mobile)
-	cd mobile && npm run format
 
 # ─── Run ────────────────────────────────────────────────────────────────────
 # Kept as `cd <crate> && cargo run` on purpose: the process cwd is user-visible
@@ -392,7 +386,7 @@ help:
 	@echo "  test-cli-diff / -tui-diff / -tui-tmux  [manual] TS→Rust migration gates"
 	@echo "  lint                                Rust (CI flags) + desktop + mobile lints"
 	@echo "  check-desktop / check-mobile        Lint + typecheck + tests without building apps"
-	@echo "  fmt / fmt-mobile                    Format code"
+	@echo "  fmt                                 Format Rust code"
 	@echo "  run-agent / -tui / -cli / -channels / -loop   Run a component (debug build)"
 	@echo "  run-desktop / run-mobile-android / run-mobile-ios   Run an app in dev mode"
 	@echo "  profile-agent / profile-quick / profile-heap  CPU/heap profiling (PROFILE_SECS=30)"

--- a/desktop/src/features/agent/AgentThread.tsx
+++ b/desktop/src/features/agent/AgentThread.tsx
@@ -160,6 +160,7 @@ export function AgentThread({
     showJumpToLatest,
     canLoadOlder,
     showLoadOlderHint,
+    coolingDown,
     handleScroll: handlePagingScroll,
     loadOlder,
   } = useMessagePaging({
@@ -467,6 +468,8 @@ export function AgentThread({
                 <button
                   type="button"
                   onClick={loadOlder}
+                  disabled={coolingDown}
+                  aria-busy={coolingDown}
                   aria-label={t("thread.loadOlder")}
                   title={t("thread.loadOlder")}
                   className="pointer-events-auto flex animate-pop-in items-center gap-1.5 rounded-full border border-line-soft bg-surface px-3 py-1 text-xs text-ink-soft shadow-panel transition-colors hover:text-ink"

--- a/desktop/src/features/agent/AgentThread.tsx
+++ b/desktop/src/features/agent/AgentThread.tsx
@@ -459,7 +459,13 @@ export function AgentThread({
         {historyError && (
           <div role="alert" className="text-danger px-4 py-2 text-sm">
             {historyError}
-            <button type="button" className="ml-2 underline" onClick={() => void retryHistory()}>{t("common:retry")}</button>
+            <button
+              type="button"
+              className="ml-2 underline"
+              onClick={() => void retryHistory()}
+            >
+              {t("common:retry")}
+            </button>
           </div>
         )}
         {showLoadOlderHint

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -102,6 +102,7 @@ export function useMessagePaging({
   const loadingOlderRef = useRef(false);
   const wheelBlockedUntilRef = useRef(0);
   const wheelProtectionRef = useRef(false);
+  const acceptingManualScrollRef = useRef(false);
   const wasAtTopRef = useRef(false);
   const [coolingDown, setCoolingDown] = useState(false);
   const [viewportRevision, setViewportRevision] = useState(0);
@@ -110,6 +111,22 @@ export function useMessagePaging({
   const cooldownTimerRef = useRef<number | null>(null);
   const renderFrameRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const nativeScrollLockRef = useRef<{
+    container: HTMLElement;
+    overflowY: string;
+    priority: string;
+  } | null>(null);
+
+  const releaseNativeScrollLock = useCallback(() => {
+    const lock = nativeScrollLockRef.current;
+    if (!lock)
+      return;
+    if (lock.overflowY)
+      lock.container.style.setProperty("overflow-y", lock.overflowY, lock.priority);
+    else
+      lock.container.style.removeProperty("overflow-y");
+    nativeScrollLockRef.current = null;
+  }, []);
 
   const finishCooldown = useCallback(() => {
     if (dataPendingRef.current || renderPendingRef.current)
@@ -122,8 +139,9 @@ export function useMessagePaging({
       return;
     }
     wheelProtectionRef.current = false;
+    releaseNativeScrollLock();
     setCoolingDown(false);
-  }, []);
+  }, [releaseNativeScrollLock]);
 
   // A React commit alone is not a painted, stable viewport. Wait for two
   // animation frames with unchanged geometry after anchor correction. Resizes
@@ -159,6 +177,17 @@ export function useMessagePaging({
 
   const protectViewport = useCallback(() => {
     wheelProtectionRef.current = true;
+    const container = scrollRef.current;
+    if (container && !nativeScrollLockRef.current) {
+      nativeScrollLockRef.current = {
+        container,
+        overflowY: container.style.getPropertyValue("overflow-y"),
+        priority: container.style.getPropertyPriority("overflow-y"),
+      };
+      // preventDefault cannot cancel the tail of every WebKit gesture. Stop
+      // native scrolling itself, while retaining programmatic anchor correction.
+      container.style.setProperty("overflow-y", "hidden");
+    }
     wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
     renderPendingRef.current = true;
     setCoolingDown(true);
@@ -166,7 +195,7 @@ export function useMessagePaging({
     if (cooldownTimerRef.current !== null)
       window.clearTimeout(cooldownTimerRef.current);
     cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
-  }, [finishCooldown]);
+  }, [finishCooldown, scrollRef]);
 
   // Once rendered, the leading message stays in the window even when new
   // exchanges arrive. Counting backwards from the tail would evict that row.
@@ -191,6 +220,7 @@ export function useMessagePaging({
     scrollRef,
     contentKey: visibleMessages,
     followEnabled,
+    isReadingAnchorLocked: () => wheelProtectionRef.current && !acceptingManualScrollRef.current,
     onScroll,
     onContentSettled: () => {
       // Anchor restoration can leave the top before its scroll event arrives.
@@ -219,13 +249,13 @@ export function useMessagePaging({
     }
     loadingOlderRef.current = true;
     wasAtTopRef.current = (scrollRef.current?.scrollTop ?? 0) <= TOP_THRESHOLD_PX;
+    preserveViewport();
     protectViewport();
     if (effectivePageStart <= 0 && loadOlderHistory) {
-      // The callback runs only for a valid page, immediately before its state
-      // update. Capture the CURRENT viewport, not the one at request start.
+      // Keep the protected anchor through the request. Explicit downward input
+      // updates it; recapturing here could adopt a not-yet-delivered native drift.
       dataPendingRef.current = true;
       void loadOlderHistory((page) => {
-        preserveViewport();
         if (page.length > 0)
           setWindowStartId(page[0]!.id);
       }).finally(() => {
@@ -238,7 +268,6 @@ export function useMessagePaging({
       });
     }
     else {
-      preserveViewport();
       const start = computePageStart(
         messages.slice(0, effectivePageStart),
         userExchangeCount,
@@ -277,12 +306,23 @@ export function useMessagePaging({
       loadOlder();
   }, [canLoadOlder, handleViewportScroll, loadOlder, scrollRef]);
 
+  const acceptManualViewport = useCallback(() => {
+    acceptingManualScrollRef.current = true;
+    try {
+      // Adopt both the new anchor and normal bottom-follow semantics.
+      handleViewportScroll();
+    }
+    finally {
+      acceptingManualScrollRef.current = false;
+    }
+  }, [handleViewportScroll]);
+
   // Keep this listener attached during the entire transaction. A wheel also
   // detects a top collision when scrollTop is clamped and no scroll event fires.
-  const wheelStateRef = useRef({ canLoadOlder, loadOlder });
+  const wheelStateRef = useRef({ canLoadOlder, loadOlder, acceptManualViewport });
   useLayoutEffect(() => {
-    wheelStateRef.current = { canLoadOlder, loadOlder };
-  }, [canLoadOlder, loadOlder]);
+    wheelStateRef.current = { canLoadOlder, loadOlder, acceptManualViewport };
+  }, [acceptManualViewport, canLoadOlder, loadOlder]);
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -293,13 +333,21 @@ export function useMessagePaging({
         return;
       if (event.ctrlKey || event.deltaY === 0)
         return;
-      if (event.deltaY > 0)
-        return;
       if (wheelProtectionRef.current) {
         if (event.cancelable)
           event.preventDefault();
+        if (event.deltaY > 0) {
+          // Native vertical scrolling is locked, but an explicit downward
+          // wheel still establishes a new reading position immediately.
+          const lineHeight = Number.parseFloat(getComputedStyle(container).lineHeight) || 16;
+          const unit = event.deltaMode === 1 ? lineHeight : event.deltaMode === 2 ? container.clientHeight : 1;
+          container.scrollTop += event.deltaY * unit;
+          wheelStateRef.current.acceptManualViewport();
+        }
         return;
       }
+      if (event.deltaY > 0)
+        return;
       const state = wheelStateRef.current;
       if (!state.canLoadOlder || container.scrollTop > TOP_THRESHOLD_PX)
         return;
@@ -317,13 +365,14 @@ export function useMessagePaging({
       mountedRef.current = true;
       return () => {
         mountedRef.current = false;
+        releaseNativeScrollLock();
         if (cooldownTimerRef.current !== null)
           window.clearTimeout(cooldownTimerRef.current);
         if (renderFrameRef.current !== null)
           window.cancelAnimationFrame(renderFrameRef.current);
       };
     },
-    [],
+    [releaseNativeScrollLock],
   );
 
   return {

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -72,13 +72,12 @@ interface UseMessagePagingResult {
 
 /** Distance from the top that counts as "at the top" for the load hint. */
 const TOP_THRESHOLD_PX = 8;
-/** Wheel events within this window after a load are ignored — one page per gesture. */
-const WHEEL_COOLDOWN_MS = 300;
+/** Block upward momentum after reaching the top or restoring a history page. */
+const WHEEL_COOLDOWN_MS = 500;
 /**
  * How long the user must rest at the top before the load button appears. This
- * is the "confirm gate": the gesture that brought the user to the top ends
- * while the timer runs, so its trailing wheel events can never auto-load — the
- * button must be visibly settled before a pull counts.
+ * is the visual confirm gate; the separate wheel protection window blocks
+ * upward momentum while the hint appears and history is restored.
  */
 const TOP_SETTLE_MS = 350;
 
@@ -108,9 +107,16 @@ export function useMessagePaging({
   // Synchronous re-entrancy guard. This ref is read in the same tick a wheel
   // event fires (a state flag would only flip after React commits), so a single
   // scroll gesture can't queue a dozen page loads — and a trailing wheel event
-  // after the commit is swallowed by the cooldown stamp.
+  // after the commit is blocked by the viewport protection window.
   const loadingOlderRef = useRef(false);
-  const lastWheelAtRef = useRef(0);
+  const wheelBlockedUntilRef = useRef(0);
+  const wheelProtectionRef = useRef(false);
+  const wasAtTopRef = useRef(false);
+
+  const protectViewport = useCallback(() => {
+    wheelProtectionRef.current = true;
+    wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
+  }, []);
 
   // Once rendered, the leading message stays in the window even when new
   // exchanges arrive. Counting backwards from the tail would evict that row.
@@ -154,6 +160,7 @@ export function useMessagePaging({
       return;
     }
     loadingOlderRef.current = true;
+    protectViewport();
     if (topSettleTimerRef.current !== null) {
       window.clearTimeout(topSettleTimerRef.current);
       topSettleTimerRef.current = null;
@@ -163,10 +170,12 @@ export function useMessagePaging({
       // The callback runs only for a valid page, immediately before its state
       // update. Capture the CURRENT viewport, not the one at request start.
       void loadOlderHistory((page) => {
+        protectViewport();
         preserveViewport();
         if (page.length > 0)
           setWindowStartId(page[0]!.id);
       }).finally(() => {
+        wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
         loadingOlderRef.current = false;
       });
     }
@@ -184,6 +193,7 @@ export function useMessagePaging({
     loadOlderHistory,
     messages,
     preserveViewport,
+    protectViewport,
     userExchangeCount,
   ]);
 
@@ -201,6 +211,9 @@ export function useMessagePaging({
     if (!container)
       return;
     const isAtTop = container.scrollTop <= TOP_THRESHOLD_PX;
+    if (isAtTop && !wasAtTopRef.current && canLoadOlder)
+      protectViewport();
+    wasAtTopRef.current = isAtTop;
     setAtTop(isAtTop);
     if (!isAtTop) {
       if (topSettleTimerRef.current !== null) {
@@ -216,33 +229,47 @@ export function useMessagePaging({
       topSettleTimerRef.current = null;
       setTopSettled(true);
     }, TOP_SETTLE_MS);
-  }, [handleViewportScroll, scrollRef]);
+  }, [canLoadOlder, handleViewportScroll, protectViewport, scrollRef]);
 
-  // Second channel for the load gesture: a wheel-scroll up while the load button
-  // is visible fires the load, alongside clicking it. The listener only mounts
-  // once the button has settled (`topSettled`), so the gesture that arrived at
-  // the top can never auto-load — the pull must happen after the button shows.
-  // The sync ref guard + cooldown stamp keep one gesture to one page load.
+  // Keep the non-passive listener mounted across loading and anchor restoration.
+  // Otherwise the momentum tail can scroll the newly prepended content even
+  // though the load hint has disappeared. Reversing direction releases the gate.
+  const wheelStateRef = useRef({ canLoadOlder, atTop, topSettled, loadOlder });
+  useLayoutEffect(() => {
+    wheelStateRef.current = { canLoadOlder, atTop, topSettled, loadOlder };
+  }, [atTop, canLoadOlder, loadOlder, topSettled]);
+
   useEffect(() => {
-    if (!canLoadOlder || !atTop || !topSettled)
-      return;
     const container = scrollRef.current;
     if (!container)
       return;
     const onWheel = (event: WheelEvent) => {
-      if (event.deltaY >= 0)
+      if (scrollRef.current !== container)
         return;
-      const now = performance.now();
-      // Swallow the tail of the same gesture so it can't queue a second page.
-      if (now - lastWheelAtRef.current < WHEEL_COOLDOWN_MS)
+      if (event.ctrlKey || event.deltaY === 0)
         return;
-      event.preventDefault();
-      lastWheelAtRef.current = now;
-      loadOlder();
+      if (event.deltaY > 0) {
+        wheelProtectionRef.current = false;
+        return;
+      }
+      if (
+        wheelProtectionRef.current
+        && (loadingOlderRef.current || performance.now() < wheelBlockedUntilRef.current)
+      ) {
+        if (event.cancelable)
+          event.preventDefault();
+        return;
+      }
+      const state = wheelStateRef.current;
+      if (!state.canLoadOlder || !state.atTop || !state.topSettled)
+        return;
+      if (event.cancelable)
+        event.preventDefault();
+      state.loadOlder();
     };
     container.addEventListener("wheel", onWheel, { passive: false });
     return () => container.removeEventListener("wheel", onWheel);
-  }, [atTop, canLoadOlder, loadOlder, scrollRef, topSettled]);
+  }, [scrollRef]);
 
   // Don't leave a pending settle timer firing setState after unmount.
   useEffect(

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -102,6 +102,7 @@ export function useMessagePaging({
   const loadingOlderRef = useRef(false);
   const wheelBlockedUntilRef = useRef(0);
   const wheelProtectionRef = useRef(false);
+  const restoreNativeMomentumRef = useRef(false);
   const acceptingManualScrollRef = useRef(false);
   const wasAtTopRef = useRef(false);
   const [coolingDown, setCoolingDown] = useState(false);
@@ -183,6 +184,7 @@ export function useMessagePaging({
 
   const protectViewport = useCallback(() => {
     wheelProtectionRef.current = true;
+    restoreNativeMomentumRef.current = false;
     const container = scrollRef.current;
     if (container && !nativeScrollLockRef.current) {
       nativeScrollLockRef.current = {
@@ -229,8 +231,12 @@ export function useMessagePaging({
     scrollRef,
     contentKey: visibleMessages,
     followEnabled,
-    isReadingAnchorLocked: () =>
-      wheelProtectionRef.current && !acceptingManualScrollRef.current,
+    shouldRestoreReadingAnchor: () => {
+      const shouldRestore
+        = wheelProtectionRef.current && restoreNativeMomentumRef.current;
+      restoreNativeMomentumRef.current = false;
+      return shouldRestore;
+    },
     onScroll,
     onContentSettled: () => {
       // Anchor restoration can leave the top before its scroll event arrives.
@@ -322,6 +328,9 @@ export function useMessagePaging({
     try {
       // Adopt both the new anchor and normal bottom-follow semantics.
       handleViewportScroll();
+      // The wheel has established the new reading position. Its follow-on
+      // native scroll must be restored to this replacement anchor.
+      restoreNativeMomentumRef.current = true;
     }
     finally {
       acceptingManualScrollRef.current = false;
@@ -364,6 +373,11 @@ export function useMessagePaging({
                 : 1;
           container.scrollTop += event.deltaY * unit;
           wheelStateRef.current.acceptManualViewport();
+        }
+        else if (!event.cancelable) {
+          // A noncancelable upward wheel is a WebKit momentum tail. Its
+          // matching scroll event must not replace the protected anchor.
+          restoreNativeMomentumRef.current = true;
         }
         return;
       }

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -74,7 +74,7 @@ interface UseMessagePagingResult {
 /** Distance from the top that counts as "at the top" for the load hint. */
 const TOP_THRESHOLD_PX = 8;
 /** Block upward momentum after reaching the top or restoring a history page. */
-const WHEEL_COOLDOWN_MS = 750;
+const WHEEL_COOLDOWN_MS = 1500;
 /**
  * How long the user must rest at the top before the load button appears. This
  * is the visual confirm gate; the separate wheel protection window blocks
@@ -119,10 +119,13 @@ export function useMessagePaging({
   const renderPendingRef = useRef(false);
   const cooldownTimerRef = useRef<number | null>(null);
   const renderFrameRef = useRef<number | null>(null);
+  const hintPaintFrameRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
 
   const finishCooldown = useCallback(() => {
     if (dataPendingRef.current || renderPendingRef.current)
+      return;
+    if (!Number.isFinite(wheelBlockedUntilRef.current))
       return;
     const remaining = wheelBlockedUntilRef.current - performance.now();
     if (remaining > 0) {
@@ -170,14 +173,36 @@ export function useMessagePaging({
 
   const protectViewport = useCallback(() => {
     wheelProtectionRef.current = true;
-    wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
+    // Start the minimum visible duration only after the hint has had a paint.
+    wheelBlockedUntilRef.current = Number.POSITIVE_INFINITY;
     renderPendingRef.current = true;
     setCoolingDown(true);
     setViewportRevision(revision => revision + 1);
     if (cooldownTimerRef.current !== null)
       window.clearTimeout(cooldownTimerRef.current);
-    cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
-  }, [finishCooldown]);
+    cooldownTimerRef.current = null;
+    if (hintPaintFrameRef.current !== null)
+      window.cancelAnimationFrame(hintPaintFrameRef.current);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!coolingDown || Number.isFinite(wheelBlockedUntilRef.current))
+      return;
+    // rAF runs before paint. The second frame gives the committed
+    // hint a paint opportunity before starting its full 1500ms visible window.
+    hintPaintFrameRef.current = window.requestAnimationFrame(() => {
+      hintPaintFrameRef.current = window.requestAnimationFrame(() => {
+        hintPaintFrameRef.current = null;
+        wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
+        cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
+      });
+    });
+    return () => {
+      if (hintPaintFrameRef.current !== null)
+        window.cancelAnimationFrame(hintPaintFrameRef.current);
+      hintPaintFrameRef.current = null;
+    };
+  }, [coolingDown, viewportRevision, finishCooldown]);
 
   // Once rendered, the leading message stays in the window even when new
   // exchanges arrive. Counting backwards from the tail would evict that row.

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -121,10 +121,16 @@ export function useMessagePaging({
     const lock = nativeScrollLockRef.current;
     if (!lock)
       return;
-    if (lock.overflowY)
-      lock.container.style.setProperty("overflow-y", lock.overflowY, lock.priority);
-    else
+    if (lock.overflowY) {
+      lock.container.style.setProperty(
+        "overflow-y",
+        lock.overflowY,
+        lock.priority,
+      );
+    }
+    else {
       lock.container.style.removeProperty("overflow-y");
+    }
     nativeScrollLockRef.current = null;
   }, []);
 
@@ -194,7 +200,10 @@ export function useMessagePaging({
     setViewportRevision(revision => revision + 1);
     if (cooldownTimerRef.current !== null)
       window.clearTimeout(cooldownTimerRef.current);
-    cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
+    cooldownTimerRef.current = window.setTimeout(
+      finishCooldown,
+      WHEEL_COOLDOWN_MS,
+    );
   }, [finishCooldown, scrollRef]);
 
   // Once rendered, the leading message stays in the window even when new
@@ -220,7 +229,8 @@ export function useMessagePaging({
     scrollRef,
     contentKey: visibleMessages,
     followEnabled,
-    isReadingAnchorLocked: () => wheelProtectionRef.current && !acceptingManualScrollRef.current,
+    isReadingAnchorLocked: () =>
+      wheelProtectionRef.current && !acceptingManualScrollRef.current,
     onScroll,
     onContentSettled: () => {
       // Anchor restoration can leave the top before its scroll event arrives.
@@ -248,7 +258,8 @@ export function useMessagePaging({
       return;
     }
     loadingOlderRef.current = true;
-    wasAtTopRef.current = (scrollRef.current?.scrollTop ?? 0) <= TOP_THRESHOLD_PX;
+    wasAtTopRef.current
+      = (scrollRef.current?.scrollTop ?? 0) <= TOP_THRESHOLD_PX;
     preserveViewport();
     protectViewport();
     if (effectivePageStart <= 0 && loadOlderHistory) {
@@ -319,7 +330,11 @@ export function useMessagePaging({
 
   // Keep this listener attached during the entire transaction. A wheel also
   // detects a top collision when scrollTop is clamped and no scroll event fires.
-  const wheelStateRef = useRef({ canLoadOlder, loadOlder, acceptManualViewport });
+  const wheelStateRef = useRef({
+    canLoadOlder,
+    loadOlder,
+    acceptManualViewport,
+  });
   useLayoutEffect(() => {
     wheelStateRef.current = { canLoadOlder, loadOlder, acceptManualViewport };
   }, [acceptManualViewport, canLoadOlder, loadOlder]);
@@ -339,8 +354,14 @@ export function useMessagePaging({
         if (event.deltaY > 0) {
           // Native vertical scrolling is locked, but an explicit downward
           // wheel still establishes a new reading position immediately.
-          const lineHeight = Number.parseFloat(getComputedStyle(container).lineHeight) || 16;
-          const unit = event.deltaMode === 1 ? lineHeight : event.deltaMode === 2 ? container.clientHeight : 1;
+          const lineHeight
+            = Number.parseFloat(getComputedStyle(container).lineHeight) || 16;
+          const unit
+            = event.deltaMode === 1
+              ? lineHeight
+              : event.deltaMode === 2
+                ? container.clientHeight
+                : 1;
           container.scrollTop += event.deltaY * unit;
           wheelStateRef.current.acceptManualViewport();
         }
@@ -360,20 +381,17 @@ export function useMessagePaging({
   }, [scrollRef]);
 
   // Cancel timer and layout work when switching conversations.
-  useEffect(
-    () => {
-      mountedRef.current = true;
-      return () => {
-        mountedRef.current = false;
-        releaseNativeScrollLock();
-        if (cooldownTimerRef.current !== null)
-          window.clearTimeout(cooldownTimerRef.current);
-        if (renderFrameRef.current !== null)
-          window.cancelAnimationFrame(renderFrameRef.current);
-      };
-    },
-    [releaseNativeScrollLock],
-  );
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      releaseNativeScrollLock();
+      if (cooldownTimerRef.current !== null)
+        window.clearTimeout(cooldownTimerRef.current);
+      if (renderFrameRef.current !== null)
+        window.cancelAnimationFrame(renderFrameRef.current);
+    };
+  }, [releaseNativeScrollLock]);
 
   return {
     visibleMessages,

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -64,6 +64,7 @@ interface UseMessagePagingResult {
   canLoadOlder: boolean;
   /** True when the user is pinned to the top and more history exists. */
   showLoadOlderHint: boolean;
+  coolingDown: boolean;
   handleScroll: () => void;
   loadOlder: () => void;
   scrollToLatest: () => void;
@@ -73,7 +74,7 @@ interface UseMessagePagingResult {
 /** Distance from the top that counts as "at the top" for the load hint. */
 const TOP_THRESHOLD_PX = 8;
 /** Block upward momentum after reaching the top or restoring a history page. */
-const WHEEL_COOLDOWN_MS = 500;
+const WHEEL_COOLDOWN_MS = 750;
 /**
  * How long the user must rest at the top before the load button appears. This
  * is the visual confirm gate; the separate wheel protection window blocks
@@ -112,11 +113,71 @@ export function useMessagePaging({
   const wheelBlockedUntilRef = useRef(0);
   const wheelProtectionRef = useRef(false);
   const wasAtTopRef = useRef(false);
+  const [coolingDown, setCoolingDown] = useState(false);
+  const [viewportRevision, setViewportRevision] = useState(0);
+  const dataPendingRef = useRef(false);
+  const renderPendingRef = useRef(false);
+  const cooldownTimerRef = useRef<number | null>(null);
+  const renderFrameRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  const finishCooldown = useCallback(() => {
+    if (dataPendingRef.current || renderPendingRef.current)
+      return;
+    const remaining = wheelBlockedUntilRef.current - performance.now();
+    if (remaining > 0) {
+      if (cooldownTimerRef.current !== null)
+        window.clearTimeout(cooldownTimerRef.current);
+      cooldownTimerRef.current = window.setTimeout(finishCooldown, remaining);
+      return;
+    }
+    wheelProtectionRef.current = false;
+    setCoolingDown(false);
+  }, []);
+
+  // A React commit alone is not a painted, stable viewport. Wait for two
+  // animation frames with unchanged geometry after anchor correction. Resizes
+  // restart this check; eager images still loading keep it pending.
+  const settleRenderedViewport = useCallback(() => {
+    if (!wheelProtectionRef.current)
+      return;
+    renderPendingRef.current = true;
+    if (renderFrameRef.current !== null)
+      window.cancelAnimationFrame(renderFrameRef.current);
+    if (dataPendingRef.current)
+      return;
+    let previousGeometry = "";
+    let stableFrames = 0;
+    const checkFrame = () => {
+      const container = scrollRef.current;
+      const geometry = container
+        ? `${container.scrollHeight}:${container.clientHeight}:${container.scrollTop}`
+        : "detached";
+      const imagesPending = container && Array.from(container.querySelectorAll("img"))
+        .some(img => img.loading !== "lazy" && !img.complete);
+      stableFrames = geometry === previousGeometry && !imagesPending ? stableFrames + 1 : 0;
+      previousGeometry = geometry;
+      if (stableFrames < 2) {
+        renderFrameRef.current = window.requestAnimationFrame(checkFrame);
+        return;
+      }
+      renderFrameRef.current = null;
+      renderPendingRef.current = false;
+      finishCooldown();
+    };
+    renderFrameRef.current = window.requestAnimationFrame(checkFrame);
+  }, [finishCooldown, scrollRef]);
 
   const protectViewport = useCallback(() => {
     wheelProtectionRef.current = true;
     wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
-  }, []);
+    renderPendingRef.current = true;
+    setCoolingDown(true);
+    setViewportRevision(revision => revision + 1);
+    if (cooldownTimerRef.current !== null)
+      window.clearTimeout(cooldownTimerRef.current);
+    cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
+  }, [finishCooldown]);
 
   // Once rendered, the leading message stays in the window even when new
   // exchanges arrive. Counting backwards from the tail would evict that row.
@@ -142,15 +203,25 @@ export function useMessagePaging({
     contentKey: visibleMessages,
     followEnabled,
     onScroll,
-    onContentSettled,
+    onContentSettled: () => {
+      // Anchor restoration can leave the top before its scroll event arrives.
+      // Re-arm top-entry detection synchronously for the next collision.
+      if (scrollRef.current && scrollRef.current.scrollTop > TOP_THRESHOLD_PX) {
+        wasAtTopRef.current = false;
+        setAtTop(false);
+        setTopSettled(false);
+      }
+      settleRenderedViewport();
+      onContentSettled?.();
+    },
   });
   useLayoutEffect(() => {
     setWindowStartId(visibleMessages[0]?.id ?? null);
   }, [visibleMessages]);
   const canLoadOlder = effectivePageStart > 0 || hasOlderHistory;
-  // The button only appears after the user has rested at the top for the settle
-  // window — arriving at the top must not, by itself, ever trigger a load.
-  const showLoadOlderHint = canLoadOlder && atTop && topSettled;
+  // Keep the hint visible throughout protection, including after the anchor
+  // moves away from the top or the final history page has been loaded.
+  const showLoadOlderHint = coolingDown || (canLoadOlder && atTop && topSettled);
 
   const loadOlder = useCallback(() => {
     if (
@@ -160,6 +231,7 @@ export function useMessagePaging({
       return;
     }
     loadingOlderRef.current = true;
+    wasAtTopRef.current = (scrollRef.current?.scrollTop ?? 0) <= TOP_THRESHOLD_PX;
     protectViewport();
     if (topSettleTimerRef.current !== null) {
       window.clearTimeout(topSettleTimerRef.current);
@@ -169,14 +241,18 @@ export function useMessagePaging({
     if (effectivePageStart <= 0 && loadOlderHistory) {
       // The callback runs only for a valid page, immediately before its state
       // update. Capture the CURRENT viewport, not the one at request start.
+      dataPendingRef.current = true;
       void loadOlderHistory((page) => {
-        protectViewport();
         preserveViewport();
         if (page.length > 0)
           setWindowStartId(page[0]!.id);
       }).finally(() => {
-        wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
+        if (!mountedRef.current)
+          return;
+        dataPendingRef.current = false;
         loadingOlderRef.current = false;
+        // Force a commit even for an empty/failed page before checking layout.
+        setViewportRevision(revision => revision + 1);
       });
     }
     else {
@@ -194,12 +270,15 @@ export function useMessagePaging({
     messages,
     preserveViewport,
     protectViewport,
+    scrollRef,
     userExchangeCount,
   ]);
 
   useLayoutEffect(() => {
-    loadingOlderRef.current = false;
-  }, [windowStartId]);
+    if (!dataPendingRef.current)
+      loadingOlderRef.current = false;
+    settleRenderedViewport();
+  }, [visibleMessages, coolingDown, viewportRevision, settleRenderedViewport]);
 
   // Compose the caller's scroll handling with top detection. `scrollTop === 0`
   // means the user is at the very top; resting there for the settle window turns
@@ -233,11 +312,11 @@ export function useMessagePaging({
 
   // Keep the non-passive listener mounted across loading and anchor restoration.
   // Otherwise the momentum tail can scroll the newly prepended content even
-  // though the load hint has disappeared. Reversing direction releases the gate.
-  const wheelStateRef = useRef({ canLoadOlder, atTop, topSettled, loadOlder });
+  // while the load hint stays visible. Downward scrolling remains available.
+  const wheelStateRef = useRef({ canLoadOlder, atTop, topSettled, loadOlder, handleScroll });
   useLayoutEffect(() => {
-    wheelStateRef.current = { canLoadOlder, atTop, topSettled, loadOlder };
-  }, [atTop, canLoadOlder, loadOlder, topSettled]);
+    wheelStateRef.current = { canLoadOlder, atTop, topSettled, loadOlder, handleScroll };
+  }, [atTop, canLoadOlder, handleScroll, loadOlder, topSettled]);
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -248,19 +327,19 @@ export function useMessagePaging({
         return;
       if (event.ctrlKey || event.deltaY === 0)
         return;
-      if (event.deltaY > 0) {
-        wheelProtectionRef.current = false;
+      if (event.deltaY > 0)
         return;
-      }
+      const state = wheelStateRef.current;
+      if (state.canLoadOlder && !wasAtTopRef.current && container.scrollTop <= TOP_THRESHOLD_PX)
+        state.handleScroll();
       if (
         wheelProtectionRef.current
-        && (loadingOlderRef.current || performance.now() < wheelBlockedUntilRef.current)
+        && (dataPendingRef.current || renderPendingRef.current || performance.now() < wheelBlockedUntilRef.current)
       ) {
         if (event.cancelable)
           event.preventDefault();
         return;
       }
-      const state = wheelStateRef.current;
       if (!state.canLoadOlder || !state.atTop || !state.topSettled)
         return;
       if (event.cancelable)
@@ -273,11 +352,19 @@ export function useMessagePaging({
 
   // Don't leave a pending settle timer firing setState after unmount.
   useEffect(
-    () => () => {
-      if (topSettleTimerRef.current !== null) {
-        window.clearTimeout(topSettleTimerRef.current);
-        topSettleTimerRef.current = null;
-      }
+    () => {
+      mountedRef.current = true;
+      return () => {
+        mountedRef.current = false;
+        if (cooldownTimerRef.current !== null)
+          window.clearTimeout(cooldownTimerRef.current);
+        if (renderFrameRef.current !== null)
+          window.cancelAnimationFrame(renderFrameRef.current);
+        if (topSettleTimerRef.current !== null) {
+          window.clearTimeout(topSettleTimerRef.current);
+          topSettleTimerRef.current = null;
+        }
+      };
     },
     [],
   );
@@ -286,6 +373,7 @@ export function useMessagePaging({
     visibleMessages,
     canLoadOlder,
     showLoadOlderHint,
+    coolingDown,
     handleScroll,
     loadOlder,
     scrollToLatest,

--- a/desktop/src/features/agent/useMessagePaging.ts
+++ b/desktop/src/features/agent/useMessagePaging.ts
@@ -62,7 +62,7 @@ interface UseMessagePagingInput {
 interface UseMessagePagingResult {
   visibleMessages: AgentMessage[];
   canLoadOlder: boolean;
-  /** True when the user is pinned to the top and more history exists. */
+  /** Visible for exactly the active loading/cooldown transaction. */
   showLoadOlderHint: boolean;
   coolingDown: boolean;
   handleScroll: () => void;
@@ -75,13 +75,6 @@ interface UseMessagePagingResult {
 const TOP_THRESHOLD_PX = 8;
 /** Block upward momentum after reaching the top or restoring a history page. */
 const WHEEL_COOLDOWN_MS = 1500;
-/**
- * How long the user must rest at the top before the load button appears. This
- * is the visual confirm gate; the separate wheel protection window blocks
- * upward momentum while the hint appears and history is restored.
- */
-const TOP_SETTLE_MS = 350;
-
 /**
  * Windowed rendering over the loaded history. Once the local window reaches
  * its oldest entry, ask the storage hook for another page. Pages are counted in user exchanges, so loading an older
@@ -101,9 +94,6 @@ export function useMessagePaging({
   onContentSettled,
 }: UseMessagePagingInput): UseMessagePagingResult {
   const [windowStartId, setWindowStartId] = useState<string | null>(null);
-  const [atTop, setAtTop] = useState(false);
-  const [topSettled, setTopSettled] = useState(false);
-  const topSettleTimerRef = useRef<number | null>(null);
 
   // Synchronous re-entrancy guard. This ref is read in the same tick a wheel
   // event fires (a state flag would only flip after React commits), so a single
@@ -119,13 +109,10 @@ export function useMessagePaging({
   const renderPendingRef = useRef(false);
   const cooldownTimerRef = useRef<number | null>(null);
   const renderFrameRef = useRef<number | null>(null);
-  const hintPaintFrameRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
 
   const finishCooldown = useCallback(() => {
     if (dataPendingRef.current || renderPendingRef.current)
-      return;
-    if (!Number.isFinite(wheelBlockedUntilRef.current))
       return;
     const remaining = wheelBlockedUntilRef.current - performance.now();
     if (remaining > 0) {
@@ -140,7 +127,8 @@ export function useMessagePaging({
 
   // A React commit alone is not a painted, stable viewport. Wait for two
   // animation frames with unchanged geometry after anchor correction. Resizes
-  // restart this check; eager images still loading keep it pending.
+  // restart this check. Image/network completion is not a render barrier; late
+  // resizes continue to be handled by the shared anchor controller.
   const settleRenderedViewport = useCallback(() => {
     if (!wheelProtectionRef.current)
       return;
@@ -156,9 +144,7 @@ export function useMessagePaging({
       const geometry = container
         ? `${container.scrollHeight}:${container.clientHeight}:${container.scrollTop}`
         : "detached";
-      const imagesPending = container && Array.from(container.querySelectorAll("img"))
-        .some(img => img.loading !== "lazy" && !img.complete);
-      stableFrames = geometry === previousGeometry && !imagesPending ? stableFrames + 1 : 0;
+      stableFrames = geometry === previousGeometry ? stableFrames + 1 : 0;
       previousGeometry = geometry;
       if (stableFrames < 2) {
         renderFrameRef.current = window.requestAnimationFrame(checkFrame);
@@ -173,36 +159,14 @@ export function useMessagePaging({
 
   const protectViewport = useCallback(() => {
     wheelProtectionRef.current = true;
-    // Start the minimum visible duration only after the hint has had a paint.
-    wheelBlockedUntilRef.current = Number.POSITIVE_INFINITY;
+    wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
     renderPendingRef.current = true;
     setCoolingDown(true);
     setViewportRevision(revision => revision + 1);
     if (cooldownTimerRef.current !== null)
       window.clearTimeout(cooldownTimerRef.current);
-    cooldownTimerRef.current = null;
-    if (hintPaintFrameRef.current !== null)
-      window.cancelAnimationFrame(hintPaintFrameRef.current);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!coolingDown || Number.isFinite(wheelBlockedUntilRef.current))
-      return;
-    // rAF runs before paint. The second frame gives the committed
-    // hint a paint opportunity before starting its full 1500ms visible window.
-    hintPaintFrameRef.current = window.requestAnimationFrame(() => {
-      hintPaintFrameRef.current = window.requestAnimationFrame(() => {
-        hintPaintFrameRef.current = null;
-        wheelBlockedUntilRef.current = performance.now() + WHEEL_COOLDOWN_MS;
-        cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
-      });
-    });
-    return () => {
-      if (hintPaintFrameRef.current !== null)
-        window.cancelAnimationFrame(hintPaintFrameRef.current);
-      hintPaintFrameRef.current = null;
-    };
-  }, [coolingDown, viewportRevision, finishCooldown]);
+    cooldownTimerRef.current = window.setTimeout(finishCooldown, WHEEL_COOLDOWN_MS);
+  }, [finishCooldown]);
 
   // Once rendered, the leading message stays in the window even when new
   // exchanges arrive. Counting backwards from the tail would evict that row.
@@ -233,8 +197,6 @@ export function useMessagePaging({
       // Re-arm top-entry detection synchronously for the next collision.
       if (scrollRef.current && scrollRef.current.scrollTop > TOP_THRESHOLD_PX) {
         wasAtTopRef.current = false;
-        setAtTop(false);
-        setTopSettled(false);
       }
       settleRenderedViewport();
       onContentSettled?.();
@@ -246,7 +208,7 @@ export function useMessagePaging({
   const canLoadOlder = effectivePageStart > 0 || hasOlderHistory;
   // Keep the hint visible throughout protection, including after the anchor
   // moves away from the top or the final history page has been loaded.
-  const showLoadOlderHint = coolingDown || (canLoadOlder && atTop && topSettled);
+  const showLoadOlderHint = coolingDown;
 
   const loadOlder = useCallback(() => {
     if (
@@ -258,11 +220,6 @@ export function useMessagePaging({
     loadingOlderRef.current = true;
     wasAtTopRef.current = (scrollRef.current?.scrollTop ?? 0) <= TOP_THRESHOLD_PX;
     protectViewport();
-    if (topSettleTimerRef.current !== null) {
-      window.clearTimeout(topSettleTimerRef.current);
-      topSettleTimerRef.current = null;
-    }
-    setTopSettled(false);
     if (effectivePageStart <= 0 && loadOlderHistory) {
       // The callback runs only for a valid page, immediately before its state
       // update. Capture the CURRENT viewport, not the one at request start.
@@ -305,43 +262,27 @@ export function useMessagePaging({
     settleRenderedViewport();
   }, [visibleMessages, coolingDown, viewportRevision, settleRenderedViewport]);
 
-  // Compose the caller's scroll handling with top detection. `scrollTop === 0`
-  // means the user is at the very top; resting there for the settle window turns
-  // the load button on. Any scroll away (or a load starting) cancels it — the
-  // button must re-settle before the next pull counts.
+  // Entering the top starts one transaction: hint + timer + history load.
+  // Programmatic anchor restoration re-arms entry detection above; events
+  // during this transaction must never restart its timer or load another page.
   const handleScroll = useCallback(() => {
     handleViewportScroll();
     const container = scrollRef.current;
     if (!container)
       return;
     const isAtTop = container.scrollTop <= TOP_THRESHOLD_PX;
-    if (isAtTop && !wasAtTopRef.current && canLoadOlder)
-      protectViewport();
+    const enteredTop = isAtTop && !wasAtTopRef.current;
     wasAtTopRef.current = isAtTop;
-    setAtTop(isAtTop);
-    if (!isAtTop) {
-      if (topSettleTimerRef.current !== null) {
-        window.clearTimeout(topSettleTimerRef.current);
-        topSettleTimerRef.current = null;
-      }
-      setTopSettled(false);
-      return;
-    }
-    if (topSettleTimerRef.current !== null)
-      return;
-    topSettleTimerRef.current = window.setTimeout(() => {
-      topSettleTimerRef.current = null;
-      setTopSettled(true);
-    }, TOP_SETTLE_MS);
-  }, [canLoadOlder, handleViewportScroll, protectViewport, scrollRef]);
+    if (enteredTop && canLoadOlder && !wheelProtectionRef.current)
+      loadOlder();
+  }, [canLoadOlder, handleViewportScroll, loadOlder, scrollRef]);
 
-  // Keep the non-passive listener mounted across loading and anchor restoration.
-  // Otherwise the momentum tail can scroll the newly prepended content even
-  // while the load hint stays visible. Downward scrolling remains available.
-  const wheelStateRef = useRef({ canLoadOlder, atTop, topSettled, loadOlder, handleScroll });
+  // Keep this listener attached during the entire transaction. A wheel also
+  // detects a top collision when scrollTop is clamped and no scroll event fires.
+  const wheelStateRef = useRef({ canLoadOlder, loadOlder });
   useLayoutEffect(() => {
-    wheelStateRef.current = { canLoadOlder, atTop, topSettled, loadOlder, handleScroll };
-  }, [atTop, canLoadOlder, handleScroll, loadOlder, topSettled]);
+    wheelStateRef.current = { canLoadOlder, loadOlder };
+  }, [canLoadOlder, loadOlder]);
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -354,18 +295,13 @@ export function useMessagePaging({
         return;
       if (event.deltaY > 0)
         return;
-      const state = wheelStateRef.current;
-      if (state.canLoadOlder && !wasAtTopRef.current && container.scrollTop <= TOP_THRESHOLD_PX)
-        state.handleScroll();
-      if (
-        wheelProtectionRef.current
-        && (dataPendingRef.current || renderPendingRef.current || performance.now() < wheelBlockedUntilRef.current)
-      ) {
+      if (wheelProtectionRef.current) {
         if (event.cancelable)
           event.preventDefault();
         return;
       }
-      if (!state.canLoadOlder || !state.atTop || !state.topSettled)
+      const state = wheelStateRef.current;
+      if (!state.canLoadOlder || container.scrollTop > TOP_THRESHOLD_PX)
         return;
       if (event.cancelable)
         event.preventDefault();
@@ -375,7 +311,7 @@ export function useMessagePaging({
     return () => container.removeEventListener("wheel", onWheel);
   }, [scrollRef]);
 
-  // Don't leave a pending settle timer firing setState after unmount.
+  // Cancel timer and layout work when switching conversations.
   useEffect(
     () => {
       mountedRef.current = true;
@@ -385,10 +321,6 @@ export function useMessagePaging({
           window.clearTimeout(cooldownTimerRef.current);
         if (renderFrameRef.current !== null)
           window.cancelAnimationFrame(renderFrameRef.current);
-        if (topSettleTimerRef.current !== null) {
-          window.clearTimeout(topSettleTimerRef.current);
-          topSettleTimerRef.current = null;
-        }
       };
     },
     [],

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -51,7 +51,7 @@ function setup(messages: AgentMessage[] = MESSAGES, userExchangeCount = 2) {
 
 async function settle() {
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(550);
+    await vi.advanceTimersByTimeAsync(800);
   });
 }
 
@@ -102,7 +102,8 @@ describe("useMessagePaging", () => {
     act(() => {
       h.current.handleScroll();
     });
-    expect(h.current.showLoadOlderHint).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    expect(h.current.coolingDown).toBe(true);
     // A second scroll while the settle timer is pending is a no-op.
     act(() => {
       h.current.handleScroll();
@@ -233,7 +234,7 @@ describe("useMessagePaging", () => {
     await settle();
     expect(wheel(-40)).toBe(true);
     expect(h.current.visibleMessages[0]?.id).toBe("u3");
-    // The hint is gone and the viewport moved away from the top, but the
+    // The hint persists after the viewport moved away from the top, and the
     // momentum must still be cancelled by the mounted listener.
     container.scrollTop = 200;
     act(() => {
@@ -245,7 +246,7 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("immediately releases protection when the user scrolls down", () => {
+  it("allows downward scrolling without shortening upward protection", () => {
     const { container, h } = setup();
     act(() => {
       h.current.loadOlder();
@@ -257,7 +258,131 @@ describe("useMessagePaging", () => {
       container.dispatchEvent(up);
     });
     expect(down.defaultPrevented).toBe(false);
-    expect(up.defaultPrevented).toBe(false);
+    expect(up.defaultPrevented).toBe(true);
+    h.unmount();
+  });
+
+  it("re-arms a full 750ms cooldown on the second top collision", async () => {
+    const { container, h } = setup();
+    act(() => {
+      h.current.handleScroll();
+    });
+    await settle();
+    act(() => {
+      h.current.loadOlder();
+    });
+    container.scrollTop = 200;
+    act(() => {
+      h.current.handleScroll();
+    });
+    await settle();
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+
+    container.scrollTop = 0;
+    // Even before the browser delivers scroll, wheel must detect re-entry.
+    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
+    act(() => {
+      container.dispatchEvent(up);
+    });
+    expect(up.defaultPrevented).toBe(true);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(749);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
+    h.unmount();
+  });
+
+  it("keeps the hint for 750ms even when the last local page renders quickly", async () => {
+    const { container, h } = setup(MESSAGES.slice(4), 2);
+    act(() => {
+      h.current.loadOlder();
+    });
+    container.scrollTop = 200;
+    act(() => {
+      h.current.handleScroll();
+    });
+    expect(h.current.canLoadOlder).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(749);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+  });
+
+  it("waits for slow data and subsequent layout without adding another 750ms", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let completeLoad!: () => void;
+    const loadOlderHistory = vi.fn(() => new Promise<void>((resolve) => {
+      completeLoad = resolve;
+    }));
+    const scrollRef = { current: container };
+    const messages = MESSAGES.slice(8);
+    const h = renderHook(() => useMessagePaging({
+      messages,
+      scrollRef,
+      userExchangeCount: 2,
+      hasOlderHistory: true,
+      loadOlderHistory,
+    }));
+    act(() => {
+      h.current.loadOlder();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(900);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
+    act(() => {
+      container.dispatchEvent(up);
+    });
+    expect(up.defaultPrevented).toBe(true);
+    await act(async () => {
+      completeLoad();
+    });
+    expect(h.current.coolingDown).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(64);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+    container.remove();
+  });
+
+  it("waits past 750ms for pending images and stable geometry", async () => {
+    const { container, h } = setup();
+    const img = document.createElement("img");
+    let complete = false;
+    Object.defineProperty(img, "complete", { get: () => complete });
+    container.append(img);
+    act(() => {
+      h.current.loadOlder();
+    });
+    await settle();
+    expect(h.current.coolingDown).toBe(true);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    complete = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(64);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
     h.unmount();
   });
 

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -51,7 +51,7 @@ function setup(messages: AgentMessage[] = MESSAGES, userExchangeCount = 2) {
 
 async function settle() {
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(400);
+    await vi.advanceTimersByTimeAsync(550);
   });
 }
 
@@ -202,8 +202,7 @@ describe("useMessagePaging", () => {
     });
     expect(h.current.visibleMessages[0]?.id).toBe("u3");
 
-    // …but the restore dropped the hint; re-settle, then the cooldown swallows
-    // the trailing wheel of the same gesture.
+    // Once the hint and cooldown settle again, another gesture loads one page.
     container.scrollTop = 0;
     act(() => {
       h.current.handleScroll();
@@ -214,6 +213,51 @@ describe("useMessagePaging", () => {
       container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
     });
     expect(h.current.visibleMessages[0]?.id).toBe("u1");
+    h.unmount();
+  });
+
+  it("cancels upward momentum after hitting the top and after loading", async () => {
+    const { container, h } = setup();
+    const wheel = (deltaY: number) => {
+      const event = new WheelEvent("wheel", { deltaY, cancelable: true });
+      act(() => {
+        container.dispatchEvent(event);
+      });
+      return event.defaultPrevented;
+    };
+    act(() => {
+      h.current.handleScroll();
+    });
+    expect(wheel(-40)).toBe(true);
+    expect(h.current.visibleMessages[0]?.id).toBe("u5");
+    await settle();
+    expect(wheel(-40)).toBe(true);
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
+    // The hint is gone and the viewport moved away from the top, but the
+    // momentum must still be cancelled by the mounted listener.
+    container.scrollTop = 200;
+    act(() => {
+      h.current.handleScroll();
+    });
+    expect(wheel(-40)).toBe(true);
+    await settle();
+    expect(wheel(-40)).toBe(false);
+    h.unmount();
+  });
+
+  it("immediately releases protection when the user scrolls down", () => {
+    const { container, h } = setup();
+    act(() => {
+      h.current.loadOlder();
+    });
+    const down = new WheelEvent("wheel", { deltaY: 40, cancelable: true });
+    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
+    act(() => {
+      container.dispatchEvent(down);
+      container.dispatchEvent(up);
+    });
+    expect(down.defaultPrevented).toBe(false);
+    expect(up.defaultPrevented).toBe(false);
     h.unmount();
   });
 

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -57,15 +57,26 @@ function setupAnchoredPaging() {
   document.body.append(container);
   let rowTop = 0;
   Object.defineProperty(container, "clientHeight", { value: 200 });
-  Object.defineProperty(container, "scrollHeight", { get: () => rowTop + 1200 });
-  vi.spyOn(container, "getBoundingClientRect").mockImplementation(() => ({ top: 0, bottom: 200 }) as DOMRect);
-  vi.spyOn(row, "getBoundingClientRect").mockImplementation(() => ({
-    top: rowTop - container.scrollTop,
-    bottom: rowTop + 200 - container.scrollTop,
-  }) as DOMRect);
+  Object.defineProperty(container, "scrollHeight", {
+    get: () => rowTop + 1200,
+  });
+  vi.spyOn(container, "getBoundingClientRect").mockImplementation(
+    () => ({ top: 0, bottom: 200 }) as DOMRect,
+  );
+  vi.spyOn(row, "getBoundingClientRect").mockImplementation(
+    () =>
+      ({
+        top: rowTop - container.scrollTop,
+        bottom: rowTop + 200 - container.scrollTop,
+      }) as DOMRect,
+  );
   const scrollRef = { current: container };
   const h = renderHook(() => {
-    const paging = useMessagePaging({ messages: MESSAGES, scrollRef, userExchangeCount: 2 });
+    const paging = useMessagePaging({
+      messages: MESSAGES,
+      scrollRef,
+      userExchangeCount: 2,
+    });
     // Model the DOM prepend before React's layout effects restore the anchor.
     rowTop = paging.visibleMessages[0]?.id === "u5" ? 0 : 600;
     return paging;
@@ -302,18 +313,23 @@ describe("useMessagePaging", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     let completeLoad!: () => void;
-    const loadOlderHistory = vi.fn(() => new Promise<void>((resolve) => {
-      completeLoad = resolve;
-    }));
+    const loadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeLoad = resolve;
+        }),
+    );
     const scrollRef = { current: container };
     const messages = MESSAGES.slice(8);
-    const h = renderHook(() => useMessagePaging({
-      messages,
-      scrollRef,
-      userExchangeCount: 2,
-      hasOlderHistory: true,
-      loadOlderHistory,
-    }));
+    const h = renderHook(() =>
+      useMessagePaging({
+        messages,
+        scrollRef,
+        userExchangeCount: 2,
+        hasOlderHistory: true,
+        loadOlderHistory,
+      }),
+    );
     act(() => {
       h.current.loadOlder();
     });

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -49,6 +49,34 @@ function setup(messages: AgentMessage[] = MESSAGES, userExchangeCount = 2) {
   return { container, scrollRef, onScroll, h };
 }
 
+function setupAnchoredPaging() {
+  const container = document.createElement("div");
+  const row = document.createElement("div");
+  row.dataset.messageId = "u5";
+  container.append(row);
+  document.body.append(container);
+  let rowTop = 0;
+  Object.defineProperty(container, "clientHeight", { value: 200 });
+  Object.defineProperty(container, "scrollHeight", { get: () => rowTop + 1200 });
+  vi.spyOn(container, "getBoundingClientRect").mockImplementation(() => ({ top: 0, bottom: 200 }) as DOMRect);
+  vi.spyOn(row, "getBoundingClientRect").mockImplementation(() => ({
+    top: rowTop - container.scrollTop,
+    bottom: rowTop + 200 - container.scrollTop,
+  }) as DOMRect);
+  const scrollRef = { current: container };
+  const h = renderHook(() => {
+    const paging = useMessagePaging({ messages: MESSAGES, scrollRef, userExchangeCount: 2 });
+    // Model the DOM prepend before React's layout effects restore the anchor.
+    rowTop = paging.visibleMessages[0]?.id === "u5" ? 0 : 600;
+    return paging;
+  });
+  act(() => {
+    container.scrollTop = 0;
+    h.current.handleScroll();
+  });
+  return { container, row, h };
+}
+
 async function settle() {
   await act(async () => {
     await vi.advanceTimersByTimeAsync(1600);
@@ -264,7 +292,8 @@ describe("useMessagePaging", () => {
       container.dispatchEvent(down);
       container.dispatchEvent(up);
     });
-    expect(down.defaultPrevented).toBe(false);
+    expect(down.defaultPrevented).toBe(true);
+    expect(container.scrollTop).toBe(40);
     expect(up.defaultPrevented).toBe(true);
     h.unmount();
   });
@@ -309,6 +338,68 @@ describe("useMessagePaging", () => {
     expect(h.current.showLoadOlderHint).toBe(false);
     h.unmount();
     container.remove();
+  });
+
+  it("restores noncancelable momentum drift during the cooldown, then unlocks", async () => {
+    const { container, row, h } = setupAnchoredPaging();
+    expect(container.scrollTop).toBe(600);
+    expect(row.getBoundingClientRect().top).toBe(0);
+    expect(container.style.overflowY).toBe("hidden");
+    const up = new WheelEvent("wheel", { deltaY: -80, cancelable: false });
+    act(() => {
+      container.dispatchEvent(up);
+      // Simulate an in-flight WebKit scroll arriving despite the native lock.
+      container.scrollTop = 520;
+      h.current.handleScroll();
+    });
+    expect(up.defaultPrevented).toBe(false);
+    expect(h.current.coolingDown).toBe(true);
+    expect(container.scrollTop).toBe(600);
+    expect(row.getBoundingClientRect().top).toBe(0);
+    await settle();
+    expect(container.style.overflowY).toBe("");
+    act(() => {
+      container.scrollTop = 520;
+      h.current.handleScroll();
+    });
+    expect(container.scrollTop).toBe(520);
+    h.unmount();
+  });
+
+  it("accepts downward wheel input as the new protected reading position", () => {
+    const { container, row, h } = setupAnchoredPaging();
+    const down = new WheelEvent("wheel", { deltaY: 80, cancelable: false });
+    act(() => {
+      container.dispatchEvent(down);
+    });
+    expect(container.scrollTop).toBe(680);
+    expect(row.getBoundingClientRect().top).toBe(-80);
+    act(() => {
+      container.scrollTop = 620;
+      h.current.handleScroll();
+    });
+    expect(container.scrollTop).toBe(680);
+    expect(row.getBoundingClientRect().top).toBe(-80);
+    h.unmount();
+    expect(container.style.overflowY).toBe("");
+  });
+
+  it("restores the original overflow style on completion and unmount", async () => {
+    const { container, h } = setup();
+    container.style.setProperty("overflow-y", "scroll", "important");
+    act(() => {
+      h.current.loadOlder();
+    });
+    expect(container.style.overflowY).toBe("hidden");
+    await settle();
+    expect(container.style.overflowY).toBe("scroll");
+    expect(container.style.getPropertyPriority("overflow-y")).toBe("important");
+    act(() => {
+      h.current.loadOlder();
+    });
+    h.unmount();
+    expect(container.style.overflowY).toBe("scroll");
+    expect(container.style.getPropertyPriority("overflow-y")).toBe("important");
   });
 
   it("restores the scroll position from the captured anchor", () => {

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -96,34 +96,120 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("settles the load hint after resting at the top", async () => {
+  it("starts loading, the hint and the 1500ms timer on the first top collision", async () => {
     const { container, h } = setup();
     container.scrollTop = 0;
     act(() => {
       h.current.handleScroll();
     });
-    expect(h.current.showLoadOlderHint).toBe(true);
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
     expect(h.current.coolingDown).toBe(true);
-    // A second scroll while the settle timer is pending is a no-op.
-    act(() => {
-      h.current.handleScroll();
-    });
-    await settle();
     expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1499);
+    });
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    // Even while still at the top, no old confirmation hint may remain.
+    expect(container.scrollTop).toBe(0);
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
     h.unmount();
   });
 
-  it("cancels the settle when scrolling away from the top", async () => {
+  it("does not reload or restart the timer for momentum during cooldown", async () => {
     const { container, h } = setup();
-    container.scrollTop = 0;
     act(() => {
       h.current.handleScroll();
     });
-    container.scrollTop = 100;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
+    act(() => {
+      container.scrollTop = 200;
+      h.current.handleScroll();
+      container.scrollTop = 0;
+      h.current.handleScroll();
+      container.dispatchEvent(up);
+    });
+    expect(up.defaultPrevented).toBe(true);
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+  });
+
+  it("starts the same transaction on the second collision without another confirmation", async () => {
+    const { container, h } = setup();
     act(() => {
       h.current.handleScroll();
     });
     await settle();
+    act(() => {
+      container.scrollTop = 200;
+      h.current.handleScroll();
+      container.scrollTop = 0;
+      h.current.handleScroll();
+    });
+    expect(h.current.visibleMessages[0]?.id).toBe("u1");
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1499);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+  });
+
+  it("loads on an upward wheel when the top produces no scroll event", async () => {
+    const { container, h } = setup();
+    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
+    act(() => {
+      container.dispatchEvent(up);
+    });
+    expect(up.defaultPrevented).toBe(true);
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await settle();
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+  });
+
+  it("counts from the collision even if React commits slowly", async () => {
+    const { h } = setup();
+    act(() => {
+      h.current.handleScroll();
+      vi.advanceTimersByTime(1800);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(64);
+    });
+    expect(h.current.coolingDown).toBe(false);
+    expect(h.current.showLoadOlderHint).toBe(false);
+    h.unmount();
+  });
+
+  it("does not wait forever for an image whose geometry is already stable", async () => {
+    const { container, h } = setup();
+    const img = document.createElement("img");
+    Object.defineProperty(img, "complete", { value: false });
+    container.append(img);
+    act(() => {
+      h.current.handleScroll();
+    });
+    await settle();
+    expect(h.current.coolingDown).toBe(false);
     expect(h.current.showLoadOlderHint).toBe(false);
     h.unmount();
   });
@@ -167,85 +253,6 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("clears a pending settle timer when a load starts", async () => {
-    const { container, h } = setup();
-    container.scrollTop = 0;
-    act(() => {
-      h.current.handleScroll();
-    });
-    act(() => {
-      h.current.loadOlder();
-    });
-    // The pre-load settle must not fire afterwards.
-    await settle();
-    expect(h.current.showLoadOlderHint).toBe(false);
-    h.unmount();
-  });
-
-  it("loads a page via the wheel gesture once settled, with a cooldown", async () => {
-    const { container, h } = setup();
-    container.scrollTop = 0;
-    act(() => {
-      h.current.handleScroll();
-    });
-    await settle();
-    expect(h.current.showLoadOlderHint).toBe(true);
-
-    // A downward wheel does nothing.
-    act(() => {
-      container.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
-    });
-    expect(h.current.visibleMessages[0]?.id).toBe("u5");
-
-    // An upward wheel loads a page…
-    act(() => {
-      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
-    });
-    expect(h.current.visibleMessages[0]?.id).toBe("u3");
-
-    // Once the hint and cooldown settle again, another gesture loads one page.
-    container.scrollTop = 0;
-    act(() => {
-      h.current.handleScroll();
-    });
-    await settle();
-    act(() => {
-      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
-      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
-    });
-    expect(h.current.visibleMessages[0]?.id).toBe("u1");
-    h.unmount();
-  });
-
-  it("cancels upward momentum after hitting the top and after loading", async () => {
-    const { container, h } = setup();
-    const wheel = (deltaY: number) => {
-      const event = new WheelEvent("wheel", { deltaY, cancelable: true });
-      act(() => {
-        container.dispatchEvent(event);
-      });
-      return event.defaultPrevented;
-    };
-    act(() => {
-      h.current.handleScroll();
-    });
-    expect(wheel(-40)).toBe(true);
-    expect(h.current.visibleMessages[0]?.id).toBe("u5");
-    await settle();
-    expect(wheel(-40)).toBe(true);
-    expect(h.current.visibleMessages[0]?.id).toBe("u3");
-    // The hint persists after the viewport moved away from the top, and the
-    // momentum must still be cancelled by the mounted listener.
-    container.scrollTop = 200;
-    act(() => {
-      h.current.handleScroll();
-    });
-    expect(wheel(-40)).toBe(true);
-    await settle();
-    expect(wheel(-40)).toBe(false);
-    h.unmount();
-  });
-
   it("allows downward scrolling without shortening upward protection", () => {
     const { container, h } = setup();
     act(() => {
@@ -259,95 +266,6 @@ describe("useMessagePaging", () => {
     });
     expect(down.defaultPrevented).toBe(false);
     expect(up.defaultPrevented).toBe(true);
-    h.unmount();
-  });
-
-  it("re-arms a full 1500ms cooldown on the second top collision", async () => {
-    const { container, h } = setup();
-    act(() => {
-      h.current.handleScroll();
-    });
-    await settle();
-    act(() => {
-      h.current.loadOlder();
-    });
-    container.scrollTop = 200;
-    act(() => {
-      h.current.handleScroll();
-    });
-    await settle();
-    expect(h.current.coolingDown).toBe(false);
-    expect(h.current.showLoadOlderHint).toBe(false);
-
-    container.scrollTop = 0;
-    // Even before the browser delivers scroll, wheel must detect re-entry.
-    const up = new WheelEvent("wheel", { deltaY: -40, cancelable: true });
-    act(() => {
-      container.dispatchEvent(up);
-    });
-    expect(up.defaultPrevented).toBe(true);
-    expect(h.current.showLoadOlderHint).toBe(true);
-    // Allow the committed hint its first paint before counting visible time.
-    act(() => {
-      vi.advanceTimersToNextFrame();
-      vi.advanceTimersToNextFrame();
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1499);
-    });
-    expect(h.current.coolingDown).toBe(true);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1);
-    });
-    expect(h.current.coolingDown).toBe(false);
-    expect(h.current.visibleMessages[0]?.id).toBe("u3");
-    h.unmount();
-  });
-
-  it("keeps the hint for 1500ms even when the last local page renders quickly", async () => {
-    const { container, h } = setup(MESSAGES.slice(4), 2);
-    act(() => {
-      h.current.loadOlder();
-    });
-    container.scrollTop = 200;
-    act(() => {
-      h.current.handleScroll();
-    });
-    expect(h.current.canLoadOlder).toBe(false);
-    expect(h.current.showLoadOlderHint).toBe(true);
-    // Allow the committed hint its first paint before counting visible time.
-    act(() => {
-      vi.advanceTimersToNextFrame();
-      vi.advanceTimersToNextFrame();
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1499);
-    });
-    expect(h.current.coolingDown).toBe(true);
-    expect(h.current.showLoadOlderHint).toBe(true);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1);
-    });
-    expect(h.current.coolingDown).toBe(false);
-    expect(h.current.showLoadOlderHint).toBe(false);
-    h.unmount();
-  });
-
-  it("does not spend the hint's visible cooldown before React commits", async () => {
-    const { h } = setup();
-    act(() => {
-      h.current.loadOlder();
-      // Simulate expensive synchronous rendering before the hint can commit.
-      vi.advanceTimersByTime(1800);
-    });
-    expect(h.current.showLoadOlderHint).toBe(true);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
-    expect(h.current.coolingDown).toBe(true);
-    expect(h.current.showLoadOlderHint).toBe(true);
-    await settle();
-    expect(h.current.coolingDown).toBe(false);
     h.unmount();
   });
 
@@ -391,27 +309,6 @@ describe("useMessagePaging", () => {
     expect(h.current.showLoadOlderHint).toBe(false);
     h.unmount();
     container.remove();
-  });
-
-  it("waits past 1500ms for pending images and stable geometry", async () => {
-    const { container, h } = setup();
-    const img = document.createElement("img");
-    let complete = false;
-    Object.defineProperty(img, "complete", { get: () => complete });
-    container.append(img);
-    act(() => {
-      h.current.loadOlder();
-    });
-    await settle();
-    expect(h.current.coolingDown).toBe(true);
-    expect(h.current.showLoadOlderHint).toBe(true);
-    complete = true;
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(64);
-    });
-    expect(h.current.coolingDown).toBe(false);
-    expect(h.current.showLoadOlderHint).toBe(false);
-    h.unmount();
   });
 
   it("restores the scroll position from the captured anchor", () => {
@@ -480,7 +377,7 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("clears a pending settle timer on unmount", async () => {
+  it("clears pending cooldown and render work on unmount", async () => {
     const { container, h } = setup();
     container.scrollTop = 0;
     act(() => {
@@ -520,20 +417,20 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("does not attach the wheel listener when the container is gone", async () => {
+  it("ignores wheel events from a detached container", async () => {
     const { container, scrollRef, h } = setup();
     container.scrollTop = 0;
     act(() => {
       h.current.handleScroll();
     });
-    // Container vanishes before the settle completes: the wheel effect runs
-    // with no container and attaches nothing.
+    // The first collision loaded a page; events from a detached container
+    // must not trigger another load.
     scrollRef.current = null;
     await settle();
     act(() => {
       container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
     });
-    expect(h.current.visibleMessages[0]?.id).toBe("u5");
+    expect(h.current.visibleMessages[0]?.id).toBe("u3");
     h.unmount();
   });
 

--- a/desktop/src/features/agent/useMessagePagingHook.test.ts
+++ b/desktop/src/features/agent/useMessagePagingHook.test.ts
@@ -51,7 +51,7 @@ function setup(messages: AgentMessage[] = MESSAGES, userExchangeCount = 2) {
 
 async function settle() {
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(800);
+    await vi.advanceTimersByTimeAsync(1600);
   });
 }
 
@@ -262,7 +262,7 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("re-arms a full 750ms cooldown on the second top collision", async () => {
+  it("re-arms a full 1500ms cooldown on the second top collision", async () => {
     const { container, h } = setup();
     act(() => {
       h.current.handleScroll();
@@ -287,8 +287,13 @@ describe("useMessagePaging", () => {
     });
     expect(up.defaultPrevented).toBe(true);
     expect(h.current.showLoadOlderHint).toBe(true);
+    // Allow the committed hint its first paint before counting visible time.
+    act(() => {
+      vi.advanceTimersToNextFrame();
+      vi.advanceTimersToNextFrame();
+    });
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(749);
+      await vi.advanceTimersByTimeAsync(1499);
     });
     expect(h.current.coolingDown).toBe(true);
     await act(async () => {
@@ -299,7 +304,7 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("keeps the hint for 750ms even when the last local page renders quickly", async () => {
+  it("keeps the hint for 1500ms even when the last local page renders quickly", async () => {
     const { container, h } = setup(MESSAGES.slice(4), 2);
     act(() => {
       h.current.loadOlder();
@@ -310,8 +315,13 @@ describe("useMessagePaging", () => {
     });
     expect(h.current.canLoadOlder).toBe(false);
     expect(h.current.showLoadOlderHint).toBe(true);
+    // Allow the committed hint its first paint before counting visible time.
+    act(() => {
+      vi.advanceTimersToNextFrame();
+      vi.advanceTimersToNextFrame();
+    });
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(749);
+      await vi.advanceTimersByTimeAsync(1499);
     });
     expect(h.current.coolingDown).toBe(true);
     expect(h.current.showLoadOlderHint).toBe(true);
@@ -323,7 +333,25 @@ describe("useMessagePaging", () => {
     h.unmount();
   });
 
-  it("waits for slow data and subsequent layout without adding another 750ms", async () => {
+  it("does not spend the hint's visible cooldown before React commits", async () => {
+    const { h } = setup();
+    act(() => {
+      h.current.loadOlder();
+      // Simulate expensive synchronous rendering before the hint can commit.
+      vi.advanceTimersByTime(1800);
+    });
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(h.current.coolingDown).toBe(true);
+    expect(h.current.showLoadOlderHint).toBe(true);
+    await settle();
+    expect(h.current.coolingDown).toBe(false);
+    h.unmount();
+  });
+
+  it("waits for slow data and subsequent layout without adding another 1500ms", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     let completeLoad!: () => void;
@@ -343,7 +371,7 @@ describe("useMessagePaging", () => {
       h.current.loadOlder();
     });
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(900);
+      await vi.advanceTimersByTimeAsync(1800);
     });
     expect(h.current.coolingDown).toBe(true);
     expect(h.current.showLoadOlderHint).toBe(true);
@@ -365,7 +393,7 @@ describe("useMessagePaging", () => {
     container.remove();
   });
 
-  it("waits past 750ms for pending images and stable geometry", async () => {
+  it("waits past 1500ms for pending images and stable geometry", async () => {
     const { container, h } = setup();
     const img = document.createElement("img");
     let complete = false;

--- a/desktop/src/features/agent/useStickyAutoScroll.ts
+++ b/desktop/src/features/agent/useStickyAutoScroll.ts
@@ -12,8 +12,8 @@ interface UseStickyAutoScrollInput {
   contentKey: unknown;
   /** False while the real message content is temporarily not mounted. */
   followEnabled?: boolean;
-  /** Reject native scroll drift while a paging transaction owns the anchor. */
-  isReadingAnchorLocked?: () => boolean;
+  /** Consume a WebKit momentum scroll that must restore the reading anchor. */
+  shouldRestoreReadingAnchor?: () => boolean;
   /** Extra work to run on every scroll event (e.g. floating-scrollbar visibility). */
   onScroll?: () => void;
   /** Run after a content-driven follow settles (e.g. update floating scrollbar). */
@@ -30,7 +30,7 @@ export function useStickyAutoScroll({
   scrollRef,
   contentKey,
   followEnabled = true,
-  isReadingAnchorLocked,
+  shouldRestoreReadingAnchor,
   onScroll,
   onContentSettled,
 }: UseStickyAutoScrollInput) {
@@ -46,8 +46,8 @@ export function useStickyAutoScroll({
   // Keep the callbacks in refs so the effect/handlers always call the latest
   // without listing them as deps (which would re-run the follow effect on every
   // render when the parent passes inline closures).
-  const anchorLockedRef = useRef(isReadingAnchorLocked);
-  anchorLockedRef.current = isReadingAnchorLocked;
+  const shouldRestoreAnchorRef = useRef(shouldRestoreReadingAnchor);
+  shouldRestoreAnchorRef.current = shouldRestoreReadingAnchor;
   const onScrollRef = useRef(onScroll);
   const onContentSettledRef = useRef(onContentSettled);
   onScrollRef.current = onScroll;
@@ -113,7 +113,7 @@ export function useStickyAutoScroll({
   const handleScroll = useCallback(() => {
     // WebKit can deliver scrolling from an already-latched, noncancelable
     // gesture. Correct it before it can replace the preserved reading anchor.
-    if (anchorLockedRef.current?.() && anchorRef.current) {
+    if (shouldRestoreAnchorRef.current?.() && anchorRef.current) {
       settleViewport();
       onScrollRef.current?.();
       return;

--- a/desktop/src/features/agent/useStickyAutoScroll.ts
+++ b/desktop/src/features/agent/useStickyAutoScroll.ts
@@ -12,6 +12,8 @@ interface UseStickyAutoScrollInput {
   contentKey: unknown;
   /** False while the real message content is temporarily not mounted. */
   followEnabled?: boolean;
+  /** Reject native scroll drift while a paging transaction owns the anchor. */
+  isReadingAnchorLocked?: () => boolean;
   /** Extra work to run on every scroll event (e.g. floating-scrollbar visibility). */
   onScroll?: () => void;
   /** Run after a content-driven follow settles (e.g. update floating scrollbar). */
@@ -28,6 +30,7 @@ export function useStickyAutoScroll({
   scrollRef,
   contentKey,
   followEnabled = true,
+  isReadingAnchorLocked,
   onScroll,
   onContentSettled,
 }: UseStickyAutoScrollInput) {
@@ -43,39 +46,12 @@ export function useStickyAutoScroll({
   // Keep the callbacks in refs so the effect/handlers always call the latest
   // without listing them as deps (which would re-run the follow effect on every
   // render when the parent passes inline closures).
+  const anchorLockedRef = useRef(isReadingAnchorLocked);
+  anchorLockedRef.current = isReadingAnchorLocked;
   const onScrollRef = useRef(onScroll);
   const onContentSettledRef = useRef(onContentSettled);
   onScrollRef.current = onScroll;
   onContentSettledRef.current = onContentSettled;
-
-  // Compose external scroll handling (e.g. floating scrollbar visibility) with
-  // sticky detection: re-derive stickiness from the caret's distance to the
-  // bottom. A programmatic scroll-to-bottom lands here too, leaving distance ≈ 0
-  // → stays stuck; a user scroll-up grows the distance → unsticks. Two
-  // thresholds: a tight one to keep following, a looser one to reveal the button.
-  const handleScroll = useCallback(() => {
-    onScrollRef.current?.();
-    const scrollContainer = scrollRef.current;
-    if (scrollContainer) {
-      const distance
-        = scrollContainer.scrollHeight
-          - scrollContainer.clientHeight
-          - scrollContainer.scrollTop;
-      // Ignore our own anchor correction. All other movement (wheel, keyboard,
-      // scrollbar or search navigation) establishes a new reading position.
-      if (
-        writtenTopRef.current === null
-        || Math.abs(scrollContainer.scrollTop - writtenTopRef.current) > 0.5
-      ) {
-        stickToBottomRef.current = distance <= STICK_THRESHOLD_PX;
-        anchorRef.current = stickToBottomRef.current
-          ? null
-          : captureAnchor(scrollContainer);
-      }
-      writtenTopRef.current = null;
-      setShowJumpToLatest(distance > JUMP_BUTTON_THRESHOLD_PX);
-    }
-  }, [scrollRef]);
 
   // Jump straight to the latest message and re-enable auto-follow.
   const scrollToLatest = useCallback(() => {
@@ -128,6 +104,42 @@ export function useStickyAutoScroll({
     );
     onContentSettledRef.current?.();
   }, [followEnabled, scrollRef]);
+
+  // Compose external scroll handling (e.g. floating scrollbar visibility) with
+  // sticky detection: re-derive stickiness from the caret's distance to the
+  // bottom. A programmatic scroll-to-bottom lands here too, leaving distance ≈ 0
+  // → stays stuck; a user scroll-up grows the distance → unsticks. Two
+  // thresholds: a tight one to keep following, a looser one to reveal the button.
+  const handleScroll = useCallback(() => {
+    // WebKit can deliver scrolling from an already-latched, noncancelable
+    // gesture. Correct it before it can replace the preserved reading anchor.
+    if (anchorLockedRef.current?.() && anchorRef.current) {
+      settleViewport();
+      onScrollRef.current?.();
+      return;
+    }
+    onScrollRef.current?.();
+    const scrollContainer = scrollRef.current;
+    if (scrollContainer) {
+      const distance
+        = scrollContainer.scrollHeight
+          - scrollContainer.clientHeight
+          - scrollContainer.scrollTop;
+      // Ignore our own anchor correction. All other movement (wheel, keyboard,
+      // scrollbar or search navigation) establishes a new reading position.
+      if (
+        writtenTopRef.current === null
+        || Math.abs(scrollContainer.scrollTop - writtenTopRef.current) > 0.5
+      ) {
+        stickToBottomRef.current = distance <= STICK_THRESHOLD_PX;
+        anchorRef.current = stickToBottomRef.current
+          ? null
+          : captureAnchor(scrollContainer);
+      }
+      writtenTopRef.current = null;
+      setShowJumpToLatest(distance > JUMP_BUTTON_THRESHOLD_PX);
+    }
+  }, [scrollRef, settleViewport]);
 
   useLayoutEffect(settleViewport, [contentKey, settleViewport]);
 

--- a/mobile/.prettierignore
+++ b/mobile/.prettierignore
@@ -1,6 +1,0 @@
-android/
-ios/
-coverage/
-node_modules/
-src/version.generated.ts
-package-lock.json

--- a/mobile/.prettierrc.json
+++ b/mobile/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "bracketSameLine": false,
-  "printWidth": 100,
-  "semi": true,
-  "singleQuote": false,
-  "trailingComma": "all"
-}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -62,7 +62,6 @@ debug APK。
 ```bash
 npm run typecheck
 npm run lint
-npm run format:check
 npm test
 npm run check
 ```
@@ -72,7 +71,6 @@ npm run check
 ```bash
 make lint-mobile
 make test-mobile
-make fmt-mobile
 make check-mobile
 ```
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -48,7 +48,6 @@
     "eslint": "^10.9.1",
     "eslint-config-expo": "^57.0.2",
     "jest-expo": "^57.0.5",
-    "prettier": "^3.9.6",
     "react-test-renderer": "19.2.3",
     "typescript": "~6.0.3"
   },
@@ -64,10 +63,8 @@
     "prebuild:ios": "npm run gen-version && expo prebuild --platform ios",
     "typecheck": "npm run gen-version && tsc --noEmit",
     "lint": "eslint .",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
     "test": "jest --runInBand",
-    "check": "npm run typecheck && npm run lint && npm run format:check && npm test"
+    "check": "npm run typecheck && npm run lint && npm test"
   },
   "private": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -898,7 +898,6 @@
         "eslint": "^10.9.1",
         "eslint-config-expo": "^57.0.2",
         "jest-expo": "^57.0.5",
-        "prettier": "^3.9.6",
         "react-test-renderer": "19.2.3",
         "typescript": "~6.0.3"
       }
@@ -19861,22 +19860,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmmirror.com/prettier/-/prettier-3.9.6.tgz",
-      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proc-log": {


### PR DESCRIPTION
Fixes history paging when macOS scroll momentum reaches the top. A collision now starts one loading and cooldown lifecycle, preserves the restored reading anchor through native momentum, and keeps the loading hint synchronized with the transaction.\n\nValidation: Desktop ESLint and TypeScript checks passed. Local test suites were not run; GitHub Actions owns test execution.