### PR TITLE
fix(agent): treat absent or zero maxTurns as unlimited

### DIFF
--- a/agent/src/agent/run_loop.rs
+++ b/agent/src/agent/run_loop.rs
@@ -2421,6 +2421,44 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn run_with_zero_max_turns_is_unlimited() {
+        // `max_turns = 0` (also the absent-setting default) means unlimited.
+        // Run well past the 50 the startup path used to hard-code, so a
+        // reintroduced floor fails here instead of only in production.
+        const ROUNDS: usize = 55;
+        let mut scripts: Vec<_> = (0..ROUNDS)
+            .map(|i| {
+                Script::Events(vec![
+                    ev_toolcall_start(0, &format!("c{i}"), "echo", "{}"),
+                    ev_toolcall_end(),
+                    ev_stop(),
+                ])
+            })
+            .collect();
+        scripts.push(Script::Events(vec![ev_text("done"), ev_stop()]));
+        let provider = ScriptedProvider::new(scripts);
+        let loop_ = Loop::new(provider, "mock")
+            .with_tools(vec![echo_tool()])
+            .with_config(crate::types::AgentConfig {
+                max_turns: 0,
+                ..Default::default()
+            });
+        let (text, messages) = loop_
+            .run_streaming_with_messages(
+                user_messages("loop"),
+                &StreamContext::default(),
+                noop_on_text,
+                |_| {},
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(text, "done");
+        // user + (assistant tool_calls + tool result) per round + final assistant
+        assert_eq!(messages.len(), 2 + ROUNDS * 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn run_returns_early_when_interrupt_flag_set() {
         let provider = ScriptedProvider::new(vec![]);
         let loop_ = Loop::new(provider, "mock");

--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -710,14 +710,13 @@ async fn async_main(
         .as_ref()
         .map(crate::models::effective_max_tokens);
 
-    // Build engine config from settings and model config
+    // Build engine config from settings and model config. The turn limit is
+    // opt-in: an absent or non-positive `maxTurns` is passed through as-is and
+    // means unlimited (see `Loop::run_streaming_with_messages`), matching
+    // `DEFAULT_MAX_TURNS` — no hidden floor is imposed here.
     let config = EngineConfig {
         cwd: cwd.clone(),
-        max_turns: if settings.max_turns > 0 {
-            settings.max_turns
-        } else {
-            50
-        },
+        max_turns: settings.max_turns,
         thinking_level: "high".to_string(),
         compaction_reserve_tokens: settings.compaction_reserve_tokens(),
         compaction_keep_recent_tokens: settings.compaction_keep_recent_tokens(),


### PR DESCRIPTION
`~/.future/agent/settings.json` documents `maxTurns: 0` as unlimited and `DEFAULT_MAX_TURNS` is 0, but the agent startup path floored any non-positive value to a hard-coded 50. Anyone who never set `maxTurns` (or set 0) was stopped mid-task with the "Reached the turn limit (50)" error.

- `agent/src/cli.rs`: pass `settings.max_turns` through unchanged — no hidden floor at startup.
- `agent/src/agent/run_loop.rs`: add a test that `max_turns: 0` keeps running past 50 tool-call rounds (fails if a floor is reintroduced).

Positive values still cap the run exactly as before.

Checks (in the worktree, `origin/main` up to date): `cargo fmt -p future-agent --check`, `cargo clippy -p future-agent --all-targets -- -D warnings`, `cargo test -p future-agent`. The 31 failures in that full run are pre-existing on this Windows host (Linux-sandbox tests, shell/path tests, a Windows file-in-use error) and reproduce identically on unmodified `main`; the new and touched tests pass.
