### PR TITLE
fix(mobile): unblock history first paint and avoid quadratic replay reads

### DIFF
--- a/desktop/src-tauri/src/agent_bridge/mod.rs
+++ b/desktop/src-tauri/src/agent_bridge/mod.rs
@@ -195,6 +195,15 @@ pub async fn get_events_since_payload(
     run_id: String,
     since_idx: i64,
 ) -> Result<future_rpc::payloads::EventsSincePayload, crate::AppError> {
+    read_events_since(session_id, run_id, since_idx, None).await
+}
+
+async fn read_events_since(
+    session_id: String,
+    run_id: String,
+    since_idx: i64,
+    page_limit: Option<i64>,
+) -> Result<future_rpc::payloads::EventsSincePayload, crate::AppError> {
     let mut client = connect_agent().await?;
     let mut cursor = since_idx;
     let mut merged: Option<future_rpc::payloads::EventsSincePayload> = None;
@@ -202,7 +211,9 @@ pub async fn get_events_since_payload(
         let command = crate::agent_proto::RpcCommand {
             run_id: run_id.clone(),
             since_idx: cursor,
-            max_events: EVENTS_PAGE_SIZE,
+            max_events: page_limit
+                .unwrap_or(EVENTS_PAGE_SIZE)
+                .clamp(1, EVENTS_PAGE_SIZE),
             ..base_command("get_events_since", session_id.clone())
         };
         let response = client
@@ -246,7 +257,11 @@ pub async fn get_events_since_payload(
         if page.run_id.is_empty() {
             page.run_id.clone_from(&run_id);
         }
-        let next = next_events_cursor(&page, cursor);
+        let next = if page_limit.is_some() {
+            None
+        } else {
+            next_events_cursor(&page, cursor)
+        };
         match &mut merged {
             None => merged = Some(page),
             Some(total) => {
@@ -269,8 +284,11 @@ pub async fn get_events_since_payload(
         projection: None,
         has_more: false,
     });
-    // The merged envelope describes the complete tail, not one page.
-    result.has_more = false;
+    // Only the full-tail API has drained all Agent pages. A bounded remote
+    // read must preserve has_more so the phone continues from its cursor.
+    if page_limit.is_none() {
+        result.has_more = false;
+    }
     Ok(result)
 }
 
@@ -283,6 +301,19 @@ pub async fn get_events_since(
     since_idx: i64,
 ) -> Result<serde_json::Value, crate::AppError> {
     serde_json::to_value(get_events_since_payload(session_id, run_id, since_idx).await?)
+        .map_err(|error| format!("Could not serialize get_events_since response: {error}").into())
+}
+
+/// One bounded Agent page for a remote continuation with a pinned watermark.
+/// Unlike the native full-tail API, this must not drain subsequent pages.
+pub(crate) async fn get_events_since_page(
+    session_id: String,
+    run_id: String,
+    since_idx: i64,
+    limit: usize,
+) -> Result<serde_json::Value, crate::AppError> {
+    let limit = limit.min(EVENTS_PAGE_SIZE as usize) as i64;
+    serde_json::to_value(read_events_since(session_id, run_id, since_idx, Some(limit)).await?)
         .map_err(|error| format!("Could not serialize get_events_since response: {error}").into())
 }
 
@@ -2184,6 +2215,29 @@ mod bridge_tests {
         assert_eq!(requests[0].max_events, EVENTS_PAGE_SIZE);
         assert_eq!(requests[1].since_idx, 2, "paging resumes at the last idx");
         assert_eq!(requests[0].run_id, "run-1");
+    }
+
+    #[tokio::test]
+    async fn events_since_remote_page_is_bounded_and_preserves_has_more() {
+        let mock = mock_agent();
+        mock.push_typed_data(
+            "get_events_since",
+            serde_json::json!({"runId": "r", "events": [{"idx": 100}], "hasMore": true}),
+        );
+        let page = get_events_since_page("s".into(), "r".into(), 99, 100)
+            .await
+            .unwrap();
+        assert_eq!(page["hasMore"], true);
+        assert_eq!(page["events"][0]["idx"], 100);
+        let requests = mock.requests_of("get_events_since");
+        assert_eq!(
+            requests.len(),
+            1,
+            "must not drain the remaining Agent pages"
+        );
+        assert_eq!(requests[0].max_events, 100);
+        assert_eq!(requests[0].since_idx, 99);
+        assert_eq!(requests[0].run_id, "r");
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -1752,6 +1752,80 @@ mod bridge_tests {
     }
 
     #[tokio::test]
+    async fn replay_continuations_keep_agent_has_more_and_stop_at_the_pinned_watermark() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("bounded-replay").await;
+        let agent = ensure_mock_agent();
+        agent.clear_scripts();
+        let session = unique("session");
+        let events = |start: i64, end: i64| -> Value {
+            json!((start..=end)
+                .map(|idx| json!({"type": "text_chunk", "idx": idx, "data": "{}"}))
+                .collect::<Vec<_>>())
+        };
+        agent.script_typed_for(
+            "get_events_since",
+            &session,
+            json!({
+                "runId": "r", "events": events(0, 4), "hasMore": false
+            }),
+        );
+        let first = bridge
+            .call(json!({
+                "id": unique("cmd"), "type": "get_events_since", "sessionId": session,
+                "runId": "r", "sinceIdx": -1, "limit": 2
+            }))
+            .await;
+        assert_eq!(first["success"], true);
+        assert_eq!(first["data"]["watermark"], 4);
+        assert_eq!(first["data"]["nextSinceIdx"], 1);
+        assert_eq!(first["data"]["hasMore"], true);
+
+        agent.script_typed_for(
+            "get_events_since",
+            &session,
+            json!({
+                "runId": "r", "events": events(2, 3), "hasMore": true
+            }),
+        );
+        let middle = bridge
+            .call(json!({
+                "id": unique("cmd"), "type": "get_events_since", "sessionId": session,
+                "runId": "r", "sinceIdx": 1, "limit": 2, "replayUntilIdx": 4
+            }))
+            .await;
+        assert_eq!(middle["success"], true);
+        assert_eq!(middle["data"]["watermark"], 4);
+        assert_eq!(middle["data"]["nextSinceIdx"], 3);
+        assert_eq!(
+            middle["data"]["hasMore"], true,
+            "Agent still has another page"
+        );
+
+        // The task kept generating, but this replay must finish at its
+        // original watermark rather than chasing the growing tail forever.
+        agent.script_typed_for(
+            "get_events_since",
+            &session,
+            json!({
+                "runId": "r", "events": events(4, 5), "hasMore": true
+            }),
+        );
+        let last = bridge
+            .call(json!({
+                "id": unique("cmd"), "type": "get_events_since", "sessionId": session,
+                "runId": "r", "sinceIdx": 3, "limit": 2, "replayUntilIdx": 4
+            }))
+            .await;
+        assert_eq!(last["success"], true);
+        assert_eq!(last["data"]["watermark"], 4);
+        assert_eq!(last["data"]["nextSinceIdx"], 4);
+        assert_eq!(last["data"]["hasMore"], false);
+        assert_eq!(last["data"]["events"].as_array().unwrap().len(), 1);
+        bridge.stop();
+    }
+
+    #[tokio::test]
     async fn transfer_control_commands() {
         let _lock = mock_agent_lock();
         let (_home, bridge) = active_bridge("cmd-transfer").await;

--- a/desktop/src-tauri/src/remote_host/business.rs
+++ b/desktop/src-tauri/src/remote_host/business.rs
@@ -118,13 +118,27 @@ pub(crate) async fn execute(cmd: IncomingCmd, sink: &dyn ReplySink) {
             } else {
                 DEFAULT_MESSAGE_PAGE_LIMIT
             };
-            match crate::agent_bridge::get_events_since(
-                cmd.session_id.clone(),
-                cmd.run_id.clone(),
-                cmd.since_idx,
-            )
-            .await
-            {
+            // The first read captures the existing protocol's fixed replay
+            // watermark. Continuations already carry it, so fetch only one
+            // Agent page rather than rereading the entire remaining tail.
+            // Keep legacy offset callers on the full-tail path.
+            let data = if cmd.replay_until_idx.is_some() && offset == 0 {
+                crate::agent_bridge::get_events_since_page(
+                    cmd.session_id.clone(),
+                    cmd.run_id.clone(),
+                    cmd.since_idx,
+                    limit,
+                )
+                .await
+            } else {
+                crate::agent_bridge::get_events_since(
+                    cmd.session_id.clone(),
+                    cmd.run_id.clone(),
+                    cmd.since_idx,
+                )
+                .await
+            };
+            match data {
                 Ok(mut data) => {
                     let source_watermark = data["events"]
                         .as_array()
@@ -147,6 +161,7 @@ pub(crate) async fn execute(cmd: IncomingCmd, sink: &dyn ReplySink) {
                             event["idx"].as_i64().is_none_or(|idx| idx <= watermark)
                         });
                     }
+                    let agent_has_more = data["hasMore"].as_bool().unwrap_or(false);
                     let mut page = paginate_events(data, offset, limit);
                     page["watermark"] = json!(watermark);
                     page["nextSinceIdx"] = page["events"]
@@ -155,6 +170,14 @@ pub(crate) async fn execute(cmd: IncomingCmd, sink: &dyn ReplySink) {
                         .and_then(|event| event.get("idx"))
                         .cloned()
                         .unwrap_or(json!(cmd.since_idx));
+                    // The local byte/count budget and the Agent page can each
+                    // leave a suffix. Stop at the original watermark even if
+                    // the run has produced more events since the first page.
+                    let next = page["nextSinceIdx"].as_i64().unwrap_or(cmd.since_idx);
+                    page["hasMore"] = json!(
+                        next < watermark
+                            && (agent_has_more || page["hasMore"].as_bool().unwrap_or(false))
+                    );
                     reply(sink, true, page, None).await;
                 }
                 Err(e) => reply(sink, false, Value::Null, Some(&e.to_string())).await,

--- a/docs/mobile-latency-diagnosis.md
+++ b/docs/mobile-latency-diagnosis.md
@@ -1,0 +1,57 @@
+# Mobile history-loading latency: reproduction and verification
+
+Date: 2026-09-12. Baseline: `c5e87eec`. Local platform: Windows.
+
+## Diagnosed causes
+
+1. Mobile's cold-open sync waited for the entire active-run replay before committing already-available history. Its 15-second history-loading timer could therefore expire even though history succeeded and every individual replay request succeeded.
+2. Each remote replay page consumed at most 100 events by default, but Desktop first read the complete remaining Agent tail, then paginated it. Long runs repeatedly decoded and transferred the same suffix over local gRPC.
+
+Basic probes did not reproduce a transport outage: recent history reads took approximately 5–151 ms; another eight long-history samples took approximately 82–415 ms. Computer-side NATS WebSocket connections took 145/158 ms and PING/PONG approximately 15–18 ms. These are not measurements of the phone's network, handshake, or rendering.
+
+## Fix
+
+- Publish a cold-open history preview before awaiting replay. Do not advance the replay cursor or mark the lane established. A failed replay leaves history readable and retries its full prefix. Ignore stale state/history completions after a lane is replaced.
+- Preserve the existing replay protocol: the first full-tail read establishes its fixed watermark. Continuations carrying that watermark and an event cursor request one bounded Agent page instead of draining the suffix. Preserve Agent `hasMore` as well as the remote byte budget, and stop at the original watermark when the task keeps generating.
+- Native full-tail consumers and legacy offset callers keep their existing behavior. No protobuf changes, new credentials, or pairing changes are required.
+
+The first snapshot is still a full-tail read; this change removes repeated full-tail reads, not that initial cost. Oversized single-exchange history/projection hardening is separate from these two verified fixes.
+
+## Measurements
+
+A read-only probe called the real running Agent over the current user's named pipe for the same retained task and fixed watermark: 7,290 events, 73 cursor pages.
+
+| Read strategy | Total events read | Local probe elapsed |
+|---|---:|---:|
+| Baseline: read full remaining tail on every page | 269,370 | 6,649 ms |
+| Fixed strategy: initial full snapshot, bounded continuations | 14,480 | 496 ms |
+| Bounded-everywhere control, without initial snapshot cost | 7,290 | 280 ms |
+
+The probe reproduces 100-event cursor progression to isolate local read amplification; it is not a phone end-to-end benchmark. Elapsed time includes local RPC and probe protobuf handling, but excludes Desktop JSON processing, relay/phone networking and React Native rendering. Real byte-budget cuts may require additional pages. The services were not restarted or replaced during these probes.
+
+A deterministic probe executed the actual Mobile `SyncEngine` and `fetchEventsSince` code with 4,800 synthetic events and explicitly simulated 350 ms per-page latency:
+
+| Observation | Baseline | Fixed |
+|---|---:|---:|
+| History available | 0 ms | 0 ms |
+| First timeline commit | 16,800 ms | 0 ms |
+| Timeline absent at 15 seconds | yes | no |
+| Replay request count | 48 | 48 |
+
+The zero is fake-clock time, not a real-world zero-latency rendering claim. Durable automated regressions now cover early history, replay failure/retry, and the actual history-loading hook remaining free of timeout while replay is delayed for 20 seconds.
+
+## Local checks
+
+- Mobile typecheck and ESLint: passed.
+- Mobile Jest: **49 suites, 702 tests passed**. On Windows, passed `--testMatch '**/__tests__/**/*.test.ts'` to avoid mixed-separator expansion of `<rootDir>`; all Mobile suites ran.
+- Desktop `cargo fmt --check`: passed.
+- Desktop `cargo clippy --all-targets -- -D warnings`: passed.
+- Desktop replay-focused tests: 11 event-reader tests plus the remote command/Agent integration regression passed. The latter checks initial watermark, intermediate `hasMore`, and termination despite newly appended events.
+- Desktop binary test: passed.
+- Desktop full library suite: **1,110 passed, 26 failed**. An unmodified-baseline run in the same worktree/environment produced **1,108 passed, the identical 26 failures**. The two added Rust tests account for the increase in passes. Baseline binary test passed; its one doc test is ignored.
+
+The unchanged Windows failures comprise three path assertions; sixteen `git_review` fixtures failing `File::set_modified` on read-only handles; four shadow-repository fixture/platform failures; and three remote fake-server scheduling assertions. They were not hidden, skipped, or repaired as unrelated changes. Linux CI and the three-platform build checks remain the merge gate.
+
+## Remaining validation boundary
+
+No real-phone failing request trace was captured in this session. These results establish the reproduced history/replay defects and their automated fixes, not a claim that every mobile connection failure is resolved. Installing updated Mobile and Desktop builds is required to exercise both fixes on a physical device.

--- a/mobile/src/remote/__tests__/syncEngine.test.ts
+++ b/mobile/src/remote/__tests__/syncEngine.test.ts
@@ -120,6 +120,58 @@ class Harness {
 }
 
 describe("SyncEngine", () => {
+  test("publishes cold history before slow replay without claiming a complete prefix", async () => {
+    jest.useFakeTimers();
+    const history = emptyTimeline();
+    history.items = [{ kind: "message", id: "prompt", role: "user", text: "hello", runId: "r" }];
+    const replay = jest.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 16_800));
+      return { events: [agentStart("r"), textChunk("r", 1, "reply"), agentEnd("r", 2)].map(event => ({ ...event })) };
+    });
+    const engine = new SyncEngine({
+      requestGetState: async () => ({ activeRun: { runId: "r" } }),
+      requestHistory: async () => history,
+      fetchReplay: replay,
+    });
+    const commits = jest.fn();
+    engine.subscribe(commits);
+    try {
+      engine.reconcile("s", "open");
+      await jest.advanceTimersByTimeAsync(15_000);
+      expect(commits).toHaveBeenCalledTimes(1);
+      expect(engine.timelineFor("s")?.items).toEqual(history.items);
+      expect(engine.streamingFor("s")).toBe(true);
+      expect(engine.cursorFor("s").size).toBe(0);
+      await jest.advanceTimersByTimeAsync(1_801);
+      expect(engine.timelineFor("s")?.items.filter(item => item.id === "prompt")).toHaveLength(1);
+      expect(engine.streamingFor("s")).toBe(false);
+      expect(engine.cursorFor("s").size).toBe(1);
+    } finally {
+      engine.clear();
+      jest.useRealTimers();
+    }
+  });
+
+  test("keeps early history readable after replay failure and retries the full prefix", async () => {
+    jest.useFakeTimers();
+    const h = new Harness("r");
+    h.history.items = [{ kind: "message", id: "prompt", role: "user", text: "hello", runId: "r" }];
+    h.replayFailures = 1;
+    h.journal.add(agentStart("r"));
+    h.journal.add(textChunk("r", 1, "reply"));
+    try {
+      h.engine.reconcile("s", "open");
+      await jest.advanceTimersByTimeAsync(10);
+      expect(h.textOf("s")).toBe("hello");
+      expect(h.engine.cursorFor("s").size).toBe(0);
+      await jest.advanceTimersByTimeAsync(600);
+      expect(h.textOf("s")).toBe("helloreply");
+    } finally {
+      h.engine.clear();
+      jest.useRealTimers();
+    }
+  });
+
   beforeEach(() => {
     resetSeq();
   });

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -102,6 +102,34 @@ describe("useTimelineController", () => {
     await flush();
   }
 
+  test("slow active-run replay does not trigger the 15-second history timeout", async () => {
+    jest.useFakeTimers();
+    options.selectedSessionId = "s1";
+    options.selectedRef.current = "s1";
+    request.mockImplementation(async (command: { type: string }) => {
+      if (command.type === "get_state") return { data: { activeRun: { runId: "r" } } };
+      if (command.type === "get_session_entries") return { data: { entries: [userEntry("u", "readable history")] } };
+      await new Promise(resolve => setTimeout(resolve, 20_000));
+      return { data: { events: [] } };
+    });
+    try {
+      render();
+      await establish();
+      expect(result.current.timelinePending).toBe(false);
+      expect(result.current.timeline.items).toHaveLength(1);
+      await act(async () => { await jest.advanceTimersByTimeAsync(15_001); });
+      expect(result.current.timelinePending).toBe(false);
+      expect(result.current.timelineError).toBeNull();
+      expect(result.current.timeline.items[0]).toMatchObject({ id: "m_u", text: "readable history" });
+      await act(async () => { await jest.advanceTimersByTimeAsync(5_000); });
+      expect(result.current.timelineError).toBeNull();
+    } finally {
+      act(() => renderer!.unmount());
+      renderer = null;
+      jest.useRealTimers();
+    }
+  });
+
   test.each(["restart", "resend"])(
     "%s refreshes an idle session and keeps disjoint history reachable",
     async mode => {

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -209,7 +209,7 @@ export class SyncEngine {
       ops: [],
       bufferedBytes: 0,
       replayQueue: [],
-      established: previous?.timeline != null,
+      established: previous?.established ?? false,
       retryAttempt: 0,
       retryNotBefore: 0,
       retryTimer: null,
@@ -372,6 +372,7 @@ export class SyncEngine {
     let targetRunId = request.runId ?? "";
     try {
       const state = await this.deps.requestGetState(lane.sessionId);
+      if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
       const activeRunId = state.activeRun?.runId ?? "";
       // The reconcile target is the requested run (a snapshot-flip run that
       // just settled is no longer active) else the active run.
@@ -381,8 +382,17 @@ export class SyncEngine {
       if (full) {
         stage = "history";
         const history = await this.deps.requestHistory(lane.sessionId);
+        if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
         let base = mergeLiveInto(history, lane.timeline);
         if (targetRunId) {
+          // History is already readable. A cold open must not wait for every
+          // replay page before its first paint (or turn a slow replay into a
+          // history timeout). This preview does NOT establish the lane or
+          // advance its cursor; live ops still queue behind the full replay.
+          if (lane.timeline === null) {
+            lane.timeline = { ...base, streaming: !!activeRunId };
+            this.commit(lane);
+          }
           stage = "replay";
           base = stripRunItems(base, targetRunId);
           base = await this.replayInto(lane, base, targetRunId, -1);
@@ -566,7 +576,7 @@ export class SyncEngine {
     // A lane with no committed timeline has no live baseline to top up — the
     // only way to build it is from durable history (idle sessions have no
     // active run for a tail reconcile to target).
-    if (lane.timeline === null) return true;
+    if (!lane.established || lane.timeline === null) return true;
     return !isPrefixComplete(lane.cursor, runId);
   }
 


### PR DESCRIPTION
## Summary
- Render cold-open history before active-run replay finishes, without claiming a complete prefix or losing retry/cursor correctness.
- Stop rereading the full remaining Agent event tail on every remote page. Keep the first snapshot for the existing fixed watermark, then use bounded Agent pages for cursor continuations.
- Preserve native full-tail consumers, legacy offset clients, byte-budget pagination and termination at the pinned watermark.

## Reproduction and verification
- Actual retained 7,290-event task, local gRPC probe: baseline 269,370 event reads / 6,649 ms; fixed read strategy 14,480 reads / 496 ms. This isolates the local read path, not physical-phone end-to-end latency.
- Actual Mobile SyncEngine with simulated 350 ms/page and 4,800 events: first history commit moves from 16.8 seconds to immediate history availability; full replay still completes correctly.
- Regression tests cover slow replay, replay failure/retry, 15-second hook timeout prevention, bounded Agent reads, continuation hasMore, and a task growing beyond the original watermark.

## Checks
- Mobile typecheck + ESLint passed; 49 Jest suites / 702 tests passed.
- Desktop cargo fmt --check and clippy --all-targets -- -D warnings passed.
- Desktop replay-focused tests and binary test passed.
- Full Windows Desktop library tests: 1,110 pass / 26 fail. Verified against unmodified c5e87eec in the same worktree/environment: 1,108 pass / the identical 26 failures (path/readonly-file-time/platform fixtures and fake-server scheduling). No new failures; the two new Rust tests pass. Linux CI remains required.

See docs/mobile-latency-diagnosis.md for measured scope, exact limitations and baseline comparison. No running user services or credentials were changed. Both updated Mobile and Desktop builds are needed for the full improvement.