### PR TITLE
fix(remote): bound large read replies and mobile cache growth

### DIFF
--- a/desktop/src-tauri/src/remote/commands.rs
+++ b/desktop/src-tauri/src/remote/commands.rs
@@ -194,10 +194,18 @@ async fn handle_command_singleflight(
     if !handshake.access_current() {
         return;
     }
-    let command_id = serde_json::from_slice::<IncomingCmd>(&msg.payload)
-        .ok()
-        .map(|cmd| cmd.id)
-        .filter(|id| !id.is_empty());
+    let command = serde_json::from_slice::<IncomingCmd>(&msg.payload).ok();
+    // Chunk reads are already idempotent against the bounded immutable cache.
+    // Do not retain a second copy of every chunk in the ten-minute command
+    // reply cache. They still pass the normal handshake/access checks below.
+    if command
+        .as_ref()
+        .is_some_and(|cmd| cmd.cmd_type == "get_read_chunk")
+    {
+        handle_command(client, msg, handshake).await;
+        return;
+    }
+    let command_id = command.map(|cmd| cmd.id).filter(|id| !id.is_empty());
     let Some(command_id) = command_id else {
         handle_command(client, msg, handshake).await;
         return;
@@ -623,6 +631,17 @@ fn encode_reply_payload(body: &Value) -> Vec<u8> {
 
 fn encode_reply_payload_with_gzip(body: &Value, gzip_enabled: bool) -> Vec<u8> {
     let plain = serde_json::to_vec(body).expect("a response Value always serializes");
+    // Enforce the decoded JSON budget too: compressing a larger reply would
+    // still be rejected by Mobile's decompression guard. Negotiated read pages
+    // reach here as small chunks; legacy/other oversized replies fail explicitly
+    // rather than being dropped by NATS and making the client time out.
+    if plain.len() > 1024 * 1024 {
+        return serde_json::to_vec(&json!({
+            "type": "response", "success": false, "data": null,
+            "error": "remote_reply_too_large"
+        }))
+        .expect("size error serializes");
+    }
     if !gzip_enabled || plain.len() < REMOTE_JSON_GZIP_THRESHOLD_BYTES {
         return plain;
     }
@@ -662,6 +681,18 @@ mod tests {
     use super::*;
     use flate2::read::GzDecoder;
     use std::io::Read;
+
+    #[test]
+    fn oversized_reply_is_an_explicit_bounded_error_even_with_gzip() {
+        let body = json!({"success": true, "data": "x".repeat(2 * 1024 * 1024)});
+        for gzip in [false, true] {
+            let bytes = encode_reply_payload_with_gzip(&body, gzip);
+            assert!(bytes.len() < 1024);
+            let value: Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["success"], false);
+            assert_eq!(value["error"], "remote_reply_too_large");
+        }
+    }
 
     #[test]
     fn model_identity_keeps_raw_slashes_and_distinguishes_providers() {
@@ -1582,6 +1613,80 @@ mod bridge_tests {
             .call(json!({ "id": unique("cmd"), "type": "set_approval_tier", "tier": "sandbox" }))
             .await;
         assert_eq!(reply["success"], json!(false));
+        bridge.stop();
+    }
+
+    #[tokio::test]
+    async fn oversized_reads_cross_the_real_reply_path_without_losing_history_or_projection() {
+        let _lock = mock_agent_lock();
+        let (_home, bridge) = active_bridge("large-read-pages").await;
+        let agent = ensure_mock_agent();
+        agent.clear_scripts();
+        let session = unique("sess");
+        let large = "中文".repeat(200_000);
+        agent.script_typed_for("get_events_since", &session, json!({
+            "runId": "r", "events": [], "truncated": true,
+            "projection": {"runId": "r", "cursor": 20, "events": [{"type": "text_chunk", "idx": 20, "data": large}]}
+        }));
+        let legacy = bridge.call(json!({"id": unique("cmd"), "type": "get_events_since", "sessionId": session, "runId": "r", "sinceIdx": -1})).await;
+        assert_eq!(legacy["success"], false);
+        assert_eq!(legacy["error"], "remote_reply_too_large");
+
+        agent.script_typed_for("get_events_since", &session, json!({
+            "runId": "r", "events": [], "truncated": true,
+            "projection": {"runId": "r", "cursor": 20, "events": [{"type": "text_chunk", "idx": 20, "data": large}]}
+        }));
+        let mut page = bridge.call(json!({"id": unique("cmd"), "type": "get_events_since", "sessionId": session, "runId": "r", "sinceIdx": -1, "chunkedRead": true})).await;
+        // The live source changes while the phone reads: pages must still be
+        // from the original immutable snapshot, not a mixture of generations.
+        agent.script_typed_for(
+            "get_events_since",
+            &session,
+            json!({"runId": "r", "events": []}),
+        );
+        let mut bytes = Vec::new();
+        loop {
+            assert_eq!(page["success"], true);
+            assert!(serde_json::to_vec(&page).unwrap().len() < 512 * 1024);
+            let part = &page["data"]["readChunk"];
+            bytes.extend(
+                URL_SAFE_NO_PAD
+                    .decode(part["data"].as_str().unwrap())
+                    .unwrap(),
+            );
+            if part["nextOffset"] == part["totalBytes"] {
+                break;
+            }
+            page = bridge.call(json!({"id": unique("cmd"), "type": "get_read_chunk", "sessionId": session, "runId": "r", "replyId": part["id"], "offset": part["nextOffset"]})).await;
+        }
+        let restored: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(restored["projection"]["cursor"], 20);
+        assert_eq!(restored["projection"]["events"][0]["data"], large);
+
+        let mut entries = vec![
+            json!({"id":"u", "kind":"user", "role":"user", "blocks":[{"kind":"text", "text":"question"}]}),
+        ];
+        entries.extend((0..12).map(|i| json!({"id":format!("a{i}"), "kind":"assistant", "role":"assistant", "runId":"r", "blocks":[{"kind":"text", "text":"x".repeat(100*1024)}]})));
+        agent.set_session_entries(&session, json!({"entries": entries}));
+        let mut page = bridge.call(json!({"id":unique("cmd"), "type":"get_session_entries", "sessionId":session, "before":i64::MAX, "limit":10, "chunkedRead":true})).await;
+        let mut bytes = Vec::new();
+        loop {
+            assert_eq!(page["success"], true);
+            let part = &page["data"]["readChunk"];
+            bytes.extend(
+                URL_SAFE_NO_PAD
+                    .decode(part["data"].as_str().unwrap())
+                    .unwrap(),
+            );
+            if part["nextOffset"] == part["totalBytes"] {
+                break;
+            }
+            page = bridge.call(json!({"id":unique("cmd"), "type":"get_read_chunk", "sessionId":session, "replyId":part["id"], "offset":part["nextOffset"]})).await;
+        }
+        let restored: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(restored["entries"].as_array().unwrap().len(), 13);
+        assert_eq!(restored["entries"][0]["id"], "u");
+        assert_eq!(restored["entries"][12]["id"], "a11");
         bridge.stop();
     }
 

--- a/desktop/src-tauri/src/remote/protocol.rs
+++ b/desktop/src-tauri/src/remote/protocol.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub(crate) struct IncomingCmd {
+    pub(crate) chunked_read: bool,
+    pub(crate) reply_id: String,
     pub(crate) replay_until_idx: Option<i64>,
     pub(crate) bridge_instance_id: String,
     pub(crate) id: String,
@@ -59,6 +61,8 @@ pub(crate) struct IncomingCmd {
 impl Default for IncomingCmd {
     fn default() -> Self {
         Self {
+            chunked_read: false,
+            reply_id: String::new(),
             replay_until_idx: None,
             bridge_instance_id: String::new(),
             id: String::new(),

--- a/desktop/src-tauri/src/remote_host/mod.rs
+++ b/desktop/src-tauri/src/remote_host/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod business;
 pub(crate) mod catalog;
 pub(crate) mod files;
 pub(crate) mod pairing;
+mod read_pages;
 use crate::remote::services::{BusinessHost, ReplySink};
 struct DesktopHost;
 impl BusinessHost for DesktopHost {
@@ -12,7 +13,17 @@ impl BusinessHost for DesktopHost {
         command: crate::remote::protocol::IncomingCmd,
         reply: &'a dyn ReplySink,
     ) -> futures::future::BoxFuture<'a, ()> {
-        Box::pin(business::execute(command, reply))
+        Box::pin(async move {
+            if command.cmd_type == "get_read_chunk" {
+                match read_pages::read(&command) {
+                    Ok(data) => reply.send(true, data, None).await,
+                    Err(error) => reply.send(false, Value::Null, Some(error)).await,
+                }
+                return;
+            }
+            let paged = read_pages::PagedReply::new(&command, reply);
+            business::execute(command, &paged).await;
+        })
     }
 }
 pub(crate) fn host() -> &'static dyn RemoteHost {
@@ -91,9 +102,11 @@ impl FileHost for DesktopHost {
     }
     fn prune_transfers(&self) {
         files::prune_expired();
+        read_pages::prune();
     }
     fn clear_transfers(&self) {
         files::clear_transfers();
+        read_pages::clear();
     }
     fn clear_preview_cache(&self) {
         files::clear_preview_cache();

--- a/desktop/src-tauri/src/remote_host/read_pages.rs
+++ b/desktop/src-tauri/src/remote_host/read_pages.rs
@@ -1,0 +1,232 @@
+//! Lossless transport pages for oversized history/replay results. Snapshots are
+//! immutable and scoped to the authenticated bridge/session/run, never refetched
+//! from a moving Agent projection while a phone is paging them.
+use crate::remote::{protocol::IncomingCmd, services::ReplySink};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use futures::future::BoxFuture;
+use serde_json::{json, Value};
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+    time::{Duration, Instant},
+};
+
+const PAGE_THRESHOLD: usize = 512 * 1024;
+const CHUNK_BYTES: usize = 192 * 1024;
+const MAX_SNAPSHOT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CACHE_BYTES: usize = 32 * 1024 * 1024;
+const TTL: Duration = Duration::from_secs(120);
+
+#[derive(Clone, PartialEq, Eq)]
+struct Owner {
+    bridge: String,
+    session: String,
+    run: String,
+}
+impl From<&IncomingCmd> for Owner {
+    fn from(cmd: &IncomingCmd) -> Self {
+        Self {
+            bridge: cmd.bridge_instance_id.clone(),
+            session: cmd.session_id.clone(),
+            run: cmd.run_id.clone(),
+        }
+    }
+}
+struct Snapshot {
+    owner: Owner,
+    bytes: Vec<u8>,
+    created: Instant,
+}
+#[derive(Default)]
+struct Cache {
+    snapshots: HashMap<String, Snapshot>,
+}
+impl Cache {
+    fn prune(&mut self) {
+        self.snapshots
+            .retain(|_, value| value.created.elapsed() < TTL);
+    }
+    fn insert(&mut self, owner: Owner, bytes: Vec<u8>) -> Result<Value, String> {
+        if bytes.len() > MAX_SNAPSHOT_BYTES {
+            return Err("remote_read_too_large".into());
+        }
+        self.prune();
+        while self
+            .snapshots
+            .values()
+            .map(|snapshot| snapshot.bytes.len())
+            .sum::<usize>()
+            + bytes.len()
+            > MAX_CACHE_BYTES
+        {
+            let oldest = self
+                .snapshots
+                .iter()
+                .min_by_key(|(_, value)| value.created)
+                .map(|(key, _)| key.clone());
+            if let Some(key) = oldest {
+                self.snapshots.remove(&key);
+            } else {
+                break;
+            }
+        }
+        let id = format!("read_{}", nkeys::KeyPair::new_user().public_key());
+        let snapshot = Snapshot {
+            owner,
+            bytes,
+            created: Instant::now(),
+        };
+        let page = chunk(&id, &snapshot, 0)?;
+        self.snapshots.insert(id, snapshot);
+        Ok(page)
+    }
+    fn read(&mut self, cmd: &IncomingCmd) -> Result<Value, String> {
+        self.prune();
+        let snapshot = self
+            .snapshots
+            .get(&cmd.reply_id)
+            .ok_or("remote_read_expired")?;
+        if snapshot.owner != Owner::from(cmd) {
+            return Err("remote_read_owner_mismatch".into());
+        }
+        let offset = usize::try_from(cmd.offset).map_err(|_| "remote_read_invalid_offset")?;
+        chunk(&cmd.reply_id, snapshot, offset)
+    }
+}
+fn chunk(id: &str, snapshot: &Snapshot, offset: usize) -> Result<Value, String> {
+    if offset >= snapshot.bytes.len() || !offset.is_multiple_of(CHUNK_BYTES) {
+        return Err("remote_read_invalid_offset".into());
+    }
+    let end = offset.saturating_add(CHUNK_BYTES).min(snapshot.bytes.len());
+    Ok(json!({"readChunk": {
+        "id": id, "offset": offset, "nextOffset": end,
+        "totalBytes": snapshot.bytes.len(),
+        "data": URL_SAFE_NO_PAD.encode(&snapshot.bytes[offset..end])
+    }}))
+}
+static CACHE: LazyLock<Mutex<Cache>> = LazyLock::new(Default::default);
+pub(super) fn prune() {
+    CACHE.lock().unwrap().prune();
+}
+pub(super) fn clear() {
+    CACHE.lock().unwrap().snapshots.clear();
+}
+pub(super) fn read(cmd: &IncomingCmd) -> Result<Value, String> {
+    CACHE.lock().unwrap().read(cmd)
+}
+
+pub(super) struct PagedReply<'a> {
+    sink: &'a dyn ReplySink,
+    owner: Owner,
+    enabled: bool,
+}
+impl<'a> PagedReply<'a> {
+    pub fn new(cmd: &IncomingCmd, sink: &'a dyn ReplySink) -> Self {
+        Self {
+            sink,
+            owner: Owner::from(cmd),
+            enabled: cmd.chunked_read
+                && matches!(
+                    cmd.cmd_type.as_str(),
+                    "get_session_entries" | "get_events_since" | "get_messages"
+                ),
+        }
+    }
+}
+impl ReplySink for PagedReply<'_> {
+    fn send<'a>(&'a self, success: bool, data: Value, error: Option<String>) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            if success && self.enabled {
+                let bytes = serde_json::to_vec(&data).expect("response Value serializes");
+                if bytes.len() > PAGE_THRESHOLD {
+                    let page = CACHE.lock().unwrap().insert(self.owner.clone(), bytes);
+                    match page {
+                        Ok(page) => self.sink.send(true, page, None).await,
+                        Err(error) => self.sink.send(false, Value::Null, Some(error)).await,
+                    }
+                    return;
+                }
+            }
+            self.sink.send(success, data, error).await;
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn command() -> IncomingCmd {
+        IncomingCmd {
+            bridge_instance_id: "bridge".into(),
+            session_id: "session".into(),
+            run_id: "run".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn oversized_projection_roundtrips_losslessly_with_small_immutable_pages() {
+        let mut cache = Cache::default();
+        let mut cmd = command();
+        let value = json!({"projection": {"cursor": 123, "events": [{"data": "中文\\\"".repeat(400_000)}]}, "events": []});
+        let bytes = serde_json::to_vec(&value).unwrap();
+        let first = cache.insert(Owner::from(&cmd), bytes.clone()).unwrap();
+        cmd.reply_id = first["readChunk"]["id"].as_str().unwrap().into();
+        let mut page = first;
+        let mut restored = Vec::new();
+        loop {
+            assert!(
+                serde_json::to_vec(&json!({"success": true, "data": page}))
+                    .unwrap()
+                    .len()
+                    < PAGE_THRESHOLD
+            );
+            let part = &page["readChunk"];
+            restored.extend(
+                URL_SAFE_NO_PAD
+                    .decode(part["data"].as_str().unwrap())
+                    .unwrap(),
+            );
+            let next = part["nextOffset"].as_i64().unwrap();
+            if next as usize == bytes.len() {
+                break;
+            }
+            cmd.offset = next;
+            page = cache.read(&cmd).unwrap();
+        }
+        assert_eq!(restored, bytes);
+        assert_eq!(serde_json::from_slice::<Value>(&restored).unwrap(), value);
+    }
+
+    #[test]
+    fn snapshot_owner_offset_expiry_and_capacity_are_bounded() {
+        let mut cache = Cache::default();
+        let mut cmd = command();
+        let page = cache
+            .insert(Owner::from(&cmd), vec![0; MAX_SNAPSHOT_BYTES])
+            .unwrap();
+        cmd.reply_id = page["readChunk"]["id"].as_str().unwrap().into();
+        cmd.offset = 1;
+        assert_eq!(cache.read(&cmd).unwrap_err(), "remote_read_invalid_offset");
+        cmd.offset = -1;
+        assert_eq!(cache.read(&cmd).unwrap_err(), "remote_read_invalid_offset");
+        cmd.offset = 0;
+        cmd.bridge_instance_id = "other".into();
+        assert_eq!(cache.read(&cmd).unwrap_err(), "remote_read_owner_mismatch");
+        cmd.bridge_instance_id = "bridge".into();
+        cache.snapshots.get_mut(&cmd.reply_id).unwrap().created = Instant::now() - TTL;
+        assert_eq!(cache.read(&cmd).unwrap_err(), "remote_read_expired");
+        for _ in 0..3 {
+            cache
+                .insert(Owner::from(&cmd), vec![0; MAX_SNAPSHOT_BYTES])
+                .unwrap();
+        }
+        assert_eq!(cache.snapshots.len(), 2);
+        assert_eq!(
+            cache
+                .insert(Owner::from(&cmd), vec![0; MAX_SNAPSHOT_BYTES + 1])
+                .unwrap_err(),
+            "remote_read_too_large"
+        );
+    }
+}

--- a/docs/mobile-latency-diagnosis.md
+++ b/docs/mobile-latency-diagnosis.md
@@ -91,3 +91,22 @@ Both paths bypass settled-document caching for this comparison; full parsing use
 React test-renderer checks show 100 transcript commits with no additional control-consumer renders; streaming start/end still render controls. A composer test similarly checks that 100 unchanged approval-array reconstructions do not redraw its docked cards, while new callbacks and streaming state do. Incrementally rendered and finalized Markdown matches ordinary rendering.
 
 Validation: Mobile typecheck/ESLint and **51 suites / 720 tests** passed; Desktop typecheck/ESLint/Stylelint and **107 files / 943 tests** passed; the shared Markdown package typecheck passed. Android and iOS production Expo exports both succeeded, including Hermes bytecode generation. No native application build/install, physical-device test, emulator frame-rate measurement, or service restart was performed.
+
+## Follow-up: oversized reads, cache budgets and refresh coalescing
+
+History/replay callers advertise `chunkedRead`. If a logical read result exceeds 512 KiB, Desktop retains an immutable JSON snapshot and returns 192 KiB binary slices encoded as base64url. Mobile checks the snapshot identity, exact offsets, chunk size, total length and current sync lane before reassembling and decoding the complete result. This preserves the existing history-page grouping and projection cursor: splitting one run into independently projected message pages could otherwise lose an overlapping assistant bubble. Ordinary replies and old Desktop replies remain compatible.
+
+Limits are explicit: 16 MiB per assembled read, 32 MiB of cached snapshot payloads, 120-second expiration, and ownership by bridge/session/run. Chunk requests pass the normal authentication/access checks but do not duplicate every chunk in the ten-minute command reply cache. Snapshots are pruned and cleared with transfer lifecycle maintenance. All final command replies additionally enforce a 1 MiB **uncompressed JSON** ceiling; unsupported/oversized results return an explicit error rather than relying on NATS to reject publication. This does not remove the Agent's existing gRPC limit or the existing per-entry presentation content caps. Data beyond the new read limit fails explicitly; it is not silently truncated by this transport.
+
+Mobile navigation now evicts least-recently-opened inactive conversation caches toward eight sessions / 16 MiB estimated serialized UTF-16 payload. Cursor state, retries, queued operations and the hook's corresponding timeline/paging/error records are removed together. The selected conversation and optimistic draft are protected; these are explicit exceptions rather than truncating content being read. Size estimates are cached until the timeline changes and evaluated on navigation, not on every streamed token; they are not exact JavaScript heap measurements.
+
+Concurrent session-list refreshes share one in-flight request and a trailing read when another event arrived during it. A 100-call burst test produces two requests, not 100, and ends with the fresh result. Client/epoch changes fence old responses.
+
+Validation on Windows:
+
+- Mobile typecheck and ESLint passed; **52 suites / 736 tests passed**. An unchanged SessionList beforeEach timeout on the first cold run passed on isolated and full reruns without relaxing its threshold.
+- Rust fmt and clippy (`--all-targets -- -D warnings`) passed. Four new Rust tests cover byte-exact Unicode snapshot reconstruction, ownership/offset/expiry/capacity, the final reply guard, and actual Desktop host/NATS-reply/Agent-mock paths for a large projection and a single 13-entry exchange.
+- Full Desktop library suite: **1,113 passed / 27 failed**. An unmodified `3034fcc0` run in the same worktree/environment produced **1,109 passed / the identical 27 failures**. The extra bridge-start timing case also passed in isolation. Binary tests passed; the existing doc test remains ignored. These Windows baseline failures were not hidden or skipped.
+- Android and iOS production Expo exports, including Hermes bytecode, succeeded.
+
+The tests also cover malformed/over-budget chunks, navigation cancellation, cache eviction followed by fresh reload, stale work completing after eviction, and old-client response compatibility. No physical-device performance claim is made. Updated Mobile and Desktop builds are both required for oversized-read chunking.

--- a/mobile/src/remote/__tests__/foregroundSync.test.ts
+++ b/mobile/src/remote/__tests__/foregroundSync.test.ts
@@ -8,6 +8,43 @@ function history(text: string): TimelineState {
 beforeEach(() => jest.useFakeTimers());
 afterEach(() => jest.useRealTimers());
 
+test("inactive timeline caches obey LRU count and byte budgets without truncating the selected session", async () => {
+  const engine = new SyncEngine({ requestGetState: async () => ({}), requestHistory: async () => history("reloaded"), fetchReplay: jest.fn() });
+  try {
+    for (let i = 0; i < 12; i++) { await engine.open(`s${i}`); await jest.advanceTimersByTimeAsync(0); }
+    expect(engine.pruneCache("s11")).toEqual(["s0", "s1", "s2", "s3"]);
+    expect(engine.timelineFor("s0")).toBeNull();
+    await engine.open("s4");
+    await jest.advanceTimersByTimeAsync(0);
+    await engine.open("s12");
+    await jest.advanceTimersByTimeAsync(0);
+    expect(engine.pruneCache("s12")).toEqual(["s5"]);
+    expect(engine.timelineFor("s4")).not.toBeNull();
+    engine.mutate("s12", () => history("x".repeat(10_000)));
+    await jest.advanceTimersByTimeAsync(0);
+    engine.pruneCache("s12", 8, 1000);
+    expect(engine.timelineFor("s12")?.items).toEqual(history("x".repeat(10_000)).items);
+    expect(engine.timelineFor("s4")).toBeNull();
+  } finally { engine.clear(); }
+});
+
+test("evicting a pending lane fences its late history result", async () => {
+  let finish!: (value: TimelineState) => void;
+  const old = new Promise<TimelineState>(resolve => { finish = resolve; });
+  const engine = new SyncEngine({ requestGetState: async () => ({}), requestHistory: async sid => sid === "old" ? old : history("current"), fetchReplay: jest.fn() });
+  try {
+    await engine.open("old");
+    await jest.advanceTimersByTimeAsync(0);
+    await engine.open("current");
+    await jest.advanceTimersByTimeAsync(0);
+    expect(engine.pruneCache("current", 1)).toEqual(["old"]);
+    finish(history("late"));
+    await jest.advanceTimersByTimeAsync(0);
+    expect(engine.timelineFor("old")).toBeNull();
+    expect(engine.timelineFor("current")?.items).toEqual(history("current").items);
+  } finally { engine.clear(); }
+});
+
 test("one opening state request feeds controls and history without another network round trip", async () => {
   const state = { model: "provider/model" };
   const requestGetState = jest.fn(async () => {

--- a/mobile/src/remote/__tests__/readPages.test.ts
+++ b/mobile/src/remote/__tests__/readPages.test.ts
@@ -1,0 +1,67 @@
+import type { RemoteClient } from "../client";
+import { encodeBase64Url } from "../codec";
+import { requestReadPage } from "../readPages";
+
+const SIZE = 192 * 1024;
+function parts(value: unknown) {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  return Array.from({ length: Math.ceil(bytes.length / SIZE) }, (_, index) => {
+    const offset = index * SIZE;
+    const nextOffset = Math.min(bytes.length, offset + SIZE);
+    return { readChunk: { id: "read_snapshot", offset, nextOffset, totalBytes: bytes.length,
+      data: encodeBase64Url(bytes.slice(offset, nextOffset)) } };
+  });
+}
+function clientFor(pages: unknown[]) {
+  const requestRetry = jest.fn();
+  for (const data of pages) requestRetry.mockResolvedValueOnce({ success: true, data });
+  return { client: { requestRetry } as unknown as RemoteClient, requestRetry };
+}
+
+test("reassembles a multi-megabyte Unicode projection without changing its cursor or content", async () => {
+  const data = { events: [], projection: { cursor: 99, events: [{ data: "中文\\\"".repeat(180_000) }] } };
+  const pages = parts(data);
+  const { client, requestRetry } = clientFor(pages);
+  const result = await requestReadPage(client, { type: "get_events_since", runId: "r" }, "s");
+  expect(result.data).toEqual(data);
+  expect(requestRetry).toHaveBeenCalledTimes(pages.length);
+  expect(requestRetry.mock.calls[0][0]).toMatchObject({ chunkedRead: true });
+  expect(requestRetry.mock.calls[1][0]).toEqual({ type: "get_read_chunk", sessionId: "s", runId: "r", replyId: "read_snapshot", offset: SIZE });
+});
+
+test("ordinary and old Desktop replies remain compatible", async () => {
+  const { client, requestRetry } = clientFor([{ entries: [] }]);
+  expect((await requestReadPage(client, { type: "get_session_entries" }, "s")).data).toEqual({ entries: [] });
+  expect(requestRetry).toHaveBeenCalledTimes(1);
+});
+
+test("a cancelled lane does not continue reading snapshot chunks", async () => {
+  let current = true;
+  const page = parts({ text: "x".repeat(SIZE * 2) })[0];
+  const requestRetry = jest.fn(async () => { current = false; return { success: true, data: page }; });
+  const client = { requestRetry } as unknown as RemoteClient;
+  await expect(requestReadPage(client, { type: "get_session_entries" }, "s", () => current)).rejects.toThrow("stale_sync_lane");
+  expect(requestRetry).toHaveBeenCalledTimes(1);
+});
+
+test.each(["owner", "offset", "total"])("rejects a changed %s between chunks", async field => {
+  const pages = parts({ text: "x".repeat(SIZE * 2) });
+  const second = pages[1]!.readChunk;
+  if (field === "owner") second.id = "another_snapshot";
+  if (field === "offset") second.offset++;
+  if (field === "total") second.totalBytes++;
+  const { client } = clientFor(pages);
+  await expect(requestReadPage(client, { type: "get_events_since" }, "s")).rejects.toThrow("remote_read_chunk_changed");
+});
+
+test.each([
+  { id: "r", offset: 0, nextOffset: 1, totalBytes: 17 * 1024 * 1024, data: "eA" },
+  { id: "r", offset: 0, nextOffset: 0, totalBytes: 1, data: "" },
+  { id: "r", offset: 0, nextOffset: 1, totalBytes: 2, data: "eA" },
+  { id: "r", offset: 0, nextOffset: 2, totalBytes: 2, data: "eA" },
+  { id: "r", offset: 0, nextOffset: 1, totalBytes: 1, data: "!" },
+])("rejects malformed or over-budget chunks without issuing another request", async readChunk => {
+  const { client, requestRetry } = clientFor([{ readChunk }]);
+  await expect(requestReadPage(client, { type: "get_session_entries" }, "s")).rejects.toThrow("remote_read_invalid_chunk");
+  expect(requestRetry).toHaveBeenCalledTimes(1);
+});

--- a/mobile/src/remote/__tests__/replay.test.ts
+++ b/mobile/src/remote/__tests__/replay.test.ts
@@ -24,7 +24,7 @@ describe("fetchEventsSince", () => {
     expect(result.truncated).toBeUndefined();
     expect(request).toHaveBeenCalledTimes(1);
     expect(request).toHaveBeenCalledWith(
-      { type: "get_events_since", sessionId: "s1", runId: "r1", sinceIdx: 0, offset: 0 },
+      { type: "get_events_since", sessionId: "s1", runId: "r1", sinceIdx: 0, offset: 0, chunkedRead: true },
       "s1",
     );
   });

--- a/mobile/src/remote/__tests__/useSessionCatalog.test.ts
+++ b/mobile/src/remote/__tests__/useSessionCatalog.test.ts
@@ -54,6 +54,33 @@ describe("useSessionCatalog", () => {
     }
   });
 
+  test("100 concurrent refreshes share one request and one trailing freshness read", async () => {
+    let finish!: (value: unknown) => void;
+    request.mockReturnValueOnce(new Promise(resolve => { finish = resolve; }))
+      .mockResolvedValueOnce({ data: { sessions: [session("latest")] } });
+    render();
+    let pending!: Promise<void>[];
+    act(() => { pending = Array.from({ length: 100 }, () => result.current.refreshSessions()); });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(new Set(pending).size).toBe(1);
+    await act(async () => { finish({ data: { sessions: [session("older")] } }); await Promise.all(pending); });
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(result.current.sessions.map(item => item.sessionId)).toEqual(["latest"]);
+  });
+
+  test("a replaced client starts a fresh refresh without waiting for the old flight", async () => {
+    let finish!: (value: unknown) => void;
+    request.mockReturnValueOnce(new Promise(resolve => { finish = resolve; }));
+    render();
+    let old!: Promise<void>;
+    act(() => { old = result.current.refreshSessions(); });
+    const nextRequest = jest.fn().mockResolvedValue({ data: { sessions: [session("new")] } });
+    clientRef.current = { requestRetry: nextRequest } as unknown as RemoteClient;
+    await act(async () => { await result.current.refreshSessions(); });
+    await act(async () => { finish({ data: { sessions: [session("old")] } }); await old; });
+    expect(result.current.sessions.map(item => item.sessionId)).toEqual(["new"]);
+  });
+
   test("late pull cannot overwrite a more recent pushed sessions snapshot", async () => {
     render();
     let resolve!: (value: unknown) => void;

--- a/mobile/src/remote/__tests__/useTimelineController.test.ts
+++ b/mobile/src/remote/__tests__/useTimelineController.test.ts
@@ -104,6 +104,35 @@ describe("useTimelineController", () => {
     await flush();
   }
 
+  test("navigation evicts inactive UI history and paging state, then reloads it on demand", async () => {
+    request.mockImplementation(async (command: { type: string; sessionId: string }) => ({ data: command.type === "get_state" ? {} : {
+      entries: [userEntry(command.sessionId, "history")], hasMore: true, nextOffset: 10,
+    } }));
+    options.selectedSessionId = "s0";
+    render();
+    for (let i = 0; i < 12; i++) {
+      const id = `s${i}`;
+      options.selectedSessionId = id;
+      options.selectedRef.current = id;
+      await act(async () => {
+        result.current.prepareTimelineOpen(id);
+        renderer!.update(createElement(Harness));
+        await result.current.syncEngineRef.current!.open(id);
+      });
+      await flush();
+    }
+    expect(result.current.syncEngineRef.current!.timelineFor("s0")).toBeNull();
+    options.selectedSessionId = "s0";
+    options.selectedRef.current = "s0";
+    act(() => { result.current.prepareTimelineOpen("s0"); renderer!.update(createElement(Harness)); });
+    expect(result.current.timelinePending).toBe(true);
+    expect(result.current.canLoadOlderTimeline).toBe(false);
+    await act(async () => { await result.current.syncEngineRef.current!.open("s0"); });
+    await flush();
+    expect(result.current.timelinePending).toBe(false);
+    expect(result.current.canLoadOlderTimeline).toBe(true);
+  });
+
   test("slow active-run replay does not trigger the 15-second history timeout", async () => {
     jest.useFakeTimers();
     options.selectedSessionId = "s1";
@@ -714,7 +743,7 @@ describe("useTimelineController", () => {
         "[remote] session timeline sync failed",
         expect.objectContaining({
           stage: "history",
-          error: expect.objectContaining({ message: "stale_history_load" }),
+          error: expect.objectContaining({ message: "stale_sync_lane" }),
         }),
       );
       errorSpy.mockRestore();

--- a/mobile/src/remote/readPages.ts
+++ b/mobile/src/remote/readPages.ts
@@ -1,0 +1,63 @@
+import type { RemoteClient } from "./client";
+import { decodeBase64Url } from "./codec";
+import type { RemoteCommand, RpcResponse } from "./types";
+
+const MAX_READ_BYTES = 16 * 1024 * 1024;
+const CHUNK_BYTES = 192 * 1024;
+interface Chunk { id: string; offset: number; nextOffset: number; totalBytes: number; data: string }
+
+function chunkOf(value: unknown): Chunk | null {
+  if (!value || typeof value !== "object" || !("readChunk" in value)) return null;
+  const chunk = value.readChunk as Partial<Chunk> | null;
+  if (!chunk || typeof chunk !== "object"
+    || typeof chunk.id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(chunk.id)
+    || typeof chunk.data !== "string" || chunk.data.length > CHUNK_BYTES * 4 / 3
+    || !Number.isSafeInteger(chunk.offset) || !Number.isSafeInteger(chunk.nextOffset)
+    || !Number.isSafeInteger(chunk.totalBytes) || chunk.totalBytes! <= 0 || chunk.totalBytes! > MAX_READ_BYTES)
+    throw new Error("remote_read_invalid_chunk");
+  return chunk as Chunk;
+}
+
+/** Reassemble only negotiated history/replay reads. Each NATS reply remains
+ * small; message grouping and projection cursors are interpreted only after the
+ * immutable JSON snapshot is complete. Old desktops ignore chunkedRead.
+ */
+export async function requestReadPage<T>(
+  client: RemoteClient,
+  command: RemoteCommand,
+  sessionId: string,
+  isCurrent: () => boolean = () => true,
+): Promise<RpcResponse<T>> {
+  if (!isCurrent()) throw new Error("stale_sync_lane");
+  const response = await client.requestRetry<unknown>({ ...command, chunkedRead: true }, sessionId);
+  if (!isCurrent()) throw new Error("stale_sync_lane");
+  let chunk = chunkOf(response.data);
+  if (!chunk) return response as RpcResponse<T>;
+  const id = chunk.id;
+  const total = chunk.totalBytes;
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (;;) {
+    if (chunk.id !== id || chunk.totalBytes !== total || chunk.offset !== offset)
+      throw new Error("remote_read_chunk_changed");
+    const part = decodeBase64Url(chunk.data);
+    if (!part || part.length === 0 || part.length > CHUNK_BYTES
+      || chunk.nextOffset !== offset + part.length || chunk.nextOffset > total
+      || (chunk.nextOffset < total && part.length !== CHUNK_BYTES))
+      throw new Error("remote_read_invalid_chunk");
+    bytes.set(part, offset);
+    offset = chunk.nextOffset;
+    if (offset === total) break;
+    if (!isCurrent()) throw new Error("stale_sync_lane");
+    const next = await client.requestRetry<unknown>({
+      type: "get_read_chunk", sessionId, replyId: id, offset,
+      ...(command.runId ? { runId: command.runId } : {}),
+      ...(command.bridgeInstanceId ? { bridgeInstanceId: command.bridgeInstanceId } : {}),
+    }, sessionId);
+    if (!isCurrent()) throw new Error("stale_sync_lane");
+    chunk = chunkOf(next.data);
+    if (!chunk) throw new Error("remote_read_invalid_chunk");
+  }
+  const data = JSON.parse(new TextDecoder().decode(bytes)) as T;
+  return { ...response, data };
+}

--- a/mobile/src/remote/replay.ts
+++ b/mobile/src/remote/replay.ts
@@ -1,4 +1,5 @@
 import type { RemoteClient } from "./client";
+import { requestReadPage } from "./readPages";
 import type { ReplayEventWire } from "./timeline";
 
 export interface EventsData {
@@ -42,7 +43,7 @@ export async function fetchEventsSince(
     // keep issuing pages or accumulating a replay nobody is displaying.
     if (!isCurrent()) throw new Error("stale_sync_lane");
     const page = (
-      await client.requestRetry<EventsPage>(
+      await requestReadPage<EventsPage>(client,
         {
           type: "get_events_since",
           sessionId,
@@ -52,6 +53,7 @@ export async function fetchEventsSince(
           ...(watermark === undefined ? {} : { replayUntilIdx: watermark }),
         },
         sessionId,
+        isCurrent,
       )
     ).data;
     if (!isCurrent()) throw new Error("stale_sync_lane");

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -112,6 +112,8 @@ interface ReconcileRequest {
 
 interface SessionLane {
   sessionId: string;
+  lastUsed: number;
+  cachedBytes?: number;
   generation: number;
   chain: Promise<void>;
   cursor: RunCursor;
@@ -134,6 +136,7 @@ export class SyncEngine {
   private lanes = new Map<string, SessionLane>();
   private subscribers = new Set<(commit: Commit) => void>();
   private generation = 0;
+  private cacheClock = 0;
   private deps: SyncDeps;
   private liveFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private liveFlushLanes = new Set<SessionLane>();
@@ -217,6 +220,8 @@ export class SyncEngine {
     if (previous?.retryTimer) clearTimeout(previous.retryTimer);
     const lane: SessionLane = {
       sessionId,
+      lastUsed: ++this.cacheClock,
+      cachedBytes: previous?.cachedBytes,
       generation: this.generation,
       chain: Promise.resolve(),
       cursor: previous ? new Map(previous.cursor) : newCursor(),
@@ -254,6 +259,33 @@ export class SyncEngine {
     return this.lanes.get(sessionId)?.timeline?.streaming ?? false;
   }
 
+  /** Evict inactive cached conversations as a unit (timeline, cursor, queued
+   * work and retry). Called on navigation, not every streaming frame. The
+   * selected session and optimistic draft are never truncated to meet a cache
+   * budget; a single large active session is an explicit exception. */
+  pruneCache(selected: string, maxSessions = 8, maxBytes = 16 * 1024 * 1024): string[] {
+    const lanes = [...this.lanes.values()].filter(lane => lane.sessionId !== "");
+    let bytes = 0;
+    for (const lane of lanes) {
+      lane.cachedBytes ??= JSON.stringify(lane.timeline).length * 2 + lane.cursor.size * 64;
+      bytes += lane.cachedBytes;
+    }
+    let count = lanes.length;
+    const evicted: string[] = [];
+    for (const lane of lanes.filter(lane => lane.sessionId !== selected).sort((a, b) => a.lastUsed - b.lastUsed)) {
+      if (count <= maxSessions && bytes <= maxBytes) break;
+      if (lane.retryTimer) clearTimeout(lane.retryTimer);
+      this.liveFlushLanes.delete(lane);
+      lane.ops = [];
+      lane.replayQueue = [];
+      this.lanes.delete(lane.sessionId);
+      bytes -= lane.cachedBytes ?? 0;
+      count--;
+      evicted.push(lane.sessionId);
+    }
+    return evicted;
+  }
+
   /** Drop all lanes (unpair / credentials cleared). */
   clear(): void {
     this.generation += 1;
@@ -271,6 +303,7 @@ export class SyncEngine {
     if (!lane) {
       lane = {
         sessionId,
+        lastUsed: ++this.cacheClock,
         generation: this.generation,
         chain: Promise.resolve(),
         cursor: newCursor(),
@@ -603,6 +636,7 @@ export class SyncEngine {
   }
 
   private commit(lane: SessionLane): void {
+    lane.cachedBytes = undefined;
     if (!lane.timeline || !this.isCurrent(lane)) return;
     for (const fn of this.subscribers) {
       fn({ sessionId: lane.sessionId, timeline: lane.timeline, cursor: lane.cursor });

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -291,6 +291,8 @@ export interface RpcResponse<T = unknown> {
 }
 
 export interface RemoteCommand {
+  chunkedRead?: boolean;
+  replyId?: string;
   replayUntilIdx?: number;
   bridgeInstanceId?: string;
   id?: string;

--- a/mobile/src/remote/useSessionCatalog.ts
+++ b/mobile/src/remote/useSessionCatalog.ts
@@ -61,6 +61,9 @@ export function useSessionCatalog(
   const titleOverridesRef = useRef<Record<string, string>>({});
   const modelsRef = useRef<RemoteModel[]>([]);
   const sessionsRef = useRef<RemoteSession[]>([]);
+  const sessionRefreshRef = useRef<{
+    client: RemoteClient; epoch: number; dirty: boolean; promise: Promise<void>;
+  } | null>(null);
   const modelRecoveryRef = useRef<{
     generation: number;
     timer: ReturnType<typeof setTimeout> | null;
@@ -127,7 +130,7 @@ export function useSessionCatalog(
     [selectedRef, markSync],
   );
 
-  const refreshSessions = useCallback(async () => {
+  const readSessions = useCallback(async () => {
     const client = clientRef.current;
     if (!client) return;
     const epoch = catalogEpoch.current;
@@ -154,6 +157,30 @@ export function useSessionCatalog(
       // the error — the reconnect handler will re-fetch.
     }
   }, [applySessionSnapshot, clientRef, markSync]);
+
+  // Coalesce terminal/approval bursts without losing a change that arrived
+  // after the in-flight server snapshot: one trailing read refreshes it.
+  const refreshSessions = useCallback((): Promise<void> => {
+    const client = clientRef.current;
+    if (!client) return Promise.resolve();
+    const epoch = catalogEpoch.current;
+    const pending = sessionRefreshRef.current;
+    if (pending?.client === client && pending.epoch === epoch) {
+      pending.dirty = true;
+      return pending.promise;
+    }
+    const flight = { client, epoch, dirty: false, promise: Promise.resolve() };
+    sessionRefreshRef.current = flight;
+    flight.promise = (async () => {
+      do {
+        flight.dirty = false;
+        await readSessions();
+      } while (flight.dirty && clientRef.current === client && catalogEpoch.current === epoch);
+    })().finally(() => {
+      if (sessionRefreshRef.current === flight) sessionRefreshRef.current = null;
+    });
+    return flight.promise;
+  }, [clientRef, readSessions]);
 
   const refreshModels = useCallback(async () => {
     markSync("models", "syncing");

--- a/mobile/src/remote/useTimelineController.ts
+++ b/mobile/src/remote/useTimelineController.ts
@@ -2,6 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RemoteClient } from "./client";
 import { fetchEventsSince } from "./replay";
+import { requestReadPage } from "./readPages";
 import type { RunCursor } from "./runCursor";
 import { SyncEngine, type ReconcileReason } from "./syncEngine";
 import {
@@ -209,7 +210,7 @@ export function useTimelineController({
       if (!client) return emptyTimeline();
       const epoch = historyEpochRef.current;
       const retained = historyPagingRef.current[sessionId];
-      const response = await client.requestRetry<EntriesData>(
+      const response = await requestReadPage<EntriesData>(client,
         {
           type: "get_session_entries",
           sessionId,
@@ -217,6 +218,7 @@ export function useTimelineController({
           limit: HISTORY_PAGE_USER_EXCHANGES,
         },
         sessionId,
+        () => epoch === historyEpochRef.current && clientRef.current === client && selectedRef.current === sessionId,
       );
       if (epoch !== historyEpochRef.current || clientRef.current !== client || selectedRef.current !== sessionId)
         throw new Error("stale_history_load");
@@ -251,7 +253,7 @@ export function useTimelineController({
     historyPagingRef.current[sessionId] = loading;
     setHistoryPaging(previous => ({ ...previous, [sessionId]: loading }));
     try {
-      const response = await client.requestRetry<EntriesData>(
+      const response = await requestReadPage<EntriesData>(client,
         {
           type: "get_session_entries",
           sessionId,
@@ -259,6 +261,7 @@ export function useTimelineController({
           limit: HISTORY_PAGE_USER_EXCHANGES,
         },
         sessionId,
+        () => historyPagingRef.current[sessionId] === loading && clientRef.current === client && selectedRef.current === sessionId,
       );
       // Reopening/reconciling may have replaced this cursor while the request
       // was in flight. Never install an old page into that new paging window.
@@ -294,8 +297,33 @@ export function useTimelineController({
     }
   }, [clientRef, selectedRef]);
 
+  const pruneTimelines = useCallback((selected: string) => {
+    const removed = syncEngineRef.current?.pruneCache(selected) ?? [];
+    if (removed.length === 0) return;
+    const next = { ...timelinesRef.current };
+    const paging = { ...historyPagingRef.current };
+    for (const id of removed) {
+      delete next[id];
+      delete paging[id];
+      delete cursorsRef.current[id];
+      delete streamingRef.current[id];
+    }
+    timelinesRef.current = next;
+    historyPagingRef.current = paging;
+    setTimelines(next);
+    setHistoryPaging(paging);
+    setTimelineErrors(previous => {
+      const errors = { ...previous };
+      for (const id of removed) delete errors[id];
+      return errors;
+    });
+  }, []);
+
+  useEffect(() => { pruneTimelines(selectedSessionId); }, [pruneTimelines, selectedSessionId]);
+
   const prepareTimelineOpen = useCallback((sessionId: string) => {
     historyEpochRef.current += 1;
+    pruneTimelines(sessionId);
     const cached = timelinesRef.current[sessionId];
     if (!cached) return;
     const windowed = latestTimelineWindow(cached, HISTORY_PAGE_USER_EXCHANGES);
@@ -313,7 +341,7 @@ export function useTimelineController({
     delete nextPaging[sessionId];
     historyPagingRef.current = nextPaging;
     setHistoryPaging(nextPaging);
-  }, []);
+  }, [pruneTimelines]);
 
   useEffect(() => {
     const engine = new SyncEngine({


### PR DESCRIPTION
## Changes
- Losslessly chunk oversized history/replay JSON without splitting logical exchanges or mixing changing projections.
- Immutable read snapshots: 192 KiB chunks, 16 MiB per read, 32 MiB cached payload, 120-second TTL, bridge/session/run ownership; chunks bypass redundant command-reply caching.
- Final 1 MiB decoded-JSON reply guard, including gzip: legacy or unsupported oversized replies fail explicitly instead of timing out.
- Mobile LRU eviction removes inactive timeline, cursor, paging and retry state together (eight sessions / 16 MiB estimated payload; current conversation and draft protected).
- Coalesce concurrent session-list refreshes and perform a trailing freshness read.

## Validation
- Mobile typecheck and ESLint passed; 52 suites / 736 tests passed.
- Android/iOS production Expo exports including Hermes bytecode passed.
- Desktop fmt and clippy --all-targets -- -D warnings passed.
- Unicode byte reconstruction, owner/offset/expiry/capacity, cancellation, eviction/reload and 100-refresh burst regressions pass.
- Integration test exercises actual Desktop host/NATS-reply/Agent-mock paths for a large projection and single 13-entry exchange.
- Windows full lib: 1,113 pass / 27 fail; unmodified 3034fcc0 in the same environment: 1,109 pass / identical 27 failures. Four new Rust tests pass. Binary test passes; doc test ignored. Linux CI is required.

Existing Agent gRPC limits and per-entry presentation caps remain unchanged. Reads above 16 MiB fail explicitly; chunk transport adds no truncation. Cache estimates are not exact heap usage. Both updated clients are needed for large-read chunking; no physical-device performance claim. Details in docs/mobile-latency-diagnosis.md.