### PR TITLE
build: stop paying for an npm install and a skills fetch on every make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	run-agent run-tui run-cli run-desktop run-mobile-android run-mobile-ios run-channels run-loop \
 	profile-agent-build profile-agent profile-quick profile-heap \
 	generate-models generate-proto \
-	install install-cli install-desktop install-skills uninstall package-desktop clean setup
+	install install-cli install-desktop install-skills update-skills uninstall package-desktop clean setup
 
 # ─── Version ────────────────────────────────────────────────────────────────
 # Single source of truth for the build version (scripts/version.mjs); exported
@@ -92,9 +92,11 @@ endif
 	@echo "Removed installed binaries from $(PREFIX)"
 
 # Symlink the built-in skill bundles (skills/builtin/*, incl. future-loop)
-# into the agent's skills directory (orphaned links are pruned).
+# into the agent's skills directory (orphaned links are pruned). Uses the
+# submodule commits already checked out, so `make install` needs no network;
+# `make update-skills` pulls the submodule's remote first.
 install-skills:
-	git submodule update --init --remote skills
+	git submodule update --init skills
 ifeq ($(OS),windows)
 	@if not exist "$(USERPROFILE)\.future\agent\skills" mkdir "$(USERPROFILE)\.future\agent\skills"
 	@for /d %%d in (skills\builtin\*) do @( \
@@ -120,6 +122,12 @@ else
 	done
 endif
 
+# Refresh the built-in skill bundles from the submodule's remote (the only
+# skills step that needs the network), then install them.
+update-skills:
+	git submodule update --init --remote skills
+	$(MAKE) install-skills
+
 # ─── Build ──────────────────────────────────────────────────────────────────
 
 build: build-cli build-desktop
@@ -129,20 +137,14 @@ build-cli:
 
 # Workspace install: shared packages, desktop, and mobile are npm workspaces, so all
 # deps hoist to the root node_modules and one `npm install` at the repo root
-# installs everything. Run it when any manifest is newer than the install stamp
-# (on Windows npm install is idempotent — just run it).
-ifeq ($(OS),windows)
+# installs everything. Run it only when a manifest is newer than npm's own
+# install stamp — scripts/npm-install-if-needed.mjs checks the whole tree, so the
+# workspace the callers name is informational only (npm install is one global
+# operation). cmd/make has no usable mtime test, so Windows used to run a full
+# `npm install` on every build.
 define npm-install-if-needed
-	@npm install --silent
+	@node scripts/npm-install-if-needed.mjs
 endef
-else
-define npm-install-if-needed
-	@if [ ! -f "node_modules/.package-lock.json" ] || [ "package.json" -nt "node_modules/.package-lock.json" ] || [ "$(1)/package.json" -nt "node_modules/.package-lock.json" ]; then \
-		echo "  npm install (workspace)"; \
-		npm install; \
-	fi
-endef
-endif
 
 # Stage the unified `future` CLI as the Tauri sidecar (externalBin).
 desktop-sidecars: build-cli
@@ -393,6 +395,7 @@ help:
 	@echo "  generate-models                     Fetch model data, regenerate Rust catalog + wiki docs"
 	@echo "  generate-proto                      Regenerate wire code (packages/rpc future.proto + channels feishu_ws)"
 	@echo "  install / install-cli / install-desktop / install-skills   Install to $(PREFIX)"
+	@echo "  update-skills                       Pull the skills submodule's remote, then install skills"
 	@echo "  setup                               Bootstrap a fresh clone (JS deps + skills + sidecar)"
 	@echo "  uninstall                           Remove installed binaries from $(PREFIX)"
 	@echo "  package-desktop                     Package desktop bundles"

--- a/scripts/npm-install-if-needed.mjs
+++ b/scripts/npm-install-if-needed.mjs
@@ -1,0 +1,63 @@
+// Install the workspace npm deps only when the manifests moved on.
+//
+// The shared packages, desktop, and mobile are npm workspaces, so one
+// `npm install` at the repo root installs all of them. The Makefile used to
+// branch per platform here: POSIX compared manifest mtimes against npm's
+// install stamp, while Windows ran `npm install` on every build because
+// cmd/make has no usable mtime test — measured at 6-13s of a ~13s
+// `make install`. Node is already required by the Makefile
+// (scripts/version.mjs), so the check lives here and both platforms share it.
+//
+// npm writes `node_modules/.package-lock.json` on every install; anything
+// newer than that stamp means the tree moved on and the deps must be refreshed.
+// A missing stamp (fresh clone, deleted node_modules) always reinstalls.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const stamp = join(root, "node_modules", ".package-lock.json");
+
+/** Every manifest npm reads for this tree: the root, the lockfile, each workspace. */
+function manifests() {
+  const paths = ["package.json", "package-lock.json"];
+  // npm tolerates a UTF-8 BOM in a manifest (Windows editors add them) but
+  // JSON.parse does not, so strip it before parsing.
+  const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8").replace(/^\uFEFF/, ""));
+  for (const entry of manifest.workspaces ?? []) {
+    if (!entry.includes("*")) {
+      paths.push(join(entry, "package.json"));
+      continue;
+    }
+    const [prefix, suffix] = entry.split("*");
+    for (const child of readdirSync(join(root, prefix), { withFileTypes: true })) {
+      if (child.isDirectory()) {
+        paths.push(join(prefix, child.name, suffix, "package.json"));
+      }
+    }
+  }
+  return paths.filter(path => existsSync(join(root, path)));
+}
+
+const installedAt = existsSync(stamp) ? statSync(stamp).mtimeMs : Number.NaN;
+const stale = !existsSync(stamp)
+  || manifests().some(path => statSync(join(root, path)).mtimeMs > installedAt);
+
+if (stale) {
+  console.log("  npm install (workspace manifests changed)");
+  // npm is npm.cmd on Windows, which cannot be spawned directly (Node rejects
+  // .cmd/.bat without a shell) — but `shell: true` cannot be combined with
+  // arguments without a deprecation warning, so go through cmd.exe explicitly.
+  // The command string is fixed, so no argument needs escaping.
+  const [command, args] = process.platform === "win32"
+    ? [process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", "npm install --silent"]]
+    : ["npm", ["install", "--silent"]];
+  try {
+    execFileSync(command, args, { cwd: root, stdio: "inherit" });
+  }
+  catch (error) {
+    console.error(`  npm install failed: ${error.message}`);
+    process.exit(error.status ?? 1);
+  }
+}


### PR DESCRIPTION
## Problem

After the dist-mtime fix (#566), a steady-state `make install` on Windows was ~13s, and two of its steps ran unconditionally even when nothing needed them:

| step | before |
|---|---|
| `npm install` | **5.7-13.3s** |
| Vite + worker check | 1.7s |
| tauri/cargo (now clean) | ~2.5s |
| skills (`--remote` fetch + copy) | **2.2-3.2s** |
| copies, make overhead | ~1s |

**npm install**: the Makefile branched per platform for this. POSIX compared manifest mtimes against npm's install stamp; Windows ran `npm install` every time, because cmd/make has no usable mtime test. Measured directly, a no-op `npm install --silent` costs 6-13s here.

**skills**: `install-skills` passed `--remote` to `git submodule update`, so every install did a network fetch. Measured: `git submodule update --init skills` is 0.6s, adding `--remote` makes it 2.6s, and the whole step was 3.2s.

## Fix

`scripts/npm-install-if-needed.mjs` now does the staleness check for both platforms: it expands the root `workspaces` globs, compares every manifest (`package.json`, `package-lock.json`, each workspace manifest) against `node_modules/.package-lock.json` — the stamp npm itself writes — and installs only when one is newer or the stamp is missing. Skipping costs one Node start (~0.07s).

Two details worth noting:

- On Windows npm is `npm.cmd`, which Node refuses to spawn without a shell (CVE-2024-27980 hardening), while `shell: true` combined with arguments triggers `DEP0190`. The script therefore invokes `cmd.exe` explicitly with a fixed command string — verified with no deprecation warning.
- The manifest is parsed with a leading BOM stripped. npm tolerates a BOM in `package.json` (Windows editors add them), `JSON.parse` does not, and this check runs on every build — a BOM would have broken `make install` rather than the install it guards.

`install-skills` no longer passes `--remote`, so `make install` uses the submodule commits already checked out and works offline. `make update-skills` keeps the refresh-from-remote behaviour (the only skills step that needs the network) and is listed in `make help`.

## Verification

Decision logic, probed in a scratch tree with a copy of the script:

| case | expected | result |
|---|---|---|
| no stamp (fresh clone, deleted node_modules) | install | `npm install (workspace manifests changed)` |
| unchanged tree | skip | silent, 0.07s |
| `packages/a/package.json` bumped after the stamp | install | `npm install (workspace manifests changed)` |
| `package.json` with a UTF-8 BOM | install, no crash | `npm install (workspace manifests changed)` |

The `workspaces` glob expansion is what case 3 exercises (`packages/*` → `packages/a/package.json`); a `desktop`/`mobile` manifest is checked the same way.

End-to-end `make install` numbers on this machine are in the PR comments below.
