### PR TITLE
fix(desktop): restore Markdown workers and prevent streaming parse starvation

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "vite build",
+    "build": "vite build && node scripts/check-streaming-worker.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\" && npm run typecheck",
     "test": "vitest run",
@@ -46,6 +46,7 @@
     "@types/react-dom": "^19.2.6",
     "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-v8": "^4.1.11",
+    "decode-named-character-reference": "^1.3.0",
     "eslint": "^10.9.1",
     "eslint-plugin-react-refresh": "^0.5.6",
     "eslint-plugin-tailwindcss": "^4.4.0",

--- a/desktop/scripts/check-streaming-worker.mjs
+++ b/desktop/scripts/check-streaming-worker.mjs
@@ -1,0 +1,27 @@
+// Exercise the actual production worker bundle without a DOM. Node/jsdom
+// imports select different package exports and miss browser-only dependencies.
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { runInNewContext } from "node:vm";
+
+const assets = process.argv[2]
+  ? pathToFileURL(`${resolve(process.argv[2])}${sep}`)
+  : new URL("../dist/assets/", import.meta.url);
+const files = (await readdir(assets)).filter(name => /^streamingMarkdown\.worker-.*\.js$/.test(name));
+assert.equal(files.length, 1, "expected one production streaming Markdown worker");
+const source = await readFile(new URL(files[0], assets), "utf8");
+const replies = [];
+const scope = { postMessage: message => replies.push(message) };
+runInNewContext(source, scope, { filename: fileURLToPath(new URL(files[0], assets)), timeout: 10_000 });
+const text = "# Heading &amp; entity\n\nA **paragraph**.\n\nTail";
+scope.onmessage({ data: { id: 1, live: true, text } });
+assert.equal(replies.length, 1);
+assert.equal(replies[0].id, 1);
+assert.equal(replies[0].text, text);
+assert.equal(replies[0].blocks.length, 3);
+assert.equal(replies[0].blocks.map(block => block.content).join(""), text);
+assert.equal(replies[0].blocks[0].live, false);
+assert.equal(replies[0].blocks.at(-1).live, true);
+console.log("Production streaming Markdown worker: DOM-free startup and parsing passed.");

--- a/desktop/src/features/markdown/useStreamingMarkdownBlocks.test.ts
+++ b/desktop/src/features/markdown/useStreamingMarkdownBlocks.test.ts
@@ -1,6 +1,7 @@
 import type { StreamingMarkdownWorkerResponse } from "./streamingMarkdown.worker";
 // @vitest-environment jsdom
-import { act } from "react";
+import { act, createElement, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook } from "../../test/renderHook";
 import * as streamingMarkdownBlocks from "./streamingMarkdownBlocks";
@@ -70,6 +71,24 @@ describe("useStreamingMarkdownBlocks", () => {
     h.unmount();
   });
 
+  it("starts work after StrictMode replays effect setup and cleanup", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    function Probe() {
+      useStreamingMarkdownBlocks("A", true);
+      return null;
+    }
+    try {
+      act(() => root.render(createElement(StrictMode, null, createElement(Probe))));
+      expect(FakeWorker.instances).toHaveLength(2);
+      expect(FakeWorker.instances[0]!.terminated).toBe(true);
+      expect(FakeWorker.instances[1]!.posted).toHaveLength(1);
+    }
+    finally {
+      act(() => root.unmount());
+    }
+  });
+
   it("creates a worker and posts the initial request", () => {
     const h = renderHook(() => useStreamingMarkdownBlocks("A", true));
     expect(FakeWorker.instances).toHaveLength(1);
@@ -124,6 +143,51 @@ describe("useStreamingMarkdownBlocks", () => {
       { id: 1, live: true, text: "A" },
       { id: 2, live: true, text: "AB" },
     ]);
+    h.unmount();
+  });
+
+  it("makes block progress when every worker response trails the token stream", () => {
+    let text = "first\n\n";
+    const h = renderHook(() => useStreamingMarkdownBlocks(text, true));
+    const worker = FakeWorker.instances[0]!;
+    for (let step = 0; step < 5; step++) {
+      const request = worker.posted[worker.posted.length - 1]!;
+      // Tokens arrive faster than the worker can split the previous snapshot.
+      text += `paragraph ${step}\n\n`;
+      h.rerender();
+      respond(worker, {
+        id: request.id,
+        text: request.text,
+        blocks: streamingMarkdownBlocks.splitStreamingMarkdown(request.text, true),
+      });
+    }
+    // Prefix-compatible responses are useful progress, not obsolete work:
+    // only the unparsed suffix should remain in the mutable final block.
+    expect(h.current.length).toBeGreaterThan(1);
+    expect(h.current.map(block => block.content).join("")).toBe(text);
+    expect(h.current[0]).toEqual({ content: "first\n\n", start: 0, live: false });
+    h.unmount();
+  });
+
+  it("does not apply a delayed response from text that was replaced", () => {
+    let text = "old\n\nparagraph";
+    const h = renderHook(() => useStreamingMarkdownBlocks(text, true));
+    const worker = FakeWorker.instances[0]!;
+    text = "new\n\nparagraph";
+    h.rerender();
+    respond(worker, {
+      id: 1,
+      text: "old\n\nparagraph",
+      blocks: streamingMarkdownBlocks.splitStreamingMarkdown("old\n\nparagraph", true),
+    });
+    expect(h.current).toEqual([{ content: text, live: true, start: 0 }]);
+    respond(worker, {
+      id: 2,
+      text,
+      blocks: streamingMarkdownBlocks.splitStreamingMarkdown(text, true),
+    });
+    expect(h.current.length).toBe(2);
+    expect(h.current.map(block => block.content).join("")).toBe(text);
     h.unmount();
   });
 

--- a/desktop/src/features/markdown/useStreamingMarkdownBlocks.ts
+++ b/desktop/src/features/markdown/useStreamingMarkdownBlocks.ts
@@ -92,7 +92,12 @@ export function useStreamingMarkdownBlocks(text: string, live: boolean): Streami
         // failures must not count toward the give-up budget.
         workerFailuresRef.current = 0;
         const latest = event.data.id === latestIdRef.current;
-        if (latest) {
+        // A worker slower than incoming pushes may NEVER return the latest
+        // id. Its parsed prefix still advances stable block boundaries; append
+        // the unparsed suffix provisionally instead of rejecting all progress
+        // and re-parsing an ever-growing tail on the UI thread. Replaced text
+        // is not a compatible prefix and must not resurrect old boundaries.
+        if (textRef.current.startsWith(event.data.text)) {
           setProjection({ blocks: event.data.blocks, text: event.data.text });
         }
         const queued = queuedRef.current;
@@ -140,6 +145,9 @@ export function useStreamingMarkdownBlocks(text: string, live: boolean): Streami
   useEffect(() => () => {
     workerRef.current?.terminate();
     workerRef.current = null;
+    // StrictMode replays setup after cleanup. A terminated worker cannot
+    // finish the old request, so the replacement must start idle.
+    activeRef.current = false;
     queuedRef.current = null;
   }, []);
 

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -50,6 +50,14 @@ function pdfjsWasm(): Plugin {
 export default defineConfig({
   plugins: [react(), tailwindcss(), pdfjsWasm()],
   clearScreen: false,
+  resolve: {
+    alias: {
+      // Vite's browser condition selects index.dom.js, which touches document
+      // at import time and crashes the Markdown worker. Use the DOM-free entry
+      // in both main/worker graphs (dev dependency prebundling shares them).
+      "decode-named-character-reference": createRequire(import.meta.url).resolve("decode-named-character-reference"),
+    },
+  },
   test: {
     setupFiles: ["./src/test/i18nTestSetup.ts"],
   },

--- a/docs/verification/desktop-stream-lag-20260912.md
+++ b/docs/verification/desktop-stream-lag-20260912.md
@@ -1,0 +1,100 @@
+# Desktop 流式输出延迟排查（2026-09-12）
+
+## 结论与验证范围
+
+- 调查会话：`20260912-111503-622625`；基线：`9452a3ed`；修复分支：`claude/desktop-stream-lag`。
+- **已复现并修复**：生产 Markdown worker 引入 DOM 专用依赖而启动失败；持续落后的 worker 结果被全部丢弃；开发环境 StrictMode 重建 worker 后保留 busy 状态。
+- **支持但未做完整端到端归因**：快速、较长的推理输出会放大前端解析负担。没有证据证明这些 DeepSeek 会话发生了缓存溢出。
+- 验证由本次实现者自行执行，不是独立审查。没有调用付费模型，没有重启、替换现有 agent/desktop，也没有修改真实会话数据库。
+- 本地检查完成；安装后的 Windows WebView2 + DeepSeek 实时复测仍待进行。不能将下列受控实验等同于所有用户卡顿已消失。
+
+## 1. 生产 worker 启动即失败
+
+`streamingMarkdown.worker.ts` 经 remark 依赖到 `decode-named-character-reference@1.3.0`。Vite 的 browser 条件选择 `index.dom.js`，该模块顶层执行 `document.createElement('i')`。Web Worker 没有 `document`。
+
+原始证据：
+
+- 主工作区 `desktop/dist/assets/streamingMarkdown.worker-C4VrdgNY.js`，构建时间 2026-09-12 11:00:52，包含该调用。
+- 用新增检查脚本执行这个**实际生产 bundle**，退出码 1：`ReferenceError: document is not defined`。
+- 本地 Chrome 153 / Vite 页面也记录到三次相同 worker 错误，成功响应数为 0。随后 hook 达到 `MAX_WORKER_FAILURES = 3`，持续走同步解析。
+- 这不是只对某个模型成立的缺陷；模型输出速度和累积长度影响退化后的代价。
+
+修复：Vite 精确 alias 该依赖到 Node 解析出的 DOM-free `index.js`，用于主页面和 worker（开发模式依赖预打包共享模块）。明确声明开发依赖，避免依赖偶然的传递依赖提升布局。
+
+`npm run build` 现在自动执行 `scripts/check-streaming-worker.mjs`，在无 DOM 的上下文中启动真实 bundle 并检查一次分块响应。普通 Vitest/Node 模块测试选择的包导出与浏览器不同，原先无法捕获这个打包错误。
+
+修复产物 `streamingMarkdown.worker-KqABNlCu.js` 通过无 DOM 启动和分块验证。
+
+产物 SHA-256：
+
+- 原产物：`87BDEC3879B6FE3956A9094DFC5F0AB1CAE0770B961A2F0B6D28AF5EC27C075B`
+- 修复产物：`F40E5611968C71480A1E0167A217F76A8674F932CDC0CA3C169550B8DBA856D2`
+
+## 2. Worker 结果饥饿
+
+原 hook 只接收 `response.id === latestId`。每次文本更新都会增加 latestId，即使新任务只是排队。如果输入快于解析，所有实际完成的结果都过期。`provisionalProjection` 只能不断把新文本拼进旧尾块，主线程仍解析越来越长的文本。
+
+修复：接受仍是当前文本前缀的完成结果，让已完成块持续推进，只有尚未解析的后缀留在可变尾块；非前缀的文本替换仍拒绝旧结果。
+
+### 受控浏览器对比
+
+真实 `MarkdownContent`、真实 parser worker；固定 60 次文本追加，总计 54,816 字符。人为让 worker 响应落后两个输入 tick，避免后台标签页定时器节流改变实验条件。两组均使用修复后的 DOM-free 打包配置，只改变结果接收条件。
+
+| 指标 | 原 latest-only 条件 | 前缀结果接收修复 |
+|---|---:|---:|
+| 成功交付的 worker 响应 | 29 | 30 |
+| worker 错误 | 0 | 0 |
+| 分块数 | 1 | 116 |
+| 可变尾块字符数 | 54,816 | 2,290 |
+| 拼接内容与输入一致 | 是 | 是 |
+| 观察到的最长 long task | 51ms | 未观察到 >=50ms long task |
+
+这是单次受控机制对比，不是模型吞吐基准或原用户现场的延迟测量。固定 160ms 延迟的早期尝试受后台定时器影响，没有可靠形成持续落后；未用该尝试作为性能结论。
+
+回归测试 `makes block progress when every worker response trails the token stream` 在原逻辑失败（分块数始终 1），修复后通过；另有文本替换防串写测试。
+
+## 3. StrictMode 生命周期
+
+开发入口启用 React StrictMode。cleanup 终止 worker，却没有清除 `activeRef`；重新 setup 时新 worker 认为旧任务仍在执行，只排队、不发任务。新增测试复现第二个 worker 收到 0 个请求，修复 cleanup 清除 busy 状态后收到 1 个请求。
+
+这是开发模式的附加问题，不用于解释生产可执行文件的行为。
+
+## 4. DeepSeek 原始会话统计与缓存假设
+
+通过 SQLite URI `mode=ro` 加 `PRAGMA query_only=ON` 查询本机 agent/app 数据库，仅输出事件类别、时间、计数和错误，不复制提示词或输出正文。检查最近 8 个 `future/deepseek-flash` run：
+
+- 按事件时间戳的自然秒统计，峰值 152–310 事件/秒；不能把事件数直接当 token 数，也不能用自然秒峰值排除更短的瞬时突发。
+- `run-20260912-110338-665082`：27,491 事件，其中 23,264 个 thinking_delta、3,945 个 tool_delta、50 个 tool_end，**没有 text_chunk**。最终错误是达到 50 轮工具调用限制，不是正文丢在 desktop。agent 与 desktop 的 terminal 持久化时间差约 19ms；这不代表逐帧 UI 延迟。
+- `run-20260912-111008-9382ed`：7,521 事件，其中 7,075 个 thinking_delta，约 27,061 推理字符，**没有 text_chunk**；最终由用户取消。
+- 部分更早的取消 run 在 desktop 被记作 completed、agent 为 cancelled，是另一个终态映射现象，本次未修改。
+
+代码中的实际容量/节流：
+
+- agent 当前 run 重放环：2,000 事件；越界可从持久化 journal 重放，并非超过 2,000 就丢正文。
+- broadcast 环：4,096 事件；落后过多会显式报 DataLoss 并重连。
+- gRPC 单消息上限：32 MiB；desktop 请求按事件数/字节预算分页。
+- desktop live projection 有 100ms 合并刷新，因此少量显示延迟是设计行为。
+
+曾考虑分页不断追赶新增事件的假设，但此次记录规模/速率及明确的 worker 复现不足以支持其为主因；没有调整任何缓存大小。现有数据不含同步 UI 帧时间与订阅游标，仍不能绝对排除传输/背压问题。
+
+## 检查与复现入口
+
+在修复 worktree 的 `desktop/` 中：
+
+```powershell
+npm run lint
+npm test
+npm run build
+```
+
+结果：完整 ESLint + `tsc --noEmit` 通过；101 个测试文件 / 873 个测试通过；生产构建及新增 worker smoke 检查通过。构建仍有现有 CSS `::highlight` 优化警告；测试有 Node localStorage 实验性提示等非失败输出。
+
+旧产物仍在时可独立复现打包失败（参数为 assets 目录）：
+
+```powershell
+node scripts/check-streaming-worker.mjs D:/future-os/desktop/dist/assets
+```
+
+关键永久回归用例位于 `desktop/src/features/markdown/useStreamingMarkdownBlocks.test.ts`。临时浏览器入口、数据库统计脚本和 CDP 读取脚本已清理，测试 Vite 服务已停止；没有留下模型任务或付费后台任务。
+
+下一步：将修复构建为 desktop 可执行文件，在用户方便重启 desktop 时复测同样的长推理/工具调用场景；若仍有卡顿，再同步记录 agent idx、desktop 读游标和 WebView long-task 时间，定位剩余链路。

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/react-dom": "^19.2.6",
         "@vitejs/plugin-react": "^6.1.1",
         "@vitest/coverage-v8": "^4.1.11",
+        "decode-named-character-reference": "^1.3.0",
         "eslint": "^10.9.1",
         "eslint-plugin-react-refresh": "^0.5.6",
         "eslint-plugin-tailwindcss": "^4.4.0",


### PR DESCRIPTION
## Summary
- Fix production Markdown worker startup: Vite selected the DOM-only decode-named-character-reference browser export, which throws `document is not defined` in workers and silently moves all parsing back to the UI thread after three failures.
- Accept useful prefix-compatible worker results even when they trail the latest text, preventing streaming block starvation under sustained input.
- Reset the busy flag when StrictMode tears down a worker so its replacement can actually start work.
- Add hook regressions and a DOM-free smoke test of the actual production worker bundle, automatically run by `npm run build`.

## Reproduction evidence
- The original production bundle fails the new startup check; the fixed bundle passes.
- Controlled Chrome test with 54,816 characters and worker delivery two input ticks behind: latest-only acceptance leaves one 54,816-character mutable block; prefix acceptance advances to 116 blocks with a 2,290-character mutable tail. Both preserve exact content.
- Read-only inspection of recent DeepSeek runs did not establish buffer overflow. This is a frontend mechanism reproduction, not a claim that all native WebView2/model end-to-end latency is resolved.
- Details: docs/verification/desktop-stream-lag-20260912.md.

## Validation
- [x] Synced with origin/main immediately before push
- [x] Desktop ESLint and TypeScript (`npm run lint`)
- [x] Full desktop Vitest suite: 101 files, 873 tests
- [x] Production build and actual worker startup/parsing smoke check
- [x] Regression tests fail on the old behavior and pass with the fix
- [ ] Installed native desktop + live DeepSeek follow-up (existing agent/desktop were not replaced)

No Rust implementation changes or buffer-size changes.