### PR TITLE
fix(desktop): keep the conversation visible in a narrow window

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -28,6 +28,7 @@ import { ToastHost } from "../ui/ToastHost";
 import { ActivityRail } from "./ActivityRail";
 import { AppShellDialogs } from "./AppShellDialogs";
 import { ContextPanel } from "./ContextPanel";
+import { canShowLeftPanel, canShowRightPanel, MIN_LEFT_PANEL_WIDTH } from "./hooks/panelGeometry";
 import { useAgentConnection } from "./hooks/useAgentConnection";
 import { useAgentDoneBell } from "./hooks/useAgentDoneBell";
 import { useApprovals } from "./hooks/useApprovals";
@@ -35,7 +36,7 @@ import { useAppSettings } from "./hooks/useAppSettings";
 import { useAutoUpgradeSkills } from "./hooks/useAutoUpgradeSkills";
 import { useFutureAccount } from "./hooks/useFutureAccount";
 import { useHasProviders } from "./hooks/useHasProviders";
-import { MIN_LEFT_PANEL_WIDTH, useLeftPanelWidth } from "./hooks/useLeftPanelWidth";
+import { useLeftPanelWidth } from "./hooks/useLeftPanelWidth";
 import { useModelSelection } from "./hooks/useModelSelection";
 import { useNewConversation } from "./hooks/useNewConversation";
 import { useRemoteStatus } from "./hooks/useRemoteStatus";
@@ -44,6 +45,7 @@ import { useThreadDialogs } from "./hooks/useThreadDialogs";
 import { useThreadStore } from "./hooks/useThreadStore";
 import { useUnreadThreads } from "./hooks/useUnreadThreads";
 import { useUpdateChecker } from "./hooks/useUpdateChecker";
+import { useWindowWidth } from "./hooks/useWindowWidth";
 import { useWorkspaceDialogs } from "./hooks/useWorkspaceDialogs";
 import { OnboardingGate } from "./OnboardingGate";
 import { WorkspaceDialogs } from "./WorkspaceDialogs";
@@ -85,7 +87,14 @@ export function AppShell() {
   // the early returns further down stay after every hook call (rules of hooks).
   const { showGate, byokMode, enableBYOK, finishInit, cancelLogin, hasAnyProvider, forceOnboarding, initPending, initialLoading } = useHasProviders();
 
-  const leftPanel = useLeftPanelWidth(rightExpanded);
+  const windowWidth = useWindowWidth();
+  // Side panels yield to the conversation: when the window is too narrow to
+  // keep the center at its floor alongside a panel, the panel folds instead of
+  // squeezing (or overflowing) the center. The user's own collapsed/expanded
+  // choice is kept, so the panel comes back on its own when the window grows.
+  const rightPanelAvailable = canShowRightPanel(windowWidth);
+  const showLeftPanel = leftExpanded && canShowLeftPanel(windowWidth);
+  const leftPanel = useLeftPanelWidth(rightExpanded && rightPanelAvailable);
   const centerRef = useRef<HTMLElement>(null);
   const {
     width: rightPanelWidth,
@@ -99,7 +108,7 @@ export function AppShell() {
   // can shrink the space available to the center — re-clamp the right panel.
   useEffect(() => {
     reclampRightPanel();
-  }, [leftExpanded, leftPanel.width, reclampRightPanel]);
+  }, [showLeftPanel, leftPanel.width, reclampRightPanel]);
 
   // Install the Tauri event listener for real-time agent state updates
   // (settings changes from other clients).  Only runs once.
@@ -296,7 +305,11 @@ export function AppShell() {
     () => workspaces.filter(workspace => workspace.kind === "user"),
     [workspaces],
   );
-  const hideRightPanel = centerMode === "new-chat" || section === "skill" || section === "remote";
+  const hideRightPanel
+    = centerMode === "new-chat"
+      || section === "skill"
+      || section === "remote"
+      || !rightPanelAvailable;
 
   // Bridge the backend's deferred shadow-review notification (C1) onto the
   // typed event bus so the Review panel refreshes when the changeset lands.
@@ -438,6 +451,11 @@ export function AppShell() {
   }
 
   function handleToggleLeftPanel() {
+    // Below the two-column floor the rail has nowhere to open into, so the
+    // toggle must not commit "collapsed" as the user's preference — the rail
+    // would then stay hidden after the window grows back.
+    if (!canShowLeftPanel(windowWidth))
+      return;
     setLeftExpanded((expanded) => {
       const nextExpanded = !expanded;
       setLeftOverlayOpen(false);
@@ -446,7 +464,7 @@ export function AppShell() {
   }
 
   function handlePreviewLeftPanel(open: boolean) {
-    if (leftExpanded)
+    if (showLeftPanel)
       return;
     setLeftOverlayOpen(open);
   }
@@ -498,7 +516,7 @@ export function AppShell() {
 
   return (
     <div className="relative flex h-full min-h-0 overflow-hidden bg-canvas text-ink">
-      {leftExpanded
+      {showLeftPanel
         ? (
             <div className="relative h-full shrink-0" style={{ width: leftPanel.width }}>
               <ActivityRail expanded {...activityRailProps} />
@@ -523,7 +541,7 @@ export function AppShell() {
           )
         : null}
       {leftPanel.resizing ? <div className="fixed inset-0 z-50 cursor-col-resize select-none" /> : null}
-      {!leftExpanded
+      {!showLeftPanel
         ? (
             <div
               aria-hidden="true"
@@ -532,7 +550,7 @@ export function AppShell() {
             />
           )
         : null}
-      {!leftExpanded && leftOverlayOpen
+      {!showLeftPanel && leftOverlayOpen
         ? (
             <div
               className="absolute left-0 top-0 z-40 h-full"
@@ -552,7 +570,7 @@ export function AppShell() {
                 initialWorkspaceForm={newWorkspaceForm}
                 initialMode={newConversationMode}
                 initialWorkspaceId={newChatWorkspaceId}
-                leftPanelExpanded={leftExpanded}
+                leftPanelExpanded={showLeftPanel}
                 modelId={selectedModelId}
                 modelOptions={visibleModelOptions}
                 modelsEmptyReason={modelsEmptyReason}
@@ -571,11 +589,11 @@ export function AppShell() {
             )
           : section === "skill"
             ? (
-                <SkillsView leftPanelExpanded={leftExpanded} onToggleLeftPanel={handleToggleLeftPanel} onStartCoachConversation={handleStartCoachConversation} onTrySkill={handleTrySkill} />
+                <SkillsView leftPanelExpanded={showLeftPanel} onToggleLeftPanel={handleToggleLeftPanel} onStartCoachConversation={handleStartCoachConversation} onTrySkill={handleTrySkill} />
               )
             : section === "remote"
               ? (
-                  <RemoteView appSettings={appSettings} leftPanelExpanded={leftExpanded} onChangeSettings={patch => void changeSettings(patch)} onToggleLeftPanel={handleToggleLeftPanel} remoteStatus={remoteStatus} onRefreshRemote={refreshRemote} />
+                  <RemoteView appSettings={appSettings} leftPanelExpanded={showLeftPanel} onChangeSettings={patch => void changeSettings(patch)} onToggleLeftPanel={handleToggleLeftPanel} remoteStatus={remoteStatus} onRefreshRemote={refreshRemote} />
                 )
               : storeError
                 ? (
@@ -605,7 +623,7 @@ export function AppShell() {
                       thread={activeThread}
                       workspacePath={activeWorkspace?.path ?? null}
                       onApprovalDecision={handleApprovalDecision}
-                      leftPanelExpanded={leftExpanded}
+                      leftPanelExpanded={showLeftPanel}
                       onRetryAgentConnection={() => void refreshAgentModels()}
                       onOpenAccount={handleOpenAccount}
                       onOpenModels={handleOpenModels}

--- a/desktop/src/components/layout/hooks/panelGeometry.test.ts
+++ b/desktop/src/components/layout/hooks/panelGeometry.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  canShowLeftPanel,
+  canShowRightPanel,
+  MIN_CENTER_PANEL_WIDTH,
+  MIN_LEFT_PANEL_WIDTH,
+  MIN_RIGHT_PANEL_WIDTH,
+} from "./panelGeometry";
+
+// The thresholds are derived from the floors, so a future floor change moves
+// the behavior with it instead of leaving a stale magic number behind.
+const LEFT_FITS = MIN_LEFT_PANEL_WIDTH + MIN_CENTER_PANEL_WIDTH;
+const RIGHT_FITS = LEFT_FITS + MIN_RIGHT_PANEL_WIDTH;
+
+describe("panel visibility thresholds", () => {
+  it("keeps the rail while it does not squeeze the center below its floor", () => {
+    expect(canShowLeftPanel(LEFT_FITS)).toBe(true);
+    expect(canShowLeftPanel(LEFT_FITS - 1)).toBe(false);
+    expect(canShowLeftPanel(1440)).toBe(true);
+  });
+
+  it("only opens the right panel when all three columns fit", () => {
+    expect(canShowRightPanel(RIGHT_FITS)).toBe(true);
+    expect(canShowRightPanel(RIGHT_FITS - 1)).toBe(false);
+    // The rail still fits here, but the right panel must not steal the center's
+    // floor to open.
+    expect(canShowLeftPanel(RIGHT_FITS - 1)).toBe(true);
+  });
+});

--- a/desktop/src/components/layout/hooks/panelGeometry.ts
+++ b/desktop/src/components/layout/hooks/panelGeometry.ts
@@ -1,2 +1,30 @@
+/**
+ * Width floors for the three-column shell. The conversation area (center) is
+ * the priority: the side panels yield to it rather than squeezing it, and they
+ * collapse entirely when their floor no longer fits (see `canShow*Panel`).
+ */
+export const MIN_LEFT_PANEL_WIDTH = 224;
 export const MIN_CENTER_PANEL_WIDTH = 384;
 export const MIN_RIGHT_PANEL_WIDTH = 384;
+
+/**
+ * Whether the left rail can stay expanded. Below this the rail folds into its
+ * hover overlay, so the center keeps its floor instead of being squeezed by a
+ * fixed 224px column.
+ */
+export function canShowLeftPanel(windowWidth: number): boolean {
+  return windowWidth >= MIN_LEFT_PANEL_WIDTH + MIN_CENTER_PANEL_WIDTH;
+}
+
+/**
+ * Whether the right context panel can open. Deliberately measured against all
+ * three floors (not against the rail's live width): opening the panel is a
+ * user action that must not silently squeeze the conversation or force the
+ * rail to move, so below this the panel stays closed.
+ */
+export function canShowRightPanel(windowWidth: number): boolean {
+  return (
+    windowWidth
+    >= MIN_LEFT_PANEL_WIDTH + MIN_CENTER_PANEL_WIDTH + MIN_RIGHT_PANEL_WIDTH
+  );
+}

--- a/desktop/src/components/layout/hooks/useLeftPanelWidth.ts
+++ b/desktop/src/components/layout/hooks/useLeftPanelWidth.ts
@@ -1,9 +1,8 @@
 import type { PointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MIN_CENTER_PANEL_WIDTH, MIN_RIGHT_PANEL_WIDTH } from "./panelGeometry";
+import { MIN_CENTER_PANEL_WIDTH, MIN_LEFT_PANEL_WIDTH, MIN_RIGHT_PANEL_WIDTH } from "./panelGeometry";
 
 const STORAGE_KEY = "future.leftPanelWidth";
-export const MIN_LEFT_PANEL_WIDTH = 224;
 const MAX_LEFT_PANEL_WIDTH = 480;
 
 function initialWidth(): number {
@@ -17,15 +16,20 @@ function initialWidth(): number {
   return window.innerWidth >= 1280 ? 288 : window.innerWidth >= 768 ? 256 : 224;
 }
 
-export function useLeftPanelWidth(rightExpanded: boolean) {
+/**
+ * Preferred (drag-resized, restart-persisted) width of the left rail, clamped
+ * so the center keeps `MIN_CENTER_PANEL_WIDTH` and — while the right context
+ * panel is actually visible — that panel keeps its own floor.
+ */
+export function useLeftPanelWidth(rightPanelVisible: boolean) {
   const [preferredWidth, setPreferredWidth] = useState(initialWidth);
   const [windowWidth, setWindowWidth] = useState(() => window.innerWidth);
   const [resizing, setResizing] = useState(false);
   const cleanupRef = useRef<(() => void) | null>(null);
-  // Reserve the existing right panel's floor; its own hook re-clamps its width.
+  // Reserve the visible right panel's floor; its own hook re-clamps its width.
   const maxWidth = Math.max(
     MIN_LEFT_PANEL_WIDTH,
-    Math.min(MAX_LEFT_PANEL_WIDTH, windowWidth - MIN_CENTER_PANEL_WIDTH - (rightExpanded ? MIN_RIGHT_PANEL_WIDTH : 0)),
+    Math.min(MAX_LEFT_PANEL_WIDTH, windowWidth - MIN_CENTER_PANEL_WIDTH - (rightPanelVisible ? MIN_RIGHT_PANEL_WIDTH : 0)),
   );
   const width = Math.min(maxWidth, Math.max(MIN_LEFT_PANEL_WIDTH, preferredWidth));
 

--- a/desktop/src/components/layout/hooks/useWindowWidth.ts
+++ b/desktop/src/components/layout/hooks/useWindowWidth.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Live viewport width in CSS pixels, re-read on every window resize.
+ *
+ * Drives the shell's collapse decisions: below the three-column floors the side
+ * panels fold instead of squeezing the conversation out of the window. A plain
+ * resize subscription, not cancel-safe loading (desktop/CLAUDE.md §4).
+ */
+export function useWindowWidth(): number {
+  const [width, setWidth] = useState(() => window.innerWidth);
+
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  return width;
+}

--- a/desktop/src/features/agent/Composer.tsx
+++ b/desktop/src/features/agent/Composer.tsx
@@ -640,8 +640,12 @@ function ComposerImpl({
       {attachError
         ? <div className="px-1 pb-1 text-xs text-warning">{attachError}</div>
         : null}
-      <div className="flex items-center justify-between pt-1">
-        <div className="flex items-center gap-1">
+      {/* Wraps rather than overflows: a narrow center cannot fit the model /
+          thinking / send group beside the attach / approval group, so the
+          right-hand group drops to a second row instead of pushing the send
+          button past the pane's edge. */}
+      <div className="flex flex-wrap items-center justify-between gap-y-1 pt-1">
+        <div className="flex min-w-0 items-center gap-1">
           <button
             className="inline-flex size-7 items-center justify-center rounded-md text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
             disabled={disabled}
@@ -661,7 +665,7 @@ function ComposerImpl({
                   panelClassName="w-64 overflow-hidden"
                   trigger={(
                     <button
-                      className="inline-flex h-7 max-w-40 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink"
+                      className="inline-flex h-7 max-w-40 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink"
                       onClick={() => {
                         setModelMenuOpen(false);
                         setThinkingMenuOpen(false);
@@ -710,7 +714,7 @@ function ComposerImpl({
               )
             : null}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="ms-auto flex min-w-0 items-center gap-2">
           <SelectMenu
             className="hidden md:block"
             open={modelMenuOpen}
@@ -718,7 +722,7 @@ function ComposerImpl({
             panelClassName="max-h-[40vh] w-56 overflow-y-auto"
             trigger={(
               <button
-                className="inline-flex h-7 max-w-48 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink"
+                className="inline-flex h-7 max-w-48 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink"
                 onClick={() => {
                   setThinkingMenuOpen(false);
                   setApprovalMenuOpen(false);
@@ -768,7 +772,7 @@ function ComposerImpl({
             panelClassName="w-40 overflow-hidden"
             trigger={(
               <button
-                className="inline-flex h-7 max-w-40 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex h-7 max-w-40 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-ink-soft transition-colors hover:bg-surface-subtle hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
                 onClick={() => {
                   setModelMenuOpen(false);
                   setApprovalMenuOpen(false);

--- a/desktop/src/styles/globals.css
+++ b/desktop/src/styles/globals.css
@@ -97,8 +97,12 @@ body,
   margin: 0;
 }
 
+/* No minimum-width floor: a window narrower than the three-column minimum must
+   reflow, not lay the shell out wider than the viewport. A wider-than-viewport
+   layout is clipped (overflow stays hidden below), which cuts the conversation
+   area's right edge off-screen. The shell instead folds its side panels as the
+   window narrows — see `canShow*Panel` in components/layout/hooks/panelGeometry.ts. */
 body {
-  min-width: 1024px;
   overflow: hidden;
   background: theme(colors.canvas);
 }


### PR DESCRIPTION
## Problem

With a narrow window the conversation area was not fully visible: `body { min-width: 1024px }` laid the shell out at 1024px inside a narrower window, and since `body` keeps `overflow: hidden` there was no way to scroll to the clipped part. Measured on a 900px viewport: `body=1024`, `main` right edge at 1024, and the composer (including its send button) 92px past the right edge. Independently, at the 1024px minimum with the context panel open the center pane is exactly its 384px floor — narrower than the composer toolbar needs, so the toolbar's controls ran past the card and overlapped the send button.

## Change

- **Drop the CSS width floor** (`desktop/src/styles/globals.css`). The shell now follows the actual viewport.
- **Side panels yield to the conversation** (`panelGeometry.ts`, `useWindowWidth.ts`, `AppShell.tsx`): below the three-column floors (608px / 992px) the left rail folds into its existing hover overlay and the right context panel stays closed, instead of squeezing the center past its floor. The user's own collapsed/expanded choice is kept in state, so a panel comes back when the window grows; the rail toggle is a no-op while there is no room, so a click can't silently persist "collapsed".
- **Composer toolbar wraps** (`Composer.tsx`): the model / thinking / send group drops to a second row (`ms-auto`, right-aligned) with `min-w-0` on the triggers so long labels truncate — no overflow or overlap at the 384px floor.

## Verification

Rendered the real `AppShell` in Chrome against a stubbed Tauri IPC (temporary harness, not committed) as sized iframes at 1440 / 1200 / 1024 / 992 / 900 / 700 / 600 / 500px, in both the default and context-panel-open states, and measured the DOM rather than eyeballing screenshots.

| viewport | before (measured) | after |
|---|---|---|
| 900 | `body=1024`, 25 elements escaping the viewport, composer right edge 92px off-screen, send button not visible | `body=900`, 0 escaping, `main` right edge = viewport, composer fits |
| 1024 + context panel open | center 384px, toolbar 1 row whose tail ran 30px past the card | center 384px, toolbar wraps to 2 right-aligned rows, everything inside the card |

Screenshots of the 1024px three-column window (context panel open, wrapped composer) and the narrow widths confirmed no clipped or overlapping controls.

`npx tsc --noEmit`, `npx eslint "src/**/*.{ts,tsx}"`, `npx stylelint "src/**/*.css"`, `npx vitest run` (91 files / 842 tests, including the new `panelGeometry.test.ts`) all pass.

Note: `tauri.conf.json` still declares `minWidth: 1024` — this PR makes anything narrower *work* (Windows snap, zoomed/scaled displays) but doesn't change what the user can drag to. Lowering that minimum is a product decision, so it is left alone.
