### PR TITLE
perf(desktop): avoid file-tree rescans on text-only stream updates

### DIFF
--- a/desktop/DEV_MD/STREAMING_RENDERING_FIXES.md
+++ b/desktop/DEV_MD/STREAMING_RENDERING_FIXES.md
@@ -88,3 +88,23 @@ npx vite preview --host 127.0.0.1 --port 5190 --outDir benchmark-dist
 打开 `/scripts/streaming-markdown-benchmark.html`。前台保持可见；每种 rows 先测 baseline 再测 worker。再次测 baseline 前必须重新加载页面，避免共享 parser 的缓存命中污染基线。结果在页面及 console 中；生产模式的 React Profiler 数字为 0，应忽略，使用 push/formatReady/heartbeat 三项。完成后删除 `benchmark-dist`。
 
 原有审查及复现记录来自本任务会话；影响记录不意味着已安装新桌面程序或已合并到 main。
+
+## 后续优化：停止文字输出引起的无效目录扫描
+
+基线：合并后的 `11fabb04`（PR #570）。
+
+真实调用链：`projectRunForLivePreview` 在历史 activityItems 非空时无条件发出 `file-tree-refresh`；`FileTreePanel` 虽将事件合并到每 2 秒一次，但 `useFileTree.refresh` 仍会重读根目录及所有展开目录。因此一次工具操作后，后续纯文本/推理输出会一直触发目录读取，与实际文件变化无关。
+
+修复只依据**新摄入事件**决定失效：工具 start/end/result，以及可能包含中断写入的 agent_end/error。文字、推理、工具参数增量和空读取不再触发目录刷新。空增量读取同时复用已有投影 snapshot，而不是重新分配 segments/activityItems。
+
+验证使用真实 `FileTreePanel`、`useFileTree`、事件总线与 run projector，替换 IPC 为 spy 并使用虚拟时钟：
+
+| 场景 | 修复前 listDirectory 调用 | 修复后 |
+|---|---:|---:|
+| 初次打开 + 首个工具操作完成 | 2 | 2 |
+| 随后 120 秒，每 100ms 一个文本/推理更新，共 1200 次 | **60** | **0** |
+| 下一个工具完成后的刷新 | 1 | 1 |
+
+单根目录的纯输出阶段消除 100% 的多余目录请求；不将此请求数变化宣称为 CPU、磁盘吞吐或 FPS 百分比。对于展开目录，实际一次 refresh 会读取根及展开目录，但多目录倍率未在这个 fixture 中实测。
+
+新增测试 `features/filetree/FileTreePanel.streaming.test.tsx` 先在基线上复现 60 次非预期调用，再在修复后通过；另验证 tool_end/tool_result/agent_end/error 仍触发刷新、空读取复用 snapshot。保留现有 2 秒刷新合并和手动刷新行为，避免为省请求而漏掉真正工具操作的文件变化。本轮 desktop 类型检查、lint 通过，全量测试为 106 个文件、915 个测试通过。

--- a/desktop/src/features/agent/threadRunProjection.async.test.ts
+++ b/desktop/src/features/agent/threadRunProjection.async.test.ts
@@ -234,6 +234,43 @@ describe("buildStreamingPreview", () => {
   });
 });
 
+describe("file-tree invalidation follows new tool events, not historical activity", () => {
+  it.each(["tool_end", "tool_result", "agent_end", "error"])("still refreshes on %s after text-only updates", async (eventType) => {
+    const runId = `tree-lifecycle-${eventType}`;
+    listRunEventsSince.mockResolvedValue(runEvents(runId, [
+      ["toolcall_start", { tool_id: "t1", tool_name: "shell" }],
+    ]));
+    await buildStreamingPreview(runId);
+    vi.mocked(emitFutureEvent).mockClear();
+    listRunEventsSince.mockResolvedValue(runEvents(runId, [
+      ["thinking_delta", { text: "reasoning" }],
+      ["text_chunk", { text: "answer" }],
+      ["toolcall_delta", { text: "arguments" }],
+    ], 1));
+    await buildStreamingPreview(runId);
+    expect(emitFutureEvent).not.toHaveBeenCalled();
+    listRunEventsSince.mockResolvedValue(runEvents(runId, [
+      [eventType, { tool_id: "t1", tool_name: "shell", text: "done", state: "cancelled" }],
+    ], 4));
+    await buildStreamingPreview(runId);
+    expect(emitFutureEvent).toHaveBeenCalledWith("file-tree-refresh", undefined);
+  });
+
+  it("reuses the cached snapshot on empty reads without another invalidation", async () => {
+    const runId = "tree-empty-read";
+    listRunEventsSince.mockResolvedValue(runEvents(runId, [
+      ["tool_start", { tool_id: "t1", tool_name: "write" }],
+    ]));
+    const before = await buildStreamingPreview(runId);
+    vi.mocked(emitFutureEvent).mockClear();
+    listRunEventsSince.mockResolvedValue([]);
+    const after = await buildStreamingPreview(runId);
+    expect(after?.segments).toBe(before?.segments);
+    expect(after?.activityItems).toBe(before?.activityItems);
+    expect(emitFutureEvent).not.toHaveBeenCalled();
+  });
+});
+
 describe("updatePendingMessageFromRunEvents", () => {
   it("returns early when the send is stale", async () => {
     listRunEventsSince.mockResolvedValue(textEvents("r-p1", "text"));

--- a/desktop/src/features/agent/threadRunProjection.ts
+++ b/desktop/src/features/agent/threadRunProjection.ts
@@ -38,6 +38,16 @@ const LIVE_PROJECTION_CACHE_MAX = 8;
 
 const liveProjectionCache = new Map<string, LiveProjectionEntry>();
 
+const FILE_TREE_INVALIDATING_EVENTS = new Set([
+  "toolcall_start",
+  "tool_start",
+  "tool_end",
+  "tool_result",
+  // An interrupted tool may have written files without emitting tool_end.
+  "agent_end",
+  "error",
+]);
+
 /**
  * Drop an incremental projector after the backend replaces its local event
  * log with an Agent projection snapshot. The next push rebuilds from the new
@@ -95,9 +105,17 @@ async function projectRunForLivePreview(
     liveProjectionCache.delete(oldest);
   }
 
-  entry.projection = entry.projector.ingest(events);
-  if (entry.projection.activityItems.length > 0)
+  const previousSequence = entry.projector.lastSequence;
+  const unseen = events.filter(event => event.sequence > previousSequence);
+  if (unseen.length > 0 || !entry.projection)
+    entry.projection = entry.projector.ingest(unseen);
+  // Historical tool activity stays in every snapshot. Text/thinking/argument
+  // deltas are not filesystem changes: invalidating on that history rescanned
+  // every expanded directory every 2s for the remainder of a long reply.
+  if (entry.projection.activityItems.length > 0
+    && unseen.some(event => FILE_TREE_INVALIDATING_EVENTS.has(event.eventType))) {
     emitFutureEvent("file-tree-refresh", undefined);
+  }
   return entry.projection;
 }
 

--- a/desktop/src/features/filetree/FileTreePanel.streaming.test.tsx
+++ b/desktop/src/features/filetree/FileTreePanel.streaming.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import type { StoredRunEvent } from "../../integrations/storage/threadStore";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+import { buildStreamingPreview, resetRunProjection } from "../agent/threadRunProjection";
+import { FileTreePanel } from "./FileTreePanel";
+
+const storage = vi.hoisted(() => ({ listDirectory: vi.fn(async () => []), listRunEventsSince: vi.fn() }));
+vi.mock("../../integrations/storage/files", async original => ({
+  ...await original<typeof import("../../integrations/storage/files")>(),
+  listDirectory: storage.listDirectory,
+}));
+vi.mock("../../integrations/storage/threadStore", async original => ({
+  ...await original<typeof import("../../integrations/storage/threadStore")>(),
+  listRunEventsSince: storage.listRunEventsSince,
+}));
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+it("does not rescan directories during 120 seconds of text after a tool completes", async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    disconnect() {}
+  });
+  const runId = "filetree-text-after-tool";
+  resetRunProjection(runId);
+  const host = document.createElement("div");
+  const root = createRoot(host);
+  let sequence = 0;
+  async function push(eventType: string, payload: Record<string, unknown>) {
+    const event: StoredRunEvent = {
+      id: `event-${sequence}`,
+      runId,
+      sequence: sequence++,
+      eventType,
+      payload: JSON.stringify(payload),
+      createdAt: 1,
+    };
+    storage.listRunEventsSince.mockResolvedValueOnce([event]);
+    await buildStreamingPreview(runId);
+  }
+  try {
+    await act(async () => root.render(<FileTreePanel rootPath="C:/synthetic-filetree-profile" isWorkspace />));
+    await act(async () => {
+      await push("toolcall_start", { tool_id: "tool-1", tool_name: "write", tool_args: { path: "a.txt" } });
+      await push("tool_end", { tool_id: "tool-1", tool_name: "write", text: "done" });
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    // Initial mount plus the coalesced tool refresh.
+    expect(storage.listDirectory).toHaveBeenCalledTimes(2);
+    storage.listDirectory.mockClear();
+    for (let tick = 0; tick < 1200; tick++) {
+      await act(async () => {
+        await push(tick % 2 ? "text_chunk" : "thinking_delta", { text: "x" });
+        await vi.advanceTimersByTimeAsync(100);
+      });
+    }
+    expect(storage.listDirectory).not.toHaveBeenCalled();
+    await act(async () => {
+      await push("toolcall_start", { tool_id: "tool-2", tool_name: "shell", tool_args: { command: "generate files" } });
+      await push("tool_end", { tool_id: "tool-2", tool_name: "shell", text: "done" });
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(storage.listDirectory).toHaveBeenCalledTimes(1);
+  }
+  finally {
+    act(() => root.unmount());
+    resetRunProjection(runId);
+  }
+}, 15000);

--- a/desktop/src/features/filetree/FileTreePanel.tsx
+++ b/desktop/src/features/filetree/FileTreePanel.tsx
@@ -48,9 +48,9 @@ export function FileTreePanel({
   const listScrollbar = useFloatingScrollbar();
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Auto-refresh when the agent completes a write/edit/shell tool so newly
-  // created or modified files appear without manual intervention. Debounced:
-  // at most one refresh per 2 s — the event fires every poll tick (220 ms).
+  // Auto-refresh on tool lifecycle/termination so newly created or modified
+  // files appear without manual intervention. Coalesce bursts to at most one
+  // refresh per 2s; text/thinking-only stream updates do not invalidate the tree.
   const { refresh: refreshTree } = tree;
   useEffect(() => {
     const unsubscribe = onFutureEvent("file-tree-refresh", () => {


### PR DESCRIPTION
## Summary

Follow-up to #570: stop using historical tool activity as evidence that every text/thinking tick changed the filesystem.

- Invalidate the file tree only for newly ingested tool start/end/result or run termination/error events (termination covers interrupted writes).
- Do not rescan directories for text, reasoning, tool argument deltas or empty reads.
- Reuse the existing projection snapshot for empty/overlapping reads.
- Retain the panel's 2s coalescing and manual refresh behavior.

## Confirmed impact

A test using the real FileTreePanel, useFileTree, event bus and run projector, with mocked IPC and virtual time, reproduced **60 unnecessary listDirectory calls** during 120 seconds of text/reasoning at 10 updates/sec after a completed tool. After the fix the same phase makes **0 calls**; initial/tool-completion refreshes remain intact.

This is a deterministic request-count improvement, not a claimed CPU/FPS or disk-throughput percentage. Impact and reproduction are recorded in `desktop/DEV_MD/STREAMING_RENDERING_FIXES.md`.

## Validation

- The integration test fails on the baseline (60 unexpected calls), then passes with the fix.
- Tool end/result, cancellation/error and empty-read snapshot identity covered by additional tests.
- Desktop typecheck and ESLint passed.
- Full desktop Vitest: **106 files / 915 tests passed**.
- No Rust, storage schema or RPC contract changes.
