### PR TITLE
fix(agent): make Ctrl-C always exit the agent

### DIFF
--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -4,6 +4,8 @@
 //! cases; `Cli::parse_from` is fed a synthetic argv whose program name is
 //! always `future-agent`, so help/error text matches the standalone binary.
 
+mod shutdown;
+
 use crate::{Engine, EngineConfig, Manager, ModelRegistry};
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -342,9 +344,14 @@ pub fn run_from_args(args: &[String]) -> Result<()> {
         }
         return Ok(());
     }
+    // Environment hydration must precede the signal thread as well as Tokio's
+    // worker threads: mutating the process environment is only sound here.
+    crate::sandbox::hydrate_from_login_shell();
+    // Outlive runtime destruction, profiler output, and Windows ACE cleanup.
+    let (_shutdown_guard, shutdown_request) = shutdown::ShutdownGuard::start()?;
     run_agent_lifecycle(
         cleanup_windows_sandbox_on_startup,
-        || run(cli),
+        || run(cli, shutdown_request),
         cleanup_windows_sandbox_on_exit,
     )
 }
@@ -389,7 +396,7 @@ fn profiler_fail_at(stage: &str) -> bool {
 }
 
 /// The full agent entry point — the former `main()` body.
-pub(crate) fn run(cli: Cli) -> Result<()> {
+fn run(cli: Cli, shutdown_request: shutdown::ShutdownRequest) -> Result<()> {
     // Resolve profile path early (before the runtime starts).
     // --profile-seconds alone implies CPU profiling with a default path —
     // but NOT when --profile-heap is set: running the CPU sampler during a
@@ -462,12 +469,6 @@ pub(crate) fn run(cli: Cli) -> Result<()> {
         );
     }
 
-    // Load the user's login-shell PATH/env BEFORE spawning any threads or the
-    // tokio runtime — set_var is only sound while single-threaded. Fixes
-    // "command not found" for user-installed tools (nvm/Homebrew/npm-global)
-    // when the agent is launched from a GUI with a minimal inherited PATH.
-    crate::sandbox::hydrate_from_login_shell();
-
     // Initialise tracing with timestamps. The console layer keeps ANSI colors;
     // the optional file layer writes through LogMirror, which shares one
     // mutexed File with the raw streaming prints (eprint_log!) — so the log
@@ -534,7 +535,7 @@ pub(crate) fn run(cli: Cli) -> Result<()> {
         .enable_all()
         .thread_stack_size(2 * 1024 * 1024)
         .build()?
-        .block_on(async_main(model_registry, cli));
+        .block_on(async_main(model_registry, cli, shutdown_request));
 
     // Write profiling flamegraph on shutdown (after the runtime drops,
     // so all async tasks have settled).  ProfilerGuard stops sampling on
@@ -593,6 +594,7 @@ pub(crate) fn run(cli: Cli) -> Result<()> {
 async fn async_main(
     model_registry: Arc<parking_lot::RwLock<ModelRegistry>>,
     cli: Cli,
+    shutdown_request: shutdown::ShutdownRequest,
 ) -> Result<()> {
     let cwd = crate::utils::home_dir().to_string_lossy().to_string();
 
@@ -818,8 +820,8 @@ async fn async_main(
         loop_template,
     };
 
-    // Ctrl+C: set the shutting_down flag so new prompts are rejected, then
-    // abort in-flight streams and exit immediately.
+    // Ctrl+C: reject new prompts and abort in-flight streams. The independent
+    // signal thread remains alive if session locks or runtime teardown stall.
     let shutting_down = app_state.shutting_down.clone();
     let sessions = app_state.sessions.clone();
 
@@ -861,13 +863,15 @@ async fn async_main(
 
     tokio::select! {
         result = server => result?,
-        _ = tokio::signal::ctrl_c() => {
-            tracing::info!("SIGINT received — aborting active streams, exiting immediately");
+        signal = shutdown_request => {
+            signal.context("Ctrl-C listener stopped unexpectedly")?
+                .context("Could not listen for Ctrl-C")?;
             shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
 
             // Interrupt in-flight runs so the process exits promptly instead
             // of waiting for a long LLM stream to finish on its own.
             abort_all_sessions(&sessions);
+            tracing::info!("Ctrl-C received — press Ctrl-C again to force exit");
         }
         _ = profile_rx => {
             // profile timer handled inside the future

--- a/agent/src/cli/shutdown.rs
+++ b/agent/src/cli/shutdown.rs
@@ -1,0 +1,280 @@
+//! Keep Ctrl-C handling alive through runtime teardown and sandbox cleanup.
+//!
+//! Tokio's default runtime drop waits indefinitely for blocking tasks. Listening
+//! on the agent runtime stops working just when those tasks (or a session/log
+//! lock) can stall shutdown. A dedicated thread/runtime has no agent work or
+//! logging on it, so a second interrupt or the grace deadline can always exit.
+
+use futures_util::{Stream, StreamExt};
+use std::io;
+use std::time::Duration;
+use tokio::sync::oneshot;
+
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+pub(super) type ShutdownRequest = oneshot::Receiver<io::Result<()>>;
+
+pub(super) struct ShutdownGuard {
+    finished: Option<oneshot::Sender<()>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ShutdownGuard {
+    pub(super) fn start() -> io::Result<(Self, ShutdownRequest)> {
+        let signals =
+            futures_util::stream::repeat_with(tokio::signal::ctrl_c).then(|signal| signal);
+        Self::with_signals(signals, SHUTDOWN_GRACE)
+    }
+
+    fn with_signals(
+        signals: impl Stream<Item = io::Result<()>> + Send + 'static,
+        grace: Duration,
+    ) -> io::Result<(Self, ShutdownRequest)> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let (requested_tx, requested_rx) = oneshot::channel();
+        let (finished_tx, finished_rx) = oneshot::channel();
+        let thread = std::thread::Builder::new()
+            .name("agent-shutdown".into())
+            .spawn(move || {
+                let force_exit = runtime.block_on(async {
+                    tokio::select! {
+                        biased;
+                        _ = finished_rx => false,
+                        force = watch_interrupts(signals, requested_tx, grace) => force,
+                    }
+                });
+                if force_exit {
+                    // Do not log here: stdout/stderr or the log-file mutex may
+                    // be what blocked shutdown. Forced exit skips destructors;
+                    // Windows Job handles close on process exit and stale ACEs
+                    // are recovered by the next agent's startup cleanup.
+                    std::process::exit(130);
+                }
+            })?;
+        Ok((
+            Self {
+                finished: Some(finished_tx),
+                thread: Some(thread),
+            },
+            requested_rx,
+        ))
+    }
+}
+
+impl Drop for ShutdownGuard {
+    fn drop(&mut self) {
+        if let Some(finished) = self.finished.take() {
+            let _ = finished.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Return true only after a successful first interrupt, followed by another
+/// interrupt or the deadline. Signal registration errors use the normal error
+/// path instead of silently masquerading as Ctrl-C.
+async fn watch_interrupts(
+    signals: impl Stream<Item = io::Result<()>>,
+    requested: oneshot::Sender<io::Result<()>>,
+    grace: Duration,
+) -> bool {
+    tokio::pin!(signals);
+    let first = signals
+        .next()
+        .await
+        .unwrap_or_else(|| Err(io::Error::other("Ctrl-C listener ended")));
+    let received = first.is_ok();
+    // Even if the server already returned (and dropped its receiver), arm the
+    // deadline: runtime destruction or sandbox cleanup may still be stuck.
+    let _ = requested.send(first);
+    if !received {
+        return false;
+    }
+    let deadline = tokio::time::sleep(grace);
+    tokio::pin!(deadline);
+    tokio::select! {
+        _ = &mut deadline => {},
+        second = signals.next() => {
+            if !matches!(second, Some(Ok(()))) {
+                // A broken listener must not disable the already-armed timer.
+                deadline.await;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    #[tokio::test(start_paused = true)]
+    async fn first_interrupt_requests_cleanup_then_deadline_forces_exit() {
+        let (signals, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (requested, request) = oneshot::channel();
+        let watcher = tokio::spawn(watch_interrupts(
+            UnboundedReceiverStream::new(rx),
+            requested,
+            SHUTDOWN_GRACE,
+        ));
+        // Merely running for a long time must not start the shutdown deadline.
+        tokio::time::advance(Duration::from_secs(60)).await;
+        assert!(!watcher.is_finished());
+        signals.send(Ok(())).unwrap();
+        request.await.unwrap().unwrap();
+        tokio::time::advance(SHUTDOWN_GRACE - Duration::from_millis(1)).await;
+        assert!(!watcher.is_finished());
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(watcher.await.unwrap());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn second_interrupt_forces_exit_without_waiting_for_deadline() {
+        let (signals, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (requested, request) = oneshot::channel();
+        let watcher = tokio::spawn(watch_interrupts(
+            UnboundedReceiverStream::new(rx),
+            requested,
+            SHUTDOWN_GRACE,
+        ));
+        signals.send(Ok(())).unwrap();
+        request.await.unwrap().unwrap();
+        let start = tokio::time::Instant::now();
+        signals.send(Ok(())).unwrap();
+        assert!(watcher.await.unwrap());
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_still_applies_after_server_and_signal_stream_end() {
+        let (requested, request) = oneshot::channel();
+        drop(request);
+        let start = tokio::time::Instant::now();
+        assert!(
+            watch_interrupts(
+                futures_util::stream::iter([Ok(())]),
+                requested,
+                SHUTDOWN_GRACE,
+            )
+            .await
+        );
+        assert_eq!(start.elapsed(), SHUTDOWN_GRACE);
+    }
+
+    #[tokio::test]
+    async fn signal_registration_failure_is_returned_without_forcing_exit() {
+        let (requested, request) = oneshot::channel();
+        assert!(
+            !watch_interrupts(
+                futures_util::stream::iter([Err(io::Error::other("registration failed"))]),
+                requested,
+                SHUTDOWN_GRACE,
+            )
+            .await
+        );
+        assert_eq!(
+            request.await.unwrap().unwrap_err().to_string(),
+            "registration failed"
+        );
+    }
+
+    // Run the force-exit path in a child test process: never send a console
+    // interrupt to the developer's running agent or to the test runner. The
+    // child exercises the real watchdog thread and process::exit on every OS.
+    #[test]
+    fn stalled_shutdown_subprocess() {
+        const CHILD_MODE: &str = "FUTURE_TEST_STALLED_SHUTDOWN";
+        if let Ok(mode) = std::env::var(CHILD_MODE) {
+            let (signals, rx) = tokio::sync::mpsc::unbounded_channel();
+            let grace = if mode == "second-interrupt" {
+                Duration::from_secs(60)
+            } else {
+                Duration::from_millis(100)
+            };
+            let (_guard, request) =
+                ShutdownGuard::with_signals(UnboundedReceiverStream::new(rx), grace).unwrap();
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .unwrap();
+            let (started_tx, started_rx) = oneshot::channel();
+            runtime.spawn_blocking(move || {
+                started_tx.send(()).unwrap();
+                loop {
+                    std::thread::park();
+                }
+            });
+            runtime.block_on(async {
+                started_rx.await.unwrap();
+                signals.send(Ok(())).unwrap();
+                request.await.unwrap().unwrap();
+            });
+            if mode == "second-interrupt" {
+                std::thread::spawn(move || {
+                    std::thread::sleep(Duration::from_millis(100));
+                    signals.send(Ok(())).unwrap();
+                });
+            }
+            if mode == "cleanup-lock" {
+                // Simulate a synchronous session/log/cleanup lock blocking the
+                // main thread before it even reaches runtime destruction.
+                let lock = std::sync::Mutex::new(());
+                let _held = lock.lock().unwrap();
+                let _blocked = lock.lock().unwrap();
+            }
+            drop(runtime); // Default drop cannot finish the blocking task.
+            panic!("stalled runtime unexpectedly returned");
+        }
+
+        for mode in ["runtime-drop", "cleanup-lock", "second-interrupt"] {
+            let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "cli::shutdown::tests::stalled_shutdown_subprocess",
+                ])
+                // The child exits the whole process, so its test-harness output
+                // is noise; keep stderr to surface a real panic.
+                .stdout(std::process::Stdio::null())
+                .env(CHILD_MODE, mode)
+                .spawn()
+                .unwrap();
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            let status = loop {
+                if let Some(status) = child.try_wait().unwrap() {
+                    break status;
+                }
+                if std::time::Instant::now() >= deadline {
+                    child.kill().unwrap();
+                    child.wait().unwrap();
+                    panic!("watchdog did not terminate child: {mode}");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            };
+            assert_eq!(status.code(), Some(130), "{mode}");
+        }
+    }
+
+    #[test]
+    fn completed_cleanup_disarms_deadline_and_joins_signal_thread() {
+        let (signals, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (guard, request) =
+            ShutdownGuard::with_signals(UnboundedReceiverStream::new(rx), SHUTDOWN_GRACE).unwrap();
+        signals.send(Ok(())).unwrap();
+        request.blocking_recv().unwrap().unwrap();
+        // Drop must cancel the already-armed timer, not wait for it to fire.
+        drop(guard);
+    }
+
+    #[test]
+    fn normal_exit_stops_and_joins_signal_thread() {
+        let (guard, request) = ShutdownGuard::start().unwrap();
+        drop(guard);
+        assert!(request.blocking_recv().is_err());
+    }
+}


### PR DESCRIPTION
## Problem

`future agent --verbose` sometimes ignores Ctrl-C: the console keeps sitting there and further presses do nothing, so the only way out is closing the terminal.

## Cause

The SIGINT handler was registered on the agent's **own** Tokio runtime (`tokio::signal::ctrl_c()` inside `tokio::select!` in `async_main`). The first Ctrl-C did run — it set `shutting_down` and aborted live sessions — but the process then stopped making progress exactly where blocking work piles up:

- `Runtime::drop` waits **indefinitely** for blocking tasks (`spawn_blocking`) to finish: sandbox process waits (`WaitForSingleObject`), session/index persistence, image decoding for vision requests.
- After the runtime is gone, `run()` writes the profiler flamegraph and `cleanup_windows_sandbox_on_exit()` revokes Windows sandbox ACEs — still no signal handler alive.

At that point the handler is already consumed, so the second (and third) Ctrl-C is dropped. `--verbose` makes it much more likely because longer, tool-heavy sessions leave more sandbox leases and blocking I/O in flight at shutdown.

## Fix

Signal handling moves out of the agent runtime into a dedicated thread with its own current-thread runtime, started before the agent runtime and outliving it (`agent/src/cli/shutdown.rs`):

- **1st Ctrl-C** → forwarded over a oneshot to the server: unchanged graceful shutdown. A registration failure is reported as a normal startup error instead of silently pretending Ctrl-C was pressed.
- **2nd Ctrl-C** → immediate forced exit.
- **5s grace deadline** after the forwarded interrupt → forced exit (status 130) even if nobody presses again.

Forced exit deliberately skips destructors only after shutdown has already stalled: the Windows Job handles close with the process, the singleton lock is released by the OS, and stale ACEs are recovered by `cleanup_windows_sandbox_on_startup()` (the documented crash-recovery path). Normal shutdowns still destroy the guard, cancel the deadline and join the signal thread, so they are not delayed.

`hydrate_from_login_shell()` moves ahead of the signal thread — the `set_var` calls must still run before any other thread exists (this was the only other single-threaded-only code on the startup path; it is not reached by the sessionless `--probe-*` / `--migrate-sessions` maintenance paths).

## Verification

- New `agent/src/cli/shutdown.rs` unit tests (paused clock): no deadline while idle, first interrupt → graceful request + deadline, second interrupt → immediate force, deadline applies even when the server already dropped the receiver, listener failure → no force.
- New `stalled_shutdown_subprocess` test runs a **real** stalled `Runtime::drop`, a synchronous cleanup lock, and the second-interrupt path in a child process and asserts exit code 130 — the watchdog thread itself is what kills the child.
- Existing `agent_shuts_down_cleanly_on_sigint` (Linux CI) now exercises the new wiring end to end: SIGINT → watchdog → graceful exit 0.
- `cargo fmt -p future-agent --check`, `cargo clippy -p future-agent --all-targets -- -D warnings` clean; `cargo test -p future-agent` shows the same failure set as unmodified `main` on this Windows host (verified by stashing the change and diffing the lists — the 31 lib + 2 `cli_smoke` failures are pre-existing Windows-only expectations: `/`-vs-`\` path literals and pprof being Unix-only). CI runs Linux, where those pass.
