### PR TITLE
fix(agent): stop --verbose log spam from HTTP/2 frame tracing

### DIFF
--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -94,9 +94,23 @@ fn load_project_context(cwd: &str) -> String {
     String::new()
 }
 
-/// Abort every live session (SIGINT / profile-timer shutdown path).
+/// Transport crates that log per-frame / per-poll detail at DEBUG. Raising the
+/// root level to `debug` for `--verbose` would otherwise bury the Agent's own
+/// logs under every HTTP/2 frame h2 sends; pin them to WARN so only their
+/// failures show up. `RUST_LOG` still overrides this filter entirely.
+const NOISY_TRANSPORT_TARGETS: &[&str] = &["h2", "tonic", "tower"];
+
 fn default_log_filter(verbose: bool) -> tracing_subscriber::EnvFilter {
-    tracing_subscriber::EnvFilter::new(if verbose { "debug" } else { "info" })
+    if !verbose {
+        return tracing_subscriber::EnvFilter::new("info");
+    }
+    let mut directives = vec!["debug".to_owned()];
+    directives.extend(
+        NOISY_TRANSPORT_TARGETS
+            .iter()
+            .map(|target| format!("{target}=warn")),
+    );
+    tracing_subscriber::EnvFilter::new(directives.join(","))
 }
 
 #[cfg(test)]
@@ -109,6 +123,12 @@ fn verbose_default_filter_enables_grpc_debug_events() {
             .finish();
         tracing::subscriber::with_default(subscriber, || {
             assert_eq!(tracing::enabled!(tracing::Level::DEBUG), verbose);
+            // The transport crates stay quiet even in verbose mode; the
+            // `enabled!` macro requires a literal target, so assert one by one.
+            assert!(!tracing::enabled!(target: "h2", tracing::Level::DEBUG));
+            assert!(!tracing::enabled!(target: "tonic", tracing::Level::DEBUG));
+            assert!(!tracing::enabled!(target: "tower", tracing::Level::DEBUG));
+            assert!(tracing::enabled!(target: "h2", tracing::Level::WARN));
         });
     }
 }
@@ -143,6 +163,7 @@ fn tcp_bind_rejects_invalid_ports_and_accepts_bracketed_ipv6() {
     assert_eq!(parse_tcp_bind("[::1]:1234").unwrap(), ("::1".into(), 1234));
 }
 
+/// Abort every live session (SIGINT / profile-timer shutdown path).
 fn abort_all_sessions(sessions: &SessionsMap) {
     for s in sessions.read().values() {
         let session = s.read();


### PR DESCRIPTION
## Problem

`future agent --verbose` floods the console with HTTP/2 frame tracing:

```
DEBUG Connection{peer=Server}: send frame=Headers { stream_id: StreamId(427), flags: (0x4: END_HEADERS) }
DEBUG [grpc] get_session_events_since session=... msg=-
```

`default_log_filter()` set the **root** level to `debug`, so `--verbose` also turned on h2's per-frame DEBUG logs and buried the Agent's own `[grpc]` / `[stream]` lines. The Agent's own debug logs are already gated by `state.verbose`; they never needed the global level.

## Change

`--verbose` still sets the root level to `debug`, but the transport crates that log per-frame detail are pinned to `warn`:

```rust
const NOISY_TRANSPORT_TARGETS: &[&str] = &["h2", "tonic", "tower"];

fn default_log_filter(verbose: bool) -> tracing_subscriber::EnvFilter {
    if !verbose {
        return tracing_subscriber::EnvFilter::new("info");
    }
    let mut directives = vec!["debug".to_owned()];
    directives
        .extend(NOISY_TRANSPORT_TARGETS.iter().map(|target| format!("{target}=warn")));
    tracing_subscriber::EnvFilter::new(directives.join(","))
}
```

- Targets are the ones actually linked into `future-agent`'s tracing tree (`cargo tree -i tracing`: `h2`, `hyper-util`, `tonic`, `tower`); `hyper-util`/`hyper` have no `debug!` call sites, so they are omitted. h2 is the flood (8 `debug!` sites, per frame), `tower`/`tonic` only add a handful.
- An explicit `RUST_LOG` still wins entirely (`try_from_default_env()` is unchanged), so full `h2=debug` dumps remain available on demand.
- Transport failures at `warn`/`error` still surface.
- Non-verbose (`info`) behaviour is unchanged.
- Also moved a misplaced `abort_all_sessions` doc comment back onto its function.

## Tests

`cargo test -p future-agent verbose_default_filter` — extends the existing test to assert `h2`/`tonic`/`tower` DEBUG is disabled while `future_agent` DEBUG is still enabled in verbose mode.

- `cargo fmt -p future-agent --check` ✅
- `cargo clippy -p future-agent --all-targets -- -D warnings` ✅
- `cargo test -p future-agent` — 1705 passed; the 31 failures are pre-existing on clean `main` under Windows (Unix-path assumptions in `sandbox::paths`, `rpc::prompt_helpers`, `sandbox::linux`, …). Re-ran the same tests in the `main` worktree at `3109ca37` and they fail identically there.
