### PR TITLE
perf(mobile): streamline conversation switches and defer hidden replay

### DIFF
--- a/docs/mobile-latency-diagnosis.md
+++ b/docs/mobile-latency-diagnosis.md
@@ -55,3 +55,20 @@ The unchanged Windows failures comprise three path assertions; sixteen `git_revi
 ## Remaining validation boundary
 
 No real-phone failing request trace was captured in this session. These results establish the reproduced history/replay defects and their automated fixes, not a claim that every mobile connection failure is resolved. Installing updated Mobile and Desktop builds is required to exercise both fixes on a physical device.
+
+## Follow-up: switching and foreground synchronization (no physical device)
+
+The next Mobile-only change shares the opening `get_state` promise between model controls and the sync engine, removes the redundant opening attachment-history fetch, and rejects obsolete navigation responses. Model/thinking commands capture the intended session before asynchronous preference writes. Draft preference loading cannot navigate over a newer selection.
+
+Only the selected conversation performs history/replay/projection work. Hidden text events do not create timeline lanes, while title, terminal and approval notifications still update the catalog. Reopening always refreshes durable history and the active prefix, so a task that finished or requested approval while hidden is recovered. Reconnect restarts visible lanes, and replay checks lane validity before and after each page. An already-issued request may finish or time out; no subsequent pages are issued for the obsolete lane. This does **not** change the wildcard transport subscription or eliminate its incoming JSON decode cost.
+
+Deterministic regressions use actual Mobile hooks/sync/replay code with scripted RPC promises and fake timers:
+
+- With a simulated 350 ms state response and 350 ms history response, the opening state is requested once, history once, and history commits at 700 ms. This verifies two sequential round trips rather than the previous duplicate-state dependency; it is not a phone rendering benchmark.
+- 100 hidden sessions receiving 10,000 text deltas cause zero history/replay requests and no new timeline allocations. Opening one of them loads its latest durable state.
+- Reconnect with multiple cached lanes refreshes only the selected lane; reopening an idle hidden session refreshes its completed history.
+- Late A success/failure cannot overwrite B's model or clear B's pending state. Deferred preference saves cannot send A's command to B.
+- Hidden/replaced replay stops at the in-flight page; approvals are restored when opened; live events arriving during an open do not enqueue a duplicate opening read.
+- A warm conversation's ten-exchange display window stays bounded through an immediate restart, with older history still reachable by pagination.
+
+Local validation: Mobile typecheck and ESLint passed; 50 suites / 718 tests passed. One initial full run hit an unchanged SessionList beforeEach 5-second timeout; both its isolated rerun and subsequent full runs passed without changing timeout settings. No physical device, emulator frame-rate measurement, production service restart, or model request was used. Markdown incremental rendering and fine-grained Context subscriptions remain separate optimization work.

--- a/mobile/src/remote/RemoteContext.tsx
+++ b/mobile/src/remote/RemoteContext.tsx
@@ -158,7 +158,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     prepareTimelineOpen,
     syncEngineRef,
     streamingRef,
-    hydrateAttachmentsRef,
     reconcileSession,
     handleEvent,
     applySessionStreaming,
@@ -187,6 +186,7 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     void refreshWorkspaces();
   }, [refreshSessions, refreshWorkspaces]);
   const resetConversation = useCallback(() => {
+    conversationEpochRef.current += 1;
     selectedRef.current = "";
     setSelectedSessionId("");
     setDraft(false);
@@ -248,7 +248,6 @@ export function RemoteProvider({ children }: PropsWithChildren) {
     clientRef,
     selectedRef,
     syncEngineRef,
-    hydrateAttachmentsRef,
     conversationEpochRef,
     models,
     setSelectedSessionId,

--- a/mobile/src/remote/__tests__/foregroundSync.test.ts
+++ b/mobile/src/remote/__tests__/foregroundSync.test.ts
@@ -1,0 +1,178 @@
+import { SyncEngine } from "../syncEngine";
+import { emptyTimeline, type TimelineState } from "../timeline";
+
+function history(text: string): TimelineState {
+  return { ...emptyTimeline(), items: [{ kind: "message", id: "u", role: "user", text }] };
+}
+
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+test("one opening state request feeds controls and history without another network round trip", async () => {
+  const state = { model: "provider/model" };
+  const requestGetState = jest.fn(async () => {
+    await new Promise(resolve => setTimeout(resolve, 350));
+    return state;
+  });
+  const requestHistory = jest.fn(async () => {
+    await new Promise(resolve => setTimeout(resolve, 350));
+    return history("ready");
+  });
+  const engine = new SyncEngine({ requestGetState, requestHistory, fetchReplay: jest.fn() });
+  const startedAt = Date.now();
+  const commits: number[] = [];
+  engine.subscribe(() => commits.push(Date.now() - startedAt));
+  try {
+    const opening = engine.open("s");
+    await jest.advanceTimersByTimeAsync(350);
+    await expect(opening).resolves.toEqual(state);
+    expect(requestGetState).toHaveBeenCalledTimes(1);
+    expect(requestHistory).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(350);
+    expect(commits).toEqual([700]);
+    expect(requestGetState).toHaveBeenCalledTimes(1);
+    expect(requestHistory).toHaveBeenCalledTimes(1);
+  } finally { engine.clear(); }
+});
+
+test("live deltas during an open do not enqueue a duplicate opening read", async () => {
+  const requestGetState = jest.fn(async () => ({ activeRun: { runId: "r" } }));
+  const requestHistory = jest.fn(async () => {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return history("prompt");
+  });
+  const engine = new SyncEngine({ requestGetState, requestHistory, fetchReplay: async () => ({ events: [
+    { type: "agent_start", idx: 0, runId: "r", data: "{}" },
+    { type: "text_chunk", idx: 1, runId: "r", data: '{"text":"hello"}' },
+  ] }) });
+  try {
+    await engine.open("s");
+    await jest.advanceTimersByTimeAsync(0);
+    for (let i = 0; i < 100; i++) engine.event("s", { type: "text_chunk", idx: 1, runId: "r", data: '{"text":"hello"}' });
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(requestGetState).toHaveBeenCalledTimes(1);
+    expect(requestHistory).toHaveBeenCalledTimes(1);
+  } finally { engine.clear(); }
+});
+
+test("ten thousand hidden deltas trigger no history, replay or timeline allocations", async () => {
+  let visible = "front";
+  const requestGetState = jest.fn(async () => ({}));
+  const requestHistory = jest.fn(async () => history("latest"));
+  const fetchReplay = jest.fn();
+  const engine = new SyncEngine({
+    isSessionVisible: sid => sid === visible, requestGetState, requestHistory, fetchReplay,
+  });
+  try {
+    for (let session = 0; session < 100; session++) {
+      for (let idx = 0; idx < 100; idx++) {
+        engine.event(`hidden-${session}`, { type: "text_chunk", data: '{"text":"x"}', runId: "r", idx });
+      }
+      engine.reconcile(`hidden-${session}`, "resend");
+    }
+    engine.restartAll("reconnect");
+    await jest.advanceTimersByTimeAsync(20);
+    expect(requestGetState).not.toHaveBeenCalled();
+    expect(requestHistory).not.toHaveBeenCalled();
+    expect(fetchReplay).not.toHaveBeenCalled();
+    for (let session = 0; session < 100; session++) expect(engine.timelineFor(`hidden-${session}`)).toBeNull();
+
+    visible = "hidden-3";
+    await engine.open(visible);
+    await jest.advanceTimersByTimeAsync(20);
+    expect(requestGetState).toHaveBeenCalledTimes(1);
+    expect(requestHistory).toHaveBeenCalledTimes(1);
+    expect(engine.timelineFor(visible)?.items).toEqual(history("latest").items);
+  } finally { engine.clear(); }
+});
+
+test("reconnect only restarts the visible lane and reopening refreshes an idle cached session", async () => {
+  let visible = "a";
+  let text = "old";
+  const requestGetState = jest.fn(async () => ({}));
+  const requestHistory = jest.fn(async () => history(text));
+  const engine = new SyncEngine({
+    isSessionVisible: sid => sid === visible, requestGetState, requestHistory, fetchReplay: jest.fn(),
+  });
+  try {
+    await engine.open("a");
+    await jest.advanceTimersByTimeAsync(0);
+    visible = "b";
+    await engine.open("b");
+    await jest.advanceTimersByTimeAsync(0);
+    requestGetState.mockClear();
+    requestHistory.mockClear();
+    engine.restartAll("reconnect");
+    await jest.advanceTimersByTimeAsync(0);
+    expect(requestGetState.mock.calls).toEqual([["b"]]);
+    expect(requestHistory.mock.calls).toEqual([["b"]]);
+    text = "completed while hidden";
+    visible = "a";
+    await engine.open("a");
+    await jest.advanceTimersByTimeAsync(0);
+    expect(engine.timelineFor("a")?.items).toEqual(history(text).items);
+  } finally { engine.clear(); }
+});
+
+test("late history from a hidden lane cannot overwrite a fresh reopen", async () => {
+  let visible = "a";
+  let finishOld!: (value: TimelineState) => void;
+  const oldHistory = new Promise<TimelineState>(resolve => { finishOld = resolve; });
+  const requestHistory = jest.fn(async () => history("fresh")).mockReturnValueOnce(oldHistory);
+  const engine = new SyncEngine({
+    isSessionVisible: sid => sid === visible,
+    requestGetState: async () => ({}), requestHistory, fetchReplay: jest.fn(),
+  });
+  try {
+    await engine.open("a");
+    await jest.advanceTimersByTimeAsync(0);
+    visible = "b";
+    await engine.open("b");
+    await jest.advanceTimersByTimeAsync(0);
+    visible = "a";
+    await engine.open("a");
+    await jest.advanceTimersByTimeAsync(0);
+    finishOld(history("obsolete"));
+    await jest.advanceTimersByTimeAsync(0);
+    expect(engine.timelineFor("a")?.items).toEqual(history("fresh").items);
+    expect(engine.timelineFor("b")?.items).toEqual(history("fresh").items);
+  } finally { engine.clear(); }
+});
+
+test("an opening request failure retries with fresh state instead of a rejected promise", async () => {
+  const requestGetState = jest.fn(async () => ({})).mockRejectedValueOnce(new Error("offline"));
+  const onFailure = jest.fn();
+  const engine = new SyncEngine({
+    requestGetState, requestHistory: async () => history("recovered"), fetchReplay: jest.fn(), onFailure,
+  });
+  try {
+    await expect(engine.open("s")).rejects.toThrow("offline");
+    await jest.advanceTimersByTimeAsync(501);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(requestGetState).toHaveBeenCalledTimes(2);
+    expect(engine.timelineFor("s")?.items).toEqual(history("recovered").items);
+  } finally { engine.clear(); }
+});
+
+test("opening a background session restores its pending approval from durable replay", async () => {
+  let visible = "front";
+  const fetchReplay = jest.fn(async () => ({ events: [
+    { type: "agent_start", runId: "r", idx: 0, data: "{}" },
+    { type: "approval_request", runId: "r", idx: 1, data: JSON.stringify({ approval_request_id: "approval-1", tool_name: "shell" }) },
+  ] }));
+  const engine = new SyncEngine({
+    isSessionVisible: sid => sid === visible,
+    requestGetState: async () => ({ activeRun: { runId: "r" } }),
+    requestHistory: async () => history("prompt"), fetchReplay,
+  });
+  try {
+    engine.event("background", { type: "approval_request", runId: "r", idx: 1, data: "{}" });
+    expect(fetchReplay).not.toHaveBeenCalled();
+    visible = "background";
+    await engine.open(visible);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(fetchReplay).toHaveBeenCalledWith("background", "r", -1, expect.any(Function));
+    expect(engine.timelineFor(visible)?.items.find(item => item.kind === "approval"))
+      .toMatchObject({ payload: { approval_request_id: "approval-1" } });
+  } finally { engine.clear(); }
+});

--- a/mobile/src/remote/__tests__/replay.test.ts
+++ b/mobile/src/remote/__tests__/replay.test.ts
@@ -92,6 +92,25 @@ test("new Desktop replay advances event cursors while pinning the first page wat
   expect(request.mock.calls[1][0]).toMatchObject({ sinceIdx: 4, offset: 0, replayUntilIdx: 9 });
 });
 
+test("a hidden or replaced lane stops after the in-flight page instead of draining the tail", async () => {
+  let visible = true;
+  let finish!: (value: { data: EventsPage }) => void;
+  const request = jest.fn(() => new Promise<{ data: EventsPage }>(resolve => { finish = resolve; }));
+  const client = { requestRetry: request } as unknown as RemoteClient;
+  const loading = fetchEventsSince(client, "s", "r", -1, () => visible);
+  const rejected = expect(loading).rejects.toThrow("stale_sync_lane");
+  visible = false;
+  finish({ data: { events: [event("a", 99)], hasMore: true, nextSinceIdx: 99, watermark: 9999 } });
+  await rejected;
+  expect(request).toHaveBeenCalledTimes(1);
+});
+
+test("an already obsolete replay does not issue any request", async () => {
+  const { client, request } = clientReturning([]);
+  await expect(fetchEventsSince(client, "s", "r", -1, () => false)).rejects.toThrow("stale_sync_lane");
+  expect(request).not.toHaveBeenCalled();
+});
+
 test("a changed replay window rejects the partial result so sync can retry from durable state", async () => {
   const { client } = clientReturning([
     { events: [event("a", 4)], hasMore: true, nextSinceIdx: 4, watermark: 9 },

--- a/mobile/src/remote/__tests__/useConversationController.test.ts
+++ b/mobile/src/remote/__tests__/useConversationController.test.ts
@@ -59,6 +59,7 @@ function model(id: string, provider?: string, extra: Partial<RemoteModel> = {}):
 
 function fakeEngine(): SyncEngine {
   return {
+    open: jest.fn(),
     reconcile: jest.fn(),
     mutate: jest.fn(
       (_sessionId: string, apply: (tl: ReturnType<typeof emptyTimeline>) => unknown) => {
@@ -100,9 +101,11 @@ async function mountController(opts: MountOpts = {}) {
   };
   const selectedRef = { current: opts.selected ?? "" };
   const syncEngineRef = { current: (opts.engine ?? null) as SyncEngine | null };
-  const hydrateAttachmentsRef = {
-    current: jest.fn(async () => {}) as (sessionId: string) => Promise<void>,
-  };
+  if (syncEngineRef.current && jest.isMockFunction(syncEngineRef.current.open)) {
+    (syncEngineRef.current.open as jest.Mock).mockImplementation(async (sessionId: string) =>
+      (await requestRetry({ type: "get_state", sessionId }, sessionId)).data,
+    );
+  }
   const conversationEpochRef = { current: 0 };
   const setSelectedSessionId = jest.fn();
   const setDraft = jest.fn();
@@ -124,7 +127,6 @@ async function mountController(opts: MountOpts = {}) {
       clientRef,
       selectedRef,
       syncEngineRef,
-      hydrateAttachmentsRef,
       conversationEpochRef,
       models: opts.models ?? [],
       setSelectedSessionId,
@@ -156,6 +158,7 @@ async function mountController(opts: MountOpts = {}) {
     clientRef,
     selectedRef,
     syncEngineRef,
+    conversationEpochRef,
     setSelectedSessionId,
     setDraft,
     setDraftMode,
@@ -178,6 +181,76 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedLoadLastModel.mockResolvedValue(null);
   mockedLoadLastThinking.mockResolvedValue(null);
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+describe("navigation races", () => {
+  it.each(["resolve", "reject"] as const)("an old A response (%s) cannot clear B's opening state", async outcome => {
+    const a = deferred<{ data: RemoteSessionState }>();
+    const b = deferred<{ data: RemoteSessionState }>();
+    const h = await mountController({ requestRetry: jest.fn().mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise) });
+    let openA!: Promise<void>;
+    let openB!: Promise<void>;
+    await act(async () => { openA = current(h).selectSession("a"); });
+    await act(async () => { openB = current(h).selectSession("b"); });
+    await act(async () => {
+      if (outcome === "resolve") a.resolve({ data: { model: "old", thinkingLevel: "high" } });
+      else a.reject(new Error("old connection"));
+      await openA;
+    });
+    expect(current(h).openingSession).toBe(true);
+    expect(current(h).modelId).toBe("");
+    expect(h.recordError).not.toHaveBeenCalled();
+    await act(async () => { b.resolve({ data: { model: "new", thinkingLevel: "off" } }); await openB; });
+    expect(current(h).modelId).toBe("new");
+    expect(current(h).openingSession).toBe(false);
+    act(() => h.renderer.unmount());
+  });
+
+  it("a late A state cannot overwrite an already-open B", async () => {
+    const a = deferred<{ data: RemoteSessionState }>();
+    const h = await mountController({ requestRetry: jest.fn().mockReturnValueOnce(a.promise).mockResolvedValueOnce({ data: { model: "b", thinkingLevel: "low" } }) });
+    let opening!: Promise<void>;
+    await act(async () => { opening = current(h).selectSession("a"); });
+    await act(async () => { await current(h).selectSession("b"); });
+    await act(async () => { a.resolve({ data: { model: "a", thinkingLevel: "high" } }); await opening; });
+    expect(current(h).modelId).toBe("b");
+    expect(current(h).thinkingLevel).toBe("low");
+    act(() => h.renderer.unmount());
+  });
+
+  it("slow draft preferences cannot navigate away from a subsequently opened session", async () => {
+    const preference = deferred<string | null>();
+    mockedLoadLastModel.mockReturnValueOnce(preference.promise);
+    const h = await mountController({ requestRetry: jest.fn().mockResolvedValue({ data: { model: "b" } }) });
+    let draft!: Promise<void>;
+    await act(async () => { draft = current(h).newConversation(); });
+    expect(h.selectedRef.current).toBe("");
+    await act(async () => { await current(h).selectSession("b"); });
+    await act(async () => { preference.resolve("old"); await draft; });
+    expect(h.selectedRef.current).toBe("b");
+    expect(current(h).modelId).toBe("b");
+    act(() => h.renderer.unmount());
+  });
+
+  it.each(["model", "thinking"] as const)("a slow %s preference write cannot send the command to another session", async setting => {
+    const saved = deferred<void>();
+    if (setting === "model") mockedSaveLastModel.mockReturnValueOnce(saved.promise);
+    else mockedSaveLastThinking.mockReturnValueOnce(saved.promise);
+    const h = await mountController({ selected: "a" });
+    let changing!: Promise<void>;
+    await act(async () => { changing = setting === "model" ? current(h).setModel("p/m") : current(h).setThinkingLevel("high"); });
+    h.selectedRef.current = "b";
+    await act(async () => { saved.resolve(); await changing; });
+    expect(h.request).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "a" }), "a");
+    act(() => h.renderer.unmount());
+  });
 });
 
 describe("selectSession", () => {
@@ -206,8 +279,8 @@ describe("selectSession", () => {
     expect(h.setDraft).toHaveBeenCalledWith(false);
     expect(current(h).modelId).toBe("openai/gpt-4");
     expect(current(h).thinkingLevel).toBe("high");
-    const engine = h.syncEngineRef.current as unknown as { reconcile: jest.Mock };
-    expect(engine.reconcile).toHaveBeenCalledWith("s1", "open");
+    const engine = h.syncEngineRef.current as unknown as { open: jest.Mock };
+    expect(engine.open).toHaveBeenCalledWith("s1");
   });
 
   it("keeps the raw model reference when no catalogue model matches", async () => {
@@ -248,8 +321,8 @@ describe("selectSession", () => {
       await current(h).selectSession("s1");
     });
     expect(h.recordError).toHaveBeenCalledWith(expect.objectContaining({ message: "offline" }));
-    const engine = h.syncEngineRef.current as unknown as { reconcile: jest.Mock };
-    expect(engine.reconcile).toHaveBeenCalledWith("s1", "open");
+    const engine = h.syncEngineRef.current as unknown as { open: jest.Mock };
+    expect(engine.open).toHaveBeenCalledWith("s1");
   });
 });
 

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -48,6 +48,7 @@ describe("useTimelineController", () => {
   }
 
   function render(): void {
+    if (options.selectedSessionId) options.selectedRef.current = options.selectedSessionId;
     act(() => {
       renderer = create(createElement(Harness));
     });
@@ -96,6 +97,7 @@ describe("useTimelineController", () => {
 
   /** Establish a session timeline by driving an "open" reconcile through the engine. */
   async function establish(sessionId = "s1"): Promise<void> {
+    options.selectedRef.current = sessionId;
     act(() => {
       result.current.reconcileSession(sessionId, "open");
     });
@@ -246,6 +248,21 @@ describe("useTimelineController", () => {
   });
 
   describe("handleEvent", () => {
+    test("background token bursts do not fetch history while status notifications stay live", async () => {
+      options.selectedSessionId = "front";
+      render();
+      for (let index = 0; index < 10_000; index++) {
+        result.current.handleEvent(evt("text_chunk", '{"text":"x"}', "r", index), `background-${index % 100}`);
+      }
+      for (const type of ["agent_end", "approval_request", "approval_decision"]) {
+        result.current.handleEvent(evt(type, "{}", "r"), "background-1");
+      }
+      await flush();
+      expect(request).not.toHaveBeenCalled();
+      expect(options.refreshSessions).toHaveBeenCalledTimes(3);
+      expect(result.current.syncEngineRef.current!.timelineFor("background-1")).toBeNull();
+    });
+
     test("ignores events with an empty session id", () => {
       render();
       result.current.handleEvent(evt("agent_start", "{}"), "");
@@ -293,6 +310,7 @@ describe("useTimelineController", () => {
     });
 
     test("user_message hydrates attachments for the session", () => {
+      options.selectedSessionId = "s1";
       render();
       const hydrate = jest.fn(async () => {});
       result.current.hydrateAttachmentsRef.current = hydrate;
@@ -399,6 +417,7 @@ describe("useTimelineController", () => {
     });
 
     test("hydrate merges durable attachments and swallows history failures", async () => {
+      options.selectedSessionId = "s1";
       render();
       const engine = result.current.syncEngineRef.current!;
       engine.mutate("s1", () => emptyTimeline());
@@ -526,7 +545,13 @@ describe("useTimelineController", () => {
       await flush();
       expect(result.current.timeline.items).toHaveLength(40);
 
-      act(() => result.current.prepareTimelineOpen("s1"));
+      request.mockResolvedValueOnce({ data: {} }).mockResolvedValueOnce({
+        data: { entries: exchanges(11, 20), hasMore: true, nextOffset: 20 },
+      });
+      await act(async () => {
+        result.current.prepareTimelineOpen("s1");
+        await result.current.syncEngineRef.current!.open("s1");
+      });
       await flush();
 
       expect(
@@ -534,7 +559,7 @@ describe("useTimelineController", () => {
           .filter(item => item.kind === "message" && item.role === "user")
           .map(item => (item.kind === "message" ? item.text : "")),
       ).toEqual(Array.from({ length: 10 }, (_, index) => `user ${index + 11}`));
-      expect(result.current.canLoadOlderTimeline).toBe(false);
+      expect(result.current.canLoadOlderTimeline).toBe(true);
     });
 
     test("timeout retains the cursor and retry returns the committed page identities", async () => {
@@ -613,6 +638,7 @@ describe("useTimelineController", () => {
 
   describe("engine deps", () => {
     test("requestGetState throws when the client is absent", async () => {
+      options.selectedSessionId = "s1";
       const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
       options.clientRef.current = null;
       render();
@@ -666,14 +692,14 @@ describe("useTimelineController", () => {
       expect(texts).toContain("replayed");
     });
 
-    test("fetchReplay throws when the client disappears before replay", async () => {
+    test("history from a replaced client is rejected before replay", async () => {
       const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
       options.selectedSessionId = "s1";
       request.mockImplementation(async (cmd: { type: string }) => {
         if (cmd.type === "get_state")
           return { success: true, data: { activeRun: { runId: "r1" } } };
         if (cmd.type === "get_session_entries") {
-          // Drop the client after history so fetchReplay sees null.
+          // Replacing the client invalidates this in-flight history page.
           options.clientRef.current = null;
           return {
             success: true,
@@ -687,7 +713,8 @@ describe("useTimelineController", () => {
       expect(errorSpy).toHaveBeenCalledWith(
         "[remote] session timeline sync failed",
         expect.objectContaining({
-          error: expect.objectContaining({ message: "not_connected" }),
+          stage: "history",
+          error: expect.objectContaining({ message: "stale_history_load" }),
         }),
       );
       errorSpy.mockRestore();

--- a/mobile/src/remote/replay.ts
+++ b/mobile/src/remote/replay.ts
@@ -29,6 +29,7 @@ export async function fetchEventsSince(
   sessionId: string,
   runId: string,
   sinceIdx: number,
+  isCurrent: () => boolean = () => true,
 ): Promise<EventsData> {
   const events: ReplayEventWire[] = [];
   let projection: EventsData["projection"] = null;
@@ -37,6 +38,9 @@ export async function fetchEventsSince(
   let cursor = sinceIdx;
   let watermark: number | undefined;
   for (;;) {
+    // An in-flight request may finish, but a hidden/replaced lane must not
+    // keep issuing pages or accumulating a replay nobody is displaying.
+    if (!isCurrent()) throw new Error("stale_sync_lane");
     const page = (
       await client.requestRetry<EventsPage>(
         {
@@ -50,6 +54,7 @@ export async function fetchEventsSince(
         sessionId,
       )
     ).data;
+    if (!isCurrent()) throw new Error("stale_sync_lane");
     if (watermark !== undefined && page.watermark !== watermark)
       throw new Error("replay_window_changed");
     events.push(...(page.events ?? []));

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -68,9 +68,11 @@ export interface ReplayResult {
  * so a session's queue stays correct across client generations.
  */
 export interface SyncDeps {
+  /** Hidden sessions keep cached UI but defer expensive history/replay until opened. */
+  isSessionVisible?(sessionId: string): boolean;
   requestGetState(sessionId: string): Promise<RemoteSessionState>;
   requestHistory(sessionId: string): Promise<TimelineState>;
-  fetchReplay(sessionId: string, runId: string, sinceIdx: number): Promise<ReplayResult>;
+  fetchReplay(sessionId: string, runId: string, sinceIdx: number, isCurrent: () => boolean): Promise<ReplayResult>;
   onFailure?(failure: SyncFailure): void;
   onRecovered?(sessionId: string): void;
 }
@@ -105,6 +107,7 @@ type Op = { kind: "event"; event: StreamEvent } | { kind: "mutate"; apply: Mutat
 interface ReconcileRequest {
   reason: ReconcileReason;
   runId?: string;
+  initialState?: Promise<RemoteSessionState>;
 }
 
 interface SessionLane {
@@ -116,6 +119,7 @@ interface SessionLane {
   ops: Op[];
   bufferedBytes: number;
   replayQueue: ReconcileRequest[];
+  reconciling?: ReconcileRequest;
   established: boolean;
   retryAttempt: number;
   retryNotBefore: number;
@@ -145,6 +149,7 @@ export class SyncEngine {
 
   /** Enqueue a live event for the session. Never throws. */
   event(sessionId: string, event: StreamEvent): void {
+    if (!this.isVisible(sessionId)) return;
     const lane = this.laneFor(sessionId);
     // First contact for a real session: establish the timeline from durable
     // history + a full replay so a mid-run join gets its prefix (H3), not just
@@ -172,22 +177,24 @@ export class SyncEngine {
 
   /** Enqueue a reconcile. Repeats of the same reason+run are folded. */
   reconcile(sessionId: string, reason: ReconcileReason, runId?: string): void {
+    if (!this.isVisible(sessionId)) return;
     this.enqueueReplay(this.laneFor(sessionId), { reason, runId });
   }
 
-  /** Reconcile every real lane (reconnect recovery). Lanes that never
+  /** Reconcile visible real lanes (all lanes when no visibility policy is set).
+   * Lanes that never
    * established (their first history load failed while the backend was down)
    * are included — this is exactly the case that must self-heal on recovery;
    * the draft lane ("") has no desktop state and is skipped by runReconcile. */
   reconcileAll(reason: ReconcileReason): void {
     for (const lane of this.lanes.values()) {
-      if (lane.sessionId !== "") this.enqueueReplay(lane, { reason });
+      if (lane.sessionId !== "" && this.isVisible(lane.sessionId)) this.enqueueReplay(lane, { reason });
     }
   }
 
   /**
    * Invalidate work that may still be awaiting an old transport generation and
-   * immediately rebuild every real lane from durable state. A reconnect must
+   * immediately rebuild visible real lanes from durable state. A reconnect must
    * not enqueue behind a request that was suspended with the previous socket.
    */
   restartAll(reason: ReconcileReason): void {
@@ -195,9 +202,17 @@ export class SyncEngine {
     for (const sessionId of sessionIds) this.restart(sessionId, reason);
   }
 
+  /** Share the opening state request with the model controls and start history
+   * immediately when it resolves, without waiting behind a previous open. */
+  open(sessionId: string): Promise<RemoteSessionState> {
+    const state = Promise.resolve().then(() => this.deps.requestGetState(sessionId));
+    this.restart(sessionId, "open", state);
+    return state;
+  }
+
   /** Immediately restart one lane, preserving its last committed UI snapshot. */
-  restart(sessionId: string, reason: ReconcileReason): void {
-    if (!sessionId) return;
+  restart(sessionId: string, reason: ReconcileReason, initialState?: Promise<RemoteSessionState>): void {
+    if (!sessionId || !this.isVisible(sessionId)) return;
     const previous = this.lanes.get(sessionId);
     if (previous?.retryTimer) clearTimeout(previous.retryTimer);
     const lane: SessionLane = {
@@ -215,7 +230,7 @@ export class SyncEngine {
       retryTimer: null,
     };
     this.lanes.set(sessionId, lane);
-    this.enqueueReplay(lane, { reason });
+    this.enqueueReplay(lane, { reason, initialState });
   }
 
   /** Apply a synchronous timeline mutation inside the lane. Never throws. */
@@ -287,9 +302,9 @@ export class SyncEngine {
   }
 
   private enqueueReplay(lane: SessionLane, request: ReconcileRequest): void {
-    const duplicate = lane.replayQueue.some(
-      (existing) => existing.reason === request.reason && existing.runId === request.runId,
-    );
+    const matches = (existing: ReconcileRequest) =>
+      existing.reason === request.reason && existing.runId === request.runId;
+    const duplicate = (lane.reconciling && matches(lane.reconciling)) || lane.replayQueue.some(matches);
     if (duplicate) return;
     if (lane.replayQueue.length >= MAX_REPLAY_QUEUE) return;
     lane.replayQueue.push(request);
@@ -314,7 +329,9 @@ export class SyncEngine {
     let justReconciledRun: string | null = null;
     const request = lane.replayQueue.shift();
     if (request) {
+      lane.reconciling = request;
       const failure = await this.runReconcile(lane, request);
+      lane.reconciling = undefined;
       if (!this.isCurrent(lane)) return;
       if (failure) {
         // Preserve both the reconcile instruction and every queued live op.
@@ -371,7 +388,11 @@ export class SyncEngine {
     let stage: SyncStage = "get_state";
     let targetRunId = request.runId ?? "";
     try {
-      const state = await this.deps.requestGetState(lane.sessionId);
+      // An opening state is consumed once. A failed reconcile must retry
+      // against fresh state, not keep reusing a rejected/stale promise.
+      const initialState = request.initialState;
+      delete request.initialState;
+      const state = await (initialState ?? this.deps.requestGetState(lane.sessionId));
       if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
       const activeRunId = state.activeRun?.runId ?? "";
       // The reconcile target is the requested run (a snapshot-flip run that
@@ -441,7 +462,7 @@ export class SyncEngine {
     runId: string,
     since: number,
   ): Promise<TimelineState> {
-    const result = await this.deps.fetchReplay(lane.sessionId, runId, since);
+    const result = await this.deps.fetchReplay(lane.sessionId, runId, since, () => this.isCurrent(lane));
     if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
     if (result.projection?.events?.length) {
       let events = normalizeReplayEvents(result.projection.events);
@@ -568,12 +589,13 @@ export class SyncEngine {
 
   private isFullReplay(lane: SessionLane, runId: string, request: ReconcileRequest): boolean {
     if (
+      request.reason === "open" ||
       request.reason === "prefix" ||
       request.reason === "resend" ||
       request.reason === "reconnect"
     )
       return true;
-    // A lane with no committed timeline has no live baseline to top up — the
+    // A lane with no established timeline has no live baseline to top up — the
     // only way to build it is from durable history (idle sessions have no
     // active run for a tail reconcile to target).
     if (!lane.established || lane.timeline === null) return true;
@@ -587,8 +609,13 @@ export class SyncEngine {
     }
   }
 
+  private isVisible(sessionId: string): boolean {
+    return sessionId === "" || this.deps.isSessionVisible?.(sessionId) !== false;
+  }
+
   private isCurrent(lane: SessionLane): boolean {
-    return lane.generation === this.generation && this.lanes.get(lane.sessionId) === lane;
+    return lane.generation === this.generation && this.lanes.get(lane.sessionId) === lane
+      && this.isVisible(lane.sessionId);
   }
 }
 

--- a/mobile/src/remote/useConversationController.ts
+++ b/mobile/src/remote/useConversationController.ts
@@ -23,7 +23,6 @@ interface ConversationControllerOptions {
   clientRef: MutableRefObject<RemoteClient | null>;
   selectedRef: MutableRefObject<string>;
   syncEngineRef: MutableRefObject<SyncEngine | null>;
-  hydrateAttachmentsRef: MutableRefObject<(sessionId: string) => Promise<void>>;
   conversationEpochRef: MutableRefObject<number>;
   models: RemoteModel[];
   setSelectedSessionId: Dispatch<SetStateAction<string>>;
@@ -44,7 +43,6 @@ export function useConversationController({
   clientRef,
   selectedRef,
   syncEngineRef,
-  hydrateAttachmentsRef,
   conversationEpochRef,
   models,
   setSelectedSessionId,
@@ -69,7 +67,9 @@ export function useConversationController({
       const client = clientRef.current;
       if (!client) return;
       setOpeningSession(true);
-      conversationEpochRef.current += 1;
+      const epoch = ++conversationEpochRef.current;
+      const isCurrent = () => conversationEpochRef.current === epoch
+        && selectedRef.current === sessionId && clientRef.current === client;
       prepareTimelineOpen(sessionId);
       setSelectedSessionId(sessionId);
       selectedRef.current = sessionId;
@@ -81,26 +81,26 @@ export function useConversationController({
         return next;
       });
       try {
-        const state = await client.requestRetry<RemoteSessionState>(
-          { type: "get_state", sessionId },
-          sessionId,
-        );
-        const currentModel = state.data.model ?? "";
+        const engine = syncEngineRef.current;
+        const state = engine
+          ? await engine.open(sessionId)
+          : (await client.requestRetry<RemoteSessionState>({ type: "get_state", sessionId }, sessionId)).data;
+        if (!isCurrent()) return;
+        const currentModel = state.model ?? "";
         const matchingModel = models.find(model => modelReference(model) === currentModel);
         setModelId(matchingModel ? modelReference(matchingModel) : currentModel);
-        setThinkingLevelState(state.data.thinkingLevel ?? "off");
+        setThinkingLevelState(state.thinkingLevel ?? "off");
       } catch (nextError) {
-        recordError(nextError);
+        if (isCurrent()) recordError(nextError);
       } finally {
-        setOpeningSession(false);
+        if (isCurrent()) setOpeningSession(false);
       }
-      syncEngineRef.current?.reconcile(sessionId, "open");
-      void hydrateAttachmentsRef.current(sessionId);
+      // The engine's history request includes attachments. An extra hydration
+      // here doubled history reads on warm opens and raced the paging cursor.
     },
     [
       clientRef,
       conversationEpochRef,
-      hydrateAttachmentsRef,
       models,
       prepareTimelineOpen,
       recordError,
@@ -114,7 +114,16 @@ export function useConversationController({
 
   const newConversation = useCallback(
     async (mode: "chat" | "workspace" = "chat", workspaceId = "") => {
+      const epoch = ++conversationEpochRef.current;
+      setOpeningSession(false);
+      setSelectedSessionId("");
+      selectedRef.current = "";
+      setDraft(true);
+      setDraftMode(mode);
+      setDraftWorkspaceId(workspaceId);
+      ensureDraftTimeline();
       const [lastModel, lastThinking] = await Promise.all([loadLastModel(), loadLastThinking()]);
+      if (conversationEpochRef.current !== epoch || selectedRef.current !== "") return;
       const defaultOption = models.find(model => model.isDefault);
       const defaultModel =
         (lastModel && models.some(model => modelReference(model) === lastModel)
@@ -122,13 +131,6 @@ export function useConversationController({
           : null) ??
         (defaultOption ? modelReference(defaultOption) : null) ??
         (models[0] ? modelReference(models[0]) : "");
-      conversationEpochRef.current += 1;
-      setSelectedSessionId("");
-      selectedRef.current = "";
-      setDraft(true);
-      setDraftMode(mode);
-      setDraftWorkspaceId(workspaceId);
-      ensureDraftTimeline();
       setModelId(defaultModel);
       setThinkingLevelState((lastThinking as ThinkingLevel | null) ?? "off");
     },
@@ -189,18 +191,19 @@ export function useConversationController({
 
   const setModel = useCallback(
     async (nextModelId: string) => {
+      const client = clientRef.current;
+      const sessionId = selectedRef.current;
       setModelId(nextModelId);
       await saveLastModel(nextModelId);
-      const client = clientRef.current;
-      if (client && selectedRef.current) {
+      if (client && clientRef.current === client && sessionId) {
         await client.request(
           {
             type: "set_model",
-            sessionId: selectedRef.current,
+            sessionId,
             modelId: nextModelId,
             providerId: modelProviderFromReference(nextModelId),
           },
-          selectedRef.current,
+          sessionId,
         );
       }
     },
@@ -209,13 +212,14 @@ export function useConversationController({
 
   const setThinkingLevel = useCallback(
     async (level: ThinkingLevel) => {
+      const client = clientRef.current;
+      const sessionId = selectedRef.current;
       setThinkingLevelState(level);
       await saveLastThinking(level);
-      const client = clientRef.current;
-      if (client && selectedRef.current) {
+      if (client && clientRef.current === client && sessionId) {
         await client.request(
-          { type: "set_thinking_level", sessionId: selectedRef.current, level },
-          selectedRef.current,
+          { type: "set_thinking_level", sessionId, level },
+          sessionId,
         );
       }
     },

--- a/mobile/src/remote/useTimelineController.ts
+++ b/mobile/src/remote/useTimelineController.ts
@@ -120,6 +120,7 @@ export function useTimelineController({
   const cursorsRef = useRef<Record<string, RunCursor>>({});
   const streamingRef = useRef<Record<string, boolean>>({});
   const historyPagingRef = useRef<Record<string, HistoryPagingState>>({});
+  const historyEpochRef = useRef(0);
   const [historyPaging, setHistoryPaging] = useState<Record<string, HistoryPagingState>>({});
   const hydrateAttachmentsRef = useRef<(sessionId: string) => Promise<void>>(async () => undefined);
 
@@ -162,6 +163,14 @@ export function useTimelineController({
         }
         return;
       }
+      if (sid !== selectedRef.current) {
+        // Background conversations need catalog/unread/approval status, not
+        // token projection or eager history/replay. Opening reloads durable
+        // history and the active prefix, including any deferred approvals.
+        if (["agent_end", "approval_request", "approval_decision"].includes(event.type))
+          void refreshSessions();
+        return;
+      }
       if (event.type === "user_message") void hydrateAttachmentsRef.current(sid);
       if (event.type === "approval_decision") {
         try {
@@ -191,13 +200,14 @@ export function useTimelineController({
       syncEngineRef.current?.event(sid, event);
       if (event.type === "agent_end") void refreshSessions();
     },
-    [reconcileSession, refreshModels, refreshSessions, setTitleOverrides],
+    [reconcileSession, refreshModels, refreshSessions, selectedRef, setTitleOverrides],
   );
 
   const loadHistory = useCallback(
     async (sessionId: string): Promise<TimelineState> => {
       const client = clientRef.current;
       if (!client) return emptyTimeline();
+      const epoch = historyEpochRef.current;
       const retained = historyPagingRef.current[sessionId];
       const response = await client.requestRetry<EntriesData>(
         {
@@ -208,13 +218,14 @@ export function useTimelineController({
         },
         sessionId,
       );
+      if (epoch !== historyEpochRef.current || clientRef.current !== client || selectedRef.current !== sessionId)
+        throw new Error("stale_history_load");
       const entries = response.data.entries ?? [];
       const nextBefore = response.data.nextOffset ?? 0;
       const latest = timelineFromEntries(entries);
-      const history = retainOlderHistoryPrefix(
-        syncEngineRef.current?.timelineFor(sessionId) ?? null,
-        latest,
-      );
+      const history = retained
+        ? retainOlderHistoryPrefix(syncEngineRef.current?.timelineFor(sessionId) ?? null, latest)
+        : latest;
       // Only retain the cursor when the old prefix actually joined this page.
       // Otherwise the latest page starts a new contiguous history window.
       const retainedOlderPages = history !== latest ? retained : null;
@@ -227,7 +238,7 @@ export function useTimelineController({
       setHistoryPaging(previous => ({ ...previous, [sessionId]: page }));
       return history;
     },
-    [clientRef],
+    [clientRef, selectedRef],
   );
 
   const loadOlderTimeline = useCallback(async () => {
@@ -284,6 +295,7 @@ export function useTimelineController({
   }, [clientRef, selectedRef]);
 
   const prepareTimelineOpen = useCallback((sessionId: string) => {
+    historyEpochRef.current += 1;
     const cached = timelinesRef.current[sessionId];
     if (!cached) return;
     const windowed = latestTimelineWindow(cached, HISTORY_PAGE_USER_EXCHANGES);
@@ -305,6 +317,7 @@ export function useTimelineController({
 
   useEffect(() => {
     const engine = new SyncEngine({
+      isSessionVisible: sessionId => sessionId === selectedRef.current,
       requestGetState: async sessionId => {
         const client = clientRef.current;
         if (!client) throw new Error("not_connected");
@@ -313,10 +326,11 @@ export function useTimelineController({
         ).data;
       },
       requestHistory: loadHistory,
-      fetchReplay: async (sessionId, runId, sinceIdx) => {
+      fetchReplay: async (sessionId, runId, sinceIdx, isCurrent) => {
         const client = clientRef.current;
         if (!client) throw new Error("not_connected");
-        const merged = await fetchEventsSince(client, sessionId, runId, sinceIdx);
+        const merged = await fetchEventsSince(client, sessionId, runId, sinceIdx,
+          () => clientRef.current === client && isCurrent());
         return { ...merged, events: merged.events ?? [] };
       },
       onFailure: failure => {
@@ -355,7 +369,7 @@ export function useTimelineController({
       syncEngineRef.current = null;
       engine.clear();
     };
-  }, [clientRef, loadHistory]);
+  }, [clientRef, loadHistory, selectedRef]);
 
   useEffect(() => {
     hydrateAttachmentsRef.current = async sessionId => {
@@ -389,6 +403,8 @@ export function useTimelineController({
   }, []);
 
   const resetTimeline = useCallback(() => {
+    historyEpochRef.current += 1;
+    timelinesRef.current = {};
     syncEngineRef.current?.clear();
     setTimelines({});
     setTimelineErrors({});


### PR DESCRIPTION
## Summary
- Share a single get_state request between opening model controls and timeline sync; remove the extra opening attachment-history fetch.
- Ignore stale navigation responses and bind delayed model/thinking commands to the intended session.
- Defer hidden-session history/replay/projection; preserve catalog/terminal/approval notifications and reload durable state on reopen.
- Stop obsolete replay pagination after its in-flight page, prioritize visible lanes on reconnect, and deduplicate opening reconciles while one is executing.
- Preserve the warm ten-exchange window through immediate lane restart.

## Validation without a physical device
- Mobile typecheck and ESLint passed.
- 50 Jest suites / 718 tests passed with the updated worktree shared packages.
- Fake-clock 350 ms state + 350 ms history: one state request, one history request, history commit at 700 ms (not a measured phone frame/render latency).
- 100 hidden sessions / 10,000 text deltas: zero history/replay requests and no timeline-lane allocations; opening restores durable history/approvals.
- Regressions cover A-to-B response reordering/failure, delayed draft/preferences, same-session reopen, reconnect prioritization, replay cancellation, and failure recovery.
- One earlier run hit a 5s beforeEach timeout in the unchanged SessionList test; isolated and subsequent complete reruns passed with unchanged timeout settings.

This does not change transport authentication, wildcard subscription/JSON decoding, native background lifecycle, or Markdown rendering. A request already on the wire may complete/time out; it will not trigger more replay pages after navigation invalidates the lane. See docs/mobile-latency-diagnosis.md for scope and limitations.