### PR TITLE
Fix remote message identity and mobile lifecycle recovery

### DIFF
--- a/agent/src/rpc/session_prompt.rs
+++ b/agent/src/rpc/session_prompt.rs
@@ -586,7 +586,12 @@ impl ServerSession {
                 serde_json::Value::String(run_lease.run_id.clone()),
             );
         }
-        user_message.ensure_journal_entry_id();
+        let user_entry_id = user_message.ensure_journal_entry_id();
+        let user_attachments = user_message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("attachments"))
+            .cloned();
         self.messages.write().push(user_message);
 
         // Log the user message so the run log shows the question alongside
@@ -633,7 +638,13 @@ impl ServerSession {
         // a bogus extra bubble.
         self.broadcaster.broadcast(crate::rpc::SseEvent::new(
             "user_message",
-            serde_json::json!({"text": user_display_text}),
+            serde_json::json!({
+                "text": user_display_text,
+                "entry_id": user_entry_id,
+                "run_id": run_lease.run_id,
+                "created_at_ms": chrono::Utc::now().timestamp_millis(),
+                "attachments": user_attachments,
+            }),
         ));
 
         // Clone shared state for the background task

--- a/agent/src/rpc/session_prompt/tests.rs
+++ b/agent/src/rpc/session_prompt/tests.rs
@@ -601,6 +601,18 @@ async fn prompt_projects_typed_model_and_tool_events_end_to_end() {
             .await
             .expect("run event timeout")
             .expect("run event");
+        if event.event_type == "user_message" {
+            let payload: serde_json::Value = serde_json::from_str(&event.data).unwrap();
+            let messages = session.messages.read();
+            let user = messages
+                .iter()
+                .find(|message| message.role == "user")
+                .unwrap();
+            assert_eq!(payload["entry_id"].as_str(), user.journal_entry_id());
+            assert_eq!(payload["run_id"], user.metadata.as_ref().unwrap()["run_id"]);
+            assert_eq!(payload["text"], "write typed");
+            assert!(payload["created_at_ms"].as_i64().unwrap() > 0);
+        }
         event_types.push(event.event_type.clone());
         if event.event_type == "agent_end" {
             break;

--- a/desktop/src/features/agent/reconcileThreadHistory.test.ts
+++ b/desktop/src/features/agent/reconcileThreadHistory.test.ts
@@ -40,3 +40,12 @@ describe("history reconciliation", () => {
     expect(reconcileThreadHistory(current, [{ ...current[0]! }], current, true, false).messages).toBe(current);
   });
 });
+
+it("live mobile user arriving during history refresh keeps canonical position", () => {
+  const previous = message("previous");
+  const liveUser = message("user_123", { role: "user", runId: "remote-run", content: "from phone", status: "complete" });
+  const storedUser = message("m_persisted", { role: "user", runId: "remote-run", content: "from phone", status: "complete" });
+  const reply = message("m_reply", { runId: "remote-run", content: "reply", status: "complete" });
+  const result = reconcileThreadHistory([previous, liveUser], [previous, storedUser, reply], [previous], false, true);
+  expect(result.messages.map(m => m.content)).toEqual(["previous", "from phone", "reply"]);
+});

--- a/desktop/src/features/agent/useThreadMessages.paging.test.tsx
+++ b/desktop/src/features/agent/useThreadMessages.paging.test.tsx
@@ -363,3 +363,14 @@ describe("on-demand history", () => {
     });
   });
 });
+
+it("a repeated mobile prompt stays after the previous reply", async () => {
+  page.mockResolvedValueOnce(history(["same prompt"], 0, false));
+  const root = createRoot(document.createElement("div"));
+  await act(async () => root.render(<Harness />));
+  await act(async () => current.setMessages(prev => [...prev, { id: "previous-reply", role: "assistant", authorKey: "author.researchCopilot", content: "previous reply", status: "complete", createdAt: "2026-01-01T00:00:01Z" }]));
+  await act(async () => window.dispatchEvent(new CustomEvent("future:agent-event", { detail: { threadId: "synthetic", sessionId: "synthetic-session", eventType: "user_message", payload: { text: "same prompt", entry_id: "second-user", run_id: "second-run" } } })));
+  const contents = current.messages.map(m => m.content);
+  await act(async () => root.unmount());
+  expect(contents).toEqual(["same prompt", "previous reply", "same prompt"]);
+});

--- a/desktop/src/features/agent/useThreadMessages.ts
+++ b/desktop/src/features/agent/useThreadMessages.ts
@@ -5,6 +5,8 @@ import {
   entriesToTurns,
   matchesSettledRun,
   turnsToMessages,
+  upsertUserMessage,
+  userMessageFromEvent,
 } from "@future-os/thread-projection";
 import {
   useCallback,
@@ -651,37 +653,18 @@ export function useThreadMessages({
 
       // A user_message that lands while this thread's load is still in flight
       // would append onto the not-yet-committed base — dropping it is
-      // lossless, the projected JSONL load carries the entry.
+      // lossless, the Agent history load carries the persisted entry.
       if (loadingRef.current)
         return;
 
-      const text
-        = typeof detail.payload.text === "string" ? detail.payload.text : "";
-      if (!text)
+      const user = userMessageFromEvent(detail.payload);
+      if (!user) {
+        // An identity-less event can only invalidate history; text is not a key.
+        void reloadMessagesQuiet(threadId);
         return;
-      setMessages((prev) => {
-        // Dedup: skip if the last user message has identical text.
-        // Checking only the last message avoids suppressing legitimate
-        // repeated prompts (e.g. sending "continue" twice).
-        const userMsgs = prev.filter(m => m.role === "user");
-        const lastUser = userMsgs[userMsgs.length - 1];
-        if (lastUser && lastUser.content === text)
-          return prev;
-        return [
-          ...prev,
-          {
-            id: `user_${Date.now()}`,
-            role: "user",
-            authorKey: "author.you",
-            content: text,
-            status: "complete",
-            createdAt: new Date().toISOString(),
-          } satisfies AgentMessage,
-        ];
-      });
-      // Bump the generation counter so an in-flight quiet reload sees that
-      // state moved under it and discards its replacement instead of
-      // clobbering this append.
+      }
+      setMessages(prev => upsertUserMessage(prev, user));
+      // Record this live write for callers that fence asynchronous updates.
       messagesGenRef.current += 1;
     };
     window.addEventListener("future:agent-event", handler);

--- a/desktop/src/features/agent/userMessageIdentity.test.ts
+++ b/desktop/src/features/agent/userMessageIdentity.test.ts
@@ -1,0 +1,21 @@
+import { upsertUserMessage, userMessageFromEvent } from "@future-os/thread-projection";
+import { expect, it } from "vitest";
+
+it("places a late user event before its own assistant, not in another exchange", () => {
+  const user = userMessageFromEvent({ entry_id: "u2", run_id: "r2", text: "same" })!;
+  const old = { ...user, id: "m_u1", runId: "r1" };
+  const reply = { ...user, id: "assistant2", role: "assistant" as const };
+  expect(upsertUserMessage([old, reply], user).map(message => message.id)).toEqual(["m_u1", "m_u2", "assistant2"]);
+});
+
+it("matches an acknowledged optimistic message by run and preserves its UI id", () => {
+  const user = userMessageFromEvent({ entry_id: "persisted", run_id: "r1", text: "same" })!;
+  const optimistic = { ...user, id: "pending_user" };
+  expect(upsertUserMessage([optimistic], user)).toEqual([optimistic]);
+});
+
+it("projects attachment-only events and rejects identity-less invalidations", () => {
+  const user = userMessageFromEvent({ entry_id: "u1", run_id: "r1", text: "", attachments: [{ path: "/tmp/a", name: "a" }] })!;
+  expect(user.attachments?.[0]?.path).toBe("/tmp/a");
+  expect(userMessageFromEvent({ text: "same" })).toBeNull();
+});

--- a/mobile/src/remote/__tests__/connectionState.test.ts
+++ b/mobile/src/remote/__tests__/connectionState.test.ts
@@ -697,12 +697,13 @@ describe("RemoteClient OS lifecycle recovery", () => {
     testClient.connection = { close };
     testClient.state = "ready";
 
-    client.pauseForBackground();
+    client.setAppActive(false);
     expect(close).toHaveBeenCalledTimes(1);
     expect(testClient.connection).toBeNull();
     expect(callbacks.onConnectionState).toHaveBeenCalledWith("reconnecting");
 
     const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    client.setAppActive(true);
     await client.recoverNow("foreground");
     expect(open).toHaveBeenCalledTimes(1);
   });
@@ -717,6 +718,7 @@ describe("RemoteClient OS lifecycle recovery", () => {
     testClient.connection = { flush, close, isClosed: () => false };
     const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
 
+    client.setAppActive(true);
     await client.recoverNow("foreground");
 
     expect(flush).toHaveBeenCalledTimes(1);
@@ -759,7 +761,58 @@ describe("RemoteClient OS lifecycle recovery", () => {
     expect(callbacks.onConnectionState).not.toHaveBeenCalled();
 
     const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    client.setNetworkAvailable(true);
     await client.recoverNow("network-restored");
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("independent app and network lifecycle", () => {
+  test("offline wake is remembered before reachability returns", async () => {
+    const { client } = recoveryClient();
+    const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    client.setAppActive(false);
+    client.setNetworkAvailable(false);
+    client.setAppActive(true);
+    await client.recoverNow("foreground");
+    expect(open).not.toHaveBeenCalled();
+    client.setNetworkAvailable(true);
+    await client.recoverNow("network-restored");
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  test("network recovery cannot activate a background app or override offline state", async () => {
+    const { client } = recoveryClient();
+    const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    client.setAppActive(false);
+    client.setNetworkAvailable(true);
+    await client.recoverNow("network-restored");
+    expect(open).not.toHaveBeenCalled();
+    client.setAppActive(true);
+    client.setNetworkAvailable(false);
+    await client.recoverNow("request-failure");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  test("a suspended probe cannot block or replace the next foreground connection", async () => {
+    const { client } = recoveryClient();
+    let release!: () => void;
+    const flush = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    (client as unknown as { connection: unknown }).connection = {
+      flush: () => flush,
+      isClosed: () => false,
+      close: async () => {},
+    };
+    const open = jest.spyOn(client, "open").mockResolvedValue(undefined);
+    const old = client.recoverNow("foreground");
+    client.setAppActive(false);
+    client.setAppActive(true);
+    await client.recoverNow("foreground");
+    expect(open).toHaveBeenCalledTimes(1);
+    release();
+    await old;
     expect(open).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/remote/__tests__/syncEngine.test.ts
+++ b/mobile/src/remote/__tests__/syncEngine.test.ts
@@ -256,8 +256,8 @@ describe("SyncEngine", () => {
     await h.settle();
     expect(h.timelineOf("s1").streaming).toBe(false);
 
-    // A reconnect re-reconciles; the prefix is now complete so it re-checks
-    // the tail only, but the full text must be stable.
+    // A reconnect refreshes durable history and replays the run even when its
+    // previously observed prefix was complete.
     h.engine.reconcileAll("reconnect");
     await h.settle();
     expect(h.textOf("s1")).toBe("first half + second half");
@@ -438,7 +438,7 @@ describe("SyncEngine", () => {
     h.history = {
       ...emptyTimeline(),
       items: [
-        { id: "h1", kind: "message", role: "user", text: "Hello" },
+        { id: "h1", kind: "message", role: "user", text: "Hello", runId: "r1" },
         { id: "h2", kind: "message", role: "assistant", text: "Hi there" },
       ],
     };
@@ -572,7 +572,7 @@ describe("SyncEngine", () => {
     h.history = {
       ...emptyTimeline(),
       items: [
-        { id: "h1", kind: "message", role: "user", text: "Hello" },
+        { id: "h1", kind: "message", role: "user", text: "Hello", runId: "r1" },
         { id: "h2", kind: "message", role: "assistant", text: "Hi" },
       ],
     };
@@ -584,7 +584,7 @@ describe("SyncEngine", () => {
       ...tl,
       items: [
         ...tl.items,
-        { id: "local-dup", kind: "message", role: "user", text: "Hello" },
+        { id: "local-dup", kind: "message", role: "user", text: "Hello", runId: "r1" },
         { id: "notice-1", kind: "notice", tone: "neutral", text: "kept" },
       ],
     }));

--- a/mobile/src/remote/__tests__/timeline.test.ts
+++ b/mobile/src/remote/__tests__/timeline.test.ts
@@ -513,25 +513,30 @@ describe("user message mirror", () => {
     expect(state.items[0]).toMatchObject({ kind: "message", role: "user", text: "check this" });
   });
 
-  test("a repeat of the last user bubble's text is deduped (own optimistic send)", () => {
-    const first = applyStreamEvent(emptyTimeline(), {
+  test("events deduplicate by identity while identical prompts remain separate", () => {
+    const event = {
       type: "user_message",
-      data: JSON.stringify({ text: "check this" }),
-    });
-    const repeat = applyStreamEvent(first, {
-      type: "user_message",
-      data: JSON.stringify({ text: "check this" }),
-    });
+      data: JSON.stringify({ text: "check this", entry_id: "u1", run_id: "r1" }),
+    };
+    const first = applyStreamEvent(emptyTimeline(), event);
+    const repeat = applyStreamEvent(first, event);
     expect(repeat.items).toHaveLength(1);
-    // A genuinely new prompt still lands.
     const next = applyStreamEvent(repeat, {
       type: "user_message",
-      data: JSON.stringify({ text: "and this" }),
+      data: JSON.stringify({ text: "check this", entry_id: "u2", run_id: "r2" }),
     });
-    expect(next.items.map(item => item.kind === "message" && item.text)).toEqual([
-      "check this",
-      "and this",
+    expect(next.items.map(item => item.id)).toEqual(["m_u1", "m_u2"]);
+    const durable = timelineFromEntries([
+      {
+        id: "u1",
+        kind: "user",
+        role: "user",
+        createdAtMs: 0,
+        runId: "r1",
+        blocks: [{ kind: "text", text: "check this" }],
+      },
     ]);
+    expect(applyStreamEvent(durable, event).items).toHaveLength(1);
   });
 });
 

--- a/mobile/src/remote/__tests__/useRemoteConnection.test.ts
+++ b/mobile/src/remote/__tests__/useRemoteConnection.test.ts
@@ -56,7 +56,7 @@ jest.mock("../client", () => {
     credentials: unknown;
     callbacks: Record<string, (...args: never[]) => unknown>;
     close = jest.fn(async () => {});
-    pauseForBackground = jest.fn();
+    setAppActive = jest.fn();
     setNetworkAvailable = jest.fn();
     open = jest.fn(async () => {});
     recoverNow = jest.fn(async () => {});
@@ -116,7 +116,7 @@ interface MockClient {
   credentials: RemoteCredentials;
   callbacks: MockClientCallbacks;
   close: jest.Mock;
-  pauseForBackground: jest.Mock;
+  setAppActive: jest.Mock;
   setNetworkAvailable: jest.Mock;
   open: jest.Mock;
   recoverNow: jest.Mock;
@@ -427,7 +427,7 @@ describe("useRemoteConnection", () => {
     test("background transition pauses the client", async () => {
       await mountConnected();
       act(() => appStateListeners()[0]!("background"));
-      expect(client().pauseForBackground).toHaveBeenCalled();
+      expect(client().setAppActive).toHaveBeenCalled();
     });
 
     test("foreground recovery refreshes network and recovers the client", async () => {
@@ -450,6 +450,7 @@ describe("useRemoteConnection", () => {
         await flush();
       });
       expect(client().recoverNow).not.toHaveBeenCalled();
+      expect(client().setAppActive).toHaveBeenLastCalledWith(true);
     });
 
     test("network restore triggers a recovery", async () => {
@@ -623,7 +624,7 @@ describe("useRemoteConnection", () => {
       cast<jest.Mock>(loadCredentials).mockResolvedValue(credentials);
       render();
       await flush();
-      expect(client().pauseForBackground).toHaveBeenCalled();
+      expect(client().setAppActive).toHaveBeenCalled();
     });
 
     test("disables the network when offline at connect time", async () => {

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -1,7 +1,7 @@
 import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { RemoteClient } from "../client";
-import { emptyTimeline } from "../timeline";
+import { applyStreamEvent, emptyTimeline } from "../timeline";
 import type { HistoryEntry, StreamEvent } from "../types";
 import { useTimelineController } from "../useTimelineController";
 
@@ -90,6 +90,72 @@ describe("useTimelineController", () => {
     });
     await flush();
   }
+
+  test.each(["restart", "resend"])(
+    "%s refreshes an idle session and keeps disjoint history reachable",
+    async mode => {
+      options.selectedSessionId = "s1";
+      options.selectedRef.current = "s1";
+      const exchanges = (start: number, end: number) =>
+        Array.from({ length: end - start + 1 }, (_, i) => start + i).flatMap(n => [
+          userEntry(`u${n}`, `user ${n}`),
+          assistantEntry(`a${n}`, `answer ${n}`),
+        ]);
+      request
+        .mockResolvedValueOnce({ success: true, data: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { entries: exchanges(11, 20), hasMore: true, nextOffset: 20 },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { entries: exchanges(1, 10), hasMore: false, nextOffset: 0 },
+        })
+        .mockResolvedValueOnce({ success: true, data: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { entries: exchanges(31, 40), hasMore: true, nextOffset: 60 },
+        });
+      render();
+      await establish();
+      await act(async () => {
+        await result.current.loadOlderTimeline();
+      });
+      await flush();
+      act(() => {
+        result.current.syncEngineRef.current!.mutate("s1", live =>
+          applyStreamEvent(live, evt("user_message", JSON.stringify({ text: "pending" }))),
+        );
+      });
+      await flush();
+      act(() => {
+        if (mode === "restart") result.current.syncEngineRef.current!.restartAll("reconnect");
+        else result.current.reconcileSession("s1", "resend");
+      });
+      await flush();
+      const users = result.current.timeline.items
+        .filter(i => i.kind === "message" && i.role === "user")
+        .map(i => (i.kind === "message" ? i.text : ""));
+      expect(users).toEqual([...Array.from({ length: 10 }, (_, i) => `user ${31 + i}`), "pending"]);
+      expect(result.current.canLoadOlderTimeline).toBe(true);
+      request.mockResolvedValueOnce({
+        success: true,
+        data: { entries: exchanges(21, 30), hasMore: true, nextOffset: 40 },
+      });
+      await act(async () => {
+        await result.current.loadOlderTimeline();
+      });
+      await flush();
+      expect(request.mock.calls.at(-1)?.[0]).toEqual(
+        expect.objectContaining({ before: 60, limit: 10 }),
+      );
+      expect(
+        result.current.timeline.items
+          .filter(i => i.kind === "message" && i.role === "user")
+          .map(i => (i.kind === "message" ? i.text : "")),
+      ).toEqual([...Array.from({ length: 20 }, (_, i) => `user ${21 + i}`), "pending"]);
+    },
+  );
 
   describe("surface", () => {
     test("returns an empty timeline when no session is selected", () => {

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -264,6 +264,7 @@ export class RemoteClient {
     this.networkAvailable = available;
     if (available) return;
     this.generation += 1;
+    this.recoveryPromise = null;
     this.clearTimers();
     this.signal({ type: "transport_disconnect" });
     this.disposeConnection("network_unavailable");
@@ -273,10 +274,13 @@ export class RemoteClient {
    * Ordinary WebSockets are not a background execution mechanism on either
    * mobile OS. Close deliberately before JavaScript is suspended so foreground
    * recovery starts from a known state instead of inheriting a half-open WSS.
+   * AppState owns this flag independently of network probes or recovery requests.
    */
-  pauseForBackground(): void {
-    if (this.stopped || !this.appActive) return;
-    this.appActive = false;
+  setAppActive(active: boolean): void {
+    if (this.stopped || active === this.appActive) return;
+    this.appActive = active;
+    if (active) return;
+    this.recoveryPromise = null;
     this.generation += 1;
     this.clearTimers();
     this.signal({ type: "transport_disconnect" });
@@ -286,9 +290,7 @@ export class RemoteClient {
   /** Validate after foregrounding, or immediately rebuild after a path change. */
   recoverNow(reason: RecoveryReason): Promise<void> {
     if (this.stopped || this.isTerminal()) return Promise.resolve();
-    if (reason === "foreground") this.appActive = true;
     if (!this.appActive) return Promise.resolve();
-    if (reason !== "foreground") this.networkAvailable = true;
     if (!this.networkAvailable) return Promise.resolve();
     if (this.recoveryPromise) return this.recoveryPromise;
     const recovery = this.runRecovery(reason).finally(() => {
@@ -327,7 +329,8 @@ export class RemoteClient {
         // Rebuild below without waiting for NATS's ping budget to expire.
       }
     }
-    if (this.stopped || !this.appActive || !this.networkAvailable) return;
+    if (this.stopped || !this.appActive || !this.networkAvailable || generation !== this.generation)
+      return;
     // Keep the old generation as the serving fallback while the replacement
     // completes its handshake, subscriptions, and flush. `connectSocket()`
     // atomically publishes the new connection and only then closes this one.

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -1,6 +1,8 @@
 import {
   createRunProjector,
   entriesToMessages,
+  userMessageFromEvent,
+  upsertUserMessage,
   type AgentActivityItem,
   type AgentMessage,
   type MessageSegment,
@@ -20,6 +22,8 @@ import { messageText } from "./codec";
 
 export interface TimelineState {
   items: TimelineItem[];
+  /** Persisted rows must not be re-appended as live messages after a page reset. */
+  durableItemIds?: Set<string>;
   seenEvents: Set<string>;
   currentRunId: string | null;
   streaming: boolean;
@@ -129,7 +133,21 @@ export function messageToItems(message: AgentMessage): TimelineItem[] {
  * shared package (`entriesToMessages`), then mapped to the render contract. */
 export function timelineFromEntries(entries: HistoryEntry[]): TimelineState {
   const messages = entriesToMessages(entries);
-  return { ...emptyTimeline(), items: messages.flatMap(messageToItems) };
+  const userRuns = new Map(
+    entries.filter(entry => entry.role === "user").map(entry => [`m_${entry.id}`, entry.runId]),
+  );
+  const items = messages
+    .flatMap(messageToItems)
+    .map(item =>
+      item.kind === "message" && item.role === "user" && userRuns.get(item.id)
+        ? { ...item, runId: userRuns.get(item.id)! }
+        : item,
+    );
+  return {
+    ...emptyTimeline(),
+    items,
+    durableItemIds: new Set(items.map(item => item.id)),
+  };
 }
 
 /** Render the model-context messages returned by get_messages. */
@@ -298,33 +316,20 @@ export function applyStreamEvent(state: TimelineState, event: StreamEvent): Time
 
   switch (event.type) {
     case "user_message": {
-      // The desktop observer mirrors prompts sent from ANY client (desktop,
-      // TUI, another phone), so every device renders the user bubble live.
-      // Dedup mirrors the desktop rule (useThreadMessages): skip when the
-      // last user bubble has identical text — that is this device's own
-      // optimistic send re-delivered through the mirror.
-      const text = textValue(data.text);
-      if (!text.trim()) break;
-      let lastUser: TimelineItem | undefined;
-      for (let i = items.length - 1; i >= 0; i -= 1) {
-        const item = items[i];
-        if (!item) continue;
-        if (item.kind === "message" && item.role === "user") {
-          lastUser = item;
-          break;
-        }
-      }
-      if (lastUser && lastUser.kind === "message" && lastUser.text.trim() === text.trim()) break;
-      items = [
-        ...items,
-        {
-          id: `user:${Date.now()}:${items.length}`,
-          kind: "message",
-          role: "user",
-          text,
-          runId,
-        },
-      ];
+      const canonical = userMessageFromEvent(data);
+      const text = canonical?.content ?? textValue(data.text);
+      if (!text.trim() && !canonical?.attachments?.length) break;
+      const user: Extract<TimelineItem, { kind: "message" }> = {
+        id: canonical?.id ?? `user:${event.runId || `${Date.now()}:${items.length}`}`,
+        kind: "message",
+        role: "user",
+        text,
+        runId: canonical?.runId ?? (event.runId || undefined),
+        ...(canonical?.attachments?.length
+          ? { attachments: canonical.attachments.map(toHistoryAttachment) }
+          : {}),
+      };
+      items = upsertUserMessage<TimelineItem>(items, user);
       break;
     }
     case "approval_request": {
@@ -401,6 +406,7 @@ export function applyStreamEvent(state: TimelineState, event: StreamEvent): Time
   }
 
   return {
+    ...state,
     items,
     seenEvents,
     currentRunId: event.runId ?? state.currentRunId,

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -529,7 +529,12 @@ export class SyncEngine {
   }
 
   private isFullReplay(lane: SessionLane, runId: string, request: ReconcileRequest): boolean {
-    if (request.reason === "prefix" || request.reason === "resend") return true;
+    if (
+      request.reason === "prefix" ||
+      request.reason === "resend" ||
+      request.reason === "reconnect"
+    )
+      return true;
     // A lane with no committed timeline has no live baseline to top up — the
     // only way to build it is from durable history (idle sessions have no
     // active run for a tail reconcile to target).
@@ -558,18 +563,26 @@ export class SyncEngine {
 function mergeLiveInto(history: TimelineState, live: TimelineState | null): TimelineState {
   if (!live) return { ...history, streaming: history.streaming };
   const historyIds = new Set(history.items.map(item => item.id));
-  const historyUserTexts = new Set(
+  const historyUserRuns = new Set(
     history.items
       .filter(item => item.kind === "message" && item.role === "user")
-      .map(item => (item.kind === "message" ? item.text : "")),
+      .map(item => item.runId)
+      .filter(Boolean),
   );
-  // Keep everything durable history doesn't carry: optimistic bubbles, notices,
+  // Keep only transient items the durable history does not carry: optimistic bubbles, notices,
   // approval cards, and live user mirrors of prompts not yet durable. The
   // active run's *assistant* items are dropped by fullReconcile's stripRunItems
-  // (the replay rebuilds them); user bubbles always survive.
+  // (the replay rebuilds them). Cached durable rows outside the new window
+  // remain reachable through paging and must not be appended after its tail.
   const folded = live.items.filter(item => {
+    if (live.durableItemIds?.has(item.id)) return false;
     if (historyIds.has(item.id)) return false;
-    if (item.kind === "message" && item.role === "user" && historyUserTexts.has(item.text)) {
+    if (
+      item.kind === "message" &&
+      item.role === "user" &&
+      !!item.runId &&
+      historyUserRuns.has(item.runId)
+    ) {
       return false;
     }
     return true;

--- a/mobile/src/remote/useRemoteConnection.ts
+++ b/mobile/src/remote/useRemoteConnection.ts
@@ -192,7 +192,7 @@ export function useRemoteConnection({
         onError: recordError,
       });
       clientRef.current = client;
-      if (AppState.currentState === "background") client.pauseForBackground();
+      client.setAppActive(AppState.currentState !== "background");
       if (networkAvailableRef.current === false) client.setNetworkAvailable(false);
       await client.open();
       await Promise.allSettled([
@@ -284,7 +284,9 @@ export function useRemoteConnection({
       const returnedToForeground = next === "active" && previous !== "active";
       const enteredBackground = next === "background" && previous !== "background";
       previous = next;
-      if (enteredBackground) clientRef.current?.pauseForBackground();
+      if (enteredBackground || returnedToForeground) {
+        clientRef.current?.setAppActive(next === "active");
+      }
       if (returnedToForeground) void recoverLifecycle("foreground");
     });
     return () => subscription.remove();

--- a/mobile/src/remote/useTimelineController.ts
+++ b/mobile/src/remote/useTimelineController.ts
@@ -11,7 +11,7 @@ import {
   timelineFromEntries,
   type TimelineState,
 } from "./timeline";
-import type { EntriesData, HistoryEntry, RemoteSessionState, StreamEvent } from "./types";
+import type { EntriesData, RemoteSessionState, StreamEvent } from "./types";
 
 const TIMELINE_LOAD_TIMEOUT_MS = 15_000;
 const HISTORY_PAGE_USER_EXCHANGES = 10;
@@ -20,23 +20,22 @@ const HISTORY_TAIL_CURSOR = Number.MAX_SAFE_INTEGER;
 interface HistoryPagingState {
   nextBefore: number;
   hasMore: boolean;
-  loadedExchanges: number;
   loading: boolean;
-}
-
-function historyUserExchanges(entries: HistoryEntry[]): number {
-  return entries.reduce((count, entry) => count + (entry.role === "user" ? 1 : 0), 0);
 }
 
 function prependHistoryPage(live: TimelineState, older: TimelineState): TimelineState {
   const liveIds = new Set(live.items.map(item => item.id));
   const olderItems = older.items.filter(item => !liveIds.has(item.id));
-  return olderItems.length === 0 ? live : { ...live, items: [...olderItems, ...live.items] };
+  return {
+    ...live,
+    items: [...olderItems, ...live.items],
+    durableItemIds: new Set([...(live.durableItemIds ?? []), ...(older.durableItemIds ?? [])]),
+  };
 }
 
 /** Replace the already-loaded tail with a fresh durable page while retaining
  * the older prefix the user explicitly paged in. Entry ids are stable across
- * journal reads, so the first overlap is the exact splice point. */
+ * history reads, so the first overlap is the exact splice point. */
 function retainOlderHistoryPrefix(
   existing: TimelineState | null,
   latest: TimelineState,
@@ -45,10 +44,22 @@ function retainOlderHistoryPrefix(
   const latestIds = new Set(latest.items.map(item => item.id));
   const overlap = existing.items.findIndex(item => latestIds.has(item.id));
   if (overlap <= 0) return latest;
-  return { ...latest, items: [...existing.items.slice(0, overlap), ...latest.items] };
+  const prefix = existing.items.slice(0, overlap);
+  return {
+    ...latest,
+    items: [...prefix, ...latest.items],
+    durableItemIds: new Set([
+      ...(latest.durableItemIds ?? []),
+      ...prefix.filter(item => existing.durableItemIds?.has(item.id)).map(item => item.id),
+    ]),
+  };
 }
 
-function diagnosticError(error: unknown): { name?: string; message: string; code?: unknown } {
+function diagnosticError(error: unknown): {
+  name?: string;
+  message: string;
+  code?: unknown;
+} {
   if (error instanceof Error) {
     return {
       name: error.name,
@@ -182,15 +193,12 @@ export function useTimelineController({
         syncEngineRef.current?.timelineFor(sessionId) ?? null,
         latest,
       );
-      const retainedOlderPages =
-        retained && retained.loadedExchanges > historyUserExchanges(entries) ? retained : null;
+      // Only retain the cursor when the old prefix actually joined this page.
+      // Otherwise the latest page starts a new contiguous history window.
+      const retainedOlderPages = history !== latest ? retained : null;
       const page: HistoryPagingState = {
         nextBefore: retainedOlderPages?.nextBefore ?? nextBefore,
         hasMore: retainedOlderPages?.hasMore ?? (response.data.hasMore === true && nextBefore > 0),
-        loadedExchanges: history.items.reduce(
-          (count, item) => count + (item.kind === "message" && item.role === "user" ? 1 : 0),
-          0,
-        ),
         loading: false,
       };
       historyPagingRef.current[sessionId] = page;
@@ -227,7 +235,6 @@ export function useTimelineController({
       const next: HistoryPagingState = {
         nextBefore,
         hasMore: response.data.hasMore === true && nextBefore > 0,
-        loadedExchanges: current.loadedExchanges + historyUserExchanges(entries),
         loading: false,
       };
       historyPagingRef.current[sessionId] = next;

--- a/packages/thread-projection/src/index.ts
+++ b/packages/thread-projection/src/index.ts
@@ -45,3 +45,4 @@ export {
   unwrapNestedJson,
 } from "./approval";
 export { isRecord, pathBasename, pathExtension, singleLine, truncate } from "./utils";
+export { userMessageFromEvent, upsertUserMessage } from "./userMessage";

--- a/packages/thread-projection/src/userMessage.ts
+++ b/packages/thread-projection/src/userMessage.ts
@@ -1,0 +1,48 @@
+import type { AgentMessage } from "./model";
+import type { SessionEntry } from "./events";
+import { entriesToMessages } from "./projection";
+
+/** User events refer to the same persisted entry and run as history pages. */
+export function userMessageFromEvent(payload: Record<string, unknown>): AgentMessage | null {
+  if (
+    typeof payload.entry_id !== "string" ||
+    !payload.entry_id ||
+    typeof payload.run_id !== "string" ||
+    !payload.run_id
+  )
+    return null;
+  const entry: SessionEntry = {
+    id: payload.entry_id,
+    kind: "user",
+    role: "user",
+    runId: payload.run_id,
+    createdAtMs: typeof payload.created_at_ms === "number" ? payload.created_at_ms : Date.now(),
+    blocks: [{ kind: "text", text: typeof payload.text === "string" ? payload.text : "" }],
+    metadata: { attachments: Array.isArray(payload.attachments) ? payload.attachments : [] },
+  };
+  const message = entriesToMessages([entry])[0];
+  return message ? { ...message, runId: payload.run_id } : null;
+}
+
+/** Identity, never text, distinguishes retries from a new identical prompt. */
+export function upsertUserMessage<T extends { id: string; role?: string; runId?: string | null }>(
+  messages: T[],
+  user: T,
+): T[] {
+  const index = messages.findIndex(
+    message =>
+      message.role === "user" &&
+      (message.id === user.id || (!!user.runId && message.runId === user.runId)),
+  );
+  if (index >= 0) {
+    const next = [...messages];
+    next[index] = { ...messages[index]!, ...user, id: messages[index]!.id };
+    return next;
+  }
+  // The assistant can arrive first through a different subscription.
+  const assistant = user.runId
+    ? messages.findIndex(message => message.role === "assistant" && message.runId === user.runId)
+    : -1;
+  const at = assistant < 0 ? messages.length : assistant;
+  return [...messages.slice(0, at), user, ...messages.slice(at)];
+}


### PR DESCRIPTION
Mobile prompts could be suppressed when their text matched an earlier prompt, and live events could duplicate or misplace messages during Desktop history refresh. Agent user events now carry the persisted entry and run identities; Desktop and Mobile share identity-based insertion and reconciliation, including attachment-only prompts and events arriving after their replies.

Android could remain disconnected after waking offline because its app-active flag was never restored. App and network availability are now independent inputs, and obsolete recovery probes cannot block or replace a newer connection. Reconnect also refreshes settled history; disjoint history pages reset their cursor so missing exchanges remain reachable without moving cached old messages to the tail.

## Validation

- Synced the isolated branch with current origin/main.
- Agent cargo fmt and Clippy, all targets with warnings denied.
- Desktop and Mobile ESLint and TypeScript checks.
- Formatting checks for changed Mobile files and the shared helper; git diff checks.
- Development regression checks passed: 534 Mobile tests, 59 targeted Desktop tests, and the Agent event projection end-to-end test.
- Final-branch test suites are delegated to GitHub Actions. Android screen-off/on device acceptance is not yet run.
