### PR TITLE
fix(agent): quiet routine refresh traffic and rustls in --verbose logs

### DIFF
--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -94,11 +94,12 @@ fn load_project_context(cwd: &str) -> String {
     String::new()
 }
 
-/// Transport crates that log per-frame / per-poll detail at DEBUG. Raising the
-/// root level to `debug` for `--verbose` would otherwise bury the Agent's own
-/// logs under every HTTP/2 frame h2 sends; pin them to WARN so only their
-/// failures show up. `RUST_LOG` still overrides this filter entirely.
-const NOISY_TRANSPORT_TARGETS: &[&str] = &["h2", "tonic", "tower"];
+/// Transport crates that log per-frame / per-handshake detail at DEBUG. Raising
+/// the root level to `debug` for `--verbose` would otherwise bury the Agent's
+/// own logs under every HTTP/2 frame h2 sends and every TLS record rustls
+/// processes; pin them to WARN so only their failures show up. `RUST_LOG` still
+/// overrides this filter entirely.
+const NOISY_TRANSPORT_TARGETS: &[&str] = &["h2", "rustls", "tonic", "tower"];
 
 fn default_log_filter(verbose: bool) -> tracing_subscriber::EnvFilter {
     if !verbose {
@@ -126,6 +127,7 @@ fn verbose_default_filter_enables_grpc_debug_events() {
             // The transport crates stay quiet even in verbose mode; the
             // `enabled!` macro requires a literal target, so assert one by one.
             assert!(!tracing::enabled!(target: "h2", tracing::Level::DEBUG));
+            assert!(!tracing::enabled!(target: "rustls", tracing::Level::DEBUG));
             assert!(!tracing::enabled!(target: "tonic", tracing::Level::DEBUG));
             assert!(!tracing::enabled!(target: "tower", tracing::Level::DEBUG));
             assert!(tracing::enabled!(target: "h2", tracing::Level::WARN));

--- a/agent/src/grpc/mod.rs
+++ b/agent/src/grpc/mod.rs
@@ -160,16 +160,31 @@ fn nonempty(value: String) -> Option<String> {
     }
 }
 
-/// Commands clients issue on a timer rather than in response to user intent:
-/// the session/run cursor replays and the "who is streaming" health probe.
-/// Under `--verbose` they would be the overwhelming majority of the request
-/// log, so they are logged at TRACE instead of DEBUG; `RUST_LOG` at
-/// `trace` (or `future_agent::grpc=trace`) still surfaces every poll.
-fn is_poller_command(command: &str) -> bool {
-    matches!(
-        command,
-        "get_events_since" | "get_session_events_since" | "list_streaming_sessions"
-    )
+/// Commands that clients issue as routine background traffic — cursor replays,
+/// panel/list reloads and the probes behind them — rather than in response to a
+/// user action. One desktop refresh cycle alone sends a dozen of them (the
+/// context panel polls every 1.5 s while a run is live, re-reading every run's
+/// tool calls), so they would drown out the commands a `--verbose` reader
+/// actually wants. They log at TRACE instead of DEBUG; `RUST_LOG=trace` (or
+/// `future_agent::grpc=trace`) still surfaces every request.
+const BACKGROUND_COMMANDS: &[&str] = &[
+    // Cursor replays and health probes.
+    "get_events_since",
+    "get_session_events_since",
+    "list_streaming_sessions",
+    // Panel / catalog reloads.
+    "get_commands",
+    "get_session_entries",
+    "get_state",
+    "get_tool_output",
+    "list_models",
+    "list_providers",
+    "list_tool_calls",
+    "refresh_skills",
+];
+
+fn is_background_command(command: &str) -> bool {
+    BACKGROUND_COMMANDS.contains(&command)
 }
 
 #[tonic::async_trait]
@@ -203,7 +218,9 @@ impl proto::future_agent_server::FutureAgent for FutureAgentService {
             } else {
                 &cmd.message
             };
-            if is_poller_command(&cmd.r#type) {
+            // `tracing::event!` needs a *constant* level, so the two levels
+            // must be separate macro invocations.
+            if is_background_command(&cmd.r#type) {
                 tracing::trace!(
                     "[grpc] {} session={} msg={:.80}",
                     cmd.r#type,
@@ -1114,10 +1131,10 @@ mod tests {
     }
 
     /// `--verbose` (a DEBUG filter) keeps user-intent commands in the request
-    /// log but drops the poller heartbeats to TRACE, so the log stays readable
-    /// while `RUST_LOG=trace` can still surface every poll.
+    /// log but drops background refresh traffic to TRACE, so the log stays
+    /// readable while `RUST_LOG=trace` can still surface every request.
     #[test]
-    fn verbose_logs_poller_commands_at_trace_only() {
+    fn verbose_logs_background_commands_at_trace_only() {
         #[derive(Clone, Default)]
         struct Capture(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
         impl std::io::Write for Capture {
@@ -1142,9 +1159,9 @@ mod tests {
         let service = FutureAgentService {
             state: grpc_app_state(true), // verbose logging branch
         };
-        let poller = proto::RpcCommand {
-            id: "cmd-poller".to_string(),
-            r#type: "get_session_events_since".to_string(),
+        let refresh = proto::RpcCommand {
+            id: "cmd-refresh".to_string(),
+            r#type: "list_tool_calls".to_string(),
             session_id: "default".to_string(),
             ..Default::default()
         };
@@ -1164,7 +1181,7 @@ mod tests {
             .unwrap();
         tracing::subscriber::with_default(subscriber, || {
             runtime.block_on(async {
-                let _ = service.execute_command(tonic::Request::new(poller)).await;
+                let _ = service.execute_command(tonic::Request::new(refresh)).await;
                 let _ = service.execute_command(tonic::Request::new(real)).await;
             });
         });
@@ -1172,7 +1189,19 @@ mod tests {
         let bytes = capture.0.lock().unwrap();
         let log = String::from_utf8_lossy(&bytes);
         assert!(log.contains("[grpc] get_agent_info"), "{log}");
-        assert!(!log.contains("[grpc] get_session_events_since"), "{log}");
+        assert!(!log.contains("[grpc] list_tool_calls"), "{log}");
+    }
+
+    /// Every name in the background set is a real command, so a typo cannot
+    /// silently turn a would-be-DEBUG line into dead TRACE-only code.
+    #[test]
+    fn background_commands_are_all_known_commands() {
+        for command in BACKGROUND_COMMANDS {
+            assert!(is_background_command(command), "{command}");
+            assert!(future_rpc::command_policy::command_policy(command).is_some());
+        }
+        assert!(!is_background_command("prompt"));
+        assert!(!is_background_command("abort"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Problem

After #559 (h2 frame tracing) and #560 (cursor/probe polls), `future agent --verbose` still fills up with the desktop **context-panel refresh burst**. The panel polls every 1.5 s while a run is live (`useContextData.ts`), and one refresh sends:

```
DEBUG [grpc] list_models session=- msg=-
DEBUG [grpc] list_providers session=- msg=-
DEBUG [grpc] get_commands session=- msg=-
DEBUG [grpc] get_state session=... msg=-
DEBUG [grpc] refresh_skills session=- msg=-
DEBUG [grpc] get_session_entries session=... msg=-
DEBUG [grpc] list_tool_calls session=... msg=-   ← a dozen in a row, one per run
```

`list_tool_calls` in particular arrives in bursts (one per run of the active thread), plus a `list_models` sweep every 10 s. None of it is a user action.

Separately, one TLS line slipped past #559's target list:

```
DEBUG Sending warning alert CloseNotify
```

rustls logs through the `log` crate (`debug!` from `rustls::log`), which `tracing-subscriber` bridges into tracing via `LogTracer` — so it carries rustls's own target and is caught by a plain target filter.

## Change

**`agent/src/grpc/mod.rs`** — widen the TRACE promotion from `is_poller_command` to `is_background_command`, backed by a `BACKGROUND_COMMANDS` table:

- cursor replays / probes: `get_events_since`, `get_session_events_since`, `list_streaming_sessions`
- panel / catalog reloads: `get_commands`, `get_session_entries`, `get_state`, `get_tool_output`, `list_models`, `list_providers`, `list_tool_calls`, `refresh_skills`

User-intent commands (`prompt`, `abort`, settings mutations, session management, …) keep logging at DEBUG. `RUST_LOG=trace` (or `future_agent::grpc=trace`) still surfaces every request.

**`agent/src/cli.rs`** — add `rustls` to `NOISY_TRANSPORT_TARGETS` (`h2`, `rustls`, `tonic`, `tower`), pinned to WARN. Its DEBUG output is per-record TLS detail; failures still surface at WARN/ERROR.

## Tests

- `verbose_logs_background_commands_at_trace_only` (renamed from the #560 test) — `list_tool_calls` is absent from a `debug`-filtered capture while `get_agent_info` is present.
- `background_commands_are_all_known_commands` (new) — every name in the table resolves through `future_rpc::command_policy::command_policy`, so a typo cannot silently dead-code a log line; `prompt`/`abort` stay outside the set.
- `verbose_default_filter_enables_grpc_debug_events` — extended to assert rustls DEBUG is off (and h2 WARN still on) under `--verbose`.

## Verification

- `cargo fmt -p future-agent --check` ✅
- `cargo clippy -p future-agent --all-targets -- -D warnings` ✅
- `cargo test -p future-agent` — 1707 passed; the 31 failures are the pre-existing Windows-only ones (`sandbox::paths`, `rpc::prompt_helpers`, `sandbox::linux`, …) that fail identically on unmodified `main`.
