### PR TITLE
perf(mobile): batch large replays and prefetch history responsively

### DIFF
--- a/desktop/src/features/agent/runProjectorBatch.test.ts
+++ b/desktop/src/features/agent/runProjectorBatch.test.ts
@@ -1,0 +1,63 @@
+import type { RunEvent } from "@future-os/thread-projection";
+import { createRunProjector } from "@future-os/thread-projection";
+import { describe, expect, it } from "vitest";
+
+function event(sequence: number, eventType: string, payload: unknown = {}): RunEvent {
+  return { id: `e${sequence}`, runId: "r", sequence, eventType, payload: JSON.stringify(payload), createdAt: 0 };
+}
+
+describe("deferred projector snapshots", () => {
+  it("append has the same arrival-order semantics as ingest of single events", () => {
+    const events = [
+      event(0, "agent_start"),
+      event(5, "text_chunk", { text: "new" }),
+      event(2, "text_chunk", { text: "old" }),
+      event(5, "text_chunk", { text: "duplicate" }),
+      event(6, "usage", { usage: { completion_tokens: 10 } }),
+      event(7, "agent_end", { state: "cancelled", usage: { completion_tokens: 20 } }),
+    ];
+    const single = createRunProjector({ preferEndTokens: true });
+    const deferred = createRunProjector({ preferEndTokens: true });
+    for (const item of events) {
+      single.ingest([item]);
+      deferred.append(item);
+    }
+    expect(deferred.lastSequence).toBe(single.lastSequence);
+    expect(deferred.snapshot()).toEqual(single.snapshot());
+  });
+
+  it("fork isolates open text and thinking slots", () => {
+    for (const type of ["text_chunk", "thinking_delta"]) {
+      const original = createRunProjector();
+      original.append(event(1, type, { text: "prefix" }));
+      const fork = original.fork();
+      fork.append(event(2, type, { text: " fork" }));
+      expect(original.lastSequence).toBe(1);
+      original.append(event(2, type, { text: " original" }));
+      const key = type === "text_chunk" ? "content" : "thinking";
+      expect(original.snapshot()[key]).toBe("prefix original");
+      expect(fork.snapshot()[key]).toBe("prefix fork");
+    }
+  });
+
+  it("fork isolates tools, compaction, usage, retry and terminal flags", () => {
+    const original = createRunProjector({ preferEndTokens: true });
+    original.ingest([
+      event(0, "tool_start", { tool_name: "shell", tool_call_id: "t", tool_args: { command: "echo hi" } }),
+      event(1, "compaction_started", { operation_id: "op" }),
+      event(2, "usage", { usage: { completion_tokens: 10 } }),
+      event(3, "stream_retry", { attempt: 1, maxRetries: 3, delayMs: 100 }),
+    ]);
+    const before = original.snapshot();
+    const fork = original.fork();
+    fork.ingest([
+      event(4, "tool_end", { tool_name: "shell", tool_call_id: "t", text: "done" }),
+      event(5, "compaction_committed", { operation_id: "op", checkpoint_id: "cp", tokens_before: 100 }),
+      event(6, "agent_end", { state: "cancelled", usage: { completion_tokens: 50 } }),
+    ]);
+    expect(original.snapshot()).toEqual(before);
+    expect(original.lastSequence).toBe(3);
+    expect(fork.snapshot()).toMatchObject({ outputTokens: 50, stopped: true });
+    expect(fork.snapshot().reconnecting).toBeUndefined();
+  });
+});

--- a/docs/mobile-latency-diagnosis.md
+++ b/docs/mobile-latency-diagnosis.md
@@ -110,3 +110,21 @@ Validation on Windows:
 - Android and iOS production Expo exports, including Hermes bytecode, succeeded.
 
 The tests also cover malformed/over-budget chunks, navigation cancellation, cache eviction followed by fresh reload, stale work completing after eviction, and old-client response compatibility. No physical-device performance claim is made. Updated Mobile and Desktop builds are both required for oversized-read chunking.
+
+## Follow-up: large replay folding and history look-ahead
+
+The Mobile replay reducer now owns one deduplication set per replay, rather than copying the growing set per event. Shared run projectors support arrival-ordered append without snapshot construction, explicit snapshots, and independent forks. Contiguous run events build one display snapshot; user/approval/error/notice and run boundaries flush it to preserve the single-event reducer's ordering. Existing `ingest` batch sorting/duplicate semantics remain unchanged.
+
+Replay folds cooperatively, yielding between slices after 512 events, approximately 256 KiB of event data, or an 8 ms work target. These checks occur between events: initial state forking, a single large payload and final snapshot construction are not preemptible, so 8 ms is not a guaranteed maximum task duration. The committed timeline/projector and cursor remain untouched while replay runs. A finished result installs its timeline and cursor together; cancellation/restart discards partial work. Projection snapshots retain their accumulator so subsequent live text appends to, rather than replaces, their prefix.
+
+History paging no longer waits for a fixed 1.5-second marker deadline. It still waits for requested IDs to commit, a native layout observation and the existing 100 ms quiet window, which can extend while layout keeps changing. Deliberate scrolling may request one page within one viewport of the history boundary (capped at 600 layout points). The existing transaction and per-gesture guards prevent programmatic scrolling/momentum from cascading through multiple pages. Idle text updates no longer rebuild the whole paging ID index.
+
+Validation uses real reducer/projector/hook implementations with synthetic events, not a physical device:
+
+- 10,000 / 50,000 / 100,000 text events (plus start/end) each produced one display snapshot and exact text/token totals. An independent timer ran before completion (after 1,024 events in the recorded run).
+- A 5,002-event comparison produced 5,002 snapshots with single-event folding versus one with batching. A recorded full-suite run measured 210 ms single-event, 15 ms synchronous batch, and 136 ms cooperative batch including timer scheduling. These are host observations, not phone latency or FPS, and no wall-clock ratio is a test gate.
+- Tests cover 300 interleaved tool calls, thinking, usage, compaction, approvals, errors, truncation, duplicates/out-of-order/untracked events, cancellation without mutating the committed prefix, restart without partial cursor publication, and projection-to-live-tail continuation.
+- Paging tests cover early one-page look-ahead, fast-page completion without the old cooldown, native-layout barriers, stale session completions, and 100 idle text updates across 1,000 rows without ID-index reads.
+- Mobile typecheck/ESLint and **53 suites / 752 tests** passed after syncing main; Desktop typecheck/ESLint/Stylelint and **109 files / 959 tests** passed. Shared thread-projection typecheck and Android/iOS production Hermes exports passed.
+
+This optimizes reconstruction after fetching replay, not the existing first full-tail read or retention of all fetched event pages. Block-level virtualization inside a giant message, data-source byte paging, and a bounded active-history window remain separate work. No native install or physical-device performance measurement was performed.

--- a/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
+++ b/mobile/src/features/chat/__tests__/useTimelinePaging.test.ts
@@ -18,14 +18,14 @@ describe("paging transaction", () => {
   let current: ReturnType<typeof useTimelinePaging>;
   const request = jest.fn<Promise<false | string[]>, []>();
   const onScroll = jest.fn();
-  function Harness({ sessionId = "a", ids = [] }: { sessionId?: string; ids?: string[] }) {
+  function Harness({ sessionId = "a", ids = [], rows }: { sessionId?: string; ids?: string[]; rows?: { id: string }[] }) {
     current = useTimelinePaging(
       sessionId,
       true,
       false,
       request,
       onScroll,
-      ids.map(id => ({ id })),
+      rows ?? ids.map(id => ({ id })),
     );
     return null;
   }
@@ -53,6 +53,18 @@ describe("paging transaction", () => {
     onScroll.mockReset();
   });
 
+  test("idle text updates do not rebuild the full history identity index", async () => {
+    const readId = jest.fn((i: number) => `row-${i}`);
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ get id() { return readId(i); } }));
+    for (let frame = 0; frame < 100; frame++) {
+      act(() => renderer.update(createElement(Harness, { rows: [...rows] })));
+    }
+    expect(readId).not.toHaveBeenCalled();
+    collide();
+    expect(readId).toHaveBeenCalledTimes(rows.length);
+    await act(async () => {});
+  });
+
   test("programmatic scroll never loads a page; collision starts request immediately", () => {
     act(() => current.onScroll(scrollEvent(1400)));
     expect(request).not.toHaveBeenCalled();
@@ -61,13 +73,41 @@ describe("paging transaction", () => {
     expect(current.pagingActive).toBe(true);
   });
 
-  test("a completed empty page retains the marker for 1500ms from collision", async () => {
+  test("a deliberate gesture prefetches at most one page within a bounded look-ahead", () => {
+    act(() => {
+      current.onScrollBeginDrag();
+      current.onScroll(scrollEvent(799));
+    });
+    expect(request).not.toHaveBeenCalled();
+    act(() => {
+      current.onScroll(scrollEvent(800));
+      current.onScroll(scrollEvent(1000));
+      current.onScroll(scrollEvent(1400));
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  test("a completed empty page only waits for the 100ms quiet window", async () => {
     collide();
     await act(async () => {});
-    await advance(1499);
+    await advance(99);
     expect(current.pagingActive).toBe(true);
     await advance(1);
     expect(current.showLoadOlderHint).toBe(false);
+  });
+
+  test("a fast committed page permits another deliberate gesture without a 1500ms cooldown", async () => {
+    request.mockResolvedValue(["older"]);
+    collide();
+    await act(async () => {});
+    act(() => renderer.update(createElement(Harness, { ids: ["older"] })));
+    act(() => current.onListLayout());
+    await advance(99);
+    expect(current.pagingActive).toBe(true);
+    await advance(1);
+    expect(current.pagingActive).toBe(false);
+    collide();
+    expect(request).toHaveBeenCalledTimes(2);
   });
 
   test("request completion and unchanged old geometry cannot satisfy a new page", async () => {
@@ -89,7 +129,7 @@ describe("paging transaction", () => {
     expect(current.showLoadOlderHint).toBe(false);
   });
 
-  test("slow response runs concurrently with minimum time, not another 1500ms", async () => {
+  test("a slow response only waits for layout quietness after completion", async () => {
     let resolve!: (result: string[]) => void;
     request.mockImplementationOnce(
       () =>
@@ -108,7 +148,7 @@ describe("paging transaction", () => {
   test("drag and momentum cannot cascade to another page even after cooldown", async () => {
     collide();
     await act(async () => {});
-    await advance(1500);
+    await advance(100);
     act(() => {
       current.onScrollEndDrag(scrollEvent(1400));
       current.onMomentumScrollEnd(scrollEvent(1400));
@@ -126,18 +166,18 @@ describe("paging transaction", () => {
     request.mockRejectedValueOnce(new Error("timeout"));
     collide();
     await act(async () => {});
-    await advance(1500);
+    await advance(100);
     expect(current.pagingActive).toBe(false);
     expect(current.pagingFailed).toBe(true);
     request.mockImplementationOnce(() => {
       throw new Error("disconnected");
     });
     act(() => current.loadOlder());
-    await advance(1500);
+    await advance(100);
     expect(current.pagingFailed).toBe(true);
     act(() => current.loadOlder());
     await act(async () => {});
-    await advance(1500);
+    await advance(100);
     expect(current.showLoadOlderHint).toBe(false);
   });
 

--- a/mobile/src/features/chat/useTimelinePaging.ts
+++ b/mobile/src/features/chat/useTimelinePaging.ts
@@ -5,7 +5,6 @@ type ScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
 type PageResult = false | string[];
 type Transaction = {
   sessionId: string;
-  deadline: number;
   expectedIds: string[] | null;
   failed: boolean;
   committed: boolean;
@@ -13,7 +12,6 @@ type Transaction = {
   layoutObserved: boolean;
 };
 
-const MIN_HINT_MS = 1_500;
 // Native VirtualizedList mounts rows in 32ms batches. Two JS animation frames
 // alone can fall entirely between those batches. Require a quiet layout window
 // after the requested ids are committed AND a native layout has been observed.
@@ -21,8 +19,8 @@ const LAYOUT_QUIET_MS = 100;
 
 /**
  * A gesture starts at most one page transaction. Network completion, React
- * commit and native layout are distinct barriers; the minimum display timer
- * starts at collision and runs concurrently with all three.
+ * commit and native layout are distinct barriers. Completion follows those
+ * barriers, not a fixed spinner duration that delays the next deliberate page.
  */
 export function useTimelinePaging(
   sessionId: string,
@@ -44,6 +42,7 @@ export function useTimelinePaging(
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const gestureRef = useRef({ active: false, used: false });
   const idsRef = useRef(new Set<string>());
+  const itemsRef = useRef(items);
   const checkRef = useRef<() => void>(() => undefined);
 
   const cancelTimer = useCallback(() => {
@@ -64,7 +63,7 @@ export function useTimelinePaging(
       if (tx.expectedIds.length === 0) tx.layoutObserved = true;
     }
     if (!tx.layoutObserved) return;
-    const remaining = Math.max(tx.deadline, tx.lastLayout + LAYOUT_QUIET_MS) - Date.now();
+    const remaining = tx.lastLayout + LAYOUT_QUIET_MS - Date.now();
     if (remaining > 0) {
       timerRef.current = setTimeout(() => checkRef.current(), remaining);
       return;
@@ -87,16 +86,21 @@ export function useTimelinePaging(
   }, [sessionId, cancelTimer]);
 
   useLayoutEffect(() => {
-    idsRef.current = new Set(items.map(item => item.id));
-    check();
+    itemsRef.current = items;
+    // Text-only streaming changes the items array too. There is no reason to
+    // rebuild a large identity index when no page transaction is waiting.
+    if (transactionRef.current) {
+      idsRef.current = new Set(items.map(item => item.id));
+      check();
+    }
   }, [items, check, sessionId]);
 
   const loadOlder = useCallback(() => {
     if (!canLoadOlder || loadingOlder || transactionRef.current) return;
-    const previousIds = idsRef.current;
+    const previousIds = new Set(itemsRef.current.map(item => item.id));
+    idsRef.current = previousIds;
     const tx: Transaction = {
       sessionId,
-      deadline: Date.now() + MIN_HINT_MS,
       expectedIds: null,
       failed: false,
       committed: false,
@@ -134,9 +138,13 @@ export function useTimelinePaging(
       const gesture = gestureRef.current;
       if (!gesture.active || gesture.used) return;
       const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+      // One page of look-ahead during a deliberate gesture, at most one
+      // viewport (600 layout points). The gesture/transaction guards prevent
+      // programmatic scrolling or momentum from cascading through history.
+      const lookAhead = Math.max(8, Math.min(layoutMeasurement.height, 600));
       if (
         contentSize.height > 0 &&
-        contentOffset.y + layoutMeasurement.height >= contentSize.height - 8
+        contentOffset.y + layoutMeasurement.height >= contentSize.height - lookAhead
       )
         loadOlder();
     },

--- a/mobile/src/remote/__tests__/batchedReplay.test.ts
+++ b/mobile/src/remote/__tests__/batchedReplay.test.ts
@@ -1,0 +1,151 @@
+import { applyReplayEvents, applyStreamEvent, applyStreamEvents, emptyTimeline, type TimelineState } from "../timeline";
+import type { StreamEvent } from "../types";
+
+let mockSnapshots = 0;
+let mockAppends = 0;
+jest.mock("@future-os/thread-projection", () => {
+  const actual = jest.requireActual<typeof import("@future-os/thread-projection")>("@future-os/thread-projection");
+  return { ...actual, createRunProjector: (options?: Parameters<typeof actual.createRunProjector>[0]) => {
+    const projector = actual.createRunProjector(options);
+    const ingest = projector.ingest;
+    const snapshot = projector.snapshot;
+    const append = projector.append;
+    projector.ingest = events => { mockSnapshots++; return ingest(events); };
+    projector.snapshot = () => { mockSnapshots++; return snapshot(); };
+    projector.append = event => { mockAppends++; append(event); };
+    return projector;
+  } };
+});
+
+function event(type: string, idx: number, data: unknown = {}, runId = "r"): StreamEvent {
+  return { type, idx, runId, data: JSON.stringify(data) };
+}
+function view(state: TimelineState) {
+  return { items: state.items, seenEvents: state.seenEvents, currentRunId: state.currentRunId, streaming: state.streaming };
+}
+function workload(count: number): StreamEvent[] {
+  return [event("agent_start", 0, { started_at_ms: 1000 }),
+    ...Array.from({ length: count }, (_, i) => event("text_chunk", i + 1, { text: "x" })),
+    event("agent_end", count + 1, { duration_ms: 1000, usage: { output_tokens: count } })];
+}
+
+beforeEach(() => {
+  mockSnapshots = 0;
+  mockAppends = 0;
+  jest.spyOn(Date, "now").mockReturnValue(10_000);
+});
+afterEach(() => jest.restoreAllMocks());
+
+test("batch folding matches single events across tools, approvals, errors, compaction and duplicates", () => {
+  const events = [
+    event("agent_start", 0, { started_at_ms: 1000 }),
+    event("user_message", 1, { text: "question" }),
+    event("thinking_start", 2), event("thinking_delta", 3, { text: "reason" }), event("thinking_end", 4),
+    event("text_chunk", 5, { text: "before" }),
+    event("tool_start", 6, { tool_name: "write", tool_call_id: "t", tool_args: { path: "file.txt" } }),
+    event("tool_end", 7, { tool_name: "write", tool_call_id: "t", text: "done", exit_code: 0 }),
+    event("approval_request", 8, { approval_request_id: "approval", tool_name: "shell" }),
+    event("text_chunk", 9, { text: "after" }),
+    event("text_chunk", 9, { text: "duplicate" }),
+    event("text_chunk", 10, { _truncated: true }),
+    event("compaction_started", 11, { operation_id: "op" }),
+    event("compaction_committed", 12, { operation_id: "op", checkpoint_id: "cp", tokens_before: 100 }),
+    event("usage", 13, { usage: { output_tokens: 20 } }),
+    event("error", 14, { error: "failed" }),
+    event("agent_end", 15, { state: "failed", duration_ms: 50, usage: { output_tokens: 30 } }),
+    event("agent_start", 0, { started_at_ms: 2000 }, "other"),
+    event("text_chunk", 1, { text: "another run" }, "other"),
+    event("agent_end", 2, { state: "cancelled", duration_ms: 50 }, "other"),
+  ];
+  const expected = events.reduce(applyStreamEvent, emptyTimeline());
+  expect(view(applyStreamEvents(emptyTimeline(), events))).toEqual(view(expected));
+});
+
+test("arrival order, untracked events and malformed payloads keep their old semantics", () => {
+  const events: StreamEvent[] = [
+    event("agent_start", 0), event("text_chunk", 5, { text: "new" }),
+    event("text_chunk", 2, { text: "old" }),
+    { type: "text_chunk", data: '{"text":"untracked"}' },
+    { type: "error", data: "bad JSON" },
+    event("ping", 6), event("agent_end", 7, { reason: "incomplete" }),
+  ];
+  expect(view(applyStreamEvents(emptyTimeline(), events)))
+    .toEqual(view(events.reduce(applyStreamEvent, emptyTimeline())));
+});
+
+test("cooperative cancellation leaves a committed tail and its projector untouched", async () => {
+  const prefix = [event("agent_start", 0), event("text_chunk", 1, { text: "prefix" })];
+  const initial = prefix.reduce(applyStreamEvent, emptyTimeline());
+  const before = view(initial);
+  let current = true;
+  let processed = 0;
+  const events = Array.from({ length: 10_000 }, (_, i) => event("text_chunk", i + 2, { text: "x" }));
+  const pending = applyReplayEvents(initial, events, {
+    isCurrent: () => current, onEvent: () => { processed++; },
+  });
+  const rejected = expect(pending).rejects.toThrow("stale_sync_lane");
+  setTimeout(() => { current = false; }, 0);
+  await rejected;
+  expect(processed).toBeGreaterThan(0);
+  expect(processed).toBeLessThan(events.length);
+  expect(view(initial)).toEqual(before);
+  const continued = applyStreamEvent(initial, event("text_chunk", 2, { text: " kept" }));
+  expect(continued.items.find(item => item.kind === "message" && item.role === "assistant"))
+    .toMatchObject({ text: "prefix kept" });
+});
+
+test.each([10_000, 50_000, 100_000])("folds %i text events with one render snapshot and yields to other tasks", async count => {
+  const events = workload(count);
+  let processed = 0;
+  let taskAt = -1;
+  const start = performance.now();
+  const resultPromise = applyReplayEvents(emptyTimeline(), events, { onEvent: () => { processed++; } });
+  setTimeout(() => { taskAt = processed; }, 0);
+  const result = await resultPromise;
+  expect(taskAt).toBeGreaterThan(0);
+  expect(taskAt).toBeLessThan(events.length);
+  expect(mockSnapshots).toBe(1);
+  expect(mockAppends).toBe(events.length);
+  expect(result.seenEvents.size).toBe(events.length);
+  expect(result.streaming).toBe(false);
+  expect(result.items[0]).toMatchObject({ text: "x".repeat(count), outputTokens: count });
+  console.warn(JSON.stringify({ events: events.length, snapshots: mockSnapshots, otherTaskAfterEvents: taskAt,
+    elapsedMs: Math.round(performance.now() - start) }));
+}, 30_000);
+
+test("hundreds of interleaved tool calls retain their exact transcript with one snapshot", async () => {
+  const events = [event("agent_start", 0, { started_at_ms: 1000 })];
+  for (let i = 0; i < 300; i++) {
+    events.push(event("tool_start", events.length, { tool_name: "shell", tool_call_id: `t${i}`, tool_args: { command: `echo ${i}` } }));
+    events.push(event("tool_end", events.length, { tool_name: "shell", tool_call_id: `t${i}`, text: "done", exit_code: 0 }));
+    events.push(event("text_chunk", events.length, { text: `after ${i}\n` }));
+  }
+  events.push(event("agent_end", events.length, { duration_ms: 1000 }));
+  const expected = events.reduce(applyStreamEvent, emptyTimeline());
+  mockSnapshots = 0;
+  const result = await applyReplayEvents(emptyTimeline(), events);
+  expect(view(result)).toEqual(view(expected));
+  expect(mockSnapshots).toBe(1);
+}, 30_000);
+
+test("records a bounded baseline comparison without timing assertions", async () => {
+  const events = workload(5000);
+  const start = performance.now();
+  const baseline = events.reduce(applyStreamEvent, emptyTimeline());
+  const baselineMs = performance.now() - start;
+  const baselineSnapshots = mockSnapshots;
+  mockSnapshots = 0;
+  const syncStart = performance.now();
+  const synchronous = applyStreamEvents(emptyTimeline(), events);
+  const syncBatchMs = performance.now() - syncStart;
+  expect(view(synchronous)).toEqual(view(baseline));
+  mockSnapshots = 0;
+  const batchStart = performance.now();
+  const result = await applyReplayEvents(emptyTimeline(), events);
+  const batchMs = performance.now() - batchStart;
+  expect(view(result)).toEqual(view(baseline));
+  expect(mockSnapshots).toBe(1);
+  expect(baselineSnapshots).toBe(events.length);
+  console.warn(JSON.stringify({ baselineEvents: events.length, baselineSnapshots, batchSnapshots: mockSnapshots,
+    baselineMs: Math.round(baselineMs), syncBatchMs: Math.round(syncBatchMs), batchMs: Math.round(batchMs) }));
+});

--- a/mobile/src/remote/__tests__/syncEngine.test.ts
+++ b/mobile/src/remote/__tests__/syncEngine.test.ts
@@ -120,6 +120,51 @@ class Harness {
 }
 
 describe("SyncEngine", () => {
+  test("a projection snapshot retains its accumulator for the following live tail", async () => {
+    const h = new Harness("r");
+    h.projection = [agentStart("r"), textChunk("r", 1, "prefix")];
+    try {
+      h.engine.reconcile("s", "open");
+      await h.settle();
+      expect(h.textOf("s")).toBe("prefix");
+      h.projection = null;
+      h.engine.event("s", textChunk("r", 2, " tail"));
+      await h.settle();
+      expect(h.textOf("s")).toBe("prefix tail");
+    } finally { h.engine.clear(); }
+  });
+
+  test("restarting during a cooperative replay sees only committed cursors and drops old work", async () => {
+    jest.useFakeTimers();
+    let during = -2;
+    let calls = 0;
+    const engine = new SyncEngine({
+      requestGetState: async () => ({ activeRun: { runId: "r" } }),
+      requestHistory: async () => emptyTimeline(),
+      fetchReplay: async () => {
+        calls++;
+        if (calls === 1) {
+          setTimeout(() => {
+            during = engine.cursorFor("s").get("r")?.highWater ?? -1;
+            engine.restart("s", "reconnect");
+          }, 0);
+          return { events: [agentStart("r"), ...Array.from({ length: 10_000 }, (_, i) => textChunk("r", i + 1, "old"))].map(ev => ({ ...ev })) };
+        }
+        return { events: [agentStart("r"), textChunk("r", 1, "replacement")].map(ev => ({ ...ev })) };
+      },
+    });
+    try {
+      engine.reconcile("s", "open");
+      await jest.runAllTimersAsync();
+      expect(during).toBe(-1);
+      expect(engine.cursorFor("s").get("r")?.highWater).toBe(1);
+      expect(engine.timelineFor("s")?.items.find(item => item.kind === "message"))
+        .toMatchObject({ text: "replacement" });
+      expect(calls).toBe(2);
+    } finally { engine.clear(); jest.useRealTimers(); }
+  });
+
+
   test("publishes cold history before slow replay without claiming a complete prefix", async () => {
     jest.useFakeTimers();
     const history = emptyTimeline();
@@ -679,17 +724,21 @@ describe("SyncEngine", () => {
     expect(h.timelineOf("s1").items.map((i) => i.id)).toEqual(["h1", "h2", "notice-1"]);
   });
   test("live queue overflow converges from the durable journal without losing text", async () => {
+    jest.useFakeTimers();
     const run = nextRunId();
     const h = new Harness(run);
-    h.journal.add(agentStart(run));
-    h.engine.event("s1", agentStart(run));
-    for (let idx = 1; idx <= 4200; idx += 1) {
-      const event = textChunk(run, idx, "a");
-      h.journal.add(event);
-      h.engine.event("s1", event);
-    }
-    await h.settle();
-    expect(h.textOf("s1")).toBe("a".repeat(4200));
-    h.engine.clear();
+    try {
+      h.journal.add(agentStart(run));
+      h.engine.event("s1", agentStart(run));
+      for (let idx = 1; idx <= 4200; idx += 1) {
+        const event = textChunk(run, idx, "a");
+        h.journal.add(event);
+        h.engine.event("s1", event);
+      }
+      // Replay intentionally crosses task boundaries now; completion, not a
+      // 20ms wall-clock sleep, is the relevant assertion boundary.
+      await jest.runAllTimersAsync();
+      expect(h.textOf("s1")).toBe("a".repeat(4200));
+    } finally { h.engine.clear(); jest.useRealTimers(); }
   });
 });

--- a/mobile/src/remote/projection.ts
+++ b/mobile/src/remote/projection.ts
@@ -203,7 +203,7 @@ export function mergeHistoryAttachments(
  * reducer reproduces the same transcript as if the run had streamed live.
  */
 export function timelineFromProjection(events: StreamEvent[]): TimelineState {
-  return events.reduce((state, event) => applyStreamEvent(state, event), emptyTimeline());
+  return applyStreamEvents(emptyTimeline(), events);
 }
 
 /**
@@ -299,14 +299,22 @@ function upsertItem(
  * settled duration) is layered on top of the projection snapshot.
  */
 export function applyStreamEvent(state: TimelineState, event: StreamEvent): TimelineState {
+  return applyEvent(state, event);
+}
+
+function applyEvent(state: TimelineState, event: StreamEvent, batch?: {
+  seenEvents: Set<string>;
+  deferRunSnapshot: boolean;
+  data: Record<string, unknown>;
+}): TimelineState {
   if (event.type === "ping") return state;
   const runId = event.runId ?? state.currentRunId ?? undefined;
   const key = event.runId != null && event.idx != null ? `${event.runId}:${event.idx}` : null;
   if (key && state.seenEvents.has(key)) return state;
 
-  const seenEvents = new Set(state.seenEvents);
+  const seenEvents = batch?.seenEvents ?? new Set(state.seenEvents);
   if (key) seenEvents.add(key);
-  const data = eventData(event);
+  const data = batch?.data ?? eventData(event);
   let items = state.items;
   let streaming = state.streaming;
   let liveRuns = state.liveRuns;
@@ -399,7 +407,7 @@ export function applyStreamEvent(state: TimelineState, event: StreamEvent): Time
 
   // Run events flow through the shared projector.
   if (runEvents && isRunEvent(event.type)) {
-    const result = applyLiveEvent(state, runId, event, data);
+    const result = applyLiveEvent(state, runId, event, data, batch?.deferRunSnapshot);
     items = result.items;
     streaming = result.streaming;
     liveRuns = result.liveRuns;
@@ -413,6 +421,83 @@ export function applyStreamEvent(state: TimelineState, event: StreamEvent): Time
     streaming,
     liveRuns,
   };
+}
+
+/** A replay owns its dedup set and mutable projectors. Yielding/cancelling it
+ * must never mutate the still-visible committed timeline or its accumulators. */
+function createReplayBatch(initial: TimelineState) {
+  const seenEvents = new Set(initial.seenEvents);
+  const liveRuns = new Map<string, LiveRunState>();
+  for (const [id, run] of initial.liveRuns ?? []) {
+    liveRuns.set(id, { ...run, projector: run.projector.fork() });
+  }
+  let state: TimelineState = { ...initial, seenEvents, liveRuns };
+  let pending: { runId: string | undefined } | null = null;
+  const flush = () => {
+    if (!pending) return;
+    const run = state.liveRuns?.get(pending.runId ?? "__norun__");
+    if (run) {
+      const item = buildLiveAssistantItem(run, pending.runId, run.projector.snapshot(), run.durationMs);
+      state = { ...state, items: upsertItem(state.items, run.assistantId, () => item, () => item) };
+    }
+    pending = null;
+  };
+  return {
+    append(event: StreamEvent) {
+      if (event.type === "ping") return;
+      const key = event.runId != null && event.idx != null ? `${event.runId}:${event.idx}` : null;
+      if (key && seenEvents.has(key)) return;
+      const runId = event.runId ?? state.currentRunId ?? undefined;
+      const data = eventData(event);
+      const deferRunSnapshot = isRunEvent(event.type)
+        && !(event.type === "text_chunk" && data._truncated === true);
+      // Materialize before an approval/user/error/notice or another run so
+      // the same ordering and upsert semantics as single-event folding hold.
+      if (pending && (!deferRunSnapshot || pending.runId !== runId)) flush();
+      state = applyEvent(state, event, { seenEvents, deferRunSnapshot, data });
+      if (deferRunSnapshot) pending = { runId };
+    },
+    finish() { flush(); return state; },
+  };
+}
+
+/** Batch folding avoids a growing Set copy and render snapshot per event. */
+export function applyStreamEvents(initial: TimelineState, events: StreamEvent[]): TimelineState {
+  if (events.length === 0) return initial;
+  const batch = createReplayBatch(initial);
+  for (const event of events) batch.append(event);
+  return batch.finish();
+}
+
+/** Cooperatively fold a large replay without committing partial cursors or UI.
+ * Limits are checked between events; a single large payload/snapshot is not
+ * preemptible. Count/byte bounds also guarantee yields under a fake clock. */
+export async function applyReplayEvents(
+  initial: TimelineState,
+  events: StreamEvent[],
+  options: { isCurrent?: () => boolean; onEvent?: (event: StreamEvent) => void } = {},
+): Promise<TimelineState> {
+  const isCurrent = options.isCurrent ?? (() => true);
+  if (!isCurrent()) throw new Error("stale_sync_lane");
+  if (events.length === 0) return initial;
+  const batch = createReplayBatch(initial);
+  let index = 0;
+  while (index < events.length) {
+    if (!isCurrent()) throw new Error("stale_sync_lane");
+    const deadline = Date.now() + 8;
+    let count = 0;
+    let bytes = 0;
+    do {
+      const event = events[index++]!;
+      options.onEvent?.(event);
+      batch.append(event);
+      count++;
+      bytes += event.data.length * 2;
+    } while (index < events.length && count < 512 && bytes < 256 * 1024 && Date.now() < deadline);
+    if (index < events.length) await new Promise<void>(resolve => setTimeout(resolve, 0));
+  }
+  if (!isCurrent()) throw new Error("stale_sync_lane");
+  return batch.finish();
 }
 
 function isRunEvent(type: string): boolean {
@@ -443,6 +528,7 @@ function applyLiveEvent(
   runId: string | undefined,
   event: StreamEvent,
   data: Record<string, unknown>,
+  deferSnapshot = false,
 ): { items: TimelineItem[]; streaming: boolean; liveRuns: Map<string, LiveRunState> } {
   const liveRuns = state.liveRuns ?? new Map<string, LiveRunState>();
   const runKey = runId ?? "__norun__";
@@ -466,7 +552,9 @@ function applyLiveEvent(
   if (event.type !== "agent_end") acc.streaming = true;
 
   // Feed through the shared projector (agent_start is a no-op for it).
-  const projection = acc.projector.ingest([toRunEvent(runKey, event)]);
+  let projection: ReturnType<RunProjector["snapshot"]> | undefined;
+  if (deferSnapshot) acc.projector.append(toRunEvent(runKey, event));
+  else projection = acc.projector.ingest([toRunEvent(runKey, event)]);
 
   let durationMs = acc.durationMs;
   if (event.type === "agent_end") {
@@ -486,13 +574,11 @@ function applyLiveEvent(
     durationMs = runDurationMs(data) ?? (acc.startedAt ? Date.now() - acc.startedAt : undefined);
     acc.durationMs = durationMs;
   }
-  const assistantItem = buildLiveAssistantItem(acc, runId, projection, durationMs);
-  const items = upsertItem(
-    state.items,
-    acc.assistantId,
-    () => assistantItem,
-    () => assistantItem,
-  );
+  let items = state.items;
+  if (projection) {
+    const assistantItem = buildLiveAssistantItem(acc, runId, projection, durationMs);
+    items = upsertItem(items, acc.assistantId, () => assistantItem, () => assistantItem);
+  }
   return { items, streaming: acc.streaming, liveRuns };
 }
 

--- a/mobile/src/remote/syncEngine.ts
+++ b/mobile/src/remote/syncEngine.ts
@@ -37,10 +37,10 @@
 
 import {
   applyStreamEvent,
+  applyReplayEvents,
   emptyTimeline,
   normalizeReplayEvents,
   stripRunItems,
-  timelineFromProjection,
   upsertTruncationNotice,
   type ReplayEventWire,
   type TimelineState,
@@ -449,7 +449,10 @@ export class SyncEngine {
           }
           stage = "replay";
           base = stripRunItems(base, targetRunId);
-          base = await this.replayInto(lane, base, targetRunId, -1);
+          const replay = await this.replayInto(lane, base, targetRunId, -1);
+          if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
+          base = replay.timeline;
+          lane.cursor = replay.cursor;
         }
         lane.timeline = base;
         this.commit(lane);
@@ -478,8 +481,10 @@ export class SyncEngine {
   private async tailReconcile(lane: SessionLane, runId: string): Promise<void> {
     if (!runId || !lane.timeline) return;
     const since = cursorHighWater(lane.cursor, runId);
-    const base = await this.replayInto(lane, lane.timeline, runId, since);
-    lane.timeline = base;
+    const replay = await this.replayInto(lane, lane.timeline, runId, since);
+    if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
+    lane.cursor = replay.cursor;
+    lane.timeline = replay.timeline;
     this.commit(lane);
   }
 
@@ -494,9 +499,10 @@ export class SyncEngine {
     base: TimelineState,
     runId: string,
     since: number,
-  ): Promise<TimelineState> {
+  ): Promise<{ timeline: TimelineState; cursor: RunCursor }> {
     const result = await this.deps.fetchReplay(lane.sessionId, runId, since, () => this.isCurrent(lane));
     if (!this.isCurrent(lane)) throw new Error("stale_sync_lane");
+    const cursor = new Map(lane.cursor);
     if (result.projection?.events?.length) {
       let events = normalizeReplayEvents(result.projection.events);
       // A folded projection's run id rides on the envelope, not necessarily on
@@ -508,32 +514,33 @@ export class SyncEngine {
       events = events.map((ev) => (ev.runId ? ev : { ...ev, runId }));
       const cursorIdx =
         result.projection.cursor ?? events.reduce((max, ev) => Math.max(max, ev.idx ?? -1), -1);
-      advanceCursor(lane.cursor, runId, cursorIdx, true);
       const stripped = stripRunItems(base, runId);
-      const projected = timelineFromProjection(events);
+      const projected = await applyReplayEvents(emptyTimeline(), events, { isCurrent: () => this.isCurrent(lane) });
+      advanceCursor(cursor, runId, cursorIdx, true);
       const settled = events.some((ev) => ev.type === "agent_end");
       return {
-        ...stripped,
-        items: [...stripped.items, ...projected.items],
-        streaming: !settled,
+        cursor,
+        timeline: {
+          ...stripped,
+          items: [...stripped.items, ...projected.items],
+          liveRuns: new Map([...(stripped.liveRuns ?? []), ...(projected.liveRuns ?? [])]),
+          seenEvents: new Set([...stripped.seenEvents, ...projected.seenEvents]),
+          currentRunId: projected.currentRunId,
+          streaming: !settled,
+        },
       };
     }
     const events = normalizeReplayEvents(result.events);
-    if (events.length === 0) return base;
-    let next = base;
-    if (since === -1) {
-      // Whole-run replay — supersede any partial items of the run.
-      next = stripRunItems(base, runId);
-    }
-    for (const ev of events) {
-      advanceCursor(lane.cursor, ev.runId ?? runId, ev.idx ?? -1, since === -1);
-      next = applyStreamEvent(next, ev);
-    }
+    if (events.length === 0) return { timeline: base, cursor };
+    let next = await applyReplayEvents(since === -1 ? stripRunItems(base, runId) : base, events, {
+      isCurrent: () => this.isCurrent(lane),
+      onEvent: ev => advanceCursor(cursor, ev.runId ?? runId, ev.idx ?? -1, since === -1),
+    });
     const settled = events.some((ev) => ev.type === "agent_end");
     if (result.truncated) next = { ...next, items: upsertTruncationNotice(next.items, runId) };
     // A settled replay overrides the live streaming flag; an empty replay
     // leaves it alone (the run may have ended between the fetch and now).
-    return { ...next, streaming: settled ? false : next.streaming };
+    return { timeline: { ...next, streaming: settled ? false : next.streaming }, cursor };
   }
 
   /**

--- a/mobile/src/remote/timeline.ts
+++ b/mobile/src/remote/timeline.ts
@@ -5,6 +5,8 @@
 export {
   appendUserMessage,
   applyStreamEvent,
+  applyStreamEvents,
+  applyReplayEvents,
   commitAcknowledgedUserMessage,
   emptyTimeline,
   markApprovalDecision,

--- a/packages/thread-projection/src/liveApply.ts
+++ b/packages/thread-projection/src/liveApply.ts
@@ -92,9 +92,37 @@ export interface RunProjector {
    * (sequence <= lastSequence) are skipped, so overlapping batches are safe.
    */
   ingest: (events: RunEvent[]) => AssistantRunProjection;
+  /** Append in arrival order without rebuilding a render snapshot. */
+  append: (event: RunEvent) => void;
+  snapshot: () => AssistantRunProjection;
+  /** Independent mutable accumulator for cancellable/cooperative replay. */
+  fork: () => RunProjector;
+}
+
+interface ProjectorCheckpoint {
+  toolActivities: Map<string, ToolActivity>;
+  slots: Slot[];
+  slottedToolIds: Set<string>;
+  openTextIndex: number;
+  openThinkingIndex: number;
+  content: string;
+  thinking: boolean;
+  sawVisibleWork: boolean;
+  activeToolCallId: string | null;
+  usageOutputSum: number;
+  sawUsageEvent: boolean;
+  agentEndOutput: number;
+  truncated: boolean;
+  stopped: boolean;
+  reconnecting?: StreamRetryState;
+  lastSequence: number;
 }
 
 export function createRunProjector(options?: { preferEndTokens?: boolean }): RunProjector {
+  return createProjector(options);
+}
+
+function createProjector(options?: { preferEndTokens?: boolean }, initial?: ProjectorCheckpoint): RunProjector {
   const toolActivities = new Map<string, ToolActivity>();
   // Ordered timeline of the exchange. Text accumulates into the open text slot;
   // each tool call pins a slot at the point it started.
@@ -122,6 +150,27 @@ export function createRunProjector(options?: { preferEndTokens?: boolean }): Run
   let stopped = false;
   let reconnecting: StreamRetryState | undefined;
   let lastSequence = -1;
+
+  if (initial) {
+    for (const [id, tool] of initial.toolActivities) toolActivities.set(id, { ...tool });
+    for (const slot of initial.slots) slots.push({ ...slot });
+    for (const id of initial.slottedToolIds) slottedToolIds.add(id);
+    const textSlot = slots[initial.openTextIndex];
+    const thinkingSlot = slots[initial.openThinkingIndex];
+    openText = textSlot?.type === "text" ? textSlot : null;
+    openThinking = thinkingSlot?.type === "thinking" ? thinkingSlot : null;
+    content = initial.content;
+    thinking = initial.thinking;
+    sawVisibleWork = initial.sawVisibleWork;
+    activeToolCallId = initial.activeToolCallId;
+    usageOutputSum = initial.usageOutputSum;
+    sawUsageEvent = initial.sawUsageEvent;
+    agentEndOutput = initial.agentEndOutput;
+    truncated = initial.truncated;
+    stopped = initial.stopped;
+    reconnecting = initial.reconnecting ? { ...initial.reconnecting } : undefined;
+    lastSequence = initial.lastSequence;
+  }
 
   function processEvent(event: RunEvent) {
     const payload = parseEventPayload(event.payload);
@@ -425,6 +474,21 @@ export function createRunProjector(options?: { preferEndTokens?: boolean }): Run
   }
 
   return {
+    append(event) {
+      // Same ordering/dedup semantics as ingest([event]), including an older
+      // event arriving after a newer one. Do not sort across arrival batches.
+      if (!(event.sequence <= lastSequence)) processEvent(event);
+      lastSequence = Math.max(lastSequence, event.sequence);
+    },
+    snapshot,
+    fork: () => createProjector(options, {
+      toolActivities, slots, slottedToolIds,
+      openTextIndex: openText ? slots.indexOf(openText) : -1,
+      openThinkingIndex: openThinking ? slots.indexOf(openThinking) : -1,
+      content, thinking, sawVisibleWork, activeToolCallId,
+      usageOutputSum, sawUsageEvent, agentEndOutput, truncated, stopped,
+      reconnecting, lastSequence,
+    }),
     get lastSequence() {
       return lastSequence;
     },


### PR DESCRIPTION
## Summary
- Fold large Mobile replays with one owned dedup set and deferred run snapshots rather than copying/rebuilding on every event.
- Add arrival-ordered append/snapshot/fork to the shared projector without changing existing ingest semantics; isolate mutable accumulators for cancellable replay.
- Yield between bounded work slices and commit the completed timeline/cursor together. Preserve projection accumulators for subsequent live tail events.
- Remove the fixed 1.5s paging cooldown, retain commit/native-layout/100ms quiet barriers, and prefetch at most one page per deliberate gesture within a capped viewport look-ahead.
- Avoid rebuilding the full paging ID index on idle streaming text updates.

## Validation
- Mobile typecheck + ESLint; 53 suites / 752 tests passed after main sync.
- Desktop typecheck + ESLint + Stylelint; 109 files / 959 tests passed. Shared thread-projection typecheck passed.
- Android and iOS production Hermes exports passed.
- 10k / 50k / 100k text events: one final display snapshot, exact content/tokens, independent tasks run before completion.
- Parity cases cover 300 interleaved tools, thinking, usage, compaction, approvals, errors, truncation, duplicates/out-of-order events; cancellation and restart preserve committed projector/cursor state.
- Paging tests cover bounded prefetch, no programmatic/momentum cascades, native layout barriers and idle index work.

A recorded 5,002-event host comparison: 5,002 snapshots / 210 ms single-event versus one snapshot / 15 ms synchronous batching or 136 ms cooperative batching including timer scheduling. Timings are not phone FPS/latency promises; deterministic correctness/work assertions are the gates.

Initial forking, single large payloads and final snapshot construction remain non-preemptible. Network replay fetching/retention, data-source paging and giant-message block virtualization are unchanged. Details: docs/mobile-latency-diagnosis.md.