### PR TITLE
fix(agent): reuse HTTP connections for Future model refreshes

### DIFF
--- a/agent/src/models/future.rs
+++ b/agent/src/models/future.rs
@@ -26,6 +26,13 @@ const FUTURE_MODELS_REFRESH_BACKOFF: u64 = 30;
 static FUTURE_MODELS_LAST_ATTEMPT: AtomicU64 = AtomicU64::new(0);
 static FUTURE_MODELS_REFRESH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
+// Keep the pool (and blocking client's internal runtime) alive across refresh
+// threads. Initialize only inside fetch_future_models' dedicated thread, never
+// on a Tokio worker. Credentials and URLs remain per-request so auth/provider
+// changes take effect without rebuilding the client.
+static FUTURE_MODELS_HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
+    std::sync::LazyLock::new(reqwest::blocking::Client::new);
+
 /// In-process cache so background refreshes take effect immediately on the
 /// next `Registry::new()` call (GUI polls every 10s), without waiting for
 /// the file cache to be read back from disk.
@@ -280,7 +287,7 @@ fn fetch_future_models(api_key: &str, base_url: &str) -> Option<Vec<Model>> {
 
     std::thread::spawn(move || {
         let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
-        let response = reqwest::blocking::Client::new()
+        let response = FUTURE_MODELS_HTTP_CLIENT
             .get(&url)
             .header("Authorization", format!("Bearer {}", api_key))
             .timeout(std::time::Duration::from_secs(10))
@@ -1186,6 +1193,59 @@ mod tests {
 
         // Connection refused → None (no server listening here).
         assert!(fetch_future_models("k", "http://127.0.0.1:1").is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_future_models_reuses_connection_with_current_credentials() {
+        use std::io::{BufRead, BufReader, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            // Accept exactly one socket: both refreshes must use it, even
+            // though fetch_future_models runs each request on a new thread.
+            let (socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let mut socket = BufReader::new(socket);
+            for key in ["first-key", "rotated-key"] {
+                let mut request = String::new();
+                loop {
+                    let mut line = String::new();
+                    assert_ne!(socket.read_line(&mut line).unwrap(), 0);
+                    if line == "\r\n" {
+                        break;
+                    }
+                    request.push_str(&line);
+                }
+                assert!(request.starts_with("GET /api/v1/models HTTP/1.1\r\n"));
+                assert!(request.lines().any(|line| {
+                    line.split_once(':').is_some_and(|(name, value)| {
+                        name.eq_ignore_ascii_case("authorization")
+                            && value.trim() == format!("Bearer {key}")
+                    })
+                }));
+                let body = r#"{"data":[{"id":"reused-model"}]}"#;
+                write!(
+                    socket.get_mut(),
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            }
+        });
+
+        // Calling from a Tokio runtime also checks that the blocking client's
+        // lazy initialization remains inside the dedicated fetch thread.
+        let first = fetch_future_models("first-key", &format!("{base}/api"));
+        let second = fetch_future_models("rotated-key", &format!("{base}/api"));
+        server.join().unwrap();
+        for models in [first, second] {
+            let models = models.expect("refresh succeeds on the shared connection");
+            assert_eq!(models.len(), 1);
+            assert_eq!(models[0].id, "reused-model");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse a process-lifetime `reqwest::blocking::Client` for Future model-catalog refreshes instead of constructing and dropping a connection pool on every `/api/v1/models` request.
- Lazily initialize the client inside the existing dedicated fetch thread so calls made from a Tokio runtime remain safe. Keep API keys, base URLs and the 10-second timeout per-request; refresh backoff and single-flight behavior are unchanged.
- Add a real HTTP/1.1 regression test that accepts exactly one TCP socket for two fetch calls, verifies a rotated Authorization header, and invokes fetching from a Tokio test runtime.

## Scope

This fixes the confirmed connection-pool lifetime issue in model-catalog refreshes. It does not claim to eliminate all new connections or speed up model generation. LLM clients already retain their HTTP clients; their SSE terminal/cancellation behavior is deliberately unchanged so completion does not wait for HTTP EOF.

**Draft / do not merge:** requested for review only.

## Validation

Rust 1.97.0, Windows, isolated HOME/USERPROFILE:

- `cargo fmt -p future-agent --check` — passed.
- `cargo clippy -p future-agent --all-targets -- -D warnings` — passed.
- `cargo test -p future-agent fetch_future_models_reuses_connection_with_current_credentials` — passed. The same regression test failed against the original per-request Client implementation (server observed EOF before the second request).
- `cargo test -p future-agent` and `cargo test -p future-agent --quiet --no-fail-fast` — run; not green on this Windows host. Patched unit suite: 1704 passed, 35 failed, 1 ignored. `cli_smoke`: 15 passed, 2 failed. All other integration test targets passed.
- Baseline comparison: temporarily restored the original production implementation and ran `cargo test -p future-agent --quiet --no-fail-fast -- --skip fetch_future_models_reuses_connection_with_current_credentials`. Baseline: 1703 passed, **the same 35 unit failures**, 1 ignored, and **the same 2 cli_smoke failures**. Restored the fix and reran checks afterward.

The pre-existing failures concern Windows/POSIX path assumptions, redirected-home assumptions, Unix shell commands, SQLite file locking, and profile smoke tests. In the changed module, the sole existing failure is `cache_path_falls_back_to_tmp_without_home` (`/home/x\\.future/...` vs `/home/x/.future/...`). These unrelated issues are not changed in this PR.
