### PR TITLE
fix(desktop): resume cached streaming bubbles after thread switches

### DIFF
--- a/desktop/src/features/agent/threadRunProjection.ts
+++ b/desktop/src/features/agent/threadRunProjection.ts
@@ -215,10 +215,14 @@ export async function upsertStreamingPreview(
     const projection = await projectRunForLivePreview(runId, shouldApply);
     if (!projection)
       return;
-    const bubbleId = `stream_${runId}`;
     const content = projection.content.trim();
 
     setMessages((current) => {
+      // Switching back restores the local send's optimistic bubble from the
+      // warm cache. Take over that still-streaming row instead of treating its
+      // different UI id as evidence that this run has already settled.
+      const bubbleId = current.find(message => message.role === "assistant"
+        && message.runId === runId && message.status === "streaming")?.id ?? `stream_${runId}`;
       const base = streamingBubbleBase(current, runId, bubbleId, content);
       if (!base)
         return current;

--- a/desktop/src/features/agent/useRunReattach.switch.test.tsx
+++ b/desktop/src/features/agent/useRunReattach.switch.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import type { MutableRefObject } from "react";
+import type { StoredRun, StoredRunEvent } from "../../integrations/storage/threadStore";
+import { act, useRef } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearThreadMessageSnapshots } from "./threadMessageCache";
+import { resetRunProjection } from "./threadRunProjection";
+import { useRunReattach } from "./useRunReattach";
+import { useThreadMessages } from "./useThreadMessages";
+
+const storage = vi.hoisted(() => ({
+  getLatestRun: vi.fn(),
+  getRun: vi.fn(),
+  getSessionEntriesPage: vi.fn(),
+  listRuns: vi.fn(),
+  listRunEventsSince: vi.fn(),
+  listRunEvents: vi.fn(),
+  listRunEventsBulk: vi.fn(),
+  storedTimeToIso: (value: number) => new Date(value).toISOString(),
+}));
+const listeners = vi.hoisted(() => new Map<string, Set<(event: unknown) => void>>());
+vi.mock("../../integrations/storage/threadStore", () => storage);
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (name: string, handler: (event: unknown) => void) => {
+    const handlers = listeners.get(name) ?? new Set();
+    handlers.add(handler);
+    listeners.set(name, handlers);
+    return () => handlers.delete(handler);
+  }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+const runId = "switch-run-a";
+const time = Date.parse("2026-09-12T00:00:00Z");
+const run = { id: runId, threadId: "A", status: "running", startedAt: time, createdAt: time, updatedAt: time } as StoredRun;
+let activeRun: StoredRun | null;
+let events: StoredRunEvent[];
+let current: ReturnType<typeof useThreadMessages>;
+let sending: MutableRefObject<boolean>;
+let root: ReturnType<typeof createRoot>;
+
+function textEvent(sequence: number, text: string): StoredRunEvent {
+  return { id: `e${sequence}`, runId, sequence, eventType: "text_chunk", payload: JSON.stringify({ text }), createdAt: time };
+}
+
+function Harness({ threadId }: { threadId: string }) {
+  const messages = useThreadMessages({ threadId, agentSessionId: `session-${threadId}` });
+  const sendingRef = useRef(false);
+  const active = messages.recentRun?.status === "running" ? messages.recentRun : null;
+  useRunReattach({
+    threadId,
+    activeRunId: active?.id ?? null,
+    activeRunStartedAt: active?.startedAt ?? null,
+    loadingThread: messages.loadingThread,
+    sendingRef,
+    setMessages: messages.setMessages,
+    refreshRecentRun: messages.refreshRecentRun,
+    reloadMessagesQuiet: messages.reloadMessagesQuiet,
+  });
+  current = messages;
+  sending = sendingRef;
+  return null;
+}
+
+async function switchTo(threadId: string) {
+  await act(async () => root.render(<Harness key={threadId} threadId={threadId} />));
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(200);
+  });
+}
+
+async function startAAndSwitchAway() {
+  await switchTo("A");
+  act(() => {
+    sending.current = true;
+    activeRun = run;
+    current.setRecentRun(run);
+    current.setMessages(messages => [...messages, {
+      id: "pending-a",
+      role: "assistant",
+      runId,
+      status: "streaming",
+      authorKey: "author.researchCopilot",
+      content: "before switch",
+      createdAt: new Date(time).toISOString(),
+    }]);
+  });
+  await switchTo("B");
+  expect(current.messages.every(message => message.runId !== runId)).toBe(true);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  listeners.clear();
+  clearThreadMessageSnapshots();
+  resetRunProjection(runId);
+  activeRun = null;
+  events = [textEvent(0, "before switch")];
+  storage.getLatestRun.mockImplementation(async (threadId: string) => threadId === "A" ? activeRun : null);
+  storage.getRun.mockImplementation(async () => activeRun);
+  storage.listRuns.mockImplementation(async (threadId: string) => threadId === "A" && activeRun ? [activeRun] : []);
+  storage.listRunEventsSince.mockImplementation(async (_runId: string, since: number) => events.filter(event => event.sequence > since));
+  storage.listRunEvents.mockImplementation(async () => events);
+  storage.listRunEventsBulk.mockResolvedValue([]);
+  storage.getSessionEntriesPage.mockImplementation(async (threadId: string) => ({
+    entries: [
+      {
+        id: `user-${threadId}`,
+        kind: "user",
+        role: "user",
+        runId: threadId === "A" ? runId : undefined,
+        run: threadId === "A" && activeRun ? { status: activeRun.status, error: activeRun.errorMessage } : undefined,
+        createdAtMs: time,
+        blocks: [{ kind: "text", text: `prompt ${threadId}` }],
+      },
+      ...(threadId === "A" && activeRun?.status === "completed"
+        ? [{
+            id: "canonical-answer",
+            kind: "assistant",
+            role: "assistant",
+            runId,
+            createdAtMs: time + 1000,
+            blocks: [{ kind: "text", text: "completed while away" }],
+          }]
+        : []),
+    ],
+    nextOffset: 0,
+    hasMore: false,
+  }));
+  root = createRoot(document.createElement("div"));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  vi.useRealTimers();
+  clearThreadMessageSnapshots();
+  resetRunProjection(runId);
+});
+
+describe("switching A -> B -> A", () => {
+  it("takes over the cached optimistic bubble and keeps applying live events", async () => {
+    await startAAndSwitchAway();
+    events.push(textEvent(1, " + while away"));
+    await switchTo("A");
+    expect(current.messages.filter(message => message.role === "assistant")).toMatchObject([
+      { id: "pending-a", content: "before switch + while away", status: "streaming" },
+    ]);
+    events.push(textEvent(2, " + after return"));
+    await act(async () => {
+      for (const handler of listeners.get("thread-runtime-updated") ?? []) {
+        handler({ payload: { updates: [{ threadId: "A", runId, revision: 1, status: "running", resetProjection: false }] } });
+      }
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(current.messages.filter(message => message.role === "assistant")).toMatchObject([
+      { id: "pending-a", content: "before switch + while away + after return", status: "streaming" },
+    ]);
+    await switchTo("B");
+    expect(current.messages.every(message => message.runId !== runId)).toBe(true);
+    events.push(textEvent(3, " + second return"));
+    await switchTo("A");
+    expect(current.messages.filter(message => message.role === "assistant")).toMatchObject([
+      { id: "pending-a", content: "before switch + while away + after return + second return", status: "streaming" },
+    ]);
+  });
+
+  it.each(["completed", "failed", "cancelled"] as const)("settles the cached streaming bubble when A became %s while B was open", async (status) => {
+    await startAAndSwitchAway();
+    activeRun = { ...run, status, endedAt: time + 1000, errorMessage: status === "failed" ? "synthetic failure" : null };
+    await switchTo("A");
+    expect(current.recentRun?.status).toBe(status);
+    expect(current.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+    expect(current.messages.find(message => message.role === "assistant")?.id).toBe("pending-a");
+    if (status === "completed") {
+      expect(current.messages.find(message => message.role === "assistant")).toMatchObject({ content: "completed while away", status: "complete" });
+    }
+    expect(current.messages.some(message => message.status === "streaming")).toBe(false);
+  });
+});

--- a/desktop/src/features/agent/useThreadMessages.ts
+++ b/desktop/src/features/agent/useThreadMessages.ts
@@ -382,7 +382,11 @@ export function useThreadMessages({
       setBlockingLoad(false);
       return;
     }
-    void reloadMessagesQuiet(threadId);
+    // A remount may restore a streaming snapshot whose run finished while
+    // another thread was open. Revalidate that cache, including terminal
+    // status; the request-time baseline still protects writes made during
+    // this read. Otherwise there is no active-run transition to settle it.
+    void reloadMessagesQuiet(threadId, true);
   }, [reloadMessagesQuiet, threadId, workspaceId]);
 
   const loadOlderHistory = useCallback(

--- a/docs/verification/desktop-stream-lag-20260912.md
+++ b/docs/verification/desktop-stream-lag-20260912.md
@@ -98,3 +98,25 @@ node scripts/check-streaming-worker.mjs D:/future-os/desktop/dist/assets
 关键永久回归用例位于 `desktop/src/features/markdown/useStreamingMarkdownBlocks.test.ts`。临时浏览器入口、数据库统计脚本和 CDP 读取脚本已清理，测试 Vite 服务已停止；没有留下模型任务或付费后台任务。
 
 下一步：将修复构建为 desktop 可执行文件，在用户方便重启 desktop 时复测同样的长推理/工具调用场景；若仍有卡顿，再同步记录 agent idx、desktop 读游标和 WebView long-task 时间，定位剩余链路。
+
+## 补充：运行中 A → B → A 后冻结
+
+2026-09-12 同一调查会话中，用户补充了明确的会话切换步骤。以已包含 #564 的 `84fb84ab` 为基线，独立分支 `claude/desktop-reattach-stall` 复现并修复了另外两个状态恢复问题，**不依赖 Markdown、输出速度或事件缓冲容量**。
+
+1. **A 仍在运行**：`threadMessageCache` 恢复了本地发送创建的 `pending-*` 流式气泡。`upsertStreamingPreview` 固定使用 `stream_<runId>` 查找气泡，`streamingBubbleBase` 看到另一个 UI id 的同 run 消息就当作已持久化的结束消息，从而拒绝每次更新。修复为按同 run 的 `streaming` 消息接管原 id，保留 DOM 身份和后续增量刷新。
+2. **A 已在后台结束**：初次历史刷新未启用终态校准，`reconcileThreadHistory` 无条件保留缓存的 streaming 消息。新组件一开始读到的 recentRun 已是 terminal，不会再发生 active → terminal 转换来触发结束刷新。修复为初次加载时允许权威历史校准缓存；请求期间发生的新写入仍受原有 request-time baseline 保护。
+
+复现入口：
+
+```powershell
+cd desktop
+npx vitest run src/features/agent/useRunReattach.switch.test.tsx
+```
+
+测试使用真实 `useThreadMessages`、`useRunReattach`、投影器、缓存和 reconciliation；仅替换存储 IPC 与 Tauri 事件传输。通过 React keyed 挂载/卸载执行 A → B → A。原代码的两个初始用例均失败：切回后仍显示 `before switch`，后台完成后仍是 `streaming`。修复后验证：
+
+- 接收离开期间的增量，切回后继续接收新事件；连续两次切换仍保持单个原 id 气泡。
+- A 的内容不进入 B。
+- 后台 `completed`、`failed`、`cancelled` 三种状态都能结束缓存的 streaming 状态。
+
+本轮最终检查：102 个测试文件 / 877 个测试、ESLint、TypeScript、生产构建、worker smoke 全部通过。属于前端集成复现与实现者自检，尚非安装版 WebView2 的点击端到端验证；没有修改真实数据库、调用付费模型、重启 agent 或替换用户正在运行的 desktop。


### PR DESCRIPTION
## Summary
Fix the reproducible freeze when a running conversation A is backgrounded by switching to B and then reopened.

- Resume the cached optimistic streaming bubble using its existing UI id. Previously the reattach path always targeted stream_<runId>, so the same-run pending bubble was mistaken for a settled reply and all updates were suppressed.
- Revalidate streaming snapshots on mount, including terminal status. A run that finished while B was open otherwise remained streaming forever because the new A instance never observed an active-to-terminal transition.
- Preserve request-time protection for newer writes and keep the original bubble identity.

## Reproduction and coverage
The new integration test uses the real message/reattach hooks, projector, cache and reconciliation with mocked storage IPC and Tauri transport. The original active-return and completed-return cases both failed on main.

- [x] A -> B -> A resumes background output and subsequent live events
- [x] A second round trip keeps one stable bubble and does not leak A into B
- [x] Completed, failed and cancelled runs settle correctly on return
- [x] Full desktop suite: 102 files, 877 tests
- [x] ESLint and TypeScript
- [x] Production build and worker startup/parsing smoke check
- [x] Synced with origin/main immediately before push

This is separate from the Markdown worker fixes in #564 and does not require high model throughput or buffer exhaustion. No running agent/desktop was replaced; installed WebView2 end-to-end confirmation remains a follow-up.