### PR TITLE
Stabilize mobile chat layout and history paging

### DIFF
--- a/mobile/src/features/chat/ChatScreen.tsx
+++ b/mobile/src/features/chat/ChatScreen.tsx
@@ -40,6 +40,10 @@ function TimelineItemGap() {
   return <View style={styles.itemGap} />;
 }
 
+function TimelineFlexSpacer() {
+  return <View />;
+}
+
 export function ChatScreen() {
   const { t } = useTranslation();
   const remote = useRemote();
@@ -51,12 +55,12 @@ export function ChatScreen() {
   const [showOffline, setShowOffline] = useState(false);
   // Android edge-to-edge: the built-in KeyboardAvoidingView is a no-op here
   // (behavior is undefined on Android) and RN's KAV mis-measures the keyboard
-  // under edge-to-edge, so we lift the floating composer + list padding by the
-  // measured keyboard height ourselves. iOS keeps relying on KAV padding.
+  // under edge-to-edge, so we inset the chat flex column by the measured
+  // keyboard height ourselves. iOS keeps relying on KAV padding.
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   const title = remote.draft ? t("chat.new") : remote.selectedTitle || t("sessions.unnamed");
-  const activeModel = remote.models.find((model) => modelReference(model) === remote.modelId);
+  const activeModel = remote.models.find(model => modelReference(model) === remote.modelId);
   const activeModelLabel =
     activeModel?.label || activeModel?.id || remote.modelId || t("chat.model");
   const supportsImages = activeModel ? activeModel.supportsImages !== false : true;
@@ -81,7 +85,7 @@ export function ChatScreen() {
   // only while undecided — once a decision lands the card disappears.
   const timelineItems = useMemo(() => remote.timeline.items, [remote.timeline]);
   const transcriptItems = useMemo(
-    () => timelineItems.filter((item) => item.kind !== "approval"),
+    () => timelineItems.filter(item => item.kind !== "approval"),
     [timelineItems],
   );
   // FlatList's physical start is the stable latest-message anchor. Reversing
@@ -128,11 +132,18 @@ export function ChatScreen() {
     [remote, t],
   );
 
-  const { listRef, atLatest, composerHeight, setComposerHeight, scrollToLatest, onScroll } =
-    useChatScroll(remote.selectedSessionId);
+  const scroll = useChatScroll(remote.selectedSessionId, transcriptItems.length);
+  const { listRef, atLatest, scrollToLatest, onScroll } = scroll;
   const {
     showLoadOlderHint,
+    pagingActive,
+    pagingFailed,
     loadOlder,
+    onListLayout,
+    onContentSizeChange,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollEnd,
     onScroll: onPagedScroll,
   } = useTimelinePaging(
     remote.selectedSessionId,
@@ -140,6 +151,7 @@ export function ChatScreen() {
     remote.loadingOlderTimeline,
     remote.loadOlderTimeline,
     onScroll,
+    timelineItems,
   );
 
   // Keep FlatList row callbacks referentially stable while still dispatching
@@ -180,14 +192,16 @@ export function ChatScreen() {
 
   const renderTimelineItem = useCallback(
     ({ item }: { item: TimelineItem }) => (
-      <TimelineCard
-        item={item}
-        isLatestAssistant={item.id === latestAssistantId}
-        onOpenAttachment={handleTimelineAttachment}
-        onOpenFile={handleTimelineFile}
-        onRetry={handleTimelineRetry}
-        onContinue={handleTimelineContinue}
-      />
+      <View onLayout={onListLayout}>
+        <TimelineCard
+          item={item}
+          isLatestAssistant={item.id === latestAssistantId}
+          onOpenAttachment={handleTimelineAttachment}
+          onOpenFile={handleTimelineFile}
+          onRetry={handleTimelineRetry}
+          onContinue={handleTimelineContinue}
+        />
+      </View>
     ),
     [
       handleTimelineAttachment,
@@ -195,6 +209,7 @@ export function ChatScreen() {
       handleTimelineFile,
       handleTimelineRetry,
       latestAssistantId,
+      onListLayout,
     ],
   );
 
@@ -213,7 +228,7 @@ export function ChatScreen() {
   // nav-bar-height gap above the keyboard.
   useEffect(() => {
     if (Platform.OS !== "android") return;
-    const showSub = Keyboard.addListener("keyboardDidShow", (event) =>
+    const showSub = Keyboard.addListener("keyboardDidShow", event =>
       setKeyboardHeight(event.endCoordinates.height),
     );
     const hideSub = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0));
@@ -231,12 +246,9 @@ export function ChatScreen() {
     return () => clearTimeout(timer);
   }, [remote.desktopOnline]);
 
-  // Lift the composer so the floating *card* clears the keyboard, not the dock:
-  // the dock's bottom edge includes composerArea's paddingBottom (spacing.md) of
-  // empty space below the card, so lifting the dock flush to the keyboard top
-  // still hides the card's bottom border + rounded corners + shadow by that
-  // padding (exactly the clipping seen with Gboard). Re-add the padding, plus a
-  // little shadow clearance, so the whole card floats above the IME.
+  // Inset the whole flex column so the composer *card* clears the keyboard. The
+  // dock includes composerArea's bottom padding, so retain a little additional
+  // clearance for the card border, rounded corners, and shadow above Gboard.
   const KEYBOARD_CLEARANCE = spacing.md + spacing.sm;
   const keyboardLift =
     Platform.OS === "android" && keyboardHeight > 0
@@ -270,17 +282,20 @@ export function ChatScreen() {
           />
         )}
 
-        <View style={styles.chatContent}>
-          {/* The inverted newest-first view makes offset zero equal "latest".
-              Older pages append at the opposite edge, so their async Markdown
-              layout cannot move the reader's current viewport. */}
+        <View
+          style={[styles.chatContent, keyboardLift > 0 ? { paddingBottom: keyboardLift } : null]}
+        >
+          {/* Inverted data puts latest at offset zero. Reading-mode native
+              anchoring handles subsequent row layout changes. */}
           <FlatList
             contentContainerStyle={[
               styles.timeline,
               {
                 // The scroll container is inverted, so logical top padding is
-                // rendered at the visual bottom beside the floating composer.
-                paddingTop: composerHeight + COMPOSER_FADE_CLEARANCE + spacing.lg + keyboardLift,
+                // rendered at the visual bottom. The composer itself now
+                // participates in flex layout; only its overlaid fade needs
+                // clearance inside the list.
+                paddingTop: COMPOSER_FADE_CLEARANCE + spacing.lg,
               },
               timelineItems.length === 0 && styles.emptyTimeline,
             ]}
@@ -288,7 +303,9 @@ export function ChatScreen() {
             initialNumToRender={10}
             inverted
             key={remote.selectedSessionId || "draft"}
-            keyExtractor={(item) => item.id}
+            keyExtractor={item => item.id}
+            ListHeaderComponent={invertedTranscriptItems.length > 0 ? TimelineFlexSpacer : null}
+            ListHeaderComponentStyle={styles.timelineFlexSpacer}
             ListEmptyComponent={
               remote.timelineError ? (
                 <View style={styles.loadingState}>
@@ -310,12 +327,26 @@ export function ChatScreen() {
                 <Text style={styles.empty}>{t("chat.noHistory")}</Text>
               )
             }
-            maintainVisibleContentPosition={{
-              minIndexForVisible: 0,
-              autoscrollToTopThreshold: 32,
-            }}
+            maintainVisibleContentPosition={scroll.maintainVisibleContentPosition}
+            automaticallyAdjustContentInsets={false}
+            contentInsetAdjustmentBehavior="never"
+            automaticallyAdjustKeyboardInsets={false}
             maxToRenderPerBatch={8}
+            onContentSizeChange={() => {
+              scroll.onContentSizeChange();
+              onContentSizeChange();
+            }}
+            onLayout={() => {
+              scroll.onLayout();
+              onListLayout();
+            }}
+            onScrollBeginDrag={() => {
+              scroll.onScrollBeginDrag();
+              onScrollBeginDrag();
+            }}
+            onMomentumScrollEnd={onMomentumScrollEnd}
             onScroll={onPagedScroll}
+            onScrollEndDrag={onScrollEndDrag}
             ref={listRef}
             renderItem={renderTimelineItem}
             scrollEventThrottle={16}
@@ -329,11 +360,15 @@ export function ChatScreen() {
           {showLoadOlderHint && (
             <Pressable
               accessibilityRole="button"
+              disabled={pagingActive}
+              accessibilityState={{ busy: pagingActive, disabled: pagingActive }}
               onPress={loadOlder}
               style={({ pressed }) => [styles.loadOlder, pressed && styles.loadOlderPressed]}
             >
               <History color={colors.inkMuted} size={14} />
-              <Text style={styles.loadOlderLabel}>{t("chat.loadOlder")}</Text>
+              <Text style={styles.loadOlderLabel}>
+                {pagingFailed ? t("common.retry") : t("chat.loadOlder")}
+              </Text>
             </Pressable>
           )}
 
@@ -347,7 +382,11 @@ export function ChatScreen() {
             remote={remote}
             t={t}
             openAttachmentMenu={openAttachmentMenu}
-            send={send}
+            send={async () => {
+              if (!message.trim() && attachments.length === 0) return;
+              scrollToLatest();
+              await send();
+            }}
             atLatest={atLatest}
             scrollToLatest={scrollToLatest}
             showOffline={showOffline}
@@ -355,8 +394,6 @@ export function ChatScreen() {
             approvalSubmitting={approvalSubmitting}
             approvalError={approvalError}
             decideApproval={decideApproval}
-            setComposerHeight={setComposerHeight}
-            keyboardLift={keyboardLift}
             selector={selector}
             setSelector={setSelector}
           />
@@ -424,12 +461,29 @@ export function ChatScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.surface },
   keyboard: { flex: 1, backgroundColor: colors.surface },
-  chatContent: { flex: 1 },
-  timelineList: { flex: 1 },
-  timeline: { paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
-  emptyTimeline: { flexGrow: 1, alignItems: "center", justifyContent: "center" },
+  chatContent: { flex: 1, minHeight: 0 },
+  timelineList: { flex: 1, minHeight: 0 },
+  // `inverted` flips the visual axis. A flexible physical header consumes only
+  // the unused height of an underfilled list and therefore becomes visual
+  // bottom space, leaving short conversations at the visual top. It collapses
+  // to zero once message rows overflow the viewport.
+  timeline: {
+    flexGrow: 1,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  timelineFlexSpacer: { flexGrow: 1 },
+  emptyTimeline: {
+    flexGrow: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   empty: { color: colors.inkMuted, fontSize: 14 },
-  loadingState: { alignItems: "center", gap: spacing.sm, paddingVertical: spacing.xl },
+  loadingState: {
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingVertical: spacing.xl,
+  },
   historyError: { color: colors.inkMuted, fontSize: 14, textAlign: "center" },
   retryButton: {
     backgroundColor: colors.accent,
@@ -465,5 +519,9 @@ const styles = StyleSheet.create({
     height: 2,
     overflow: "hidden",
   },
-  transferFill: { height: 2, borderRadius: radius.pill, backgroundColor: colors.accent },
+  transferFill: {
+    height: 2,
+    borderRadius: radius.pill,
+    backgroundColor: colors.accent,
+  },
 });

--- a/mobile/src/features/chat/__tests__/useChatScroll.test.ts
+++ b/mobile/src/features/chat/__tests__/useChatScroll.test.ts
@@ -19,8 +19,14 @@ describe("useChatScroll inverted-list model", () => {
   let renderer: ReactTestRenderer | null = null;
   let result: { current: ReturnType<typeof useChatScroll> };
 
-  function Harness({ sessionId = "s1" }: { sessionId?: string }): null {
-    result.current = useChatScroll(sessionId);
+  function Harness({
+    sessionId = "s1",
+    itemCount = 0,
+  }: {
+    sessionId?: string;
+    itemCount?: number;
+  }): null {
+    result.current = useChatScroll(sessionId, itemCount);
     return null;
   }
 
@@ -39,31 +45,95 @@ describe("useChatScroll inverted-list model", () => {
   test("treats the invariant offset zero as latest", () => {
     expect(result.current.atLatest).toBe(true);
 
-    act(() => result.current.onScroll(scrollEvent(200)));
+    act(() => {
+      result.current.onScrollBeginDrag();
+      result.current.onScroll(scrollEvent(200));
+    });
     expect(result.current.atLatest).toBe(false);
 
     act(() => result.current.onScroll(scrollEvent(0)));
     expect(result.current.atLatest).toBe(true);
   });
 
+  test("short-list relayout cannot steal initial following or enable native compensation", () => {
+    const scrollToOffset = jest.fn();
+    (result.current.listRef as { current: unknown }).current = { scrollToOffset };
+    act(() => {
+      result.current.onScroll(scrollEvent(200));
+      result.current.onContentSizeChange();
+      result.current.onLayout();
+    });
+    expect(result.current.atLatest).toBe(true);
+    expect(result.current.maintainVisibleContentPosition).toBeUndefined();
+    expect(scrollToOffset).toHaveBeenLastCalledWith({ offset: 0, animated: false });
+  });
+
+  test("native anchoring owns late layout only while reading history", () => {
+    const scrollToOffset = jest.fn();
+    (result.current.listRef as { current: unknown }).current = { scrollToOffset };
+    act(() => {
+      result.current.onScrollBeginDrag();
+      result.current.onScroll(scrollEvent(600));
+      result.current.onContentSizeChange();
+      result.current.onLayout();
+    });
+    expect(scrollToOffset).not.toHaveBeenCalled();
+    expect(result.current.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 0 });
+    act(() => result.current.scrollToLatest());
+    expect(result.current.maintainVisibleContentPosition).toBeUndefined();
+  });
+
   test("back to latest has one deterministic target", () => {
     const scrollToOffset = jest.fn();
     (result.current.listRef as { current: unknown }).current = { scrollToOffset };
-    act(() => result.current.onScroll(scrollEvent(200)));
+    act(() => {
+      result.current.onScrollBeginDrag();
+      result.current.onScroll(scrollEvent(200));
+    });
 
     act(() => result.current.scrollToLatest());
 
     expect(scrollToOffset).toHaveBeenCalledTimes(1);
-    expect(scrollToOffset).toHaveBeenCalledWith({ animated: true, offset: 0 });
+    expect(scrollToOffset).toHaveBeenCalledWith({ animated: false, offset: 0 });
     expect(result.current.atLatest).toBe(true);
   });
 
   test("a newly entered session starts at latest without a measurement race", () => {
-    act(() => result.current.onScroll(scrollEvent(200)));
+    act(() => {
+      result.current.onScrollBeginDrag();
+      result.current.onScroll(scrollEvent(200));
+    });
     expect(result.current.atLatest).toBe(false);
 
     act(() => renderer!.update(createElement(Harness, { sessionId: "s2" })));
 
     expect(result.current.atLatest).toBe(true);
+  });
+
+  test("positions the first real page at latest without animation", () => {
+    const scrollToOffset = jest.fn();
+    (result.current.listRef as { current: unknown }).current = { scrollToOffset };
+
+    act(() => renderer!.update(createElement(Harness, { itemCount: 20 })));
+
+    expect(scrollToOffset).toHaveBeenCalledTimes(1);
+    expect(scrollToOffset).toHaveBeenCalledWith({ animated: false, offset: 0 });
+    expect(result.current.atLatest).toBe(true);
+  });
+
+  test("does not reset to latest when an older page changes the item count", () => {
+    const scrollToOffset = jest.fn();
+    (result.current.listRef as { current: unknown }).current = { scrollToOffset };
+    act(() => renderer!.update(createElement(Harness, { itemCount: 20 })));
+    scrollToOffset.mockClear();
+    act(() => {
+      result.current.onScrollBeginDrag();
+      result.current.onScroll(scrollEvent(600));
+    });
+
+    act(() => renderer!.update(createElement(Harness, { itemCount: 40 })));
+
+    expect(scrollToOffset).not.toHaveBeenCalled();
+    expect(result.current.atLatest).toBe(false);
   });
 });

--- a/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
+++ b/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
@@ -7,105 +7,168 @@ function scrollEvent(y: number): NativeSyntheticEvent<NativeScrollEvent> {
   return {
     nativeEvent: {
       contentOffset: { x: 0, y },
-      contentInset: { top: 0, left: 0, bottom: 0, right: 0 },
-      contentSize: { width: 320, height: 2_000 },
+      contentSize: { width: 320, height: 2000 },
       layoutMeasurement: { width: 320, height: 600 },
-      zoomScale: 1,
     },
   } as NativeSyntheticEvent<NativeScrollEvent>;
 }
 
-describe("timeline paging on an inverted list", () => {
-  let renderer: ReactTestRenderer | null = null;
-  let result: { current: ReturnType<typeof useTimelinePaging> };
-  const forwarded = jest.fn();
-  const requestOlder = jest.fn<Promise<void>, []>();
-
-  function Harness({
-    sessionId = "s1",
-    canLoadOlder = true,
-    loadingOlder = false,
-  }: {
-    sessionId?: string;
-    canLoadOlder?: boolean;
-    loadingOlder?: boolean;
-  }): null {
-    result.current = useTimelinePaging(
+describe("paging transaction", () => {
+  let renderer: ReactTestRenderer;
+  let current: ReturnType<typeof useTimelinePaging>;
+  const request = jest.fn<Promise<false | string[]>, []>();
+  const onScroll = jest.fn();
+  function Harness({ sessionId = "a", ids = [] }: { sessionId?: string; ids?: string[] }) {
+    current = useTimelinePaging(
       sessionId,
-      canLoadOlder,
-      loadingOlder,
-      requestOlder,
-      forwarded,
+      true,
+      false,
+      request,
+      onScroll,
+      ids.map(id => ({ id })),
     );
     return null;
   }
-
+  const advance = async (ms: number) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+  const collide = () =>
+    act(() => {
+      current.onScrollBeginDrag();
+      current.onScroll(scrollEvent(1400));
+    });
   beforeEach(() => {
     jest.useFakeTimers();
-    requestOlder.mockResolvedValue(undefined);
-    result = { current: undefined as never };
+    request.mockResolvedValue([]);
     act(() => {
       renderer = create(createElement(Harness));
     });
   });
-
   afterEach(() => {
-    if (renderer) act(() => renderer!.unmount());
-    renderer = null;
+    act(() => renderer.unmount());
     jest.useRealTimers();
-    forwarded.mockReset();
-    requestOlder.mockReset();
+    request.mockReset();
+    onScroll.mockReset();
   });
 
-  test("latest offset is not mistaken for the older-history edge", () => {
-    act(() => result.current.onScroll(scrollEvent(0)));
-    act(() => jest.advanceTimersByTime(350));
-
-    expect(forwarded).toHaveBeenCalledTimes(1);
-    expect(result.current.showLoadOlderHint).toBe(false);
-    expect(requestOlder).not.toHaveBeenCalled();
+  test("programmatic scroll never loads a page; collision starts request immediately", () => {
+    act(() => current.onScroll(scrollEvent(1400)));
+    expect(request).not.toHaveBeenCalled();
+    collide();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(current.pagingActive).toBe(true);
   });
 
-  test("automatically requests once after settling at the visual top", async () => {
-    act(() => result.current.onScroll(scrollEvent(1_400)));
-    expect(result.current.showLoadOlderHint).toBe(true);
-    await act(async () => jest.advanceTimersByTime(350));
-    expect(requestOlder).toHaveBeenCalledTimes(1);
-
-    // Remaining at the same edge cannot cascade through every page. Leaving
-    // and returning is the explicit gesture that re-arms one automatic page.
-    act(() => result.current.onScroll(scrollEvent(1_400)));
-    await act(async () => jest.advanceTimersByTime(350));
-    expect(requestOlder).toHaveBeenCalledTimes(1);
-    act(() => result.current.onScroll(scrollEvent(100)));
-    act(() => result.current.onScroll(scrollEvent(1_400)));
-    await act(async () => jest.advanceTimersByTime(350));
-    expect(requestOlder).toHaveBeenCalledTimes(2);
+  test("a completed empty page retains the marker for 1500ms from collision", async () => {
+    collide();
+    await act(async () => {});
+    await advance(1499);
+    expect(current.pagingActive).toBe(true);
+    await advance(1);
+    expect(current.showLoadOlderHint).toBe(false);
   });
 
-  test("leaving the older edge cancels the delayed automatic load", () => {
-    act(() => result.current.onScroll(scrollEvent(1_400)));
-    act(() => result.current.onScroll(scrollEvent(100)));
-    act(() => jest.advanceTimersByTime(350));
-
-    expect(result.current.showLoadOlderHint).toBe(false);
-    expect(requestOlder).not.toHaveBeenCalled();
+  test("request completion and unchanged old geometry cannot satisfy a new page", async () => {
+    request.mockResolvedValue(["older"]);
+    collide();
+    await act(async () => {});
+    act(() => current.onListLayout());
+    await advance(2000);
+    expect(current.pagingActive).toBe(true);
+    act(() => renderer.update(createElement(Harness, { ids: ["older"] })));
+    await advance(200);
+    expect(current.pagingActive).toBe(true);
+    act(() => current.onListLayout());
+    await advance(99);
+    expect(current.pagingActive).toBe(true);
+    // Late row layout restarts the quiet window.
+    act(() => current.onListLayout());
+    await advance(100);
+    expect(current.showLoadOlderHint).toBe(false);
   });
 
-  test("does not request while loading or when no older page exists", () => {
-    act(() => renderer!.update(createElement(Harness, { loadingOlder: true })));
-    act(() => result.current.loadOlder());
-    act(() => renderer!.update(createElement(Harness, { canLoadOlder: false })));
-    act(() => result.current.loadOlder());
-    expect(requestOlder).not.toHaveBeenCalled();
+  test("slow response runs concurrently with minimum time, not another 1500ms", async () => {
+    let resolve!: (result: string[]) => void;
+    request.mockImplementationOnce(
+      () =>
+        new Promise(done => {
+          resolve = done;
+        }),
+    );
+    collide();
+    await advance(2000);
+    expect(current.pagingActive).toBe(true);
+    await act(async () => resolve([]));
+    await advance(100);
+    expect(current.showLoadOlderHint).toBe(false);
   });
 
-  test("switching sessions clears a pending edge load", () => {
-    act(() => result.current.onScroll(scrollEvent(1_400)));
-    expect(result.current.showLoadOlderHint).toBe(true);
-    act(() => renderer!.update(createElement(Harness, { sessionId: "s2" })));
-    expect(result.current.showLoadOlderHint).toBe(false);
-    act(() => jest.advanceTimersByTime(350));
-    expect(requestOlder).not.toHaveBeenCalled();
+  test("drag and momentum cannot cascade to another page even after cooldown", async () => {
+    collide();
+    await act(async () => {});
+    await advance(1500);
+    act(() => {
+      current.onScrollEndDrag(scrollEvent(1400));
+      current.onMomentumScrollEnd(scrollEvent(1400));
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    // Another deliberate drag at the clamped edge can load again.
+    act(() => {
+      current.onScrollBeginDrag();
+      current.onScrollEndDrag(scrollEvent(1400));
+    });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  test("timeout and synchronous failures expose a retry without unhandled rejection", async () => {
+    request.mockRejectedValueOnce(new Error("timeout"));
+    collide();
+    await act(async () => {});
+    await advance(1500);
+    expect(current.pagingActive).toBe(false);
+    expect(current.pagingFailed).toBe(true);
+    request.mockImplementationOnce(() => {
+      throw new Error("disconnected");
+    });
+    act(() => current.loadOlder());
+    await advance(1500);
+    expect(current.pagingFailed).toBe(true);
+    act(() => current.loadOlder());
+    await act(async () => {});
+    await advance(1500);
+    expect(current.showLoadOlderHint).toBe(false);
+  });
+
+  test("old-session completion cannot change the new-session transaction", async () => {
+    let resolveOld!: (result: false) => void;
+    request.mockImplementationOnce(
+      () =>
+        new Promise(done => {
+          resolveOld = done;
+        }),
+    );
+    collide();
+    act(() => renderer.update(createElement(Harness, { sessionId: "b" })));
+    request.mockResolvedValueOnce(["b-page"]);
+    collide();
+    await act(async () => resolveOld(false));
+    await advance(2000);
+    expect(current.pagingActive).toBe(true);
+    expect(current.pagingFailed).toBe(false);
+    act(() => renderer.update(createElement(Harness, { sessionId: "b", ids: ["b-page"] })));
+    act(() => current.onListLayout());
+    await advance(100);
+    expect(current.showLoadOlderHint).toBe(false);
+  });
+
+  test("returning to a previous session cannot resurrect its marker", async () => {
+    request.mockImplementationOnce(() => new Promise(() => {}));
+    collide();
+    act(() => renderer.update(createElement(Harness, { sessionId: "b" })));
+    act(() => renderer.update(createElement(Harness, { sessionId: "a" })));
+    expect(current.showLoadOlderHint).toBe(false);
+    expect(current.pagingActive).toBe(false);
   });
 });

--- a/mobile/src/features/chat/components/ComposerDock.tsx
+++ b/mobile/src/features/chat/components/ComposerDock.tsx
@@ -9,7 +9,7 @@ import {
   X,
 } from "lucide-react-native";
 import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
-import type { Dispatch, SetStateAction } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import type { TFunction } from "i18next";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import { PendingApprovalCard } from "../../../components/TimelineCard";
@@ -22,6 +22,9 @@ import { COMPOSER_FADE_CLEARANCE, formatBytes } from "../utils";
 type Remote = ReturnType<typeof useRemote>;
 
 type PendingApproval = Extract<TimelineItem, { kind: "approval" }>;
+
+const INPUT_MIN_HEIGHT = 46;
+const INPUT_MAX_HEIGHT = 160;
 
 export function ComposerDock({
   message,
@@ -41,8 +44,6 @@ export function ComposerDock({
   approvalSubmitting,
   approvalError,
   decideApproval,
-  setComposerHeight,
-  keyboardLift,
   selector,
   setSelector,
 }: {
@@ -63,16 +64,12 @@ export function ComposerDock({
   approvalSubmitting: string | null;
   approvalError: string | null;
   decideApproval: (id: string, decision: "approved" | "rejected") => Promise<void>;
-  setComposerHeight: (value: number) => void;
-  keyboardLift: number;
   selector: "model" | "thinking" | null;
   setSelector: (value: "model" | "thinking" | null) => void;
 }) {
+  const [inputHeight, setInputHeight] = useState(INPUT_MIN_HEIGHT);
   return (
-    <View
-      onLayout={(event) => setComposerHeight(event.nativeEvent.layout.height)}
-      style={[styles.composerDock, keyboardLift > 0 ? { bottom: keyboardLift } : null]}
-    >
+    <View style={styles.composerDock}>
       <View pointerEvents="none" style={styles.composerFade}>
         <Svg height="100%" width="100%">
           <Defs>
@@ -103,13 +100,11 @@ export function ComposerDock({
       {!remote.draft && remote.desktopOnline && remote.models.length === 0 && !remote.modelId && (
         <Text style={styles.offlineComposer}>{t("connection.noModelsHint")}</Text>
       )}
-      {pendingApprovals.map((item) => (
+      {pendingApprovals.map(item => (
         <View key={item.id} style={styles.dockedApproval}>
           <PendingApprovalCard
             error={approvalSubmitting === item.payload.approval_request_id ? null : approvalError}
-            onDecision={(decision) =>
-              void decideApproval(item.payload.approval_request_id, decision)
-            }
+            onDecision={decision => void decideApproval(item.payload.approval_request_id, decision)}
             payload={item.payload}
             submitting={approvalSubmitting === item.payload.approval_request_id}
           />
@@ -145,7 +140,7 @@ export function ComposerDock({
                     accessibilityLabel={t("attachment.remove", { name: attachment.name })}
                     hitSlop={8}
                     onPress={() =>
-                      setAttachments((current) => {
+                      setAttachments(current => {
                         deleteTemporaryAttachment(current[index]!);
                         return current.filter((_, itemIndex) => itemIndex !== index);
                       })
@@ -157,18 +152,29 @@ export function ComposerDock({
               ))}
             </ScrollView>
           )}
-          {attachments.some((a) => a.kind === "image") && !supportsImages && (
+          {attachments.some(a => a.kind === "image") && !supportsImages && (
             <Text style={styles.attachmentWarning}>{t("attachment.imagesUnsupported")}</Text>
           )}
           <TextInput
             accessibilityLabel={t("chat.placeholder")}
+            autoCapitalize="none"
+            autoCorrect={false}
             editable={remote.desktopOnline && !remote.timeline.streaming && !remote.busy}
             multiline
+            onContentSizeChange={event =>
+              setInputHeight(
+                Math.max(
+                  INPUT_MIN_HEIGHT,
+                  Math.min(INPUT_MAX_HEIGHT, event.nativeEvent.contentSize.height),
+                ),
+              )
+            }
             onChangeText={setMessage}
             onSubmitEditing={() => void send()}
             placeholder={t("chat.placeholder")}
             placeholderTextColor={colors.inkMuted}
-            style={styles.input}
+            spellCheck={false}
+            style={[styles.input, { height: message ? inputHeight : INPUT_MIN_HEIGHT }]}
             value={message}
           />
           <View style={styles.composerToolbar}>
@@ -260,10 +266,7 @@ export function ComposerDock({
 
 const styles = StyleSheet.create({
   composerDock: {
-    position: "absolute",
-    right: 0,
-    bottom: 0,
-    left: 0,
+    flexShrink: 0,
     backgroundColor: colors.surface,
   },
   composerFade: {
@@ -348,8 +351,8 @@ const styles = StyleSheet.create({
     fontSize: 11,
   },
   input: {
-    minHeight: 46,
-    maxHeight: 160,
+    minHeight: INPUT_MIN_HEIGHT,
+    maxHeight: INPUT_MAX_HEIGHT,
     color: colors.ink,
     ...chatTypography,
     paddingHorizontal: spacing.lg,

--- a/mobile/src/features/chat/useChatScroll.ts
+++ b/mobile/src/features/chat/useChatScroll.ts
@@ -1,55 +1,95 @@
-import { useCallback, useRef, useState, type RefObject } from "react";
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { FlatList, type NativeScrollEvent, type NativeSyntheticEvent } from "react-native";
 import type { TimelineItem } from "../../remote/types";
 
 const AT_LATEST_THRESHOLD_PX = 32;
+const READING_ANCHOR = { minIndexForVisible: 0 };
 
 export interface ChatScrollApi {
   listRef: RefObject<FlatList<TimelineItem> | null>;
   atLatest: boolean;
-  composerHeight: number;
-  setComposerHeight: (value: number) => void;
+  maintainVisibleContentPosition: typeof READING_ANCHOR | undefined;
   scrollToLatest: () => void;
+  onScrollBeginDrag: () => void;
+  onLayout: () => void;
+  onContentSizeChange: () => void;
   onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
 /**
- * Scroll ownership for the inverted transcript.
- *
- * ChatScreen presents newest-first data through an inverted FlatList, making
- * offset zero the single, stable definition of "latest". This hook therefore
- * never derives a bottom offset from asynchronously measured Markdown or tries
- * to compensate for pages changing the content height.
+ * Exactly one owner of the inverted viewport:
+ * - following: physical offset zero, including late native layouts;
+ * - reading: native maintainVisibleContentPosition preserves a message anchor.
+ * Never enable native anchor compensation while following. Underfilled lists
+ * reposition their rows as they grow, which otherwise produces invalid offsets.
  */
-export function useChatScroll(selectedSessionId: string): ChatScrollApi {
+export function useChatScroll(sessionId: string, itemCount: number): ChatScrollApi {
   const listRef = useRef<FlatList<TimelineItem>>(null);
-  const [latestState, setLatestState] = useState({ sessionId: selectedSessionId, value: true });
-  const atLatest = latestState.sessionId === selectedSessionId ? latestState.value : true;
-  const [composerHeight, setComposerHeight] = useState(0);
+  const followingRef = useRef(true);
+  const manualScrollRef = useRef(false);
+  const [state, setState] = useState({ sessionId, following: true });
+  const atLatest = state.sessionId !== sessionId || state.following;
+  if (state.sessionId !== sessionId) setState({ sessionId, following: true });
 
-  const setAtLatest = useCallback(
-    (value: boolean) => setLatestState({ sessionId: selectedSessionId, value }),
-    [selectedSessionId],
+  const setFollowing = useCallback(
+    (following: boolean) => {
+      followingRef.current = following;
+      setState(previous =>
+        previous.sessionId === sessionId && previous.following === following
+          ? previous
+          : { sessionId, following },
+      );
+    },
+    [sessionId],
   );
 
+  const pinLatest = useCallback(() => {
+    if (followingRef.current) {
+      listRef.current?.scrollToOffset({ animated: false, offset: 0 });
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    manualScrollRef.current = false;
+    followingRef.current = true;
+  }, [sessionId]);
+
+  // A commit is only an early attempt. Native content/viewport layout callbacks
+  // repeat this after the actual geometry changes, including keyboard/composer.
+  useLayoutEffect(() => {
+    if (itemCount > 0) pinLatest();
+  }, [sessionId, itemCount, pinLatest]);
+
   const scrollToLatest = useCallback(() => {
-    setAtLatest(true);
-    listRef.current?.scrollToOffset({ animated: true, offset: 0 });
-  }, [setAtLatest]);
+    manualScrollRef.current = false;
+    setFollowing(true);
+    listRef.current?.scrollToOffset({ animated: false, offset: 0 });
+  }, [setFollowing]);
+
+  const onScrollBeginDrag = useCallback(() => {
+    manualScrollRef.current = true;
+    // Transfer ownership before the next native layout can follow the tail.
+    setFollowing(false);
+  }, [setFollowing]);
 
   const onScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      setAtLatest(Math.max(0, event.nativeEvent.contentOffset.y) <= AT_LATEST_THRESHOLD_PX);
+      if (!manualScrollRef.current) return;
+      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+      const fits = contentSize.height <= layoutMeasurement.height + 1;
+      setFollowing(fits || Math.max(0, contentOffset.y) <= AT_LATEST_THRESHOLD_PX);
     },
-    [setAtLatest],
+    [setFollowing],
   );
 
   return {
     listRef,
     atLatest,
-    composerHeight,
-    setComposerHeight,
+    maintainVisibleContentPosition: atLatest ? undefined : READING_ANCHOR,
     scrollToLatest,
+    onScrollBeginDrag,
+    onLayout: pinLatest,
+    onContentSizeChange: pinLatest,
     onScroll,
   };
 }

--- a/mobile/src/features/chat/useTimelinePaging.ts
+++ b/mobile/src/features/chat/useTimelinePaging.ts
@@ -1,95 +1,185 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 
-const OLDER_EDGE_THRESHOLD_PX = 8;
-const OLDER_EDGE_SETTLE_MS = 350;
+type ScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
+type PageResult = false | string[];
+type Transaction = {
+  sessionId: string;
+  deadline: number;
+  expectedIds: string[] | null;
+  failed: boolean;
+  committed: boolean;
+  lastLayout: number;
+  layoutObserved: boolean;
+};
 
-interface TimelinePagingApi {
-  showLoadOlderHint: boolean;
-  loadOlder: () => void;
-  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
-}
+const MIN_HINT_MS = 1_500;
+// Native VirtualizedList mounts rows in 32ms batches. Two JS animation frames
+// alone can fall entirely between those batches. Require a quiet layout window
+// after the requested ids are committed AND a native layout has been observed.
+const LAYOUT_QUIET_MS = 100;
 
 /**
- * Loads one older page after the user settles at the visual top of the
- * inverted list. Older rows are appended to the inverted data, so pagination
- * cannot shift the existing rows and no height/offset compensation is needed.
+ * A gesture starts at most one page transaction. Network completion, React
+ * commit and native layout are distinct barriers; the minimum display timer
+ * starts at collision and runs concurrently with all three.
  */
 export function useTimelinePaging(
   sessionId: string,
   canLoadOlder: boolean,
   loadingOlder: boolean,
-  requestOlder: () => void | Promise<void>,
-  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void,
-): TimelinePagingApi {
-  const [edgeState, setEdgeState] = useState({ sessionId, atOlderEdge: false });
-  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const requestPendingRef = useRef(false);
-  const autoLoadAttemptedRef = useRef(false);
+  requestOlder: () => Promise<PageResult>,
+  onScroll: (event: ScrollEvent) => void,
+  items: readonly { id: string }[] = [],
+) {
+  const [presentation, setPresentation] = useState({
+    sessionId,
+    active: false,
+    failed: false,
+  });
+  if (presentation.sessionId !== sessionId) {
+    setPresentation({ sessionId, active: false, failed: false });
+  }
+  const transactionRef = useRef<Transaction | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gestureRef = useRef({ active: false, used: false });
+  const idsRef = useRef(new Set<string>());
+  const checkRef = useRef<() => void>(() => undefined);
 
-  const clearSettleTimer = useCallback(() => {
-    if (settleTimerRef.current == null) return;
-    clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = null;
+  const cancelTimer = useCallback(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = null;
   }, []);
 
-  useEffect(() => {
-    clearSettleTimer();
-    requestPendingRef.current = false;
-    autoLoadAttemptedRef.current = false;
-  }, [clearSettleTimer, sessionId]);
+  const check = useCallback(() => {
+    cancelTimer();
+    const tx = transactionRef.current;
+    if (!tx || tx.expectedIds === null) return;
+    if (!tx.committed) {
+      if (!tx.expectedIds.every(id => idsRef.current.has(id))) return;
+      tx.committed = true;
+      tx.lastLayout = Date.now();
+      tx.layoutObserved = false;
+      // Empty/failed pages have no new native rows to wait for.
+      if (tx.expectedIds.length === 0) tx.layoutObserved = true;
+    }
+    if (!tx.layoutObserved) return;
+    const remaining = Math.max(tx.deadline, tx.lastLayout + LAYOUT_QUIET_MS) - Date.now();
+    if (remaining > 0) {
+      timerRef.current = setTimeout(() => checkRef.current(), remaining);
+      return;
+    }
+    transactionRef.current = null;
+    setPresentation({ sessionId: tx.sessionId, active: false, failed: tx.failed });
+  }, [cancelTimer]);
 
-  useEffect(() => {
-    if (loadingOlder || !canLoadOlder) clearSettleTimer();
-  }, [canLoadOlder, clearSettleTimer, loadingOlder]);
+  useLayoutEffect(() => {
+    checkRef.current = check;
+  }, [check]);
 
-  useEffect(() => () => clearSettleTimer(), [clearSettleTimer]);
+  useLayoutEffect(() => {
+    transactionRef.current = null;
+    gestureRef.current = { active: false, used: false };
+    return () => {
+      transactionRef.current = null;
+      cancelTimer();
+    };
+  }, [sessionId, cancelTimer]);
 
-  const atOlderEdge = edgeState.sessionId === sessionId && edgeState.atOlderEdge;
-  const showLoadOlderHint = canLoadOlder && atOlderEdge && !loadingOlder;
+  useLayoutEffect(() => {
+    idsRef.current = new Set(items.map(item => item.id));
+    check();
+  }, [items, check, sessionId]);
 
   const loadOlder = useCallback(() => {
-    if (!canLoadOlder || loadingOlder || requestPendingRef.current) return;
-    requestPendingRef.current = true;
-    clearSettleTimer();
+    if (!canLoadOlder || loadingOlder || transactionRef.current) return;
+    const previousIds = idsRef.current;
+    const tx: Transaction = {
+      sessionId,
+      deadline: Date.now() + MIN_HINT_MS,
+      expectedIds: null,
+      failed: false,
+      committed: false,
+      lastLayout: Date.now(),
+      layoutObserved: false,
+    };
+    transactionRef.current = tx;
+    gestureRef.current.used = true;
+    setPresentation({ sessionId, active: true, failed: false });
+    const complete = (result: PageResult) => {
+      // Identity guards every continuation, including failures from old sessions.
+      if (transactionRef.current !== tx) return;
+      tx.failed = result === false;
+      tx.expectedIds = result === false ? [] : result.filter(id => !previousIds.has(id));
+      checkRef.current();
+    };
     try {
-      void Promise.resolve(requestOlder()).finally(() => {
-        requestPendingRef.current = false;
-      });
-    } catch (error) {
-      requestPendingRef.current = false;
-      throw error;
+      void requestOlder().then(complete, () => complete(false));
+    } catch {
+      complete(false);
     }
-  }, [canLoadOlder, clearSettleTimer, loadingOlder, requestOlder]);
+  }, [canLoadOlder, loadingOlder, requestOlder, sessionId]);
 
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      onScroll(event);
+  const onListLayout = useCallback(() => {
+    const tx = transactionRef.current;
+    if (!tx) return;
+    tx.lastLayout = Date.now();
+    // Only native layouts after the React commit satisfy the render barrier.
+    if (tx.committed) tx.layoutObserved = true;
+    checkRef.current();
+  }, []);
+
+  const detectCollision = useCallback(
+    (event: ScrollEvent) => {
+      const gesture = gestureRef.current;
+      if (!gesture.active || gesture.used) return;
       const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
-      const isAtOlderEdge =
-        contentOffset.y + layoutMeasurement.height >= contentSize.height - OLDER_EDGE_THRESHOLD_PX;
-      setEdgeState({ sessionId, atOlderEdge: isAtOlderEdge });
-
-      if (!isAtOlderEdge || !canLoadOlder || loadingOlder) {
-        clearSettleTimer();
-        if (!isAtOlderEdge) autoLoadAttemptedRef.current = false;
-        return;
-      }
       if (
-        settleTimerRef.current != null ||
-        requestPendingRef.current ||
-        autoLoadAttemptedRef.current
-      ) {
-        return;
-      }
-      settleTimerRef.current = setTimeout(() => {
-        settleTimerRef.current = null;
-        autoLoadAttemptedRef.current = true;
+        contentSize.height > 0 &&
+        contentOffset.y + layoutMeasurement.height >= contentSize.height - 8
+      )
         loadOlder();
-      }, OLDER_EDGE_SETTLE_MS);
     },
-    [canLoadOlder, clearSettleTimer, loadOlder, loadingOlder, onScroll, sessionId],
+    [loadOlder],
   );
 
-  return { showLoadOlderHint, loadOlder, onScroll: handleScroll };
+  const handleScroll = useCallback(
+    (event: ScrollEvent) => {
+      onScroll(event);
+      detectCollision(event);
+    },
+    [detectCollision, onScroll],
+  );
+
+  const onScrollBeginDrag = useCallback(() => {
+    gestureRef.current = { active: true, used: transactionRef.current !== null };
+  }, []);
+  const onScrollEndDrag = useCallback(
+    (event: ScrollEvent) => {
+      detectCollision(event);
+      // Momentum belongs to this same gesture and shares its used flag.
+    },
+    [detectCollision],
+  );
+  const onMomentumScrollEnd = useCallback(
+    (event: ScrollEvent) => {
+      detectCollision(event);
+      gestureRef.current.active = false;
+    },
+    [detectCollision],
+  );
+
+  const current = presentation.sessionId === sessionId;
+  return {
+    showLoadOlderHint: current && (presentation.active || presentation.failed),
+    pagingActive: current && presentation.active,
+    pagingFailed: current && presentation.failed,
+    loadOlder,
+    onListLayout,
+    onContentSizeChange: onListLayout,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollEnd,
+    onScroll: handleScroll,
+  };
 }

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -66,7 +66,7 @@ interface RemoteContextValue {
   refreshWorkspaces(): Promise<void>;
   selectSession(sessionId: string): Promise<void>;
   retryTimeline(): Promise<void>;
-  loadOlderTimeline(): Promise<void>;
+  loadOlderTimeline(): Promise<false | string[]>;
   newConversation(mode?: "chat" | "workspace", workspaceId?: string): Promise<void>;
   closeConversation(): void;
   sendMessage(
@@ -155,6 +155,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     canLoadOlderTimeline,
     loadingOlderTimeline,
     loadOlderTimeline,
+    prepareTimelineOpen,
     syncEngineRef,
     streamingRef,
     hydrateAttachmentsRef,
@@ -257,6 +258,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     setUnreadSessions,
     setApprovalTierState,
     ensureDraftTimeline,
+    prepareTimelineOpen,
     recordError,
     removeSession,
     removeWorkspace,
@@ -287,7 +289,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     recordError,
   });
   const selectedTitle =
-    sessions.find((session) => session.sessionId === selectedSessionId)?.title ?? "";
+    sessions.find(session => session.sessionId === selectedSessionId)?.title ?? "";
   const agentAvailable = presence?.agentAvailable !== false;
   const connectionPresentation = useMemo(
     () =>

--- a/mobile/src/remote/__tests__/useConversationController.test.ts
+++ b/mobile/src/remote/__tests__/useConversationController.test.ts
@@ -111,6 +111,7 @@ async function mountController(opts: MountOpts = {}) {
   const setUnreadSessions = jest.fn();
   const setApprovalTierState = jest.fn();
   const ensureDraftTimeline = jest.fn();
+  const prepareTimelineOpen = jest.fn();
   const recordError = jest.fn();
   const removeSession = opts.removeSession ?? jest.fn(async () => true);
   const removeWorkspace = opts.removeWorkspace ?? jest.fn(async () => true);
@@ -133,6 +134,7 @@ async function mountController(opts: MountOpts = {}) {
       setUnreadSessions,
       setApprovalTierState,
       ensureDraftTimeline,
+      prepareTimelineOpen,
       recordError,
       removeSession,
       removeWorkspace,
@@ -161,6 +163,7 @@ async function mountController(opts: MountOpts = {}) {
     setUnreadSessions,
     setApprovalTierState,
     ensureDraftTimeline,
+    prepareTimelineOpen,
     recordError,
     removeSession,
     closeConversation,
@@ -199,6 +202,7 @@ describe("selectSession", () => {
       await current(h).selectSession("s1");
     });
     expect(h.setSelectedSessionId).toHaveBeenCalledWith("s1");
+    expect(h.prepareTimelineOpen).toHaveBeenCalledWith("s1");
     expect(h.setDraft).toHaveBeenCalledWith(false);
     expect(current(h).modelId).toBe("openai/gpt-4");
     expect(current(h).thinkingLevel).toBe("high");

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -9,7 +9,13 @@ type Options = Parameters<typeof useTimelineController>[0];
 type Result = ReturnType<typeof useTimelineController>;
 
 function userEntry(id: string, text: string): HistoryEntry {
-  return { id, kind: "user", role: "user", createdAtMs: 0, blocks: [{ kind: "text", text }] };
+  return {
+    id,
+    kind: "user",
+    role: "user",
+    createdAtMs: 0,
+    blocks: [{ kind: "text", text }],
+  };
 }
 function assistantEntry(id: string, text: string, runId?: string): HistoryEntry {
   return {
@@ -22,7 +28,12 @@ function assistantEntry(id: string, text: string, runId?: string): HistoryEntry 
   };
 }
 function evt(type: string, data: string, runId?: string, idx?: number): StreamEvent {
-  return { type, data, ...(runId ? { runId } : {}), ...(idx != null ? { idx } : {}) };
+  return {
+    type,
+    data,
+    ...(runId ? { runId } : {}),
+    ...(idx != null ? { idx } : {}),
+  };
 }
 
 describe("useTimelineController", () => {
@@ -442,7 +453,11 @@ describe("useTimelineController", () => {
         .map(i => (i.kind === "message" ? i.text : ""));
       expect(texts).toEqual(["older", "older answer", "latest", "answer"]);
       expect(request.mock.calls[2]?.[0]).toEqual(
-        expect.objectContaining({ type: "get_session_entries", before: 20, limit: 10 }),
+        expect.objectContaining({
+          type: "get_session_entries",
+          before: 20,
+          limit: 10,
+        }),
       );
       expect(result.current.canLoadOlderTimeline).toBe(false);
 
@@ -457,7 +472,44 @@ describe("useTimelineController", () => {
       );
     });
 
-    test("rejects a non-advancing backward cursor", async () => {
+    test("reopening a warm timeline renders only the latest ten exchanges", async () => {
+      options.selectedSessionId = "s1";
+      options.selectedRef.current = "s1";
+      const exchanges = (start: number, end: number) =>
+        Array.from({ length: end - start + 1 }, (_, i) => start + i).flatMap(n => [
+          userEntry(`u${n}`, `user ${n}`),
+          assistantEntry(`a${n}`, `answer ${n}`),
+        ]);
+      request
+        .mockResolvedValueOnce({ success: true, data: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { entries: exchanges(11, 20), hasMore: true, nextOffset: 20 },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { entries: exchanges(1, 10), hasMore: false, nextOffset: 0 },
+        });
+      render();
+      await establish();
+      await act(async () => {
+        await result.current.loadOlderTimeline();
+      });
+      await flush();
+      expect(result.current.timeline.items).toHaveLength(40);
+
+      act(() => result.current.prepareTimelineOpen("s1"));
+      await flush();
+
+      expect(
+        result.current.timeline.items
+          .filter(item => item.kind === "message" && item.role === "user")
+          .map(item => (item.kind === "message" ? item.text : "")),
+      ).toEqual(Array.from({ length: 10 }, (_, index) => `user ${index + 11}`));
+      expect(result.current.canLoadOlderTimeline).toBe(false);
+    });
+
+    test("timeout retains the cursor and retry returns the committed page identities", async () => {
       const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
       options.selectedSessionId = "s1";
       options.selectedRef.current = "s1";
@@ -467,9 +519,54 @@ describe("useTimelineController", () => {
           success: true,
           data: { entries: [userEntry("e2", "latest")], hasMore: true, nextOffset: 20 },
         })
+        .mockRejectedValueOnce(new Error("timeout"))
         .mockResolvedValueOnce({
           success: true,
-          data: { entries: [userEntry("e1", "older")], hasMore: true, nextOffset: 20 },
+          data: { entries: [userEntry("e1", "older")], hasMore: false, nextOffset: 0 },
+        });
+      render();
+      await establish();
+      await act(async () => {
+        expect(await result.current.loadOlderTimeline()).toBe(false);
+      });
+      expect(result.current.canLoadOlderTimeline).toBe(true);
+      expect(result.current.loadingOlderTimeline).toBe(false);
+      const page: { ids: false | string[] } = { ids: false };
+      await act(async () => {
+        page.ids = await result.current.loadOlderTimeline();
+      });
+      await flush();
+      expect(page.ids).toEqual(expect.arrayContaining([expect.any(String)]));
+      expect(result.current.timeline.items.map(item => item.id)).toEqual(
+        expect.arrayContaining(page.ids === false ? [] : page.ids),
+      );
+      expect(request.mock.calls[2][0].before).toBe(20);
+      expect(request.mock.calls[3][0].before).toBe(20);
+      expect(result.current.canLoadOlderTimeline).toBe(false);
+      errorSpy.mockRestore();
+    });
+
+    test("rejects a non-advancing backward cursor", async () => {
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      options.selectedSessionId = "s1";
+      options.selectedRef.current = "s1";
+      request
+        .mockResolvedValueOnce({ success: true, data: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            entries: [userEntry("e2", "latest")],
+            hasMore: true,
+            nextOffset: 20,
+          },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            entries: [userEntry("e1", "older")],
+            hasMore: true,
+            nextOffset: 20,
+          },
         });
       render();
       await establish();
@@ -497,7 +594,9 @@ describe("useTimelineController", () => {
       await flush();
       expect(errorSpy).toHaveBeenCalledWith(
         "[remote] session timeline sync failed",
-        expect.objectContaining({ error: expect.objectContaining({ message: "not_connected" }) }),
+        expect.objectContaining({
+          error: expect.objectContaining({ message: "not_connected" }),
+        }),
       );
       errorSpy.mockRestore();
     });
@@ -508,7 +607,10 @@ describe("useTimelineController", () => {
         if (cmd.type === "get_state")
           return { success: true, data: { activeRun: { runId: "r1" } } };
         if (cmd.type === "get_session_entries")
-          return { success: true, data: { entries: [userEntry("e1", "hi")], hasMore: false } };
+          return {
+            success: true,
+            data: { entries: [userEntry("e1", "hi")], hasMore: false },
+          };
         if (cmd.type === "get_events_since")
           return {
             success: true,
@@ -545,7 +647,10 @@ describe("useTimelineController", () => {
         if (cmd.type === "get_session_entries") {
           // Drop the client after history so fetchReplay sees null.
           options.clientRef.current = null;
-          return { success: true, data: { entries: [userEntry("e1", "hi")], hasMore: false } };
+          return {
+            success: true,
+            data: { entries: [userEntry("e1", "hi")], hasMore: false },
+          };
         }
         return { success: true, data: {} };
       });
@@ -553,7 +658,9 @@ describe("useTimelineController", () => {
       await establish();
       expect(errorSpy).toHaveBeenCalledWith(
         "[remote] session timeline sync failed",
-        expect.objectContaining({ error: expect.objectContaining({ message: "not_connected" }) }),
+        expect.objectContaining({
+          error: expect.objectContaining({ message: "not_connected" }),
+        }),
       );
       errorSpy.mockRestore();
     });
@@ -595,7 +702,14 @@ describe("useTimelineController", () => {
       const engine = result.current.syncEngineRef.current!;
       engine.mutate("s1", () => ({
         ...emptyTimeline(),
-        items: [{ id: "m1", kind: "message" as const, role: "assistant" as const, text: "x" }],
+        items: [
+          {
+            id: "m1",
+            kind: "message" as const,
+            role: "assistant" as const,
+            text: "x",
+          },
+        ],
       }));
       await flush();
       result.current.applySessionStreaming("s1", true);

--- a/mobile/src/remote/useConversationController.ts
+++ b/mobile/src/remote/useConversationController.ts
@@ -33,6 +33,7 @@ interface ConversationControllerOptions {
   setUnreadSessions: Dispatch<SetStateAction<Set<string>>>;
   setApprovalTierState: Dispatch<SetStateAction<string>>;
   ensureDraftTimeline(): void;
+  prepareTimelineOpen(sessionId: string): void;
   recordError(error: unknown): void;
   removeSession(sessionId: string, threadId: string): Promise<boolean>;
   removeWorkspace(workspaceId: string): Promise<boolean>;
@@ -53,6 +54,7 @@ export function useConversationController({
   setUnreadSessions,
   setApprovalTierState,
   ensureDraftTimeline,
+  prepareTimelineOpen,
   recordError,
   removeSession,
   removeWorkspace,
@@ -68,6 +70,7 @@ export function useConversationController({
       if (!client) return;
       setOpeningSession(true);
       conversationEpochRef.current += 1;
+      prepareTimelineOpen(sessionId);
       setSelectedSessionId(sessionId);
       selectedRef.current = sessionId;
       setDraft(false);
@@ -99,6 +102,7 @@ export function useConversationController({
       conversationEpochRef,
       hydrateAttachmentsRef,
       models,
+      prepareTimelineOpen,
       recordError,
       selectedRef,
       setDraft,

--- a/mobile/src/remote/useTimelineController.ts
+++ b/mobile/src/remote/useTimelineController.ts
@@ -23,6 +23,28 @@ interface HistoryPagingState {
   loading: boolean;
 }
 
+function latestTimelineWindow(timeline: TimelineState, userExchangeCount: number): TimelineState {
+  let remaining = userExchangeCount;
+  let start = 0;
+  for (let index = timeline.items.length - 1; index >= 0; index -= 1) {
+    const item = timeline.items[index];
+    if (item?.kind !== "message" || item.role !== "user") continue;
+    remaining -= 1;
+    if (remaining === 0) {
+      start = index;
+      break;
+    }
+  }
+  if (remaining > 0 || start === 0) return timeline;
+  const items = timeline.items.slice(start);
+  const visibleIds = new Set(items.map(item => item.id));
+  return {
+    ...timeline,
+    items,
+    durableItemIds: new Set([...(timeline.durableItemIds ?? [])].filter(id => visibleIds.has(id))),
+  };
+}
+
 function prependHistoryPage(live: TimelineState, older: TimelineState): TimelineState {
   const liveIds = new Set(live.items.map(item => item.id));
   const olderItems = older.items.filter(item => !liveIds.has(item.id));
@@ -212,7 +234,7 @@ export function useTimelineController({
     const sessionId = selectedRef.current;
     const current = historyPagingRef.current[sessionId];
     const client = clientRef.current;
-    if (!sessionId || !client || !current?.hasMore || current.loading) return;
+    if (!sessionId || !client || !current?.hasMore || current.loading) return false;
 
     const loading = { ...current, loading: true };
     historyPagingRef.current[sessionId] = loading;
@@ -227,6 +249,9 @@ export function useTimelineController({
         },
         sessionId,
       );
+      // Reopening/reconciling may have replaced this cursor while the request
+      // was in flight. Never install an old page into that new paging window.
+      if (historyPagingRef.current[sessionId] !== loading) return false;
       const entries = response.data.entries ?? [];
       const nextBefore = response.data.nextOffset ?? 0;
       if (response.data.hasMore && (nextBefore <= 0 || nextBefore >= current.nextBefore)) {
@@ -241,7 +266,11 @@ export function useTimelineController({
       setHistoryPaging(previous => ({ ...previous, [sessionId]: next }));
       const older = timelineFromEntries(entries);
       syncEngineRef.current?.mutate(sessionId, live => prependHistoryPage(live, older));
+      // The sync lane may still be busy. The view waits until these exact
+      // message ids reach its committed data before declaring paging complete.
+      return older.items.map(item => item.id);
     } catch (error) {
+      if (historyPagingRef.current[sessionId] !== loading) return false;
       const failed = { ...current, loading: false };
       historyPagingRef.current[sessionId] = failed;
       setHistoryPaging(previous => ({ ...previous, [sessionId]: failed }));
@@ -250,8 +279,29 @@ export function useTimelineController({
         before: current.nextBefore,
         error: diagnosticError(error),
       });
+      return false;
     }
   }, [clientRef, selectedRef]);
+
+  const prepareTimelineOpen = useCallback((sessionId: string) => {
+    const cached = timelinesRef.current[sessionId];
+    if (!cached) return;
+    const windowed = latestTimelineWindow(cached, HISTORY_PAGE_USER_EXCHANGES);
+    if (windowed === cached) return;
+
+    // A reopened conversation may have many explicitly paged rows in memory.
+    // Keep cache warmth, but restore the same bounded first-render window as a
+    // cold open; the authoritative tail reconcile below will restore its cursor.
+    const nextTimelines = { ...timelinesRef.current, [sessionId]: windowed };
+    timelinesRef.current = nextTimelines;
+    setTimelines(nextTimelines);
+    syncEngineRef.current?.mutate(sessionId, () => windowed);
+
+    const nextPaging = { ...historyPagingRef.current };
+    delete nextPaging[sessionId];
+    historyPagingRef.current = nextPaging;
+    setHistoryPaging(nextPaging);
+  }, []);
 
   useEffect(() => {
     const engine = new SyncEngine({
@@ -373,7 +423,10 @@ export function useTimelineController({
         sessionId,
         timeoutMs: TIMELINE_LOAD_TIMEOUT_MS,
       });
-      setTimelineErrors(previous => ({ ...previous, [sessionId]: "timeout" }));
+      setTimelineErrors(previous => ({
+        ...previous,
+        [sessionId]: "timeout",
+      }));
     }, TIMELINE_LOAD_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, [selectedRef, selectedSessionId, timelineError, timelinePending]);
@@ -409,6 +462,7 @@ export function useTimelineController({
     canLoadOlderTimeline: selectedHistoryPaging?.hasMore ?? false,
     loadingOlderTimeline: selectedHistoryPaging?.loading ?? false,
     loadOlderTimeline,
+    prepareTimelineOpen,
     syncEngineRef,
     streamingRef,
     hydrateAttachmentsRef,


### PR DESCRIPTION
## Changes

Stabilize mobile conversation layout and history paging. The composer participates in flex layout and grows with multiline input. Short conversations align at the top, while latest-following and historical reading use separate scroll ownership to avoid competing offset corrections.

History loads start on a deliberate edge collision and show their marker for at least 1.5 seconds, until the requested message IDs are committed and native layout settles. Each drag and its momentum can trigger only one page; failures expose retry, stale responses are rejected, and cached reopens render the latest ten exchanges. Disable composer autocorrection, capitalization and spell checking.

## Validation

- Mobile ESLint, TypeScript, changed-file Prettier and git diff checks.
- Regression coverage for viewport ownership, delayed page commits, gesture deduplication, timeout retry, session changes and ten-exchange cache windows.
- Test suites are left to GitHub Actions for this PR submission.
- iOS Metro/Hermes export passed during implementation; interactive native visual verification was not performed by the agent.
