### PR TITLE
build(desktop): keep dist mtimes stable so unchanged embeds skip a full Rust rebuild

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "vite build && node scripts/check-streaming-worker.mjs",
+    "build": "vite build && node scripts/stabilize-dist-mtimes.mjs && node scripts/check-streaming-worker.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\" && npm run typecheck",
     "test": "vitest run",

--- a/desktop/scripts/stabilize-dist-mtimes.mjs
+++ b/desktop/scripts/stabilize-dist-mtimes.mjs
@@ -1,0 +1,93 @@
+// Keep `dist/` mtimes stable so an unchanged frontend does not rebuild the
+// Rust crate.
+//
+// Vite rewrites every file under `dist/` on each build, so byte-identical
+// outputs come out with brand-new mtimes. Tauri embeds `dist/` into the crate
+// (`tauri::generate_context!` expands to `include_bytes!` for every asset), and
+// cargo rebuilds that crate whenever an embedded file's mtime changes — so
+// every `make install` / `tauri build` paid a full ~2min desktop rebuild even
+// with no frontend change and no source change at all.
+//
+// Run right after `vite build`: for every output whose bytes are unchanged,
+// write back the timestamp recorded the last time, so cargo sees an untouched
+// frontend. Only timestamps are ever rewritten, never content, so a stale
+// `dist/` can never be embedded — a changed asset keeps its fresh mtime and the
+// crate rebuilds as it must.
+//
+// The state file records the timestamp actually on disk *after* the write,
+// because that is what cargo stores in its fingerprint. Writing a value through
+// the seconds-as-double conversion in `utimes` is not bit-exact but it is a
+// fixed point, so re-applying a recorded value is a no-op for cargo.
+import { createHash } from "node:crypto";
+import { mkdirSync, readdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopDir = fileURLToPath(new URL("..", import.meta.url));
+const distDir = join(desktopDir, "dist");
+const statePath = join(desktopDir, "node_modules", ".cache", "futureos-dist-mtimes.json");
+
+/** Every file under `dir`, recursively. */
+function walk(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+}
+
+/** `{ [distRelativePath]: { hash, mtimeNs } }`, or `{}` when absent/unreadable. */
+function readState() {
+  try {
+    return JSON.parse(readFileSync(statePath, "utf8"));
+  }
+  catch {
+    return {};
+  }
+}
+
+/** Set the file's mtime and return the value the filesystem ended up storing. */
+function applyMtime(path, mtimeNs) {
+  const { atimeNs } = statSync(path, { bigint: true });
+  utimesSync(path, Number(atimeNs) / 1e9, Number(mtimeNs) / 1e9);
+  return statSync(path, { bigint: true }).mtimeNs;
+}
+
+function main() {
+  let files;
+  try {
+    files = walk(distDir);
+  }
+  catch (error) {
+    console.warn(`frontend dist mtimes: skipped (${error.message})`);
+    return;
+  }
+
+  const previous = readState();
+  const current = {};
+  let preserved = 0;
+  let changed = 0;
+
+  for (const path of files) {
+    const name = relative(distDir, path).split("\\").join("/");
+    const hash = createHash("sha256").update(readFileSync(path)).digest("hex");
+    const recorded = previous[name];
+    // Unchanged content keeps the timestamp cargo already has for it; anything
+    // else is normalized to a value we can reproduce verbatim next time.
+    const mtimeNs = recorded?.hash === hash
+      ? recorded.mtimeNs
+      : statSync(path, { bigint: true }).mtimeNs;
+    current[name] = { hash, mtimeNs: applyMtime(path, mtimeNs).toString() };
+    if (recorded?.hash === hash) {
+      preserved++;
+    }
+    else {
+      changed++;
+    }
+  }
+
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(current)}\n`);
+  console.log(`frontend dist: ${preserved} unchanged (mtime preserved), ${changed} changed/new`);
+}
+
+main();


### PR DESCRIPTION
## Problem

On Windows, `make install` (or any `tauri build`) spent ~130s recompiling the desktop crate **even when nothing changed at all** — no source edit, no frontend edit, warm `target/`.

Measured before the fix (`make install` on a warm tree, no changes):

| step | before |
|---|---|
| CLI cargo | 0.27s |
| npm + Vite + worker check | ~6s |
| **desktop cargo** | **~130s** |
| skills update | ~2s |
| **total** | **144.6s** |

## Root cause

`npm run build` runs Vite, and Vite rewrites **every** file under `desktop/dist/`. Tauri embeds `dist/` into the desktop crate (`tauri::generate_context!` expands to `include_bytes!` for every asset), and cargo invalidates that crate whenever an embedded file's mtime changes.

Measured on a no-op build:

```
before files=380   after files=380
identical content + same mtime : 0
identical content + NEW mtime  : 380   <-- needless invalidation
different content              : 0
```

So the desktop crate (lib + Thin-LTO link of the 35MB binary) was rebuilt on **every** install, even when every embedded byte was unchanged. Cargo stays clean (0.5s) when dist mtimes are left alone.

## Fix

`npm run build` now runs `scripts/stabilize-dist-mtimes.mjs` right after Vite: for every output whose bytes are unchanged it writes the recorded timestamp back, so cargo sees an untouched frontend.

- **Timestamps only, never content** — a stale `dist/` cannot be embedded. A changed asset keeps its fresh mtime and the crate rebuilds as it must.
- State lives in `desktop/node_modules/.cache` (gitignored). CI and fresh clones have none, so their first build behaves exactly as before; the pass is also a no-op when `dist/` is missing.
- `utimes` round-trips through seconds-as-double with ~400ns error, so the pass stores the timestamp actually on disk *after* writing and re-applies that value; pushing a value through the conversion a second time is a fixed point, which is what keeps cargo's fingerprint stable.

## Verification

Desktop JS checks on the merged tree: `tsc --noEmit`, `eslint "src/**/*.{ts,tsx}"`, `eslint scripts/stabilize-dist-mtimes.mjs`, `stylelint`, `vitest run` (877 tests) — all pass.

Stabilizer behavior (worktree, real builds):

- run 1 (no state): `380 changed/new`; runs 2-3: `380 unchanged (mtime preserved)` with byte-identical content and identical mtimes.
- editing `desktop/index.html`: `379 unchanged, 1 changed/new` and exactly that asset kept a fresh mtime — a real change still invalidates the crate.
- reverting the edit: `1 changed/new`; the following no-op build: `380 unchanged`.

End-to-end `make install` on the merged tree (`#3`-`#5` are steady state, after the one-time normalization plus a genuine CLI rebuild caused by the new commit hash):

| run | total | desktop cargo |
|---|---|---|
| #1 (first after the change) | 203.9s | 2m09s |
| #2 | 144.8s | 2m08s |
| #3 | **13.5s** | 0.46s |
| #4 | **15.9s** | 0.42s |
| #5 | **13.2s** | 0.40s |

Steady-state `make install` therefore drops from ~145s to ~13s; the remainder is npm (~6s), Vite (~1.7s), copies and the skills update. Further wins are available separately (skip `npm install` on Windows when manifests are unchanged, avoid the network skills update on a plain install), but the desktop rebuild was ~90% of the cost.
