### PR TITLE
fix(loop): enforce task write scopes and validate dependency edits atomically

### DIFF
--- a/orchestration/loop/src/agents/supervision.rs
+++ b/orchestration/loop/src/agents/supervision.rs
@@ -340,6 +340,10 @@ mod tests {
         let lock = lock_file(&store, "g", "watch.lock").unwrap();
         lock.lock_exclusive().unwrap();
         assert!(running(&store, "g"));
+        // Other parallel tests spawn subprocesses. A concurrent fork may briefly
+        // inherit this file description, so drop alone need not release flock
+        // before the next assertion. Explicitly release the test-owned lock.
+        FileExt::unlock(&lock).unwrap();
         drop(lock);
         assert!(!running(&store, "g"));
     }

--- a/orchestration/loop/src/agents/workspace_guard.rs
+++ b/orchestration/loop/src/agents/workspace_guard.rs
@@ -6,9 +6,9 @@
 //! claim degrades to serial (refused with a retry hint) unless the caller
 //! passes an explicit `--force`.
 //!
-//! The guard is ADVISORY and fail-open: an agent that declares no
-//! workspaces cannot be assessed and never blocks (legacy peers keep
-//! working). Every successful claim by a workspace-declaring agent also
+//! Todo write scopes take precedence over the agent's fallback workspaces.
+//! The guard is ADVISORY and fail-open only when neither declares a write
+//! set. Every successful claim with a write set also
 //! appends a `WorkspaceLockAcquired` ledger event so `agent list` can show
 //! who occupies which paths.
 
@@ -49,7 +49,9 @@ fn lexical_normalize(path: &std::path::Path) -> String {
             Component::CurDir => {}
             Component::ParentDir => {
                 // Keep leading `..` on relative paths; otherwise pop.
-                if !out.pop() {
+                if out.file_name().is_some_and(|name| name != "..") {
+                    out.pop();
+                } else if !out.has_root() {
                     out.push(comp.as_os_str());
                 }
             }
@@ -65,27 +67,44 @@ fn lexical_normalize(path: &std::path::Path) -> String {
 /// lexical normalization. Storage stays a plain string so replay is
 /// platform-agnostic.
 pub fn normalize_workspace_path(raw: &str) -> String {
-    let expanded = expand_home(raw.trim());
-    let path = std::path::PathBuf::from(expanded);
+    normalize_workspace_path_at(
+        raw,
+        &std::env::current_dir().expect("invariant: process cwd must be readable"),
+    )
+}
+
+/// Resolve against a stable project anchor, including symlinked parents of
+/// files that have not been created yet (e.g. /tmp/new.md on macOS).
+pub fn normalize_workspace_path_at(raw: &str, base: &std::path::Path) -> String {
+    let path = std::path::PathBuf::from(expand_home(raw.trim()));
     let abs = if path.is_absolute() {
         path
     } else {
-        std::env::current_dir()
-            .expect("invariant: process cwd must be readable")
-            .join(path)
+        base.join(path)
     };
-    if let Ok(canon) = abs.canonicalize() {
-        return canon.to_string_lossy().into_owned();
+    // Resolve existing prefixes before interpreting later `..` components.
+    // Lexically collapsing the whole path first would lose symlink semantics;
+    // canonicalizing only the full path misses not-yet-created output files.
+    let mut resolved = std::path::PathBuf::new();
+    for component in abs.components() {
+        resolved.push(component.as_os_str());
+        resolved = std::path::PathBuf::from(lexical_normalize(&resolved));
+        if let Ok(canon) = resolved.canonicalize() {
+            resolved = canon;
+        }
     }
-    lexical_normalize(&abs)
+    resolved.to_string_lossy().into_owned()
 }
 
 /// True when two workspace paths overlap: equal, or one is an ancestor of
 /// the other. Component-aware, so `/repo/a` never overlaps `/repo/ab`
 /// while `/repo/a` and `/repo/a/sub` do.
 pub fn paths_overlap(a: &str, b: &str) -> bool {
-    let pa = std::path::Path::new(a);
-    let pb = std::path::Path::new(b);
+    // Windows paths are case-insensitive; preserve component boundaries.
+    #[cfg(windows)]
+    let (a, b) = (a.to_lowercase(), b.to_lowercase());
+    let pa = std::path::Path::new(&a);
+    let pb = std::path::Path::new(&b);
     pa == pb || pa.starts_with(pb) || pb.starts_with(pa)
 }
 
@@ -105,8 +124,7 @@ pub struct WorkspaceConflict {
     pub holder_lease_expires_at: u64,
 }
 
-/// The declared workspace set of an agent (empty = undeclared → guard is
-/// fail-open for that agent).
+/// The agent's fallback write set, used only when a task has no write scopes.
 pub fn agent_workspaces(goal: &Goal, agent_id: &str) -> Vec<String> {
     goal.agent_profiles
         .iter()
@@ -115,42 +133,96 @@ pub fn agent_workspaces(goal: &Goal, agent_id: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Compute the live workspace conflicts for `agent_id` claiming work at
-/// `now`: every OTHER registered agent that (a) declares workspaces,
-/// (b) holds at least one live lease, and (c) whose declared set overlaps
-/// the claimer's. Empty = safe to claim. Fail-open: an empty claimer set
-/// yields no conflicts (nothing to compare against).
+/// Agent-list advisory: compare this agent's active task scopes (or its
+/// fallback declaration when idle) with peers' live task scopes. Actual claims
+/// must use `todo_workspace_conflicts` with the selected task under the lock.
 pub fn live_workspace_conflicts(goal: &Goal, agent_id: &str, now: u64) -> Vec<WorkspaceConflict> {
-    let mine = agent_workspaces(goal, agent_id);
+    let held: Vec<_> = goal
+        .todos
+        .iter()
+        .filter(|t| live_holder(t, agent_id, now))
+        .collect();
+    let mine = if held.is_empty() {
+        agent_workspaces(goal, agent_id)
+    } else {
+        held.iter()
+            .flat_map(|t| todo_workspaces(goal, agent_id, t))
+            .collect()
+    };
+    conflicts_for_paths(goal, agent_id, &mine, now)
+}
+
+/// Effective write set: task declaration, or the agent's conservative fallback.
+/// Relative task paths are anchored to the goal, never the inspecting worker cwd.
+pub fn todo_workspaces(goal: &Goal, agent_id: &str, todo: &crate::state::Todo) -> Vec<String> {
+    let scopes: Vec<_> = todo
+        .required_write_scope
+        .iter()
+        .filter(|s| !s.trim().is_empty())
+        .collect();
+    if scopes.is_empty() {
+        return agent_workspaces(goal, agent_id);
+    }
+    scopes
+        .iter()
+        .map(|s| normalize_workspace_path_at(s, std::path::Path::new(&goal.cwd)))
+        .collect()
+}
+
+pub fn todo_workspace_conflicts(
+    goal: &Goal,
+    agent_id: &str,
+    todo: &crate::state::Todo,
+    now: u64,
+) -> Vec<WorkspaceConflict> {
+    conflicts_for_paths(goal, agent_id, &todo_workspaces(goal, agent_id, todo), now)
+}
+
+fn live_holder(todo: &crate::state::Todo, agent_id: &str, now: u64) -> bool {
+    !matches!(
+        todo.status,
+        crate::state::TodoStatus::Done | crate::state::TodoStatus::Superseded
+    ) && todo.claimed_by.as_deref() == Some(agent_id)
+        && todo.lease_expires_at.is_some_and(|expires| expires > now)
+        && todo.holder_pid.is_none_or(crate::compat::pid_alive)
+}
+
+fn conflicts_for_paths(
+    goal: &Goal,
+    agent_id: &str,
+    mine: &[String],
+    now: u64,
+) -> Vec<WorkspaceConflict> {
     if mine.is_empty() {
         return vec![];
     }
     let mut conflicts = vec![];
-    for profile in &goal.agent_profiles {
-        if profile.id == agent_id || profile.workspaces.is_empty() {
-            continue;
-        }
+    let holders: std::collections::BTreeSet<_> = goal
+        .todos
+        .iter()
+        .filter_map(|t| t.claimed_by.as_deref())
+        .filter(|id| *id != agent_id)
+        .collect();
+    for holder in holders {
+        let mut overlapping = Vec::new();
         let mut held: Vec<&crate::state::Todo> = goal
             .todos
             .iter()
             .filter(|t| {
-                !matches!(
-                    t.status,
-                    crate::state::TodoStatus::Done | crate::state::TodoStatus::Superseded
-                ) && t.claimed_by.as_deref() == Some(profile.id.as_str())
-                    && t.lease_expires_at.map(|e| e > now).unwrap_or(false)
-                    && t.holder_pid.is_none_or(crate::compat::pid_alive)
+                if !live_holder(t, holder, now) {
+                    return false;
+                }
+                let paths: Vec<_> = todo_workspaces(goal, holder, t)
+                    .into_iter()
+                    .filter(|w| mine.iter().any(|m| paths_overlap(m, w)))
+                    .collect();
+                let overlaps = !paths.is_empty();
+                overlapping.extend(paths);
+                overlaps
             })
             .collect();
-        if held.is_empty() {
-            continue;
-        }
-        let overlapping: Vec<String> = profile
-            .workspaces
-            .iter()
-            .filter(|w| mine.iter().any(|m| paths_overlap(m, w)))
-            .cloned()
-            .collect();
+        overlapping.sort();
+        overlapping.dedup();
         if overlapping.is_empty() {
             continue;
         }
@@ -162,7 +234,7 @@ pub fn live_workspace_conflicts(goal: &Goal, agent_id: &str, now: u64) -> Vec<Wo
             .unwrap_or(now);
         conflicts.push(WorkspaceConflict {
             schema_version: WORKSPACE_GUARD_SCHEMA_VERSION.to_string(),
-            holder_agent_id: profile.id.clone(),
+            holder_agent_id: holder.to_string(),
             holder_todo_ids: held.iter().map(|t| t.id.clone()).collect(),
             overlapping_paths: overlapping,
             holder_lease_expires_at: earliest,

--- a/orchestration/loop/src/console.rs
+++ b/orchestration/loop/src/console.rs
@@ -717,7 +717,7 @@ fn build_cli_registry() -> CommandRegistry {
             ("--title T", "short title", "optional"),
             ("--task-repository R", "task repository label", "optional"),
             ("--continuation-policy P", "continuation policy", "optional"),
-            ("--required-write-scope P", "write scopes", "comma-separated"),
+            ("--required-write-scope P", "task write scopes", "comma-separated paths relative to goal cwd; overrides agent workspace for this task; omit for agent fallback"),
             ("--goal-bound", "goal-bound flag", "boolean"),
             ("--global-gate", "global gate flag", "boolean; a user_gate + global_gate implies goal_bound"),
             ("--note TEXT", "free-form note", "optional"),
@@ -1903,7 +1903,11 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
         } else if k == "--gate-question" {
             gate_question = Some(v);
         } else if k == "--blocks" {
-            blocks = v.split(',').map(|s| s.to_string()).collect();
+            blocks = v
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
         } else if k == "--priority" {
             priority = Some(v);
         } else if k == "--action-kind" {
@@ -2106,7 +2110,7 @@ fn todo_add(store: &mut Store, args: &[String]) -> Result<()> {
     if !write_scopes.is_empty() {
         todo.required_write_scope = write_scopes;
     }
-    store.append(Event::TodoAdded {
+    store.append_todo_change(Event::TodoAdded {
         goal_id: goal_id.clone(),
         todo,
         ts: now_epoch(),
@@ -2167,19 +2171,9 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
         bail!("agent `{agent}` is not registered for goal {goal_id} — `{} agent register --goal {goal_id} --agent-id {agent}` first", prog());
     }
     let now = crate::state::now_epoch();
-    // P0-1 workspace guard: refuse (degrade to serial) when a peer holds a
-    // live lease in an overlapping declared workspace, unless --force.
-    let conflicts = crate::agents::workspace_guard::live_workspace_conflicts(&goal, &agent, now);
-    if !conflicts.is_empty() && !force {
-        bail!(
-            "workspace conflict — claiming would race a peer writing the same workspace:\n{}\
-             degrade to serial: retry after the holder's lease expires, or pass --force",
-            crate::agents::workspace_guard::render_conflicts(&conflicts, now)
-        );
-    }
     // Existence + status gate (replayed state): unknown todos and done/
-    // superseded todos refuse before the atomic claim below. The atomic
-    // path itself only evaluates the lease chain.
+    // superseded todos refuse before the atomic claim below, which rechecks
+    // ownership, terminal status, leases and task write conflicts under lock.
     let t = goal
         .todo(&todo_id)
         .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found in goal {goal_id}"))?;
@@ -2191,43 +2185,15 @@ fn todo_claim(store: &mut Store, args: &[String]) -> Result<()> {
     // previously let concurrent `todo claim` processes all win the same
     // todo. Dead holders are reclaimed inside via the pid probe.
     let claimed = store
-        .try_claim_todo(&goal_id, &todo_id, &agent, lease_secs)?
+        .try_claim_todo_with_workspace(&goal_id, &todo_id, &agent, lease_secs, None, force)?
         .claimed;
     if !claimed {
         bail!("todo {todo_id} cannot be claimed: another agent holds a live lease");
     }
     let expires = now + lease_secs;
-    append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
     refresh_next_action(store, &goal_id)?;
     sync_compat(store, &goal_id)?;
     println!("todo {todo_id} claimed by {agent} until epoch {expires} ✔");
-    Ok(())
-}
-
-/// P0-1: append the advisory write-lock record after a successful claim by
-/// a workspace-declaring agent (empty declared set → no record, the guard
-/// is fail-open). `goal` must be the pre-claim replay carrying the
-/// claimer's profile; `forced` marks a claim that overrode a conflict.
-fn append_workspace_lock(
-    store: &mut Store,
-    goal_id: &str,
-    agent_id: &str,
-    todo_id: &str,
-    goal: &Goal,
-    forced: bool,
-) -> Result<()> {
-    let paths = crate::agents::workspace_guard::agent_workspaces(goal, agent_id);
-    if paths.is_empty() {
-        return Ok(());
-    }
-    store.append(Event::WorkspaceLockAcquired {
-        goal_id: goal_id.to_string(),
-        agent_id: agent_id.to_string(),
-        todo_id: todo_id.to_string(),
-        paths,
-        forced,
-        ts: crate::state::now_epoch(),
-    })?;
     Ok(())
 }
 
@@ -4538,6 +4504,7 @@ fn claim_selected_with_lease(
     packet: &mut crate::contract::ShouldRunPacket,
     agent_id: Option<&str>,
     lease_secs: u64,
+    force_workspace: bool,
 ) -> Result<Option<String>> {
     let mut todo_id_opt = None;
     for _ in 0..3 {
@@ -4552,12 +4519,13 @@ fn claim_selected_with_lease(
         match &agent_id {
             Some(aid) => {
                 if store
-                    .try_claim_todo_with_pid(
+                    .try_claim_todo_with_workspace(
                         goal_id,
                         &tid,
                         aid,
                         lease_secs,
                         Some(std::process::id()),
+                        force_workspace,
                     )?
                     .claimed
                 {
@@ -4872,40 +4840,20 @@ async fn run_turns(
         // win the same todo; on contention, re-decide against the fresh
         // ledger and pick the next runnable todo (up to 3 re-decides).
         //
-        // P0-1 workspace guard: if a PEER agent holds a live lease in an
-        // overlapping declared workspace, degrade to serial — stop the run
-        // with a retry hint (the scheduler will relaunch later) unless the
-        // operator passed --force-workspace.
-        let mut forced_ws = false;
-        if let Some(aid) = agent_id {
-            let now = crate::state::now_epoch();
-            let conflicts =
-                crate::agents::workspace_guard::live_workspace_conflicts(&goal, aid, now);
-            if !conflicts.is_empty() && !force_workspace {
-                bail!(
-                    "workspace conflict — running would race a peer writing the same workspace:\n{}\
-                     degrade to serial: rerun after the holder's lease expires, \
-                     or pass --force-workspace",
-                    crate::agents::workspace_guard::render_conflicts(&conflicts, now)
-                );
-            }
-            forced_ws = !conflicts.is_empty() && force_workspace;
-        }
-        let Some(todo_id) =
-            claim_selected_with_lease(store, goal_id, &mut packet, agent_id, lease_secs)?
+        // Guard the actual selected task and append its write-set audit inside
+        // the atomic claim; a stale pre-claim workspace check races peer claims.
+        let Some(todo_id) = claim_selected_with_lease(
+            store,
+            goal_id,
+            &mut packet,
+            agent_id,
+            lease_secs,
+            force_workspace,
+        )?
         else {
             println!("   no selected todo; stopping");
             break;
         };
-        // P0-1: record the advisory write lock for the claimed todo (audit
-        // trail for agent list / history). Best-effort against the
-        // turn-start replay — profiles rarely change mid-turn.
-        if let Some(aid) = agent_id {
-            let goal = store
-                .replay(goal_id)?
-                .ok_or_else(|| goal_vanished_error(goal_id))?;
-            append_workspace_lock(store, goal_id, aid, &todo_id, &goal, forced_ws)?;
-        }
         let goal = store
             .replay(goal_id)?
             .ok_or_else(|| anyhow::anyhow!("goal {goal_id} not found (deleted while running?)"))?;
@@ -5913,20 +5861,6 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    // P0-1 workspace guard (claim only): checked before the mutable todo
-    // borrow below; same conflict semantics as `todo claim`.
-    if sub == "claim" {
-        let conflicts =
-            crate::agents::workspace_guard::live_workspace_conflicts(&goal, &agent, now);
-        if !conflicts.is_empty() && !force {
-            bail!(
-                "workspace conflict — claiming would race a peer writing the same workspace:\n{}\
-                 degrade to serial: retry after the holder's lease expires, or pass --force",
-                crate::agents::workspace_guard::render_conflicts(&conflicts, now)
-            );
-        }
-    }
-
     let todo_status_open = goal
         .todo(&todo_id)
         .ok_or_else(|| anyhow::anyhow!("todo {todo_id} not found"))?
@@ -5938,14 +5872,14 @@ fn cmd_lease(store: &mut Store, args: &[String]) -> Result<()> {
                 bail!("task lease requires an open todo");
             }
             // Atomic claim (same TOCTOU-safe path as `todo claim`): check +
-            // append under one ledger lock; steals record TodoExpired first.
-            let outcome = store.try_claim_todo(&goal_id, &todo_id, &agent, lease_secs)?;
+            // append and workspace guard under one ledger lock.
+            let outcome = store.try_claim_todo_with_workspace(
+                &goal_id, &todo_id, &agent, lease_secs, None, force,
+            )?;
             if !outcome.claimed {
                 bail!("todo already has an active lease held by another agent");
             }
             let expires = now + crate::work_items::task_lease::normalize_ttl(lease_secs)?;
-            // P0-1: advisory workspace write lock (audit for agent list).
-            append_workspace_lock(store, &goal_id, &agent, &todo_id, &goal, force)?;
             let _ = sync_compat(store, &goal_id);
             println!(
                 "todo {todo_id} lease acquired by {agent} until {expires} {}✔",
@@ -8678,7 +8612,7 @@ fn todo_update(store: &mut Store, args: &[String]) -> Result<()> {
                 text
             }
         });
-    store.append(Event::TodoUpdated {
+    store.append_todo_change(Event::TodoUpdated {
         goal_id: goal_id.clone(),
         todo_id: todo_id.clone(),
         text: text.clone(),
@@ -9108,8 +9042,8 @@ mod coverage_tests {
         // No selection: the claim loop exits immediately, nothing claimed.
         let mut packet = decide_for(&g, SystemTime::now(), Some("racer"));
         packet.interaction_contract.agent_channel.selected_todo = None;
-        let r =
-            claim_selected_with_lease(&mut store, "g", &mut packet, Some("racer"), 3600).unwrap();
+        let r = claim_selected_with_lease(&mut store, "g", &mut packet, Some("racer"), 3600, false)
+            .unwrap();
         assert_eq!(r, None);
     }
 
@@ -9149,8 +9083,8 @@ mod coverage_tests {
         // Force a stale selection (as if t1 were free at decide time).
         packet.interaction_contract.agent_channel.selected_todo = Some("t1".to_string());
         packet.interaction_contract.mode = crate::contract::TurnMode::BoundedDelivery;
-        let r =
-            claim_selected_with_lease(&mut store, "g", &mut packet, Some("racer"), 3600).unwrap();
+        let r = claim_selected_with_lease(&mut store, "g", &mut packet, Some("racer"), 3600, false)
+            .unwrap();
         // The fresh decide filters other-claimed todos → mode change → stop.
         assert_eq!(r, None);
     }
@@ -10510,9 +10444,16 @@ mod residual_branch_tests {
     #[test]
     fn auto_register_workspaces_empty_cwd_declares_nothing() {
         assert!(auto_register_workspaces("").is_empty());
+        let dir = tempfile::tempdir().unwrap();
         assert_eq!(
-            auto_register_workspaces("/tmp/w"),
-            vec!["/tmp/w".to_string()]
+            auto_register_workspaces(dir.path().join("w").to_str().unwrap()),
+            vec![dir
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join("w")
+                .to_string_lossy()
+                .into_owned()]
         );
     }
 

--- a/orchestration/loop/src/store.rs
+++ b/orchestration/loop/src/store.rs
@@ -753,7 +753,7 @@ impl Store {
             self.registry.push(RegistryEntry {
                 goal_id: goal.goal_id.clone(),
                 objective: goal.objective.clone(),
-                cwd: goal.cwd.clone(),
+                cwd: crate::agents::workspace_guard::normalize_workspace_path(&goal.cwd),
                 status: "active".to_string(),
                 created_at: goal.created_at,
             });
@@ -817,8 +817,60 @@ impl Store {
             event,
         };
         let line = format!("{}\n", serde_json::to_string(&stored)?);
-        append_event_locked(dir.join(EVENTS_FILE), &line, &event_id).context("append event")?;
+        append_event_locked(dir.join(EVENTS_FILE), &line, &event_id, |_| Ok(()))
+            .context("append event")?;
         self.ensure_schema_stamp(&goal_id)?;
+        Ok(event_id)
+    }
+
+    /// Validate CLI dependency edits against the latest ledger under the append
+    /// lock. Raw append remains available for replay/import of legacy events.
+    pub fn append_todo_change(&mut self, event: Event) -> Result<String> {
+        let goal_id = event.goal_id();
+        let entry = self
+            .registry
+            .iter()
+            .find(|g| g.goal_id == goal_id)
+            .context("goal is not registered")?;
+        let dir = self.ensure_goal_dir(goal_id)?;
+        let from = self
+            .goal_schema_version(goal_id)
+            .unwrap_or_else(|| LEGACY_EVENT_STORE_SCHEMA_VERSION.to_string());
+        let event_id = derive_event_id(&event);
+        let stored = StoredEvent {
+            event_id: event_id.clone(),
+            producer: None,
+            source_ref: None,
+            source_section: None,
+            source_line: None,
+            privacy: None,
+            fencing_token: None,
+            event,
+        };
+        let line = format!("{}\n", serde_json::to_string(&stored)?);
+        append_event_locked(dir.join(EVENTS_FILE), &line, &event_id, |text| {
+            let mut goal = Goal::new(&entry.goal_id, &entry.objective, &entry.cwd);
+            for stored in parse_ledger(&dir, &from, text)? {
+                apply(&mut goal, stored.event);
+            }
+            let changed_id = match &stored.event {
+                Event::TodoAdded { todo, .. } => Some(todo.id.as_str()),
+                Event::TodoUpdated {
+                    todo_id,
+                    blocks: Some(_),
+                    ..
+                } => Some(todo_id.as_str()),
+                Event::TodoUpdated { .. } => None,
+                _ => bail!("expected a todo add/update event"),
+            };
+            apply(&mut goal, stored.event.clone());
+            if let Some(id) = changed_id {
+                crate::work_items::task_graph::validate_dependency_change(&goal, id)
+                    .map_err(anyhow::Error::msg)?;
+            }
+            Ok(())
+        })?;
+        self.ensure_schema_stamp(&entry.goal_id)?;
         Ok(event_id)
     }
 
@@ -861,6 +913,22 @@ impl Store {
         lease_secs: u64,
         holder_pid: Option<u32>,
     ) -> Result<AtomicClaimOutcome> {
+        self.try_claim_todo_with_workspace(
+            goal_id, todo_id, agent_id, lease_secs, holder_pid, false,
+        )
+    }
+
+    /// Workspace check, lease claim and effective-write-set audit share one lock.
+    /// Force bypasses workspace conflicts only, never ownership or lease checks.
+    pub fn try_claim_todo_with_workspace(
+        &self,
+        goal_id: &str,
+        todo_id: &str,
+        agent_id: &str,
+        lease_secs: u64,
+        holder_pid: Option<u32>,
+        force_workspace: bool,
+    ) -> Result<AtomicClaimOutcome> {
         use std::io::{Read, Seek, SeekFrom, Write};
         let now = crate::state::now_epoch();
         // Normalize the TTL here (0 → default, >max → error) so every
@@ -879,7 +947,12 @@ impl Store {
         let result = (|| -> Result<AtomicClaimOutcome> {
             // Use the canonical event fold under the claim lock. A separate
             // partial parser drifted from replay (renewal, owner and completion).
-            let mut goal = Goal::new(goal_id, "", "");
+            let entry = self
+                .registry
+                .iter()
+                .find(|g| g.goal_id == goal_id)
+                .context("goal is not registered")?;
+            let mut goal = Goal::new(goal_id, &entry.objective, &entry.cwd);
             let from = self
                 .goal_schema_version(goal_id)
                 .unwrap_or_else(|| LEGACY_EVENT_STORE_SCHEMA_VERSION.to_string());
@@ -921,6 +994,27 @@ impl Store {
                     }
                 }
             }
+            if !Path::new(&goal.cwd).is_absolute()
+                && goal.todos.iter().any(|t| {
+                    (t.id == todo_id
+                        || (t.claimed_by.is_some()
+                            && t.lease_expires_at.is_some_and(|expiry| expiry > now)
+                            && !matches!(t.status, TodoStatus::Done | TodoStatus::Superseded)))
+                        && t.required_write_scope.iter().any(|scope| {
+                            !scope.trim().is_empty() && !Path::new(scope.trim()).is_absolute()
+                        })
+                })
+            {
+                bail!("cannot resolve relative task write scopes: legacy goal cwd is not absolute; recreate the goal with an absolute --cwd and re-declare its write scopes");
+            }
+            let conflicts = crate::agents::workspace_guard::todo_workspace_conflicts(
+                &goal, agent_id, todo, now,
+            );
+            if !conflicts.is_empty() && !force_workspace {
+                bail!("workspace conflict — claiming would race a peer writing the same workspace:\n{}degrade to serial: retry after the holder releases its lease; declare disjoint --required-write-scope paths (goal-relative), or override only with proven disjoint writes (--force-workspace for run, --force for claim)",
+                    crate::agents::workspace_guard::render_conflicts(&conflicts, now));
+            }
+            let paths = crate::agents::workspace_guard::todo_workspaces(&goal, agent_id, todo);
             // Steal when the prior lease belongs to another agent: a live
             // lease with a live holder already returned `claimed=false`
             // above, so reaching here means the lease lapsed or its holder
@@ -951,7 +1045,28 @@ impl Store {
                 fencing_token: None,
                 event,
             };
-            let line = format!("{}\n", serde_json::to_string(&stored)?);
+            let mut line = format!("{}\n", serde_json::to_string(&stored)?);
+            if !paths.is_empty() {
+                let event = Event::WorkspaceLockAcquired {
+                    goal_id: goal_id.to_string(),
+                    agent_id: agent_id.to_string(),
+                    todo_id: todo_id.to_string(),
+                    paths,
+                    forced: !conflicts.is_empty() && force_workspace,
+                    ts: now,
+                };
+                let audit = StoredEvent {
+                    event_id: derive_event_id(&event),
+                    producer: None,
+                    source_ref: None,
+                    source_section: None,
+                    source_line: None,
+                    privacy: None,
+                    fencing_token: None,
+                    event,
+                };
+                line.push_str(&format!("{}\n", serde_json::to_string(&audit)?));
+            }
             file.write_all(line.as_bytes())?;
             Ok(AtomicClaimOutcome {
                 claimed: true,
@@ -1210,16 +1325,24 @@ fn append_locked(path: PathBuf, bytes: &[u8]) -> std::io::Result<()> {
 /// `StateEventConflictError`): the same event id with identical content is
 /// skipped (idempotent replay/backfill re-run); the same id with different
 /// content fails closed.
-fn append_event_locked(path: PathBuf, line: &str, event_id: &str) -> Result<()> {
-    use std::io::Write;
-    let file = fs::OpenOptions::new()
+fn append_event_locked(
+    path: PathBuf,
+    line: &str,
+    event_id: &str,
+    validate: impl FnOnce(&str) -> Result<()>,
+) -> Result<()> {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    let mut file = fs::OpenOptions::new()
         .create(true)
         .read(true)
         .append(true)
         .open(&path)?;
     file.lock_exclusive()?;
     let result = (|| -> Result<()> {
-        let existing = fs::read_to_string(&path).unwrap_or_default();
+        // Read through the locked handle (required by Windows byte-range locks).
+        file.seek(SeekFrom::Start(0))?;
+        let mut existing = String::new();
+        file.read_to_string(&mut existing)?;
         let new_value: serde_json::Value = serde_json::from_str(line).context("serialize event")?;
         let new_fingerprint = event_fingerprint(&new_value);
         for existing_line in existing.lines().filter(|l| !l.trim().is_empty()) {
@@ -1236,8 +1359,8 @@ fn append_event_locked(path: PathBuf, line: &str, event_id: &str) -> Result<()> 
             }
             bail!("conflicting event_id `{event_id}` — same id, different content (StateEventConflictError)");
         }
-        let mut f = &file;
-        f.write_all(line.as_bytes())?;
+        validate(&existing)?;
+        file.write_all(line.as_bytes())?;
         Ok(())
     })();
     let _ = FileExt::unlock(&file);

--- a/orchestration/loop/src/turn_envelope.rs
+++ b/orchestration/loop/src/turn_envelope.rs
@@ -166,6 +166,18 @@ pub fn compose_turn_envelope(goal: &Goal, todo: &Todo, prev: Option<&RunRecord>)
 
     // Instruction.
     out.push_str(&format!("TODO {}: {}\n", todo.id, todo.text));
+    let writer = todo
+        .claimed_by
+        .as_deref()
+        .or(todo.owner.as_deref())
+        .unwrap_or("");
+    let scopes = crate::agents::workspace_guard::todo_workspaces(goal, writer, todo);
+    if !scopes.is_empty() {
+        out.push_str(&format!(
+            "Declared write set (coordination contract, not a filesystem sandbox): {}\nStay within these paths, including logs/caches; if additional writes are needed, stop and ask the supervisor to revise the plan.\n",
+            scopes.join(", ")
+        ));
+    }
 
     if let Some(acceptance) = &todo.acceptance {
         out.push_str(&format!(
@@ -295,6 +307,26 @@ mod tests {
             "completion contract footer present"
         );
         assert!(msg.contains("objective: Ship the thing"));
+    }
+
+    #[test]
+    fn envelope_includes_the_task_write_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut goal = Goal::new("g", "work", dir.path().to_str().unwrap());
+        let mut todo = Todo::advancement("t", "write report");
+        todo.required_write_scope = vec!["papers/a.md".into()];
+        goal.add(todo);
+        let message = compose_turn_message(&goal, goal.todo("t").unwrap(), None);
+        assert!(message.contains("Declared write set"));
+        assert!(message.contains(
+            &dir.path()
+                .canonicalize()
+                .unwrap()
+                .join("papers/a.md")
+                .to_string_lossy()
+                .to_string()
+        ));
+        assert!(message.contains("stop and ask the supervisor"));
     }
 
     #[test]

--- a/orchestration/loop/src/work_items/task_graph.rs
+++ b/orchestration/loop/src/work_items/task_graph.rs
@@ -63,6 +63,45 @@ fn is_blocking_source(todo: &Todo) -> bool {
     matches!(todo.class, TaskClass::UserGate | TaskClass::Blocker)
 }
 
+/// Validate a proposed add/update without requiring unrelated legacy damage to
+/// be repaired first. Only the changed references and cycles through that node
+/// are rejected; this lets an operator clear bad edges one todo at a time.
+pub fn validate_dependency_change(goal: &Goal, todo_id: &str) -> Result<(), String> {
+    let todo = goal
+        .todo(todo_id)
+        .ok_or_else(|| format!("unknown todo `{todo_id}`"))?;
+    for id in predecessor_ids(todo) {
+        if id == todo_id {
+            return Err(format!("todo `{todo_id}` cannot reference itself"));
+        }
+        if goal.todo(&id).is_none() {
+            return Err(format!("todo `{todo_id}` references unknown todo `{id}`"));
+        }
+    }
+    let mut outgoing: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for todo in &goal.todos {
+        for other in predecessor_ids(todo) {
+            let (from, to) = if is_blocking_source(todo) {
+                (todo.id.clone(), other)
+            } else {
+                (other, todo.id.clone())
+            };
+            outgoing.entry(from).or_default().push(to);
+        }
+    }
+    let mut pending = outgoing.get(todo_id).cloned().unwrap_or_default();
+    let mut visited = BTreeSet::new();
+    while let Some(id) = pending.pop() {
+        if id == todo_id {
+            return Err(format!("dependency cycle involving todo `{todo_id}`"));
+        }
+        if visited.insert(id.clone()) {
+            pending.extend(outgoing.get(&id).into_iter().flatten().cloned());
+        }
+    }
+    Ok(())
+}
+
 /// Build the graph from a goal's todos. Validation (fail closed):
 /// - a predecessor reference to an unknown todo id is an error;
 /// - a self-reference is an error;

--- a/orchestration/loop/tests/agent_run_drive.rs
+++ b/orchestration/loop/tests/agent_run_drive.rs
@@ -201,6 +201,75 @@ fn run_workspace_conflict_and_force_workspace() {
 }
 
 #[test]
+fn run_uses_selected_todo_scope_instead_of_auto_registered_cwd() {
+    let cr = cli_root();
+    let goal = init_goal(&cr, "disjoint task writes");
+    let onboarding = first_todo_id(&cr.root, &goal);
+    cli_ok(&[
+        "todo",
+        "complete",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &onboarding,
+        "--evidence",
+        "setup checked",
+        "--no-follow-up",
+    ]);
+    for (agent, path) in [("a1", "papers/a.md"), ("a2", "papers/b.md")] {
+        cli_ok(&[
+            "todo",
+            "add",
+            "--goal",
+            &goal,
+            "--text",
+            agent,
+            "--owner",
+            agent,
+            "--required-write-scope",
+            path,
+        ]);
+        // Exercise the same automatic whole-cwd fallback used by run.
+        let mut store = open_store(&cr);
+        future_loop::console::ensure_run_identity(&mut store, &goal, Some(agent), false).unwrap();
+    }
+    let first = common::todo_id_by_text(&cr.root, &goal, "a1");
+    let second = common::todo_id_by_text(&cr.root, &goal, "a2");
+    cli_ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        &goal,
+        "--todo-id",
+        &first,
+        "--agent-id",
+        "a1",
+    ]);
+    let (_rt, shared) = mock_env(MockState {
+        events: completed_events("mock-run-1"),
+        ..Default::default()
+    });
+    cli_ok(&[
+        "run",
+        "--goal",
+        &goal,
+        "--agent-id",
+        "a2",
+        "--max-turns",
+        "3",
+    ]);
+    let store = open_store(&cr);
+    let replay = store.replay(&goal).unwrap().unwrap();
+    assert_eq!(replay.todo(&second).unwrap().status, TodoStatus::Done);
+    assert!(replay.todo(&first).unwrap().claimed_by.is_some());
+    assert_eq!(shared.lock().unwrap().prompts, 1);
+    assert!(!store.events(&goal).unwrap().iter().any(|e| matches!(
+        e.event,
+        future_loop::store::Event::WorkspaceLockAcquired { forced: true, .. }
+    )));
+}
+
+#[test]
 fn run_failing_turns_exhaust_repair_budget() {
     let cr = cli_root();
     let events = vec![ev(

--- a/orchestration/loop/tests/console_drive_a.rs
+++ b/orchestration/loop/tests/console_drive_a.rs
@@ -138,6 +138,7 @@ fn todo_add_class_matrix() {
         "--text",
         "user does this",
     ]);
+    let dependent = add_todo(&cr, &gid, "dependent work");
     let blocker = {
         cli_ok(&[
             "todo",
@@ -149,7 +150,7 @@ fn todo_add_class_matrix() {
             "--text",
             "blocked on ext",
             "--blocks",
-            "todo_later",
+            &dependent,
         ]);
         todo_id_by_text(&cr.root, &gid, "blocked on ext")
     };
@@ -207,7 +208,7 @@ fn todo_add_class_matrix() {
     let store = open_store(&cr);
     let g = store.replay(&gid).unwrap().unwrap();
     let b = g.todos.iter().find(|t| t.id == blocker).unwrap();
-    assert_eq!(b.blocked_by_gate.as_deref(), Some("todo_later"));
+    assert_eq!(b.blocked_by_gate.as_deref(), Some(dependent.as_str()));
     assert!(b.class == future_loop::state::TaskClass::Blocker);
     let m = g.todos.iter().find(|t| t.text == "watch it").unwrap();
     assert!(m.resume_when.is_some(), "cadence sets the first due time");
@@ -338,8 +339,18 @@ fn todo_add_flag_matrix() {
         "0",
     ]);
     // --blocks on an advancement todo (dependency chain applies to all classes).
+    let a = add_todo(&cr, &gid, "prerequisite a");
+    let b = add_todo(&cr, &gid, "prerequisite b");
+    let dependencies = format!("{a},{b}");
     cli_ok(&[
-        "todo", "add", "--goal", &gid, "--text", "chained", "--blocks", "a,b",
+        "todo",
+        "add",
+        "--goal",
+        &gid,
+        "--text",
+        "chained",
+        "--blocks",
+        &dependencies,
     ]);
     // global-gate user_gate forces goal_bound.
     cli_ok(&[
@@ -416,7 +427,10 @@ fn todo_add_flag_matrix() {
     let clamped = g.todos.iter().find(|t| t.text.contains("clamped")).unwrap();
     assert_eq!(clamped.max_validation_attempts, 1);
     let chained = g.todos.iter().find(|t| t.text.contains("chained")).unwrap();
-    assert_eq!(chained.blocked_by_gate.as_deref(), Some("a,b"));
+    assert_eq!(
+        chained.blocked_by_gate.as_deref(),
+        Some(dependencies.as_str())
+    );
     let gg = g
         .todos
         .iter()
@@ -910,7 +924,10 @@ fn todo_archive_supersede_update() {
             .contains("already done")
     );
 
-    // update: full field set.
+    // update: full field set, with real prerequisites rather than dangling IDs.
+    let x = add_todo(&cr, &gid, "prerequisite x");
+    let y = add_todo(&cr, &gid, "prerequisite y");
+    let dependencies = format!("{x},{y}");
     let u = add_todo(&cr, &gid, "update me");
     cli_ok(&[
         "todo",
@@ -932,7 +949,7 @@ fn todo_archive_supersede_update() {
         "--resume-when",
         "45",
         "--blocks",
-        "x,y",
+        &dependencies,
         "--owner",
         "worker-a",
     ]);
@@ -944,7 +961,7 @@ fn todo_archive_supersede_update() {
         assert_eq!(t.evidence.as_deref(), Some("half done"));
         assert_eq!(t.note.as_deref(), Some("n"));
         assert_eq!(t.priority, future_loop::state::Priority::P0);
-        assert_eq!(t.blocked_by_gate.as_deref(), Some("x,y"));
+        assert_eq!(t.blocked_by_gate.as_deref(), Some(dependencies.as_str()));
         assert_eq!(t.owner.as_deref(), Some("worker-a"));
         assert!(
             t.resume_when.is_some(),

--- a/orchestration/loop/tests/console_drive_c.rs
+++ b/orchestration/loop/tests/console_drive_c.rs
@@ -81,14 +81,14 @@ fn task_graph_surface() {
         "todo", "add", "--goal", &gid, "--text", "second", "--blocks", &first,
     ]);
     cli_ok(&["task-graph", "--goal", &gid]);
-    // A cycle does NOT fail — it is reported (⚠ cycle) with no topo order.
+    // New cycles are rejected before write; legacy graph rendering stays readable.
     let gid2 = init_goal(&cr, "cycle goal");
     let x = first_todo_id(&cr.root, &gid2);
     cli_ok(&[
         "todo", "add", "--goal", &gid2, "--text", "y", "--blocks", &x,
     ]);
     let y = common::todo_id_by_text(&cr.root, &gid2, "y");
-    cli_ok(&[
+    assert!(cli_err(&[
         "todo",
         "update",
         "--goal",
@@ -97,11 +97,12 @@ fn task_graph_surface() {
         &x,
         "--blocks",
         &y,
-    ]);
+    ])
+    .contains("cycle"));
     cli_ok(&["task-graph", "--goal", &gid2]);
     // Unknown refs fail closed.
     let gid3 = init_goal(&cr, "unknown ref goal");
-    cli_ok(&[
+    assert!(cli_err(&[
         "todo",
         "add",
         "--goal",
@@ -110,7 +111,17 @@ fn task_graph_surface() {
         "dangling",
         "--blocks",
         "todo_ghost",
-    ]);
+    ])
+    .contains("unknown todo"));
+    // Imported legacy damage remains diagnosable (raw append is not a CLI edit).
+    open_store(&cr)
+        .append(future_loop::store::Event::TodoAdded {
+            goal_id: gid3.clone(),
+            todo: future_loop::state::Todo::advancement("legacy", "legacy")
+                .blocking(&["todo_ghost"]),
+            ts: now_epoch(),
+        })
+        .unwrap();
     assert!(cli_err(&["task-graph", "--goal", &gid3]).contains("unknown todo"));
     assert!(cli_err(&["task-graph"]).contains("--goal required"));
     assert!(cli_err(&["task-graph", "--goal", "goal_nope"]).contains("not found"));

--- a/orchestration/loop/tests/write_scope_dependencies.rs
+++ b/orchestration/loop/tests/write_scope_dependencies.rs
@@ -1,0 +1,577 @@
+//! Real CLI and concurrent-process regressions; no live agent or model calls.
+use future_loop::agents::workspace_guard::{live_workspace_conflicts, normalize_workspace_path_at};
+use future_loop::state::{Goal, Todo};
+use future_loop::store::{Event, Store};
+use std::process::{Command, Output};
+use std::sync::{Arc, Barrier};
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    store: Store,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(dir.path().join("observer")).unwrap();
+        let mut store = Store::open(dir.path().join("state").to_str().unwrap()).unwrap();
+        store
+            .register(&Goal::new("g", "test", project.to_str().unwrap()))
+            .unwrap();
+        store
+            .append(Event::GoalStarted {
+                goal_id: "g".into(),
+                ts: 1,
+            })
+            .unwrap();
+        Self { dir, store }
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_future-loop"));
+        cmd.args(args)
+            .current_dir(self.dir.path().join("observer"))
+            .env("FUTURE_LOOP_ROOT", self.store.root_path())
+            .env("HOME", self.dir.path().join("home"))
+            .env("USERPROFILE", self.dir.path().join("home"));
+        cmd
+    }
+
+    fn ok(&self, args: &[&str]) -> String {
+        let output = self.command(args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    fn rejected(&self, args: &[&str], error: &str) {
+        let before = self.store.raw_ledger_lines("g").unwrap();
+        let output = self.command(args).output().unwrap();
+        assert!(!output.status.success(), "{args:?} unexpectedly succeeded");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(error),
+            "{output:?}"
+        );
+        assert_eq!(
+            before,
+            self.store.raw_ledger_lines("g").unwrap(),
+            "rejection must not append events"
+        );
+    }
+
+    fn seed(&mut self, id: &str, scopes: &[&str]) {
+        let mut todo = Todo::advancement(id, "work");
+        todo.required_write_scope = scopes.iter().map(|s| s.to_string()).collect();
+        self.store
+            .append(Event::TodoAdded {
+                goal_id: "g".into(),
+                todo,
+                ts: 2,
+            })
+            .unwrap();
+    }
+
+    fn onboard(&self, agent: &str) {
+        self.ok(&[
+            "agent",
+            "onboard",
+            "--goal",
+            "g",
+            "--agent-id",
+            agent,
+            "--workspace",
+            self.dir.path().join("project").to_str().unwrap(),
+        ]);
+    }
+}
+
+#[test]
+fn cli_add_output_and_dependency_validation_are_transactional() {
+    let mut f = Fixture::new();
+    f.seed("t1", &[]);
+    f.seed("t2", &[]);
+    let out = f.ok(&[
+        "todo",
+        "add",
+        "--goal",
+        "g",
+        "--text",
+        "dependent",
+        "--blocks",
+        " t1 , t2 ",
+    ]);
+    let words: Vec<_> = out.split_whitespace().collect();
+    assert_eq!(words[0], "todo");
+    assert!(words[1].starts_with("todo_"));
+    assert!(words[1][5..].bytes().all(|b| b.is_ascii_hexdigit()));
+    assert_eq!(&words[2..], &["added", "to", "g", "✔"]);
+    f.rejected(
+        &[
+            "todo",
+            "add",
+            "--goal",
+            "g",
+            "--text",
+            "bad",
+            "--blocks",
+            "todo_ghost",
+        ],
+        "unknown todo",
+    );
+    f.rejected(
+        &["todo", "add", "--goal", "g", "--text", "bad", "--blocks"],
+        "requires a comma-separated",
+    );
+    f.rejected(
+        &[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            "t1",
+            "--blocks",
+            "garbage",
+        ],
+        "unknown todo",
+    );
+    f.rejected(
+        &[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            "t1",
+            "--blocks",
+            "t1",
+        ],
+        "cannot reference itself",
+    );
+    f.rejected(
+        &[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            "t1",
+            "--blocks",
+            words[1],
+        ],
+        "cycle",
+    );
+    f.ok(&[
+        "todo",
+        "update",
+        "--goal",
+        "g",
+        "--todo-id",
+        words[1],
+        "--blocks",
+        "t2",
+    ]);
+    assert_eq!(
+        f.store
+            .replay("g")
+            .unwrap()
+            .unwrap()
+            .todo(words[1])
+            .unwrap()
+            .blocked_by_gate
+            .as_deref(),
+        Some("t2")
+    );
+    f.ok(&[
+        "todo",
+        "update",
+        "--goal",
+        "g",
+        "--todo-id",
+        words[1],
+        "--blocks",
+        "",
+    ]);
+    assert!(f
+        .store
+        .replay("g")
+        .unwrap()
+        .unwrap()
+        .todo(words[1])
+        .unwrap()
+        .blocked_by_gate
+        .is_none());
+    f.ok(&["task-graph", "--goal", "g"]);
+}
+
+#[test]
+fn legacy_damage_can_be_repaired_incrementally_including_gate_edges() {
+    let mut f = Fixture::new();
+    for (id, dep) in [("a", "missing-a"), ("b", "missing-b")] {
+        f.store
+            .append(Event::TodoAdded {
+                goal_id: "g".into(),
+                todo: Todo::advancement(id, "legacy").blocking(&[dep]),
+                ts: 2,
+            })
+            .unwrap();
+    }
+    f.ok(&[
+        "todo",
+        "update",
+        "--goal",
+        "g",
+        "--todo-id",
+        "a",
+        "--blocks",
+        "",
+    ]);
+    f.rejected(&["task-graph", "--goal", "g"], "unknown todo");
+    f.ok(&[
+        "todo",
+        "update",
+        "--goal",
+        "g",
+        "--todo-id",
+        "b",
+        "--blocks",
+        "a",
+    ]);
+    let gate = f.ok(&[
+        "todo", "add", "--goal", "g", "--class", "blocker", "--text", "gate", "--blocks", "a",
+    ]);
+    let gate_id = gate.split_whitespace().nth(1).unwrap();
+    // gate -> a -> b; declaring gate -> b duplicates an edge, not a cycle.
+    f.ok(&[
+        "todo",
+        "update",
+        "--goal",
+        "g",
+        "--todo-id",
+        gate_id,
+        "--blocks",
+        "a,b",
+    ]);
+    f.ok(&["task-graph", "--goal", "g"]);
+    // A blocking-source cycle is rejected in the correct direction.
+    let gate2 = f.ok(&[
+        "todo", "add", "--goal", "g", "--class", "blocker", "--text", "gate2", "--blocks", gate_id,
+    ]);
+    let gate2_id = gate2.split_whitespace().nth(1).unwrap();
+    f.rejected(
+        &[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            gate_id,
+            "--blocks",
+            gate2_id,
+        ],
+        "cycle",
+    );
+}
+
+fn race(commands: Vec<Command>) -> Vec<Output> {
+    let barrier = Arc::new(Barrier::new(commands.len()));
+    let handles: Vec<_> = commands
+        .into_iter()
+        .map(|mut cmd| {
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                cmd.output().unwrap()
+            })
+        })
+        .collect();
+    handles.into_iter().map(|h| h.join().unwrap()).collect()
+}
+
+#[test]
+fn concurrent_dependency_updates_cannot_jointly_introduce_a_cycle() {
+    let mut f = Fixture::new();
+    f.seed("a", &[]);
+    f.seed("b", &[]);
+    let results = race(vec![
+        f.command(&[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            "a",
+            "--blocks",
+            "b",
+        ]),
+        f.command(&[
+            "todo",
+            "update",
+            "--goal",
+            "g",
+            "--todo-id",
+            "b",
+            "--blocks",
+            "a",
+        ]),
+    ]);
+    assert_eq!(
+        results.iter().filter(|o| o.status.success()).count(),
+        1,
+        "{results:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&results.iter().find(|o| !o.status.success()).unwrap().stderr)
+            .contains("cycle")
+    );
+    f.ok(&["task-graph", "--goal", "g"]);
+}
+
+#[test]
+fn four_workers_with_relative_disjoint_scopes_claim_without_force() {
+    let mut f = Fixture::new();
+    let mut commands = vec![];
+    for n in 0..4 {
+        let id = format!("t{n}");
+        let agent = format!("w{n}");
+        f.seed(&id, &[&format!("papers/{n}.md")]);
+        f.onboard(&agent);
+        commands.push(f.command(&[
+            "todo",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            &id,
+            "--agent-id",
+            &agent,
+        ]));
+    }
+    let results = race(commands);
+    assert!(results.iter().all(|o| o.status.success()), "{results:?}");
+    let goal = f.store.replay("g").unwrap().unwrap();
+    for n in 0..4 {
+        assert!(
+            live_workspace_conflicts(&goal, &format!("w{n}"), future_loop::state::now_epoch())
+                .is_empty()
+        );
+    }
+    let audits: Vec<_> = f
+        .store
+        .events("g")
+        .unwrap()
+        .into_iter()
+        .filter_map(|e| match e.event {
+            Event::WorkspaceLockAcquired { paths, forced, .. } => Some((paths, forced)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(audits.len(), 4);
+    for (paths, forced) in audits {
+        assert!(!forced);
+        assert_eq!(paths.len(), 1);
+        assert!(std::path::Path::new(&paths[0])
+            .starts_with(f.dir.path().join("project").canonicalize().unwrap()));
+    }
+}
+
+#[test]
+fn concurrent_overlapping_claims_have_only_one_winner_and_force_is_audited() {
+    let mut f = Fixture::new();
+    let mut commands = vec![];
+    for n in 0..4 {
+        let id = format!("t{n}");
+        let agent = format!("w{n}");
+        f.seed(&id, &["papers/"]);
+        f.onboard(&agent);
+        // Cover both manual claim surfaces with the same atomic guard.
+        commands.push(f.command(&[
+            if n % 2 == 0 { "todo" } else { "lease" },
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            &id,
+            "--agent-id",
+            &agent,
+        ]));
+    }
+    let results = race(commands);
+    assert_eq!(
+        results.iter().filter(|o| o.status.success()).count(),
+        1,
+        "{results:?}"
+    );
+    for output in results.iter().filter(|o| !o.status.success()) {
+        assert!(String::from_utf8_lossy(&output.stderr).contains("workspace conflict"));
+    }
+    let loser = results.iter().position(|o| !o.status.success()).unwrap();
+    f.ok(&[
+        "lease",
+        "claim",
+        "--goal",
+        "g",
+        "--todo-id",
+        &format!("t{loser}"),
+        "--agent-id",
+        &format!("w{loser}"),
+        "--force",
+    ]);
+    assert!(f
+        .store
+        .events("g")
+        .unwrap()
+        .iter()
+        .any(|e| matches!(e.event, Event::WorkspaceLockAcquired { forced: true, .. })));
+}
+
+#[test]
+fn missing_scopes_fall_back_and_absolute_aliases_cannot_evade_conflicts() {
+    let mut f = Fixture::new();
+    f.seed("relative", &["papers/a.md"]);
+    let absolute = f.dir.path().join("project").join("papers/a.md");
+    f.seed("absolute", &[absolute.to_str().unwrap()]);
+    f.seed("fallback", &[]);
+    for agent in ["a", "b", "c"] {
+        f.onboard(agent);
+    }
+    f.ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        "g",
+        "--todo-id",
+        "relative",
+        "--agent-id",
+        "a",
+    ]);
+    f.rejected(
+        &[
+            "todo",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            "absolute",
+            "--agent-id",
+            "b",
+        ],
+        "workspace conflict",
+    );
+    f.rejected(
+        &[
+            "lease",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            "fallback",
+            "--agent-id",
+            "c",
+        ],
+        "workspace conflict",
+    );
+    assert_eq!(
+        normalize_workspace_path_at("papers/a.md", &f.dir.path().join("project")),
+        normalize_workspace_path_at(absolute.to_str().unwrap(), f.dir.path())
+    );
+}
+
+#[test]
+fn legacy_relative_goal_anchor_is_rejected_instead_of_using_observer_cwd() {
+    let mut f = Fixture::new();
+    f.seed("t", &["papers/a.md"]);
+    f.onboard("w");
+    let registry = std::path::Path::new(&f.store.root_path()).join("registry.json");
+    let mut json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&registry).unwrap()).unwrap();
+    json[0]["cwd"] = serde_json::json!(".");
+    std::fs::write(&registry, serde_json::to_vec(&json).unwrap()).unwrap();
+    f.rejected(
+        &[
+            "todo",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            "t",
+            "--agent-id",
+            "w",
+        ],
+        "legacy goal cwd is not absolute",
+    );
+}
+
+#[test]
+fn force_does_not_bypass_ownership_or_another_agents_lease() {
+    let mut f = Fixture::new();
+    let todo = Todo::advancement("owned", "work").owned_by("a");
+    f.store
+        .append(Event::TodoAdded {
+            goal_id: "g".into(),
+            todo,
+            ts: 2,
+        })
+        .unwrap();
+    f.seed("leased", &["papers/a.md"]);
+    f.onboard("a");
+    f.onboard("b");
+    f.rejected(
+        &[
+            "todo",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            "owned",
+            "--agent-id",
+            "b",
+            "--force",
+        ],
+        "cannot be claimed",
+    );
+    f.ok(&[
+        "todo",
+        "claim",
+        "--goal",
+        "g",
+        "--todo-id",
+        "leased",
+        "--agent-id",
+        "a",
+    ]);
+    f.rejected(
+        &[
+            "lease",
+            "claim",
+            "--goal",
+            "g",
+            "--todo-id",
+            "leased",
+            "--agent-id",
+            "b",
+            "--force",
+        ],
+        "active lease",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn nonexistent_files_below_symlinked_parents_have_the_same_scope() {
+    let f = Fixture::new();
+    std::os::unix::fs::symlink(f.dir.path().join("project"), f.dir.path().join("alias")).unwrap();
+    assert_eq!(
+        normalize_workspace_path_at("alias/papers/new.md", f.dir.path()),
+        normalize_workspace_path_at("project/papers/new.md", f.dir.path())
+    );
+    assert_eq!(
+        normalize_workspace_path_at("alias/missing/../papers/new.md", f.dir.path()),
+        normalize_workspace_path_at("project/papers/new.md", f.dir.path())
+    );
+}


### PR DESCRIPTION
## Summary
- Use goal-relative required_write_scope per task, falling back to the agent workspace only when omitted. Normalize existing symlink prefixes for future output files and refuse ambiguous legacy relative goal anchors.
- Check workspace conflicts and append lease/audit records under one ledger lock for run, todo claim and lease claim. Keep ownership/lease protection even with force; include the write contract in worker prompts.
- Validate CLI dependency edits under the append lock: reject unknown/self/cyclic references without writing, while allowing incremental repair of unrelated legacy damage.
- Update legacy fixtures, stabilize the test-owned watchdog lock release, and bump skills to future-loop 4.2.0 (futuregene/future-skills#57).

## Validation
- cargo fmt -p future-loop --check
- cargo clippy -p future-loop --all-targets -- -D warnings
- cargo test -p future-loop (full suite)
- cargo clippy -p future-loop --target x86_64-pc-windows-msvc --all-targets -- -D warnings
- cargo test -p future-cli (full suite, isolated HOME/USERPROFILE, API-key env removed)
- Skills: all offline checks and new documented-regex fixtures passed
- Real concurrent CLI processes: four disjoint claimants all succeed, overlapping claimants have one winner, opposing dependency updates cannot jointly create a cycle; mock-agent run exercises task scopes without force.

## Boundaries / validation history
Declarations are a coordination contract, not a filesystem sandbox; undeclared legacy agents retain fail-open behavior. Native Windows execution remains for CI, not claimed locally. Initial full checks exposed old dangling-reference fixtures and a macOS path-alias assertion, now corrected. An existing watchdog test twice raced concurrent subprocess inheritance; explicit test-owned unlock removes that cleanup race. The first CLI pass inherited local auth in an existing web_search stdin test (fixed query x); the isolated full rerun passed without real credentials.