### PR TITLE
fix(mobile): preserve turn order when reopening active sessions

### DIFF
--- a/mobile/src/remote/__tests__/syncEngine.test.ts
+++ b/mobile/src/remote/__tests__/syncEngine.test.ts
@@ -1,6 +1,6 @@
-import { emptyTimeline } from "../timeline";
+import { emptyTimeline, timelineFromEntries } from "../timeline";
 import { SyncEngine, type ReplayResult } from "../syncEngine";
-import type { StreamEvent } from "../types";
+import type { HistoryEntry, StreamEvent } from "../types";
 
 /** Deterministic run id generator. */
 let seq = 0;
@@ -648,6 +648,81 @@ describe("SyncEngine", () => {
     await new Promise((resolve) => setTimeout(resolve, 650));
     expect(h.textOf("s1")).toBe("abc");
     expect(h.timelineOf("s1").streaming).toBe(false);
+  });
+
+  test.each(["open", "reconnect"] as const)(
+    "%s preserves turn order when cached replies become durable during another run",
+    async reason => {
+      const h = new Harness("r1");
+      const firstPrompt: HistoryEntry = {
+        id: "u1", kind: "user", role: "user", createdAtMs: 1, runId: "r1",
+        blocks: [{ kind: "text", text: "first question" }],
+      };
+      h.history = timelineFromEntries([firstPrompt]);
+      h.journal.add(agentStart("r1"));
+      h.journal.add(textChunk("r1", 1, "first reply"));
+      h.journal.add(agentEnd("r1", 2));
+      try {
+        await h.engine.open("s");
+        await h.settle();
+        expect(h.timelineOf("s").items.map(item => item.id)).toEqual(["m_u1", "assistant:r1"]);
+
+        // While the phone is away, r1 is persisted with its entry id and a
+        // second prompt starts. Reopening must not append the cached r1 reply
+        // after u2 just because its live id differs from the durable entry id.
+        h.active("r2");
+        h.history = timelineFromEntries([
+          firstPrompt,
+          {
+            id: "a1", kind: "assistant", role: "assistant", createdAtMs: 2, runId: "r1",
+            blocks: [{ kind: "text", text: "first reply" }],
+          },
+          {
+            id: "u2", kind: "user", role: "user", createdAtMs: 3, runId: "r2",
+            blocks: [{ kind: "text", text: "second question" }],
+            metadata: { attachments: [{ path: "/photo.jpg", name: "photo.jpg", kind: "image" }] },
+          },
+        ]);
+        // The replay endpoint returns only the requested run.
+        h.journal.events = [agentStart("r2"), textChunk("r2", 1, "second reply")];
+        for (let reopen = 0; reopen < 2; reopen += 1) {
+          h.engine.restart("s", reason);
+          await h.settle();
+          expect(h.timelineOf("s").items.map(item => item.id)).toEqual([
+            "m_u1", "m_a1", "m_u2", "assistant:r2",
+          ]);
+          expect(h.timelineOf("s").items[2]).toMatchObject({
+            role: "user", text: "second question", attachments: [{ name: "photo.jpg" }],
+          });
+          expect(h.timelineOf("s").streaming).toBe(true);
+        }
+      } finally {
+        h.engine.clear();
+      }
+    },
+  );
+
+  test("history dedup requires both role and run identity, not matching text", async () => {
+    const h = new Harness();
+    h.history.items = [
+      { id: "u1", kind: "message", role: "user", text: "same", runId: "r1" },
+      { id: "a1", kind: "message", role: "assistant", text: "same", runId: "r1" },
+      { id: "u2", kind: "message", role: "user", text: "same", runId: "r2" },
+    ];
+    try {
+      h.engine.mutate("s", live => ({
+        ...live,
+        items: [{ id: "assistant:r2", kind: "message", role: "assistant", text: "same", runId: "r2" }],
+      }));
+      await h.settle();
+      await h.engine.open("s");
+      await h.settle();
+      expect(h.timelineOf("s").items.map(item => item.id)).toEqual([
+        "u1", "a1", "u2", "assistant:r2",
+      ]);
+    } finally {
+      h.engine.clear();
+    }
   });
 
   test("full reconcile drops a live user mirror duplicating a durable prompt", async () => {

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -657,20 +657,23 @@ export class SyncEngine {
  * Build the full-reconcile base: durable history is the settled truth; fold in
  * the live cache's items that history doesn't carry and that aren't part of
  * the active run (optimistic bubbles, notices, approval cards) so they survive
- * the rebuild. Live user messages that duplicate a history prompt are dropped.
+ * the rebuild. Live messages already represented by a durable message of the
+ * same role and run are dropped, even when their live and entry ids differ.
  */
 function mergeLiveInto(history: TimelineState, live: TimelineState | null): TimelineState {
   if (!live) return { ...history, streaming: history.streaming };
   const historyIds = new Set(history.items.map((item) => item.id));
-  const historyUserRuns = new Set(
-    history.items
-      .filter((item) => item.kind === "message" && item.role === "user")
-      .map((item) => item.runId)
-      .filter(Boolean),
+  const historyMessageRuns = new Set(
+    history.items.flatMap((item) =>
+      item.kind === "message" && item.runId ? [`${item.role}:${item.runId}`] : [],
+    ),
   );
   // Keep only transient items the durable history does not carry: optimistic bubbles, notices,
-  // approval cards, and live user mirrors of prompts not yet durable. The
-  // active run's *assistant* items are dropped by fullReconcile's stripRunItems
+  // approval cards, and live user mirrors of prompts not yet durable.
+  // Settled assistant mirrors have live ids (assistant:<run>) rather than
+  // durable entry ids (m_<entry>). Drop them by role + run identity too, or a
+  // warm open appends an old reply between the newest prompt and its reply.
+  // The active run's *assistant* items are dropped by fullReconcile's stripRunItems
   // (the replay rebuilds them). Cached durable rows outside the new window
   // remain reachable through paging and must not be appended after its tail.
   const folded = live.items.filter((item) => {
@@ -678,9 +681,8 @@ function mergeLiveInto(history: TimelineState, live: TimelineState | null): Time
     if (historyIds.has(item.id)) return false;
     if (
       item.kind === "message" &&
-      item.role === "user" &&
       !!item.runId &&
-      historyUserRuns.has(item.runId)
+      historyMessageRuns.has(`${item.role}:${item.runId}`)
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Deduplicate cached messages against durable history by role and run identity, not only entry ID.
- Prevent the previous live assistant reply from being appended between the newest user prompt and its streaming reply on reopen/reconnect.
- Add regression coverage for repeated reopen/reconnect, attachment retention, and role/run identity boundaries.

## Validation
- Mobile typecheck and full ESLint passed.
- All 52 Mobile Jest suites passed (739 tests); Windows testMatch override only corrects path matching.
- Regression tests reproduced the duplicate assistant before the fix.
- Android device verification and APK rebuild are not included.