### PR TITLE
fix(agent): keep --verbose free of poller RPC heartbeats

### DIFF
--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -160,6 +160,18 @@ fn nonempty(value: String) -> Option<String> {
     }
 }
 
+/// Commands clients issue on a timer rather than in response to user intent:
+/// the session/run cursor replays and the "who is streaming" health probe.
+/// Under `--verbose` they would be the overwhelming majority of the request
+/// log, so they are logged at TRACE instead of DEBUG; `RUST_LOG` at
+/// `trace` (or `future_agent::grpc=trace`) still surfaces every poll.
+fn is_poller_command(command: &str) -> bool {
+    matches!(
+        command,
+        "get_events_since" | "get_session_events_since" | "list_streaming_sessions"
+    )
+}
+
 #[tonic::async_trait]
 impl proto::future_agent_server::FutureAgent for FutureAgentService {
     type StreamEventsStream =
@@ -181,20 +193,31 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
 
         // Log requests in verbose mode
         if self.state.verbose {
-            tracing::debug!(
-                "[grpc] {} session={} msg={:.80}",
-                cmd.r#type,
-                if cmd.session_id.is_empty() {
-                    "-"
-                } else {
-                    &cmd.session_id
-                },
-                if cmd.message.is_empty() {
-                    "-"
-                } else {
-                    &cmd.message
-                }
-            );
+            let session = if cmd.session_id.is_empty() {
+                "-"
+            } else {
+                &cmd.session_id
+            };
+            let message = if cmd.message.is_empty() {
+                "-"
+            } else {
+                &cmd.message
+            };
+            if is_poller_command(&cmd.r#type) {
+                tracing::trace!(
+                    "[grpc] {} session={} msg={:.80}",
+                    cmd.r#type,
+                    session,
+                    message
+                );
+            } else {
+                tracing::debug!(
+                    "[grpc] {} session={} msg={:.80}",
+                    cmd.r#type,
+                    session,
+                    message
+                );
+            }
         }
 
         // Convert proto command to internal command
@@ -1088,6 +1111,68 @@ mod tests {
     fn nonempty_maps_empty_to_none() {
         assert_eq!(nonempty(String::new()), None);
         assert_eq!(nonempty("x".to_string()), Some("x".to_string()));
+    }
+
+    /// `--verbose` (a DEBUG filter) keeps user-intent commands in the request
+    /// log but drops the poller heartbeats to TRACE, so the log stays readable
+    /// while `RUST_LOG=trace` can still surface every poll.
+    #[test]
+    fn verbose_logs_poller_commands_at_trace_only() {
+        #[derive(Clone, Default)]
+        struct Capture(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+        impl std::io::Write for Capture {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let capture = Capture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_env_filter(tracing_subscriber::EnvFilter::new("debug"))
+            .with_writer(move || writer.clone())
+            .finish();
+
+        let service = FutureAgentService {
+            state: grpc_app_state(true), // verbose logging branch
+        };
+        let poller = proto::RpcCommand {
+            id: "cmd-poller".to_string(),
+            r#type: "get_session_events_since".to_string(),
+            session_id: "default".to_string(),
+            ..Default::default()
+        };
+        let real = proto::RpcCommand {
+            id: "cmd-real".to_string(),
+            r#type: "get_agent_info".to_string(),
+            session_id: "default".to_string(),
+            ..Default::default()
+        };
+
+        // The subscriber must be the thread's default for the whole run, so
+        // drive the runtime inside `with_default` instead of using
+        // `#[tokio::test]` (whose runtime owns the test thread).
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        tracing::subscriber::with_default(subscriber, || {
+            runtime.block_on(async {
+                let _ = service.execute_command(tonic::Request::new(poller)).await;
+                let _ = service.execute_command(tonic::Request::new(real)).await;
+            });
+        });
+
+        let bytes = capture.0.lock().unwrap();
+        let log = String::from_utf8_lossy(&bytes);
+        assert!(log.contains("[grpc] get_agent_info"), "{log}");
+        assert!(!log.contains("[grpc] get_session_events_since"), "{log}");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Problem

After #559 silenced h2's HTTP/2 frame tracing, `future agent --verbose` still floods with the Agent's own request log:

```
DEBUG [grpc] get_session_events_since session=20260912-095239-c50b90 msg=-
DEBUG [grpc] get_session_events_since session=20260911-214608-89c957 msg=-
DEBUG [grpc] list_streaming_sessions session=- msg=-
...
```

These are not user actions. Clients poll them on a timer:

- `get_session_events_since` — desktop/mobile observer cursor replay, once per session per reconnect/backoff tick (`desktop/src-tauri/src/agent_bridge/observer.rs`, `mobile/src/remote/replay.ts`)
- `get_events_since` — run-level cursor replay (`desktop/src-tauri/src/agent_bridge/mod.rs`, `mobile/src/remote/replay.ts`)
- `list_streaming_sessions` — connectivity/bulk streaming-status probe (`desktop/src-tauri/src/agent_bridge/client.rs`, `remote_host/availability.rs`, `tui/src/agent_supervisor.rs`)

With several sessions attached, a few seconds of log is hundreds of identical heartbeats.

## Change

`agent/src/grpc/mod.rs` logs those three poller commands at **TRACE** instead of DEBUG; every user-driven command (`prompt`, `abort`, settings, session management, …) keeps logging at DEBUG.

```rust
fn is_poller_command(command: &str) -> bool {
    matches!(
        command,
        "get_events_since" | "get_session_events_since" | "list_streaming_sessions"
    )
}
```

- Nothing is lost: `RUST_LOG=trace` (or `future_agent::grpc=trace`) shows every poll, and an explicit `RUST_LOG` still overrides the `--verbose` default entirely.
- Non-verbose runs are unchanged (the whole block remains gated by `state.verbose`).

## Tests

New `grpc::tests::verbose_logs_poller_commands_at_trace_only` drives `execute_command` through a capturing subscriber with the `--verbose` filter and asserts `[grpc] get_agent_info` is present while `[grpc] get_session_events_since` is not. Driving the current-thread runtime inside `tracing::subscriber::with_default` keeps the thread-local subscriber in effect for the whole call (the reason this is a plain `#[test]`, not `#[tokio::test]`).

- `cargo fmt -p future-agent --check` ✅
- `cargo clippy -p future-agent --all-targets -- -D warnings` ✅
- `cargo test -p future-agent` — 1706 passed; same 31 pre-existing Windows-only failures as on unmodified `main` (`sandbox::paths`, `rpc::prompt_helpers`, `sandbox::linux`, …), which fail identically at `3109ca37`.
