### PR TITLE
fix(loop): discard an agent session that never reached a prompt

### DIFF
--- a/agent/src/rpc/mod.rs
+++ b/agent/src/rpc/mod.rs
@@ -492,10 +492,22 @@ fn get_state_internal(
         0.0
     };
 
-    let parent_session_id = loaded
-        .as_ref()
-        .map(|s| s.parent_session_id.clone())
-        .unwrap_or_default();
+    // In-memory first: a session created via `new_session` knows its parent
+    // immediately, but only commits it to disk (session_info) at its first
+    // run boundary. Reading disk-first therefore reported `parentSessionId`
+    // as absent for every freshly created, not-yet-prompted session — clients
+    // that bind lineage on `session_created` (desktop `import_discovered_session`)
+    // lost the parent permanently, since a session with no entries never
+    // reappears in `list_sessions` for a later heal pass. Disk stays the
+    // durable fallback (it is written from this same field).
+    let parent_session_id = if !sess.parent_session_id.is_empty() {
+        sess.parent_session_id.clone()
+    } else {
+        loaded
+            .as_ref()
+            .map(|s| s.parent_session_id.clone())
+            .unwrap_or_default()
+    };
     let active_run = sess
         .runtime
         .snapshot()
@@ -1298,6 +1310,35 @@ mod tests {
         assert!(text.contains("1.25"), "{text}");
         assert!(text.contains("\"runId\""), "{text}");
         assert!(!text.contains("\"run_id\""), "no legacy alias: {text}");
+    }
+
+    #[test]
+    fn get_state_reports_parent_before_it_is_committed_to_disk() {
+        let (_dir, state) = bare_app_state();
+        // `new_session` with a parent (what `loop run` does) keeps the lineage
+        // in memory; the parent only reaches disk at the first run boundary.
+        // Nothing is persisted here, so the disk fallback cannot supply it.
+        let mut session = crate::rpc::ServerSession::new_with_queue_budget(
+            "fresh".to_string(),
+            std::sync::Arc::new(tokio::sync::RwLock::new(crate::agent::Loop::new(
+                std::sync::Arc::new(crate::test_support::EmptyProvider),
+                "mock",
+            ))),
+            state.session_manager.clone(),
+            "/tmp",
+            std::sync::Arc::new(SseBroadcaster::new()),
+            state.approval_gate.clone(),
+            state.model_registry.clone(),
+            state.queue_budget.clone(),
+        );
+        session.parent_session_id = "parent-1".to_string();
+        state.create_session(session);
+        let payload = get_state_internal(&state, "fresh", None).unwrap();
+        let text = payload.to_string();
+        assert!(
+            text.contains("\"parentSessionId\":\"parent-1\""),
+            "unprompted session must report its in-memory parent: {text}"
+        );
     }
 
     #[test]

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -4333,6 +4333,10 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     let parent_session = parent_session
         .as_deref()
         .or(goal0.supervisor_session_id.as_deref());
+    // Whether this invocation minted the session (as opposed to resuming a
+    // live one). A freshly minted session that never reaches a prompt belongs
+    // to no one: see the unused-session cleanup after the turn loop.
+    let mut created_session = false;
     let session_id = match want_session {
         Some(id) if client.session_alive(&id).await => {
             println!("   ⤺ resuming session {id}");
@@ -4340,11 +4344,13 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         }
         Some(id) => {
             println!("   ⚠ retained session {id} is no longer alive — starting fresh");
+            created_session = true;
             client
                 .new_child_session(&goal0.cwd, &session_title, parent_session)
                 .await?
         }
         None => {
+            created_session = true;
             client
                 .new_child_session(&goal0.cwd, &session_title, parent_session)
                 .await?
@@ -4377,6 +4383,10 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
     // resumable advisory) on the goal and lets the NEXT caller decide
     // resume-vs-fresh via --resume-session.
     let mut last_failure_kind: Option<crate::state::FailureKind> = None;
+    // Set by `run_turns` the moment a turn actually reaches the model. Stays
+    // false when the loop breaks out before executing anything (wait/terminal
+    // decision, workspace conflict, no claimable todo).
+    let mut executed_turn = false;
     // Down-channel steering: watch the ledger for supervisor steering
     // instructions targeting THIS worker and abort the session mid-turn so the
     // next turn drains the instruction into its envelope. Aborted after the
@@ -4397,9 +4407,26 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         max_incomplete_retries,
         force_workspace,
         &mut last_failure_kind,
+        &mut executed_turn,
     )
     .await;
     steer_handle.abort();
+
+    // A session we minted but never prompted is an empty husk: nothing ran, so
+    // nothing references it — but it still shows up in `session list` / the
+    // desktop sidebar under the goal objective, and no later pass heals it
+    // (a session with no entries never reappears in `list_sessions`). Drop it
+    // instead of leaving a permanently-unrepairable empty conversation. Common
+    // causes: the workspace guard refusing turn 1 (degrade-to-serial) or a
+    // wait/terminal first decision. Best-effort — a delete failure must not
+    // fail the run itself.
+    let discarded_unused_session = created_session && !executed_turn;
+    if discarded_unused_session {
+        match client.delete_session(&session_id).await {
+            Ok(()) => println!("   ↦ discarded unused session {session_id} (no turn ran)"),
+            Err(e) => println!("   ⚠ could not discard unused session {session_id}: {e}"),
+        }
+    }
 
     // Post-run supervision: sweep dead holders (best-effort — the run's own
     // writeback already landed; a lost notification must not fail it).
@@ -4438,13 +4465,17 @@ async fn cmd_run(store: &mut Store, args: &[String]) -> Result<()> {
         }
     }
 
-    // Session retention: never delete the agent session. The session (and its
-    // accumulated exploration) stays on the agent; the NEXT caller decides
+    // Session retention: never delete a session that did work. A session (and
+    // its accumulated exploration) stays on the agent; the NEXT caller decides
     // resume-vs-fresh explicitly. The default is a fresh session; the only
     // resume path is an explicit pin (`--resume-session <id>`), so this
     // resumable classification is advisory data for the orchestrator's own
-    // judgment, not a directive.
-    if resumable {
+    // judgment, not a directive. The one exception is a session this run
+    // minted and never prompted — discarded above, so there is nothing to
+    // resume and saying otherwise would point at a deleted id.
+    if discarded_unused_session {
+        println!("   ↦ no session retained (the unused one was discarded)");
+    } else if resumable {
         println!(
             "   ⤺ session {session_id} retained (resumable) — resume it with --resume-session {session_id}"
         );
@@ -4643,6 +4674,7 @@ async fn run_turns(
     max_incomplete_retries: u32,
     force_workspace: bool,
     last_failure_kind: &mut Option<crate::state::FailureKind>,
+    executed_turn: &mut bool,
 ) -> Result<()> {
     let mut turn = 0u32;
     // P2: goal-monotonic turn counter. `turn` below restarts at 1 on every
@@ -4889,6 +4921,9 @@ async fn run_turns(
         );
         notes.extend(next_continue_note.take());
         let turn_note = (!notes.is_empty()).then(|| notes.join("\n\n"));
+        // Past this point the turn reaches the model, so the session is in use
+        // and must outlive the run (see the unused-session cleanup in `cmd_run`).
+        *executed_turn = true;
         let turn_future = execute_turn(
             client,
             session_id,

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -156,7 +156,7 @@ fn run_workspace_conflict_and_force_workspace() {
     ]);
     // A second open todo for a2 to pick up after forcing.
     let second = add_todo(&cr, &goal, "second task");
-    let (_rt, _shared) = mock_env(MockState {
+    let (_rt, shared) = mock_env(MockState {
         events: completed_events("mock-run-1"),
         ..Default::default()
     });
@@ -171,6 +171,19 @@ fn run_workspace_conflict_and_force_workspace() {
         "2",
     ]);
     assert!(err.contains("workspace conflict"), "{err}");
+    // The refused run still minted a session (session creation precedes the
+    // guard, which is evaluated per turn) but never prompted it, so the session
+    // must be discarded rather than left as an empty conversation titled with
+    // the goal objective.
+    {
+        let st = shared.lock().unwrap();
+        assert_eq!(st.sessions_created, 1, "session is minted before the guard");
+        assert!(
+            st.live_sessions.is_empty(),
+            "unused session must be discarded, got {:?}",
+            st.live_sessions
+        );
+    }
     // --force-workspace lets a2 claim the second todo and complete it.
     cli_ok(&[
         "run",
@@ -444,7 +457,16 @@ fn run_monitor_not_due_waits() {
     ]);
     append_monitor(&cr, &goal, "mon_future", 3600);
     cli_ok(&["run", "--goal", &goal, "--anonymous", "--max-turns", "3"]);
-    assert_eq!(shared.lock().unwrap().prompts, 0, "no turn while waiting");
+    let st = shared.lock().unwrap();
+    assert_eq!(st.prompts, 0, "no turn while waiting");
+    // The run minted a session, then decided to wait — nothing was ever
+    // prompted, so the empty session must not be left behind.
+    assert_eq!(st.sessions_created, 1);
+    assert!(
+        st.live_sessions.is_empty(),
+        "unused session must be discarded, got {:?}",
+        st.live_sessions
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## 问题

`loop run` 在进入 turn 循环**之前**就创建 agent session，但若干「第一轮直接退出」的路径从未 prompt：

- P0-1 workspace guard 拒绝与 peer 抢同一工作区（degrade-to-serial）
- 第一轮判定为 wait / terminal
- 没有可 claim 的 todo

会话被留下：**内容为空**、标题是 goal objective、且 `parentSessionId` 缺失。而且**永远无法自愈** —— 没有 entry 的会话不会出现在 `list_sessions` 里，桌面端由 `session_created` 推送建立的 stub（`import_discovered_session`）也就永远等不到后台 import 的修复。

**实测**：一个 32-worker 的 goal 产生了**正好 32 个**这样的空会话，每次被拒/提前退出的 run 一个 —— 包括 workspace guard 开始串行化同 cwd worker 池之后的每一次 relaunch。

## 改动

| commit | 内容 |
|---|---|
| `fix(loop)` | 当会话是本次调用新建、且**从未执行过任何 turn** 时，把它删掉。`run_turns` 现在回报 turn 是否真的到达过模型；**跑过 turn 的会话仍然永不删除**（retention 契约不变），retention 提示也不再宣传一个已被删除的 id。 |
| `fix(agent)` | `get_state` 原本 `session_name` 读内存、`parent_session_id` 读磁盘，于是「新建但尚未 prompt」的会话**完全不含** `parentSessionId` 字段。改为内存优先、磁盘兜底（磁盘本就由同一字段写入，持久化后二者不可能不一致）。 |

## 验证

两个早期退出路径都加了断言（**去掉修复即失败**，报 `unused session must be discarded, got {"mock-session-1"}`）：

- `run_workspace_conflict_and_force_workspace` —— guard 拒绝后不得留下会话
- `run_monitor_not_due_waits` —— wait 退出后不得留下会话

`get_state` 新增 `get_state_reports_parent_before_it_is_committed_to_disk`：**去掉修复即失败**，实际输出里根本没有 `parentSessionId` 键（与线上症状一致）。

现有契约测试 `console_sweep` 的「session must be retained after a completed run」仍然通过，确认**跑过 turn 的会话不受影响**。

```
cargo fmt -p future-loop -p future-agent --check   # clean
cargo clippy -p future-loop -p future-agent --all-targets -- -D warnings   # clean
cargo test -p future-loop        # 67 test binaries, 0 failed
cargo test -p future-agent       # 1714 lib tests (+ integration), 0 failed
```

未改动 `packages/rpc` 的线上契约形状（`parentSessionId` 本就是 optional 字段），改的只是它**何时**被填充。
